### PR TITLE
add simple internationalisation handling

### DIFF
--- a/lib/ocamlorg_web/middleware.ml
+++ b/lib/ocamlorg_web/middleware.ml
@@ -36,13 +36,3 @@ let i18n next_handler request =
       Dream.redirect request redirection
   else
     next_handler request
-
-(* Only used to catch the 404 status coming from serving the site directory
-   without a namespace. *)
-let catch_404 next_handler request =
-  let open Lwt.Syntax in
-  let* response = next_handler request in
-  if Dream.status response = `Not_Found then
-    Page_handler.not_found request
-  else
-    Lwt.return response

--- a/lib/ocamlorg_web/router.ml
+++ b/lib/ocamlorg_web/router.ml
@@ -1,4 +1,4 @@
-let v3_loader root path _request =
+let v3_loader root path request =
   let headers, path =
     let fpath = Fpath.v path in
     if Fpath.is_dir_path fpath || not (Fpath.exists_ext fpath) then
@@ -10,21 +10,21 @@ let v3_loader root path _request =
   in
   match Asset.read (root ^ path) with
   | None ->
-    Dream.empty `Not_Found
+    Page_handler.not_found request
   | Some asset ->
     Dream.respond ~headers asset
 
-let loader root path _request =
+let loader root path request =
   match Asset.read (root ^ path) with
   | None ->
-    Dream.empty `Not_Found
+    Page_handler.not_found request
   | Some asset ->
     Dream.respond ~headers:(Dream.mime_lookup path) asset
 
 let site_route =
   Dream.scope
     ""
-    [ Middleware.i18n; Middleware.catch_404 ]
+    [ Middleware.i18n ]
     [ Dream.get "/**" (Dream.static ~loader:v3_loader "site/") ]
 
 let package_route =


### PR DESCRIPTION
This PR adds a simple i18n solution for now, just use `en` as we don't have any `fr` (or other) pages in v3. It is written so in the future we can accommodate different locales (that is a rabbit hole in itself), seems `Cohttp` have made an effort to implement useful functions for this (see https://github.com/mirage/ocaml-cohttp/blob/master/cohttp/src/accept.ml) but our transitive dependency was lost in the "great ocurrent purge" and it doesn't look like `Httpaf` has anything like that. 

If we do implement this approach later, [RFC4647](https://datatracker.ietf.org/doc/html/rfc4647) may be useful 🤷 ... as I said, rabbit hole. 

This PR also fixes that `/foo/bar` now also redirects to `index.html` by assuming if there is no extension to the path then it is a directory. For everything in the scope of the `v3` site I couldn't find a counterexample, concretely this means the navigation links accessed from `/packages` should now work :))  