### PR TITLE
Add opam users module

### DIFF
--- a/lib/ocamlorg/dune
+++ b/lib/ocamlorg/dune
@@ -1,15 +1,6 @@
 (library
  (name ocamlorg)
- (libraries
-  opam-format
-  bos
-  fpath
-  logs
-  fmt
-  lwt
-  lwt.unix
-  yojson
-  cohttp
-  cohttp-lwt-unix))
+ (libraries opam-format bos fpath logs fmt lwt lwt.unix yojson cohttp
+   cohttp-lwt-unix))
 
 (include_subdirs unqualified)

--- a/lib/ocamlorg/ocamlorg.ml
+++ b/lib/ocamlorg/ocamlorg.ml
@@ -1,1 +1,2 @@
+module Opam_user = Opam_user
 module Package = Package

--- a/lib/ocamlorg/ocamlorg.mli
+++ b/lib/ocamlorg/ocamlorg.mli
@@ -1,3 +1,4 @@
 (** Backend for the OCaml.org website. *)
 
+module Opam_user = Opam_user
 module Package = Package

--- a/lib/ocamlorg/opam_user.ml
+++ b/lib/ocamlorg/opam_user.ml
@@ -1,0 +1,90 @@
+type t =
+  { name : string
+  ; handle : string option
+  ; image : string option
+  }
+
+let make ~name ?handle ?image () = { name; handle; image }
+
+let all =
+  [ { name = "Xavier Leroy"
+    ; handle = Some "xavierleroy"
+    ; image = Some "https://avatars.githubusercontent.com/u/3845810?v=4"
+    }
+  ; { name = "Damien Doligez"
+    ; handle = Some "damiendoligez"
+    ; image = Some "https://avatars.githubusercontent.com/u/19104?v=4"
+    }
+  ; { name = "David Allsopp"
+    ; handle = Some "dra27"
+    ; image = Some "https://avatars.githubusercontent.com/u/5250680?v=4"
+    }
+  ; { name = "Alain Frisch"
+    ; handle = Some "alainfrisch"
+    ; image = Some "https://avatars.githubusercontent.com/u/3305274?v=4"
+    }
+  ; { name = "Gabriel Scherer"
+    ; handle = Some "gasche"
+    ; image = Some "https://avatars.githubusercontent.com/u/426238?v=4"
+    }
+  ; { name = "Jacques Garrigue"
+    ; handle = Some "garrigue"
+    ; image = Some "https://avatars.githubusercontent.com/u/870242?v=4"
+    }
+  ; { name = "Anil Madhavapeddy"
+    ; handle = Some "avsm"
+    ; image = Some "https://avatars.githubusercontent.com/u/53164?v=4"
+    }
+  ; { name = "Lucas Pluvinage"
+    ; handle = Some "TheLortex"
+    ; image = Some "https://avatars.githubusercontent.com/u/966015?v=4"
+    }
+  ; { name = "Jon Ludlam"
+    ; handle = Some "jonludlam"
+    ; image = Some "https://avatars.githubusercontent.com/u/210963?v=4"
+    }
+  ; { name = "Thibaut Mattio"
+    ; handle = Some "tmattio"
+    ; image = Some "https://avatars.githubusercontent.com/u/6162008?v=4"
+    }
+  ; { name = "Anton Bachin"
+    ; handle = Some "aantron"
+    ; image = Some "https://avatars.githubusercontent.com/u/12073668?v=4"
+    }
+  ; { name = "Patrick Ferris"
+    ; handle = Some "patricoferris"
+    ; image = Some "https://avatars.githubusercontent.com/u/20166594?v=4"
+    }
+  ; { name = "Didier Rémy"
+    ; handle = Some "diremy"
+    ; image = Some "https://avatars.githubusercontent.com/u/1357930?v=4"
+    }
+  ; { name = "Gabriel Radanne"
+    ; handle = Some "Drup"
+    ; image = Some "https://avatars.githubusercontent.com/u/801124?v=4"
+    }
+  ; { name = "Daniel Bünzli"
+    ; handle = Some "dbuenzli"
+    ; image = Some "https://avatars.githubusercontent.com/u/485596?v=4"
+    }
+  ]
+
+let find_by_name s =
+  let pattern = String.lowercase_ascii s in
+  let contains s1 s2 =
+    try
+      let len = String.length s2 in
+      for i = 0 to String.length s1 - len do
+        if String.sub s1 i len = s2 then raise Exit
+      done;
+      false
+    with
+    | Exit ->
+      true
+  in
+  all
+  |> List.find_opt (fun { name; _ } ->
+         if contains pattern (String.lowercase_ascii @@ name) then
+           true
+         else
+           false)

