### PR TITLE
make opam-repo state initialisation explicit

### DIFF
--- a/lib/ocamlorg/package.mli
+++ b/lib/ocamlorg/package.mli
@@ -1,8 +1,7 @@
 (* This module manages the synchronisation of a local clone of
-   opam-monorepository to access the opam packages and their metadata.
-
-   It also uses the output of the occurent documentation pipeline to render
-   packages documentation. *)
+   opam-monorepository to access the opam packages and their metadata. It also
+   uses the output of the occurent documentation pipeline to render packages
+   documentation. *)
 
 (** The name of an opam package. *)
 module Name : sig
@@ -68,6 +67,8 @@ module Documentation : sig
     }
 end
 
+type state
+
 type t
 
 val name : t -> Name.t
@@ -105,23 +106,26 @@ val documentation_page
 (** Get the rendered content of an HTML page for a package given its URL
     relative to the root page of the documentation. *)
 
-val all_packages_latest : unit -> t list
-(** Get the list of the latest version of every opam packages.
+val init : ?disable_polling:bool -> unit -> state
+(** [init ()] initialises the opam-repository state. By default
+    [disable_polling] is set to [false], but can be disabled for tests. *)
 
-    The name and versions of the packages are read from the file system, the
-    metadata are loaded lazily to improve performance. *)
+val all_packages_latest : state -> t list
+(** Get the list of the latest version of every opam packages. The name and
+    versions of the packages are read from the file system, the metadata are
+    loaded lazily to improve performance. *)
 
-val get_packages_with_name : Name.t -> t list option
+val get_packages_with_name : state -> Name.t -> t list option
 (** Get the list of packages with the given name. *)
 
-val get_package_versions : Name.t -> Version.t list option
+val get_package_versions : state -> Name.t -> Version.t list option
 (** Get the list of versions for a package name. *)
 
-val get_package_latest : Name.t -> t option
+val get_package_latest : state -> Name.t -> t option
 (** Get the latest version of a package given a package name. *)
 
-val get_package : Name.t -> Version.t -> t option
+val get_package : state -> Name.t -> Version.t -> t option
 (** Get a package given its name and version. *)
 
-val search_package : string -> t list
+val search_package : state -> string -> t list
 (** Search package names that match the given string. *)

--- a/lib/ocamlorg_web/graphql.ml
+++ b/lib/ocamlorg_web/graphql.ml
@@ -234,7 +234,7 @@ let packages_result =
             ~resolve:(fun _ p -> p.packages)
         ]))
 
