### PR TITLE
Update site docker references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ADD package.json package.json
 RUN npm install
 
 # Download site static files
-COPY --from=patricoferris/ocamlorg:latest /data asset/site/
+COPY --from=ocurrent/v3.ocaml.org:live /data asset/site/
 
 # Build project
 COPY --chown=opam:opam . .

--- a/script/update-site.sh
+++ b/script/update-site.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker pull patricoferris/ocamlorg:latest
-docker cp $(docker create --rm patricoferris/ocamlorg:latest):/data asset/site
+docker pull ocurrent/v3.ocaml.org:live
+docker cp $(docker create --rm ocurrent/v3.ocaml.org:live):/data asset/site


### PR DESCRIPTION
The new image is now at https://hub.docker.com/layers/ocurrent/v3.ocaml.org/live/images/sha256-fcb623b673bb354ad7aca170225c093735ca19b07145a2fb6a6d764f710e196d?context=explore