### PR TITLE
add state from package list function

### DIFF
--- a/lib/ocamlorg/package.ml
+++ b/lib/ocamlorg/package.ml
@@ -109,6 +109,20 @@ type state =
       Info.t lazy_t OpamPackage.Version.Map.t OpamPackage.Name.Map.t
   }
 
+let state_of_package_list (pkgs : t list) =
+  let map = OpamPackage.Name.Map.empty in
+  let add_version (pkg : t) map =
+    let new_map =
+      match OpamPackage.Name.Map.find_opt pkg.name map with
+      | None ->
+        OpamPackage.Version.Map.(add pkg.version pkg.info empty)
+      | Some version_map ->
+        OpamPackage.Version.Map.add pkg.version pkg.info version_map
+    in
+    OpamPackage.Name.Map.add pkg.name new_map map
+  in
+  { packages = List.fold_left (fun map v -> add_version v map) map pkgs }
+
 let read_versions package_name =
   let versions = Opam_repository.list_package_versions package_name in
   List.fold_left

--- a/lib/ocamlorg/package.mli
+++ b/lib/ocamlorg/package.mli
@@ -71,6 +71,10 @@ type state
 
 type t
 
+val state_of_package_list : t list -> state
+(** [state_of_package_list ts] produces the opam-repository state from a list of
+    packages *)
+
 val name : t -> Name.t
 (** Get the name of a package. *)
 

--- a/test/ocamlorg_web/graphql_test.ml
+++ b/test/ocamlorg_web/graphql_test.ml
@@ -132,6 +132,16 @@ let get_single_package_test name () =
       name
       (Package.Name.to_string (Package.name package))
 
+let state_test () =
+  let state = Package.state_of_package_list packages in
+  let pkg =
+    Package.search_package state "abt"
+    |> List.map Package.name
+    |> List.map Package.Name.to_string
+  in
+  let expect = [ "abt" ] in
+  Alcotest.(check (list string)) "same package" expect pkg
+
 let () =
   Alcotest.run
     "ocamlorg"
@@ -177,4 +187,6 @@ let () =
             `Quick
             (get_single_package_test "ocaml")
         ] )
+    ; ( "state test"
+      , [ Alcotest.test_case "same package from state" `Quick state_test ] )
     ]


### PR DESCRIPTION
This PR adds a function to generate `Package.state` (i.e. the opam-repository state as a map) from a list of packages. This should be useful when testing code that requires state (like the GraphQL tests) as we can now build our own list of packages and produce "state" from it rather than relying on the opam-repository cloning and building (i.e. what is used in production).