-let schema : Dream.request Graphql_lwt.Schema.schema =
+let schema t : Dream.request Graphql_lwt.Schema.schema =
   Graphql_lwt.Schema.(
     schema
       [ field
@@ -268,7 +268,7 @@ let schema : Dream.request Graphql_lwt.Schema.schema =
                   ~typ:int
               ]
           ~resolve:(fun _ () startswith offset limit ->
-            let packages = Package.all_packages_latest () in
+            let packages = Package.all_packages_latest t in
             let total_packages = List.length packages in
             let limit =
               match limit with None -> total_packages | Some limit -> limit
@@ -286,7 +286,7 @@ let schema : Dream.request Graphql_lwt.Schema.schema =
                   ~typ:(non_null string)
               ]
           ~resolve:(fun _ () name ->
-            let all_packages = Package.all_packages_latest () in
+            let all_packages = Package.all_packages_latest t in
             List.find_opt
               (fun package ->
                 is_package name (Package.Name.to_string (Package.name package)))

--- a/lib/ocamlorg_web/graphql.mli
+++ b/lib/ocamlorg_web/graphql.mli
@@ -30,6 +30,6 @@ val get_info : (Package.Name.t * string option) list -> package_info list
 (** This function returns the list part Package.Info such as
     Package.Info.dependencies *)
 
-val schema : Dream.request Graphql_lwt.Schema.schema
+val schema : Package.state -> Dream.request Graphql_lwt.Schema.schema
 (** This schema allows to query for opam packages from the opam-repository as
     graphql api data *)

--- a/lib/ocamlorg_web/handlers/package_handler.ml
+++ b/lib/ocamlorg_web/handlers/package_handler.ml
@@ -11,10 +11,10 @@ let index _req =
     Packages_template.render
   |> Dream.html
 
-let search req =
+let search t req =
   match Dream.query "q" req with
   | Some search ->
-    let packages = Ocamlorg.Package.search_package search in
+    let packages = Ocamlorg.Package.search_package t search in
     Page_layout_template.render
       ~title:"OCaml Packages · Search community packages"
       ~description:
@@ -25,10 +25,10 @@ let search req =
   | None ->
     Dream.redirect req "/packages"
 
-let package req =
+let package t req =
   let package = Dream.param "name" req in
   let find_default_version name =
-    Ocamlorg.Package.get_package_latest name
+    Ocamlorg.Package.get_package_latest t name
     |> Option.map (fun pkg -> Ocamlorg.Package.version pkg)
   in
   let name = Ocamlorg.Package.Name.of_string package in
@@ -42,12 +42,12 @@ let package req =
   | None ->
     Page_handler.not_found req
 
-let package_versioned kind req =
+let package_versioned t kind req =
   let name = Ocamlorg.Package.Name.of_string @@ Dream.param "name" req in
   let version =
     Ocamlorg.Package.Version.of_string @@ Dream.param "version" req
   in
-  let package = Ocamlorg.Package.get_package name version in
+  let package = Ocamlorg.Package.get_package t name version in
   match package with
   | None ->
     Page_handler.not_found req
@@ -73,7 +73,7 @@ let package_versioned kind req =
     let* status = Ocamlorg.Package.status ~kind package in
     let content = Package_template.render ~readme ~license package in
     let versions =
-      Ocamlorg.Package.get_package_versions name |> Option.value ~default:[]
+      Ocamlorg.Package.get_package_versions t name |> Option.value ~default:[]
     in
     Package_layout_template.render
       ~title:
@@ -94,7 +94,7 @@ let package_versioned kind req =
       content
     |> Dream.html
 
-let package_doc kind req =
+let package_doc t kind req =
   let name = Ocamlorg.Package.Name.of_string @@ Dream.param "name" req in
   let version =
     Ocamlorg.Package.Version.of_string @@ Dream.param "version" req
@@ -106,7 +106,7 @@ let package_doc kind req =
     | Universe ->
       Package_template.Universe (Dream.param "hash" req)
   in
-  let package = Ocamlorg.Package.get_package name version in
+  let package = Ocamlorg.Package.get_package t name version in
   match package with
   | None ->
     Page_handler.not_found req
@@ -130,7 +130,7 @@ let package_doc kind req =
         (Ocamlorg.Package.info package).Ocamlorg.Package.Info.description
       in
       let versions =
-        Ocamlorg.Package.get_package_versions name |> Option.value ~default:[]
+        Ocamlorg.Package.get_package_versions t name |> Option.value ~default:[]
       in
       let extra_nav = Package_doc_header_template.render doc.module_path in
       let canonical_module =

--- a/lib/ocamlorg_web/ocamlorg_web.ml
+++ b/lib/ocamlorg_web/ocamlorg_web.ml
@@ -5,8 +5,9 @@ module Handlers = struct
 end
 
 let run () =
+  let state = Ocamlorg.Package.init () in
   Dream_cli.run ~debug:Config.debug ~interface:"0.0.0.0" ~port:Config.port
   @@ Dream.logger
   @@ Middleware.no_trailing_slash
-  @@ Router.router
+  @@ Router.router state
   @@ Page_handler.not_found

--- a/lib/ocamlorg_web/router.ml
+++ b/lib/ocamlorg_web/router.ml
@@ -44,41 +44,41 @@ let preview_routes =
     ; Dream.get "/media/**" (Dream.static ~loader:media_loader "")
     ]
 
-let package_route =
+let package_route t =
   Dream.scope
     ""
     []
     [ Dream.get "/packages" Package_handler.index
     ; Dream.get "/packages/" Package_handler.index
-    ; Dream.get "/packages/search" Package_handler.search
-    ; Dream.get "/p/:name" Package_handler.package
-    ; Dream.get "/u/:hash/:name" Package_handler.package
+    ; Dream.get "/packages/search" (Package_handler.search t)
+    ; Dream.get "/p/:name" (Package_handler.package t)
+    ; Dream.get "/u/:hash/:name" (Package_handler.package t)
     ; Dream.get
         "/p/:name/:version"
-        (Package_handler.package_versioned Package_handler.Package)
+        ((Package_handler.package_versioned t) Package_handler.Package)
     ; Dream.get
         "/u/:hash/:name/:version"
-        (Package_handler.package_versioned Package_handler.Universe)
+        ((Package_handler.package_versioned t) Package_handler.Universe)
     ; Dream.get
         "/p/:name/:version/doc/**"
-        (Package_handler.package_doc Package_handler.Package)
+        ((Package_handler.package_doc t) Package_handler.Package)
     ; Dream.get
         "/u/:hash/:name/:version/doc/**"
-        (Package_handler.package_doc Package_handler.Universe)
+        ((Package_handler.package_doc t) Package_handler.Universe)
     ]
 
-let graphql_route =
+let graphql_route t =
   Dream.scope
     ""
     []
-    [ Dream.any "/api" (Dream.graphql Lwt.return Graphql.schema)
+    [ Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t))
     ; Dream.get "/graphiql" (Dream.graphiql "/api")
     ]
 
-let router =
+let router t =
   Dream.router
-    [ package_route
-    ; graphql_route
+    [ package_route t
+    ; graphql_route t
     ; preview_routes
     ; Dream.get "/assets/**" (Dream.static ~loader "")
       (* Used for the previews *)


### PR DESCRIPTION
This PR makes the opam-repository state initialisation explicit instead of happening at the `Package` module's startup-time. It's a little more verbose but we were running into problems in #73 where we needed some things from `Package` and so we were kicking off the opam clone/update. Now you very explicitly have to call `Package.init` to get the `state` and then pass this to all the functions that need it. The reason for passing it around is that if we still allow those functions to access the global state (the `s` variable) we could quite easily forget to initialise the state.

The `?disable_polling` parameter is probably not needed because in the graphql tests we simply won't be calling `init` at any point. @dinakajoy it might be worth trying to write the tests on top of this PR to see if this helps.

cc: @pitag-ha who has been helping tackle this problem :)) 