--- a/lib/ocamlorg/opam_user.mli
+++ b/lib/ocamlorg/opam_user.mli
@@ -1,0 +1,11 @@
+type t =
+  { name : string
+  ; handle : string option
+  ; image : string option
+  }
+
+val all : t list
+
+val make : name:string -> ?handle:string -> ?image:string -> unit -> t
+
+val find_by_name : string -> t option

--- a/lib/ocamlorg/package.ml
+++ b/lib/ocamlorg/package.ml
@@ -12,11 +12,11 @@ module Info = struct
   type t =
     { synopsis : string
     ; description : string
-    ; authors : string list
+    ; authors : Opam_user.t list
+    ; maintainers : Opam_user.t list
     ; license : string
     ; homepage : string list
     ; tags : string list
-    ; maintainers : string list
     ; dependencies : (OpamPackage.Name.t * string option) list
     ; depopts : (OpamPackage.Name.t * string option) list
     ; conflicts : (OpamPackage.Name.t * string option) list
@@ -60,8 +60,18 @@ module Info = struct
   let of_opamfile (opam : OpamFile.OPAM.t) =
     let open OpamFile.OPAM in
     { synopsis = synopsis opam |> Option.value ~default:"No synopsis"
-    ; authors = author opam
-    ; maintainers = maintainer opam
+    ; authors =
+        author opam
+        |> List.map (fun name ->
+               Option.value
+                 (Opam_user.find_by_name name)
+                 ~default:(Opam_user.make ~name ()))
+    ; maintainers =
+        maintainer opam
+        |> List.map (fun name ->
+               Option.value
+                 (Opam_user.find_by_name name)
+                 ~default:(Opam_user.make ~name ()))
     ; license = license opam |> String.concat "; "
     ; description =
         descr opam |> Option.map OpamFile.Descr.body |> Option.value ~default:""

--- a/lib/ocamlorg/package.mli
+++ b/lib/ocamlorg/package.mli
@@ -37,11 +37,11 @@ module Info : sig
   type t =
     { synopsis : string
     ; description : string
-    ; authors : string list
+    ; authors : Opam_user.t list
+    ; maintainers : Opam_user.t list
     ; license : string
     ; homepage : string list
     ; tags : string list
-    ; maintainers : string list
     ; dependencies : (Name.t * string option) list
     ; depopts : (Name.t * string option) list
     ; conflicts : (Name.t * string option) list

--- a/lib/ocamlorg_web/handlers/preview_handler.ml
+++ b/lib/ocamlorg_web/handlers/preview_handler.ml
@@ -27,5 +27,7 @@ let tutorial req =
     Dream.not_found req
 
 let tutorials _req =
-  Page_layout_template.render ~title:"Tutorials" Preview_tutorials_template.render
+  Page_layout_template.render
+    ~title:"Tutorials"
+    Preview_tutorials_template.render
   |> Dream.html

--- a/lib/ocamlorg_web/schema.ml
+++ b/lib/ocamlorg_web/schema.ml
@@ -1,5 +1,25 @@
 open Ocamlorg
 
+let opam_user =
+  Graphql_lwt.Schema.(
+    obj "opam_user" ~fields:(fun _info ->
+        [ field
+            "name"
+            ~typ:(non_null string)
+            ~args:Arg.[]
+            ~resolve:(fun _info user -> user.Opam_user.name)
+        ; field
+            "github_username"
+            ~typ:string
+            ~args:Arg.[]
+            ~resolve:(fun _info user -> user.Opam_user.handle)
+        ; field
+            "avatar"
+            ~typ:string
+            ~args:Arg.[]
+            ~resolve:(fun _info user -> user.Opam_user.image)
+        ]))
+
 let versionned_package =
   Graphql_lwt.Schema.(
     obj "versionned_package" ~fields:(fun _info ->
@@ -31,11 +51,18 @@ let versionned_package =
               info.Package.Info.description)
         ; field
             "authors"
-            ~typ:(non_null (list (non_null string)))
+            ~typ:(non_null (list (non_null opam_user)))
             ~args:Arg.[]
             ~resolve:(fun _info package ->
               let info = Package.info package in
               info.Package.Info.authors)
+        ; field
+            "maintainers"
+            ~typ:(non_null (list (non_null opam_user)))
+            ~args:Arg.[]
+            ~resolve:(fun _info package ->
+              let info = Package.info package in
+              info.Package.Info.maintainers)
         ; field
             "license"
             ~typ:(non_null string)
@@ -57,13 +84,6 @@ let versionned_package =
             ~resolve:(fun _info package ->
               let info = Package.info package in
               info.Package.Info.tags)
-        ; field
-            "maintainers"
-            ~typ:(non_null (list (non_null string)))
-            ~args:Arg.[]
-            ~resolve:(fun _info package ->
-              let info = Package.info package in
-              info.Package.Info.maintainers)
         ]))
 
 let package =
@@ -105,4 +125,6 @@ let schema : Dream.request Graphql_lwt.Schema.schema =
                 packages)
       ])
 
-let default_query = "{\\n  packages {\\n    versions {\\n      name\\n      version\\n    }\\n  }\\n}"
+let default_query =
+  "{\\n  packages {\\n    versions {\\n      name\\n      version\\n    }\\n  \
+   }\\n}"

--- a/lib/ocamlorg_web/templates/pages/package_template.eml
+++ b/lib/ocamlorg_web/templates/pages/package_template.eml
@@ -2,6 +2,22 @@ type kind =
 | Blessed
 | Universe of string
 
+let render_user_list users = 
+  <ul class="space-y-3">
+    <% users |> List.iter begin fun author -> %>
+    <li class="flex justify-start">
+      <a href="<%s match author.Ocamlorg.Opam_user.handle with | None -> "" | Some handle -> "https://github.com/" ^ handle %>" class="flex items-center space-x-3">
+        <% (match author.Ocamlorg.Opam_user.image with | None -> () | Some avatar -> %>
+        <div class="flex-shrink-0">
+          <img class="h-10 w-10 rounded-full" src="<%s avatar %>" alt="">
+        </div>
+        <% ); %>
+        <div class="text-sm font-medium text-gray-900"><%s author.Ocamlorg.Opam_user.name %></div>
+      </a>
+    </li>
+    <% end; %>
+  </ul>
+
 let render ~kind:_ ~readme ~license:_ package =
   let package_name = Ocamlorg.Package.(Name.to_string (name package)) in
   let package_version = Ocamlorg.Package.(Version.to_string (version package)) in
@@ -67,29 +83,23 @@ let render ~kind:_ ~readme ~license:_ package =
         <dl class="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500">Authors</dt>
-            <dd class="mt-1 text-sm text-gray-900">
-              <% package_authors |> List.iter begin fun author -> %>
-              <%s author %>
-              <br />
-              <% end; %>
+            <dd class="mt-2 text-sm text-gray-900">
+              <%s! render_user_list package_authors %>
             </dd>
           </div>
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500">Maintainers</dt>
-            <dd class="mt-1 text-sm text-gray-900">
-              <% package_maintainers |> List.iter begin fun maintainer -> %>
-              <%s maintainer %>
-              <br />
-              <% end; %>
+            <dd class="mt-2 text-sm text-gray-900">
+              <%s! render_user_list package_maintainers %>
             </dd>
           </div>
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500">License</dt>
-            <dd class="mt-1 text-sm text-gray-900"><%s package_license %></dd>
+            <dd class="mt-2 text-sm text-gray-900"><%s package_license %></dd>
           </div>
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500">Homepage</dt>
-            <dd class="mt-1 text-sm text-gray-900">
+            <dd class="mt-2 text-sm text-gray-900">
               <% package_homepages |> List.iter begin fun homepage -> %>
               <a href="<%s homepage %>" class="font-medium text-orange-600 hover:text-orange-500"> <%s homepage %>
               <br />
@@ -102,7 +112,7 @@ let render ~kind:_ ~readme ~license:_ package =
               | Some source -> %>
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500">Sources</dt>
-            <dd class="mt-1 text-sm text-gray-900">
+            <dd class="mt-2 text-sm text-gray-900">
               <ul class="border border-gray-200 bg-white rounded-md divide-y divide-gray-200">
                 <li class="pl-3 pr-4 flex items-center justify-between text-sm">
                   <div class="w-0 flex-1 flex items-center">
@@ -129,7 +139,7 @@ let render ~kind:_ ~readme ~license:_ package =
           <% ; %>
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500">Dependencies</dt>
-            <dd class="mt-1 text-sm text-gray-900 max-h-80 overflow-y-auto">
+            <dd class="mt-2 text-sm text-gray-900 max-h-80 overflow-y-auto">
               <ul class="divide-y divide-gray-100">
                 <% package_deps |> List.iter begin fun (name, cstr) -> %>
                 <li class="py-2">


### PR DESCRIPTION
This allows to add avatars to opam users in packages metadata:

![image](https://user-images.githubusercontent.com/6162008/127171601-013ca7f9-57a2-461a-adbd-fd0a8cecfdd4.png)

I'm not sure this is ethical to add users info from Github without their consent though. What do you think?
As a first step, we can start with our own information (if everybody agrees), and users who want their info on the website can open PRs. Later on, the data can probably be hosted in `ood` instead.