### PR TITLE
Improve project setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 *
+!data/
+!gettext/
 !asset/
 !src/
 !dune

--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,6 +1,3 @@
-src/ocamlorg_data/*.ml
-src/ocamlorg_data/*/*.ml
-
 node_modules/*
 node_modules/*/*
 node_modules/*/*/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Ood
+# Contributing to OCaml.org
 
 The **O**Caml.**o**rg **D**ata repository contains the data for ocaml.org in a structured format. Contributions are very welcome whether that be:
 
@@ -32,6 +32,30 @@ make deps
 
 Note we use [tailwind-css](https://tailwindcss.com/) in `ood-preview` so we also install that using npm.
 
+### Running the server
+
+After building the project, you can run the server with:
+
+```bash
+make start
+```
+
+To start the server in watch mode, you can run:
+
+```bash
+make watch
+```
+
+This will restart the server on filesystem changes.
+
+### Running tests
+
+You can run the unit test suite with:
+
+```bash
+make test
+```
+
 ## Submitting a PR
 
 To submit a PR make sure you create a new branch, add the code and commit it. 
@@ -47,22 +71,82 @@ From here you can then open a PR from Github. Before committing your code it is 
 
  - Format the code: this should be as simple as `make fmt`
  - Make sure it builds: running `make build`, this is also very important if you add data to the repository as it will "crunch" the data into the static OCaml modules (more information below)
- - Run the tests: this will check ood-preview and that all the data is correctly formatted and can be invoked with `make test`
+ - Run the tests: this will check that all the data is correctly formatted and can be invoked with `make test`
 
-### Static OCaml Modules with Data
+## Adding or updating datas
 
-As explained on the README, `src/ood` contains the information in the `data` directory, packed inside OCaml modules. This makes the data very easy to consume from multiple different projects like from ReScript in the [front-end of the website](https://github.com/ocaml/v3.ocaml.org). It means most consumers of the ocaml.org data do not have to worry about re-implementing parsers for the data.
+As explained on the README, `src/ocaml` contains the information in the `data` directory, packed inside OCaml modules. This makes the data very easy to consume from multiple different projects like from ReScript in the [front-end of the website](https://github.com/ocaml/v3.ocaml.org). It means most consumers of the ocaml.org data do not have to worry about re-implementing parsers for the data.
 
 If you are simply adding information to the `data` directory that's fine, before merging one of the maintainers can do the build locally and push the changes. If you can do a `make build` to also generate the OCaml as part of your PR that would be fantastic.
 
-## Ood Preview
+## Repository structure
 
-`ood-preview` is a simple dream server rendering the data as HTML. This is useful for testing designs, ensuring links to videos are correct etc. There is no obligation to touch any of this code, but you might find it fun to play around with designs and learn a little bit about dream.
+The following snippet describes OCaml.org's repository structure.
 
-To run the server just execute `make preview` from the terminal. This sets up a live-reload script so when you change a template file the project should recompile and the browser window will refresh.
+```text
+.
+├── asset/
+|   The static assets served by the site.
+│
+├── data/
+|   Data used by ocaml.org in Yaml and Markdown format.
+│
+├── gettext/
+|   `.PO` files for static content translation.
+│
+├── src/
+|   The source code of ocaml.org.
+│
+├── tool/
+|   Sources for development tools such as the `ocamlorg_data` code generator.
+│
+├── dune
+├── dune-project
+|   Dune file used to mark the root of the project and define project-wide parameters.
+|   For the documentation of the syntax, see https://dune.readthedocs.io/en/stable/dune-files.html#dune-project.
+│
+├── ocamlorg-data.opam
+├── ocamlorg.opam
+├── ocamlorg.opam.template
+│   opam package definitions.
+│   To know more about creating and publishing opam packages, see https://opam.ocaml.org/doc/Packaging.html.
+│
+├── package-lock.json
+├── package.json
+|   Package file for NPM packages. This is used to defined the JavaScript dependencies of the project.
+│
+├── CHANGES.md
+│
+├── CONTRIBUTING.md
+│
+├── Dockerfile
+|   Dockerfile used to build and deploy the site in production.
+│
+├── LICENSE
+├── LICENSE-3RD-PARTY
+|   Licenses of the source code, data and vendored third-party projects.
+│
+├── Makefile
+|   `Makefile` containing common development commands.
+│
+├── README.md
+│
+└── tailwind.config.js
+    Configuration used by TailwindCSS to generate the CSS file for the site.
+```
 
-## Testing my changes against v3.ocaml.org
+## Deploying
 
-[v3.ocaml.org](https://github.com/ocaml/v3.ocaml.org) vendors ood in order to reuse the data. Our CI checks that a PR doesn't break any assumptions that v3 makes about types or functions that are exposed from the `src/ood` package.
+Commits added on `main` are automatically deployed on https://v3.ocaml.org/.
 
-If you want to test it before hand, have a look at the change we make to the `update-ood.sh` script in the `v3-ocaml-org` Github Action job in `.github/workflows/ci.yml`. Instead of checking out `main` we check out the PR reference.
+The deployment pipeline is managed in https://github.com/ocurrent/ocurrent-deployer which listens to the `main` branch and build the site using the `Dockerfile` at the root of the project.
+
+To test the deployment locally, you can run the following commands:
+
+```
+docker build -t v3.ocaml.org .
+docker run -p 8080:8080  v3.ocaml.org
+```
+
+This will build the docker image and run a docker container with the port `8080` mapped to the HTTP server.
+With the docker container running, you can visit the site at http://localhost:8080/.

--- a/README.md
+++ b/README.md
@@ -2,89 +2,38 @@
 
 [![Actions Status](https://github.com/ocaml/v3.ocaml.org-server/workflows/CI/badge.svg)](https://github.com/ocaml/v3.ocaml.org-server/actions)
 
-ocamlorg is a Dream-based server for the next version of the ocaml.org website.
+ocamlorg is a Dream-based server for the next version of the ocaml.org website. It is currently served at https://v3.ocaml.org/.
 
-It serves the OCaml packages pages and their documentation by using the data available at https://docs-data.ocaml.org/ and serves the static files generated from the NextJS application at https://github.com/ocaml/v3.ocaml.org.
+It serves the OCaml packages pages and their documentation by using the data available at https://docs-data.ocaml.org/ and serves pages that use the content generated from `data/`.
 
-## Set up your development environment
+## Getting started
 
-You need opam. You can install it by following [opam's documentation](https://opam.ocaml.org/doc/Install.html).
+You can setup the project with:
 
-With opam installed, you can install the dependencies in a new local switch with:
-
-```bash
+```
 make switch
 ```
 
-Or globally, with:
+And run it with:
 
-```bash
-make deps
 ```
-
-Then, build the project with:
-
-```bash
-make build
-```
-
-### Running the server
-
-After building the project, you can run the server with:
-
-```bash
 make start
 ```
 
-To start the server in watch mode, you can run:
+See our [`contributing guide`](./CONTRIBUTING.md) for more detailed instructions.
 
-```bash
-make watch
-```
+## Contributing
 
-This will restart the server on filesystem changes and reload the pages automatically. The watch script depends on `fswatch`, so make sure to install it before running the script.
+We'd love your help improving ocaml.org!
 
-### Running tests
+See our contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 
-You can run the unit test suite with:
+## License
 
-```bash
-make test
-```
+**TL;DR:** 
 
-## Repository structure
+- The code is released under ISC
+- The data is released under CC BY-SA 4.0
+- The vendored files are listed with their licenses in [`LICENSE-3RD-PARTY`](./LICENSE-3RD-PARTY)
 
-The following snippet describes OCaml.org's repository structure.
-
-```text
-.
-├── bin/
-|   Source for {{ project_slug }}'s binary. This links to the library defined in `lib/`.
-│
-├── lib/
-|   Source for OCaml.org's library. Contains OCaml.org's core functionalities.
-│
-├── test/
-|   Unit tests and integration tests for OCaml.org.
-│
-├── dune-project
-|   Dune file used to mark the root of the project and define project-wide parameters.
-|   For the documentation of the syntax, see https://dune.readthedocs.io/en/stable/dune-files.html#dune-project.
-│
-├── LICENSE
-│
-├── Makefile
-|   `Makefile` containing common development commands.
-│
-├── README.md
-│
-└── ocamlorg.opam
-    opam package definition.
-    To know more about creating and publishing opam packages, see https://opam.ocaml.org/doc/Packaging.html.
-```
-
-## Deploying
-
-Commits added on `main` are automatically deployed on https://v3.ocaml.org/
-
-The deployment pipeline is managed in https://github.com/ocurrent/ocurrent-deployer.
+See our [`LICENSE`](./LICENSE) for the complete licenses.

--- a/src/ocamlorg/lib/config.ml
+++ b/src/ocamlorg/lib/config.ml
@@ -5,7 +5,7 @@ let opam_polling =
 
 let documentation_url =
   Sys.getenv_opt "OCAMLORG_DOC_URL"
-  |> Option.value ~default:"https://docs-data.ocaml.org/current/"
+  |> Option.value ~default:"https://docs-data.ocaml.org/live/"
 
 let opam_repository_path =
   Sys.getenv_opt "OCAMLORG_REPO_PATH"

--- a/src/ocamlorg_data/academic_institution.ml
+++ b/src/ocamlorg_data/academic_institution.ml
@@ -1,5 +1,7 @@
-
-type location = { lat : float; long : float }
+type location =
+  { lat : float
+  ; long : float
+  }
 
 type course =
   { name : string
@@ -20,779 +22,688 @@ type t =
   ; body_html : string
   }
 
-let all = 
-[
-  { name = {js|Universidade da Beira Interior|js}
-  ; slug = {js|universidade-da-beira-interior|js}
-  ; description = {js|The University of Beira Interior is a public university located in the city of Covilhã, Portugal.
+let all =
+  [ { name = {js|Universidade da Beira Interior|js}
+    ; slug = {js|universidade-da-beira-interior|js}
+    ; description =
+        {js|The University of Beira Interior is a public university located in the city of Covilhã, Portugal.
 |js}
-  ; url = {js|https://www.ubi.pt/en/|js}
-  ; logo = Some {js|/academic_institution/beira.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Certified Programming|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/PC/pc.html|js}
-  };
-  
-  { name = {js|Computation Theory|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/TC/tcomp.html|js}
-  };
-  
-  { name = {js|Computational Logic|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/LC/lc.html|js}
-  };
-  
-  { name = {js|Functional Programming, Algorithms and Data-structures|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/PF/pf.html|js}
-  };
-  
-  { name = {js|Programming Languages and Compilers Design|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/DLPC/dlpc.html|js}
-  };
-  
-  { name = {js|Proof and Programming Theory|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/TPP/tpp.html|js}
-  };
-  
-  { name = {js|Software Reliability and Security|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www.di.ubi.pt/~desousa/CF/confia.html|js}
-  }]
-  ; location = Some 
-  { long = -7.509000
-  ; lat = 40.277900
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Birmingham|js}
-  ; slug = {js|university-of-birmingham|js}
-  ; description = {js|The University of Birmingham is a public research university located in Edgbaston, Birmingham, United Kingdom. It received its royal charter in 1900 as a successor to Queen's College, Birmingham, and Mason Science College, making it the first English civic or 'red brick' university to receive its own royal charter.
+    ; url = {js|https://www.ubi.pt/en/|js}
+    ; logo = Some {js|/academic_institution/beira.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Certified Programming|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/PC/pc.html|js}
+          }
+        ; { name = {js|Computation Theory|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/TC/tcomp.html|js}
+          }
+        ; { name = {js|Computational Logic|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/LC/lc.html|js}
+          }
+        ; { name =
+              {js|Functional Programming, Algorithms and Data-structures|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/PF/pf.html|js}
+          }
+        ; { name = {js|Programming Languages and Compilers Design|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/DLPC/dlpc.html|js}
+          }
+        ; { name = {js|Proof and Programming Theory|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/TPP/tpp.html|js}
+          }
+        ; { name = {js|Software Reliability and Security|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://www.di.ubi.pt/~desousa/CF/confia.html|js}
+          }
+        ]
+    ; location = Some { long = -7.509000; lat = 40.277900 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Birmingham|js}
+    ; slug = {js|university-of-birmingham|js}
+    ; description =
+        {js|The University of Birmingham is a public research university located in Edgbaston, Birmingham, United Kingdom. It received its royal charter in 1900 as a successor to Queen's College, Birmingham, and Mason Science College, making it the first English civic or 'red brick' university to receive its own royal charter.
 |js}
-  ; url = {js|https://www.birmingham.ac.uk/index.aspx|js}
-  ; logo = Some {js|/academic_institution/Birmingham.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Foundations of Computer Science|js}
-  ; acronym = Some {js|FOCS1112|js}
-  ; online_resource  = Some {js|https://sites.google.com/site/focs1112/|js}
-  }]
-  ; location = Some 
-  { long = -1.930500
-  ; lat = 52.450800
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://www.birmingham.ac.uk/index.aspx|js}
+    ; logo = Some {js|/academic_institution/Birmingham.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Foundations of Computer Science|js}
+          ; acronym = Some {js|FOCS1112|js}
+          ; online_resource =
+              Some {js|https://sites.google.com/site/focs1112/|js}
+          }
+        ]
+    ; location = Some { long = -1.930500; lat = 52.450800 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Boston College|js}
-  ; slug = {js|boston-college|js}
-  ; description = {js|Boston College is a private, Jesuit research university in Chestnut Hill, Massachusetts. Founded in 1863, the university has more than 9,300 full-time undergraduates and nearly 5,000 graduate students. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Boston College|js}
+    ; slug = {js|boston-college|js}
+    ; description =
+        {js|Boston College is a private, Jesuit research university in Chestnut Hill, Massachusetts. Founded in 1863, the university has more than 9,300 full-time undergraduates and nearly 5,000 graduate students. 
 |js}
-  ; url = {js|https://www.bc.edu/|js}
-  ; logo = Some {js|/academic_institution/boston.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Computer Science I|js}
-  ; acronym = Some {js|CS1101|js}
-  ; online_resource  = Some {js|https://www.cs.bc.edu/~muller/teaching/cs1101/s16/|js}
-  }]
-  ; location = Some 
-  { long = -71.168500
-  ; lat = 42.335500
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://www.bc.edu/|js}
+    ; logo = Some {js|/academic_institution/boston.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Computer Science I|js}
+          ; acronym = Some {js|CS1101|js}
+          ; online_resource =
+              Some {js|https://www.cs.bc.edu/~muller/teaching/cs1101/s16/|js}
+          }
+        ]
+    ; location = Some { long = -71.168500; lat = 42.335500 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Cambridge|js}
-  ; slug = {js|university-of-cambridge|js}
-  ; description = {js|The University of Cambridge is a collegiate research university in Cambridge, United Kingdom. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Cambridge|js}
+    ; slug = {js|university-of-cambridge|js}
+    ; description =
+        {js|The University of Cambridge is a collegiate research university in Cambridge, United Kingdom. 
 |js}
-  ; url = {js|https://www.cam.ac.uk/|js}
-  ; logo = Some {js|/academic_institution/cambridge.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Advanced Functional Programming|js}
-  ; acronym = Some {js|L28|js}
-  ; online_resource  = Some {js|https://www.cl.cam.ac.uk/teaching/1415/L28/|js}
-  }]
-  ; location = Some 
-  { long = 0.114900
-  ; lat = 52.204300
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|ISAE/Supaéro|js}
-  ; slug = {js|isaesuparo|js}
-  ; description = {js|The Institut supérieur de l'aéronautique et de l'espace is a French engineering school, founded in 1909. It was the world's first dedicated aerospace engineering school.
+    ; url = {js|https://www.cam.ac.uk/|js}
+    ; logo = Some {js|/academic_institution/cambridge.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Advanced Functional Programming|js}
+          ; acronym = Some {js|L28|js}
+          ; online_resource =
+              Some {js|https://www.cl.cam.ac.uk/teaching/1415/L28/|js}
+          }
+        ]
+    ; location = Some { long = 0.114900; lat = 52.204300 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|ISAE/Supaéro|js}
+    ; slug = {js|isaesuparo|js}
+    ; description =
+        {js|The Institut supérieur de l'aéronautique et de l'espace is a French engineering school, founded in 1909. It was the world's first dedicated aerospace engineering school.
 |js}
-  ; url = {js|https://www.isae-supaero.fr/en/|js}
-  ; logo = None
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Functional programming and introduction to type systems|js}
-  ; acronym = None
-  ; online_resource  = None
-  }]
-  ; location = Some 
-  { long = 1.474600
-  ; lat = 43.565900
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Aix-Marseille University|js}
-  ; slug = {js|aix-marseille-university|js}
-  ; description = {js|Aix-Marseille University is a public research university located in the region of Provence, southern France. 
+    ; url = {js|https://www.isae-supaero.fr/en/|js}
+    ; logo = None
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name =
+              {js|Functional programming and introduction to type systems|js}
+          ; acronym = None
+          ; online_resource = None
+          }
+        ]
+    ; location = Some { long = 1.474600; lat = 43.565900 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Aix-Marseille University|js}
+    ; slug = {js|aix-marseille-university|js}
+    ; description =
+        {js|Aix-Marseille University is a public research university located in the region of Provence, southern France. 
 |js}
-  ; url = {js|https://www.univ-amu.fr/en|js}
-  ; logo = Some {js|/academic_institution/aix.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Functional Programming|js}
-  ; acronym = None
-  ; online_resource  = None
-  }]
-  ; location = Some 
-  { long = 5.377400
-  ; lat = 43.304800
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Aarhus University|js}
-  ; slug = {js|aarhus-university|js}
-  ; description = {js|Aarhus University (Danish: Aarhus Universitet, abbreviated AU) is the largest and second oldest research university in Denmark.The university belongs to the Coimbra Group, the Guild, and Utrecht Network of European universities and is a member of the European University Association.
+    ; url = {js|https://www.univ-amu.fr/en|js}
+    ; logo = Some {js|/academic_institution/aix.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Functional Programming|js}
+          ; acronym = None
+          ; online_resource = None
+          }
+        ]
+    ; location = Some { long = 5.377400; lat = 43.304800 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Aarhus University|js}
+    ; slug = {js|aarhus-university|js}
+    ; description =
+        {js|Aarhus University (Danish: Aarhus Universitet, abbreviated AU) is the largest and second oldest research university in Denmark.The university belongs to the Coimbra Group, the Guild, and Utrecht Network of European universities and is a member of the European University Association.
 |js}
-  ; url = {js|https://international.au.dk/|js}
-  ; logo = Some {js|/academic_institution/arhus.png|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|The compilation course (along with Java)|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://kursuskatalog.au.dk/en/course/100489/Compilation|js}
-  }]
-  ; location = Some 
-  { long = 10.203000
-  ; lat = 56.168100
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://international.au.dk/|js}
+    ; logo = Some {js|/academic_institution/arhus.png|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|The compilation course (along with Java)|js}
+          ; acronym = None
+          ; online_resource =
+              Some
+                {js|https://kursuskatalog.au.dk/en/course/100489/Compilation|js}
+          }
+        ]
+    ; location = Some { long = 10.203000; lat = 56.168100 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Brown University|js}
-  ; slug = {js|brown-university|js}
-  ; description = {js|Brown University is a private Ivy League research university in Providence, Rhode Island. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Brown University|js}
+    ; slug = {js|brown-university|js}
+    ; description =
+        {js|Brown University is a private Ivy League research university in Providence, Rhode Island. 
 |js}
-  ; url = {js|https://www.brown.edu/|js}
-  ; logo = Some {js|/academic_institution/brown.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|An Integrated introducion (along with Racket, Scala and Java)|js}
-  ; acronym = Some {js|CS 17/18|js}
-  ; online_resource  = Some {js|https://cs17-spring2021.github.io/|js}
-  }]
-  ; location = Some 
-  { long = -71.402500
-  ; lat = 41.826800
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|California Institute of Technology|js}
-  ; slug = {js|california-institute-of-technology|js}
-  ; description = {js|The California Institute of Technology is a private research university in Pasadena, California. 
+    ; url = {js|https://www.brown.edu/|js}
+    ; logo = Some {js|/academic_institution/brown.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name =
+              {js|An Integrated introducion (along with Racket, Scala and Java)|js}
+          ; acronym = Some {js|CS 17/18|js}
+          ; online_resource = Some {js|https://cs17-spring2021.github.io/|js}
+          }
+        ]
+    ; location = Some { long = -71.402500; lat = 41.826800 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|California Institute of Technology|js}
+    ; slug = {js|california-institute-of-technology|js}
+    ; description =
+        {js|The California Institute of Technology is a private research university in Pasadena, California. 
 |js}
-  ; url = {js|https://www.caltech.edu/|js}
-  ; logo = Some {js|/academic_institution/caltech.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Fundamentals of Computer Programming|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://users.cms.caltech.edu/~mvanier/|js}
-  }]
-  ; location = Some 
-  { long = -118.125300
-  ; lat = 34.137700
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Columbia University|js}
-  ; slug = {js|columbia-university|js}
-  ; description = {js|Columbia University is a private Ivy League research university in New York City. 
+    ; url = {js|https://www.caltech.edu/|js}
+    ; logo = Some {js|/academic_institution/caltech.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Fundamentals of Computer Programming|js}
+          ; acronym = None
+          ; online_resource =
+              Some {js|https://users.cms.caltech.edu/~mvanier/|js}
+          }
+        ]
+    ; location = Some { long = -118.125300; lat = 34.137700 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Columbia University|js}
+    ; slug = {js|columbia-university|js}
+    ; description =
+        {js|Columbia University is a private Ivy League research university in New York City. 
 |js}
-  ; url = {js|https://www.columbia.edu/|js}
-  ; logo = Some {js|/academic_institution/columbia.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages and Translators|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://www1.cs.columbia.edu/~sedwards/classes/2014/w4115-fall/index.html|js}
-  }]
-  ; location = Some 
-  { long = -73.962600
-  ; lat = 40.807500
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://www.columbia.edu/|js}
+    ; logo = Some {js|/academic_institution/columbia.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Programming Languages and Translators|js}
+          ; acronym = None
+          ; online_resource =
+              Some
+                {js|https://www1.cs.columbia.edu/~sedwards/classes/2014/w4115-fall/index.html|js}
+          }
+        ]
+    ; location = Some { long = -73.962600; lat = 40.807500 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Cornell University|js}
-  ; slug = {js|cornell-university|js}
-  ; description = {js|Cornell University is a private, statutory, Ivy League and land-grant research university in Ithaca, New York. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Cornell University|js}
+    ; slug = {js|cornell-university|js}
+    ; description =
+        {js|Cornell University is a private, statutory, Ivy League and land-grant research university in Ithaca, New York. 
 |js}
-  ; url = {js|https://www.cornell.edu/|js}
-  ; logo = Some {js|/academic_institution/cornell.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Data Structures and Functional Programming|js}
-  ; acronym = Some {js|CS 3110|js}
-  ; online_resource  = Some {js|https://www.cs.cornell.edu/courses/cs3110/2016fa/|js}
-  }]
-  ; location = Some 
-  { long = -76.473500
-  ; lat = 42.453400
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University Pierre & Marie Curie|js}
-  ; slug = {js|university-pierre--marie-curie|js}
-  ; description = {js|Pierre and Marie Curie University, titled as UPMC from 2007 to 2017 and also known as Paris 6, was a public research university in Paris, France, from 1971 to 2017. The university was located on the Jussieu Campus in the Latin Quarter of the 5th arrondissement of Paris, France. 
+    ; url = {js|https://www.cornell.edu/|js}
+    ; logo = Some {js|/academic_institution/cornell.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Data Structures and Functional Programming|js}
+          ; acronym = Some {js|CS 3110|js}
+          ; online_resource =
+              Some {js|https://www.cs.cornell.edu/courses/cs3110/2016fa/|js}
+          }
+        ]
+    ; location = Some { long = -76.473500; lat = 42.453400 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University Pierre & Marie Curie|js}
+    ; slug = {js|university-pierre--marie-curie|js}
+    ; description =
+        {js|Pierre and Marie Curie University, titled as UPMC from 2007 to 2017 and also known as Paris 6, was a public research university in Paris, France, from 1971 to 2017. The university was located on the Jussieu Campus in the Latin Quarter of the 5th arrondissement of Paris, France. 
 |js}
-  ; url = {js|https://www.sorbonne-universite.fr/|js}
-  ; logo = Some {js|/academic_institution/curie.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Types and static analysis|js}
-  ; acronym = Some {js|5I555|js}
-  ; online_resource  = Some {js|https://www-apr.lip6.fr/~chaillou/Public/enseignement/2014-2015/tas/|js}
-  };
-  
-  { name = {js|Models of programming and languages interoperability|js}
-  ; acronym = Some {js|LI332|js}
-  ; online_resource  = Some {js|https://www-licence.ufr-info-p6.jussieu.fr/lmd/licence/2014/ue/LI332-2014oct/|js}
-  }]
-  ; location = Some 
-  { long = 2.357500
-  ; lat = 48.847100
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://www.sorbonne-universite.fr/|js}
+    ; logo = Some {js|/academic_institution/curie.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Types and static analysis|js}
+          ; acronym = Some {js|5I555|js}
+          ; online_resource =
+              Some
+                {js|https://www-apr.lip6.fr/~chaillou/Public/enseignement/2014-2015/tas/|js}
+          }
+        ; { name = {js|Models of programming and languages interoperability|js}
+          ; acronym = Some {js|LI332|js}
+          ; online_resource =
+              Some
+                {js|https://www-licence.ufr-info-p6.jussieu.fr/lmd/licence/2014/ue/LI332-2014oct/|js}
+          }
+        ]
+    ; location = Some { long = 2.357500; lat = 48.847100 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Epita|js}
-  ; slug = {js|epita|js}
-  ; description = {js|The École Pour l'Informatique et les Techniques Avancées, more commonly known as EPITA, is a private French grande école specialized in the field of computer science and software engineering created in 1984 by Patrice Dumoucel. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Epita|js}
+    ; slug = {js|epita|js}
+    ; description =
+        {js|The École Pour l'Informatique et les Techniques Avancées, more commonly known as EPITA, is a private French grande école specialized in the field of computer science and software engineering created in 1984 by Patrice Dumoucel. 
 |js}
-  ; url = {js|https://www.epita.fr/|js}
-  ; logo = None
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Introduction to Algorithms (Year 1 & 2)|js}
-  ; acronym = None
-  ; online_resource  = None
-  }]
-  ; location = Some 
-  { long = 2.362800
-  ; lat = 48.815700
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Harvard University|js}
-  ; slug = {js|harvard-university|js}
-  ; description = {js|Harvard University is a private Ivy League research university in Cambridge, Massachusetts. higher education academy. 
+    ; url = {js|https://www.epita.fr/|js}
+    ; logo = None
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Introduction to Algorithms (Year 1 & 2)|js}
+          ; acronym = None
+          ; online_resource = None
+          }
+        ]
+    ; location = Some { long = 2.362800; lat = 48.815700 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Harvard University|js}
+    ; slug = {js|harvard-university|js}
+    ; description =
+        {js|Harvard University is a private Ivy League research university in Cambridge, Massachusetts. higher education academy. 
 |js}
-  ; url = {js|https://www.harvard.edu/|js}
-  ; logo = Some {js|/academic_institution/harvard.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Principles of Programming Language Compilation|js}
-  ; acronym = Some {js|CS153|js}
-  ; online_resource  = None
-  };
-  
-  { name = {js|Introduction to Computer Science II- Abstraction & Design|js}
-  ; acronym = Some {js|CS51|js}
-  ; online_resource  = None
-  }]
-  ; location = Some 
-  { long = -71.116700
-  ; lat = 42.377000
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://www.harvard.edu/|js}
+    ; logo = Some {js|/academic_institution/harvard.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Principles of Programming Language Compilation|js}
+          ; acronym = Some {js|CS153|js}
+          ; online_resource = None
+          }
+        ; { name =
+              {js|Introduction to Computer Science II- Abstraction & Design|js}
+          ; acronym = Some {js|CS51|js}
+          ; online_resource = None
+          }
+        ]
+    ; location = Some { long = -71.116700; lat = 42.377000 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Indian Institute of Technology, Delhi|js}
-  ; slug = {js|indian-institute-of-technology-delhi|js}
-  ; description = {js|Indian Institute of Technology Delhi is a public technical and research university located in Hauz Khas in South Delhi, Delhi, India. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Indian Institute of Technology, Delhi|js}
+    ; slug = {js|indian-institute-of-technology-delhi|js}
+    ; description =
+        {js|Indian Institute of Technology Delhi is a public technical and research university located in Hauz Khas in South Delhi, Delhi, India. 
 |js}
-  ; url = {js|https://home.iitd.ac.in/|js}
-  ; logo = Some {js|/academic_institution/iitd.png|js}
-  ; continent = {js|Asia|js}
-  ; courses = 
- [
-  { name = {js|Introduction to Computers and Programming (along with Pascal and Java)|js}
-  ; acronym = Some {js|CSL 101|js}
-  ; online_resource  = Some {js|https://www.cse.iitd.ac.in/~ssen/csl101/details.html|js}
-  }]
-  ; location = Some 
-  { long = 77.192800
-  ; lat = 28.545700
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Indian Institute of Technology, Madras|js}
-  ; slug = {js|indian-institute-of-technology-madras|js}
-  ; description = {js|Indian Institute of Technology Madras is a public technical and research university located in Chennai, India.
+    ; url = {js|https://home.iitd.ac.in/|js}
+    ; logo = Some {js|/academic_institution/iitd.png|js}
+    ; continent = {js|Asia|js}
+    ; courses =
+        [ { name =
+              {js|Introduction to Computers and Programming (along with Pascal and Java)|js}
+          ; acronym = Some {js|CSL 101|js}
+          ; online_resource =
+              Some {js|https://www.cse.iitd.ac.in/~ssen/csl101/details.html|js}
+          }
+        ]
+    ; location = Some { long = 77.192800; lat = 28.545700 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Indian Institute of Technology, Madras|js}
+    ; slug = {js|indian-institute-of-technology-madras|js}
+    ; description =
+        {js|Indian Institute of Technology Madras is a public technical and research university located in Chennai, India.
 |js}
-  ; url = {js|https://www.iitm.ac.in/|js}
-  ; logo = Some {js|/academic_institution/iitm.png|js}
-  ; continent = {js|Asia|js}
-  ; courses = 
- [
-  { name = {js|Paradigms of Programming|js}
-  ; acronym = Some {js|CS 3100|js}
-  ; online_resource  = Some {js|https://kcsrk.info/cs3100_m20/|js}
-  }]
-  ; location = Some 
-  { long = 80.233620
-  ; lat = 12.991510
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Illinois at Urbana-Champaign|js}
-  ; slug = {js|university-of-illinois-at-urbana-champaign|js}
-  ; description = {js|The University of Illinois Urbana-Champaign is a public land-grant research university in Illinois in the twin cities of Champaign and Urbana.
+    ; url = {js|https://www.iitm.ac.in/|js}
+    ; logo = Some {js|/academic_institution/iitm.png|js}
+    ; continent = {js|Asia|js}
+    ; courses =
+        [ { name = {js|Paradigms of Programming|js}
+          ; acronym = Some {js|CS 3100|js}
+          ; online_resource = Some {js|https://kcsrk.info/cs3100_m20/|js}
+          }
+        ]
+    ; location = Some { long = 80.233620; lat = 12.991510 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Illinois at Urbana-Champaign|js}
+    ; slug = {js|university-of-illinois-at-urbana-champaign|js}
+    ; description =
+        {js|The University of Illinois Urbana-Champaign is a public land-grant research university in Illinois in the twin cities of Champaign and Urbana.
 |js}
-  ; url = {js|https://illinois.edu/|js}
-  ; logo = Some {js|/academic_institution/illinois.jpeg|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages and Compilers|js}
-  ; acronym = Some {js|CS 421|js}
-  ; online_resource  = Some {js|https://courses.engr.illinois.edu/cs421/fa2014/|js}
-  }]
-  ; location = Some 
-  { long = -88.227200
-  ; lat = 40.102000
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://illinois.edu/|js}
+    ; logo = Some {js|/academic_institution/illinois.jpeg|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Programming Languages and Compilers|js}
+          ; acronym = Some {js|CS 421|js}
+          ; online_resource =
+              Some {js|https://courses.engr.illinois.edu/cs421/fa2014/|js}
+          }
+        ]
+    ; location = Some { long = -88.227200; lat = 40.102000 }
+    ; body_md = {js|
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Innsbruck|js}
-  ; slug = {js|university-of-innsbruck|js}
-  ; description = {js|The University of Innsbruck is a public university in Innsbruck, the capital of the Austrian federal state of Tyrol, founded in 1669. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Innsbruck|js}
+    ; slug = {js|university-of-innsbruck|js}
+    ; description =
+        {js|The University of Innsbruck is a public university in Innsbruck, the capital of the Austrian federal state of Tyrol, founded in 1669. 
 |js}
-  ; url = {js|https://www.uibk.ac.at/index.html.en|js}
-  ; logo = Some {js|/academic_institution/university-of-innsbruck-logo.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Programming in OCAML|js}
-  ; acronym = Some {js|SS 06|js}
-  ; online_resource  = Some {js|https://cl-informatik.uibk.ac.at/teaching/ss06/ocaml/schedule.php|js}
-  }]
-  ; location = Some 
-  { long = 11.404100
-  ; lat = 47.269200
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of California, Los Angeles|js}
-  ; slug = {js|university-of-california-los-angeles|js}
-  ; description = {js|The University of California, Los Angeles is a public land-grant research university in Los Angeles, California.
+    ; url = {js|https://www.uibk.ac.at/index.html.en|js}
+    ; logo = Some {js|/academic_institution/university-of-innsbruck-logo.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Programming in OCAML|js}
+          ; acronym = Some {js|SS 06|js}
+          ; online_resource =
+              Some
+                {js|https://cl-informatik.uibk.ac.at/teaching/ss06/ocaml/schedule.php|js}
+          }
+        ]
+    ; location = Some { long = 11.404100; lat = 47.269200 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of California, Los Angeles|js}
+    ; slug = {js|university-of-california-los-angeles|js}
+    ; description =
+        {js|The University of California, Los Angeles is a public land-grant research university in Los Angeles, California.
 |js}
-  ; url = {js|https://www.ucla.edu/|js}
-  ; logo = Some {js|/academic_institution/ucla.jpg|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages (along with Python and Java)|js}
-  ; acronym = Some {js|CS 131|js}
-  ; online_resource  = Some {js|https://web.cs.ucla.edu/classes/winter18/cs131/|js}
-  }]
-  ; location = Some 
-  { long = -118.445200
-  ; lat = 34.068900
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Maryland|js}
-  ; slug = {js|university-of-maryland|js}
-  ; description = {js|The University of Maryland, College Park is a public land-grant research university in College Park, Maryland.
+    ; url = {js|https://www.ucla.edu/|js}
+    ; logo = Some {js|/academic_institution/ucla.jpg|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Programming Languages (along with Python and Java)|js}
+          ; acronym = Some {js|CS 131|js}
+          ; online_resource =
+              Some {js|https://web.cs.ucla.edu/classes/winter18/cs131/|js}
+          }
+        ]
+    ; location = Some { long = -118.445200; lat = 34.068900 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Maryland|js}
+    ; slug = {js|university-of-maryland|js}
+    ; description =
+        {js|The University of Maryland, College Park is a public land-grant research university in College Park, Maryland.
 |js}
-  ; url = {js|https://www.umd.edu/|js}
-  ; logo = Some {js|/academic_institution/maryland.gif|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Organization of Programming Languages-(along with Ruby, Prolog, Java)|js}
-  ; acronym = Some {js|CMSC 330|js}
-  ; online_resource  = Some {js|https://www.cs.umd.edu/class/fall2014/cmsc330/|js}
-  }]
-  ; location = Some 
-  { long = -76.942600
-  ; lat = 38.986900
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Massachusetts|js}
-  ; slug = {js|university-of-massachusetts|js}
-  ; description = {js|The University of Massachusetts is the five-campus public university system and the only public research system in the Commonwealth of Massachusetts. 
+    ; url = {js|https://www.umd.edu/|js}
+    ; logo = Some {js|/academic_institution/maryland.gif|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name =
+              {js|Organization of Programming Languages-(along with Ruby, Prolog, Java)|js}
+          ; acronym = Some {js|CMSC 330|js}
+          ; online_resource =
+              Some {js|https://www.cs.umd.edu/class/fall2014/cmsc330/|js}
+          }
+        ]
+    ; location = Some { long = -76.942600; lat = 38.986900 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Massachusetts|js}
+    ; slug = {js|university-of-massachusetts|js}
+    ; description =
+        {js|The University of Massachusetts is the five-campus public university system and the only public research system in the Commonwealth of Massachusetts. 
 |js}
-  ; url = {js|https://www.massachusetts.edu/|js}
-  ; logo = None
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages|js}
-  ; acronym = Some {js|CS691F|js}
-  ; online_resource  = Some {js|https://people.cs.umass.edu/~arjun/courses/cs691f/|js}
-  }]
-  ; location = Some 
-  { long = -71.036500
-  ; lat = 42.314200
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|McGill University|js}
-  ; slug = {js|mcgill-university|js}
-  ; description = {js|McGill University is a public research university located in Montreal, Quebec, Canada.
+    ; url = {js|https://www.massachusetts.edu/|js}
+    ; logo = None
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Programming Languages|js}
+          ; acronym = Some {js|CS691F|js}
+          ; online_resource =
+              Some {js|https://people.cs.umass.edu/~arjun/courses/cs691f/|js}
+          }
+        ]
+    ; location = Some { long = -71.036500; lat = 42.314200 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|McGill University|js}
+    ; slug = {js|mcgill-university|js}
+    ; description =
+        {js|McGill University is a public research university located in Montreal, Quebec, Canada.
 |js}
-  ; url = {js|https://www.mcgill.ca/|js}
-  ; logo = Some {js|/academic_institution/mcgill_logo.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages and Paradigms|js}
-  ; acronym = Some {js|COMP 302|js}
-  ; online_resource  = Some {js|https://www.cs.mcgill.ca/~bpientka/cs302/|js}
-  }]
-  ; location = Some 
-  { long = -73.577200
-  ; lat = 45.504800
-  }
-  
-  ; body_md = {js|
+    ; url = {js|https://www.mcgill.ca/|js}
+    ; logo = Some {js|/academic_institution/mcgill_logo.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Programming Languages and Paradigms|js}
+          ; acronym = Some {js|COMP 302|js}
+          ; online_resource =
+              Some {js|https://www.cs.mcgill.ca/~bpientka/cs302/|js}
+          }
+        ]
+    ; location = Some { long = -73.577200; lat = 45.504800 }
+    ; body_md = {js|
 
 
 |js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Université Paris-Diderot|js}
-  ; slug = {js|universit-paris-diderot|js}
-  ; description = {js|Paris Diderot University, also known as Paris 7, was a French university located in Paris, France. It was one of the seven universities of the Paris public higher education academy. 
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Université Paris-Diderot|js}
+    ; slug = {js|universit-paris-diderot|js}
+    ; description =
+        {js|Paris Diderot University, also known as Paris 7, was a French university located in Paris, France. It was one of the seven universities of the Paris public higher education academy. 
 |js}
-  ; url = {js|https://u-paris.fr/en/|js}
-  ; logo = None
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Advanced Functional Programming|js}
-  ; acronym = Some {js|PFAV|js}
-  ; online_resource  = Some {js|https://www.dicosmo.org/CourseNotes/pfav/|js}
-  };
-  
-  { name = {js|Functional Programming|js}
-  ; acronym = Some {js|PF5|js}
-  ; online_resource  = Some {js|https://www.irif.fr/~treinen/teaching/pf5/|js}
-  }]
-  ; location = Some 
-  { long = 2.382200
-  ; lat = 48.827600
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Pennsylvania|js}
-  ; slug = {js|university-of-pennsylvania|js}
-  ; description = {js|The University of Pennsylvania is a private Ivy League research university in Philadelphia, Pennsylvania.
+    ; url = {js|https://u-paris.fr/en/|js}
+    ; logo = None
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Advanced Functional Programming|js}
+          ; acronym = Some {js|PFAV|js}
+          ; online_resource =
+              Some {js|https://www.dicosmo.org/CourseNotes/pfav/|js}
+          }
+        ; { name = {js|Functional Programming|js}
+          ; acronym = Some {js|PF5|js}
+          ; online_resource =
+              Some {js|https://www.irif.fr/~treinen/teaching/pf5/|js}
+          }
+        ]
+    ; location = Some { long = 2.382200; lat = 48.827600 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Pennsylvania|js}
+    ; slug = {js|university-of-pennsylvania|js}
+    ; description =
+        {js|The University of Pennsylvania is a private Ivy League research university in Philadelphia, Pennsylvania.
 |js}
-  ; url = {js|https://www.upenn.edu/|js}
-  ; logo = Some {js|/academic_institution/penn.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Compilers|js}
-  ; acronym = Some {js|CIS341|js}
-  ; online_resource  = Some {js|https://www.cis.upenn.edu/~cis341/current/|js}
-  };
-  
-  { name = {js|Programming Languages and Techniques I|js}
-  ; acronym = Some {js|CIS120|js}
-  ; online_resource  = Some {js|https://www.seas.upenn.edu/~cis120/current/|js}
-  }]
-  ; location = Some 
-  { long = -75.193200
-  ; lat = 39.952200
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Princeton University|js}
-  ; slug = {js|princeton-university|js}
-  ; description = {js|Princeton University is a private Ivy League research university in Princeton, New Jersey. 
+    ; url = {js|https://www.upenn.edu/|js}
+    ; logo = Some {js|/academic_institution/penn.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Compilers|js}
+          ; acronym = Some {js|CIS341|js}
+          ; online_resource =
+              Some {js|https://www.cis.upenn.edu/~cis341/current/|js}
+          }
+        ; { name = {js|Programming Languages and Techniques I|js}
+          ; acronym = Some {js|CIS120|js}
+          ; online_resource =
+              Some {js|https://www.seas.upenn.edu/~cis120/current/|js}
+          }
+        ]
+    ; location = Some { long = -75.193200; lat = 39.952200 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Princeton University|js}
+    ; slug = {js|princeton-university|js}
+    ; description =
+        {js|Princeton University is a private Ivy League research university in Princeton, New Jersey. 
 |js}
-  ; url = {js|https://www.princeton.edu/|js}
-  ; logo = Some {js|/academic_institution/princeton.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Functional Programming|js}
-  ; acronym = Some {js|COS 326|js}
-  ; online_resource  = Some {js|https://www.cs.princeton.edu/courses/archive/fall14/cos326//|js}
-  }]
-  ; location = Some 
-  { long = -74.655100
-  ; lat = 40.343100
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Rennes 1|js}
-  ; slug = {js|university-of-rennes-1|js}
-  ; description = {js|The University of Rennes 1 is a public university located in the city of Rennes, France. It is under the Academy of Rennes. 
+    ; url = {js|https://www.princeton.edu/|js}
+    ; logo = Some {js|/academic_institution/princeton.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Functional Programming|js}
+          ; acronym = Some {js|COS 326|js}
+          ; online_resource =
+              Some
+                {js|https://www.cs.princeton.edu/courses/archive/fall14/cos326//|js}
+          }
+        ]
+    ; location = Some { long = -74.655100; lat = 40.343100 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Rennes 1|js}
+    ; slug = {js|university-of-rennes-1|js}
+    ; description =
+        {js|The University of Rennes 1 is a public university located in the city of Rennes, France. It is under the Academy of Rennes. 
 |js}
-  ; url = {js|https://international.univ-rennes1.fr/en/welcome-universite-de-rennes-1|js}
-  ; logo = Some {js|/academic_institution/reness.png|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Compilation|js}
-  ; acronym = Some {js|COMP|js}
-  ; online_resource  = None
-  };
-  
-  { name = {js|Semantics|js}
-  ; acronym = Some {js|SEM|js}
-  ; online_resource  = None
-  };
-  
-  { name = {js|Programming 2|js}
-  ; acronym = Some {js|PRG2|js}
-  ; online_resource  = None
-  }]
-  ; location = Some 
-  { long = -1.673000
-  ; lat = 48.115900
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|Rice University|js}
-  ; slug = {js|rice-university|js}
-  ; description = {js|William Marsh Rice University, commonly known as Rice University, is a private research university in Houston, Texas. 
+    ; url =
+        {js|https://international.univ-rennes1.fr/en/welcome-universite-de-rennes-1|js}
+    ; logo = Some {js|/academic_institution/reness.png|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Compilation|js}
+          ; acronym = Some {js|COMP|js}
+          ; online_resource = None
+          }
+        ; { name = {js|Semantics|js}
+          ; acronym = Some {js|SEM|js}
+          ; online_resource = None
+          }
+        ; { name = {js|Programming 2|js}
+          ; acronym = Some {js|PRG2|js}
+          ; online_resource = None
+          }
+        ]
+    ; location = Some { long = -1.673000; lat = 48.115900 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|Rice University|js}
+    ; slug = {js|rice-university|js}
+    ; description =
+        {js|William Marsh Rice University, commonly known as Rice University, is a private research university in Houston, Texas. 
 |js}
-  ; url = {js|https://www.rice.edu/|js}
-  ; logo = Some {js|/academic_institution/rice.jpg|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Principles of Programming Languages|js}
-  ; acronym = Some {js|COMP 311|js}
-  ; online_resource  = Some {js|https://www.cs.rice.edu/~javaplt/311/info.html|js}
-  }]
-  ; location = Some 
-  { long = -95.401800
-  ; lat = 29.717400
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of California, San Diego|js}
-  ; slug = {js|university-of-california-san-diego|js}
-  ; description = {js|The University of California, San Diego(UC San Diego or, colloquially, UCSD) is a public land-grant research university in San Diego, California.
+    ; url = {js|https://www.rice.edu/|js}
+    ; logo = Some {js|/academic_institution/rice.jpg|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Principles of Programming Languages|js}
+          ; acronym = Some {js|COMP 311|js}
+          ; online_resource =
+              Some {js|https://www.cs.rice.edu/~javaplt/311/info.html|js}
+          }
+        ]
+    ; location = Some { long = -95.401800; lat = 29.717400 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of California, San Diego|js}
+    ; slug = {js|university-of-california-san-diego|js}
+    ; description =
+        {js|The University of California, San Diego(UC San Diego or, colloquially, UCSD) is a public land-grant research university in San Diego, California.
 |js}
-  ; url = {js|https://ucsd.edu/|js}
-  ; logo = Some {js|/academic_institution/ucsd_logo.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages Principles and Paradigms (along with Python and Prolog)|js}
-  ; acronym = Some {js|CSE130-a|js}
-  ; online_resource  = Some {js|https://cseweb.ucsd.edu/classes/wi14/cse130-a/|js}
-  }]
-  ; location = Some 
-  { long = -117.234000
-  ; lat = 32.880100
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Minnesota Twin Cities|js}
-  ; slug = {js|university-of-minnesota-twin-cities|js}
-  ; description = {js|The University of Minnesota, Twin Cities is a public land-grant research university in the Twin Cities of Minneapolis and Saint Paul, Minnesota. 
+    ; url = {js|https://ucsd.edu/|js}
+    ; logo = Some {js|/academic_institution/ucsd_logo.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name =
+              {js|Programming Languages Principles and Paradigms (along with Python and Prolog)|js}
+          ; acronym = Some {js|CSE130-a|js}
+          ; online_resource =
+              Some {js|https://cseweb.ucsd.edu/classes/wi14/cse130-a/|js}
+          }
+        ]
+    ; location = Some { long = -117.234000; lat = 32.880100 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Minnesota Twin Cities|js}
+    ; slug = {js|university-of-minnesota-twin-cities|js}
+    ; description =
+        {js|The University of Minnesota, Twin Cities is a public land-grant research university in the Twin Cities of Minneapolis and Saint Paul, Minnesota. 
 |js}
-  ; url = {js|https://twin-cities.umn.edu/|js}
-  ; logo = None
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Advanced Programming Principles|js}
-  ; acronym = Some {js|CSCI 2041|js}
-  ; online_resource  = Some {js|https://www-users.cs.umn.edu/~kauffman/2041/syllabus.html|js}
-  }]
-  ; location = Some 
-  { long = -93.227700
-  ; lat = 44.974000
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Massachusetts Amherst|js}
-  ; slug = {js|university-of-massachusetts-amherst|js}
-  ; description = {js|The University of Massachusetts Amherst is a public land-grant research university in Amherst, Massachusetts. 
+    ; url = {js|https://twin-cities.umn.edu/|js}
+    ; logo = None
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Advanced Programming Principles|js}
+          ; acronym = Some {js|CSCI 2041|js}
+          ; online_resource =
+              Some
+                {js|https://www-users.cs.umn.edu/~kauffman/2041/syllabus.html|js}
+          }
+        ]
+    ; location = Some { long = -93.227700; lat = 44.974000 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Massachusetts Amherst|js}
+    ; slug = {js|university-of-massachusetts-amherst|js}
+    ; description =
+        {js|The University of Massachusetts Amherst is a public land-grant research university in Amherst, Massachusetts. 
 |js}
-  ; url = {js|https://www.umass.edu/|js}
-  ; logo = Some {js|/academic_institution/umas.jpeg|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|University of Massachusetts Amherst|js}
-  ; acronym = Some {js|CMPSCI 631|js}
-  ; online_resource  = Some {js|https://people.cs.umass.edu/~arjun/main/teaching/631/|js}
-  }]
-  ; location = Some 
-  { long = -72.530100
-  ; lat = 42.386800
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Virginia|js}
-  ; slug = {js|university-of-virginia|js}
-  ; description = {js|The University of Virginia is a public research university in Charlottesville, Virginia. 
+    ; url = {js|https://www.umass.edu/|js}
+    ; logo = Some {js|/academic_institution/umas.jpeg|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|University of Massachusetts Amherst|js}
+          ; acronym = Some {js|CMPSCI 631|js}
+          ; online_resource =
+              Some {js|https://people.cs.umass.edu/~arjun/main/teaching/631/|js}
+          }
+        ]
+    ; location = Some { long = -72.530100; lat = 42.386800 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Virginia|js}
+    ; slug = {js|university-of-virginia|js}
+    ; description =
+        {js|The University of Virginia is a public research university in Charlottesville, Virginia. 
 |js}
-  ; url = {js|https://www.virginia.edu/|js}
-  ; logo = Some {js|/academic_institution/virginia.png|js}
-  ; continent = {js|North America|js}
-  ; courses = 
- [
-  { name = {js|Programming Languages|js}
-  ; acronym = Some {js|CS 4610|js}
-  ; online_resource  = None
-  }]
-  ; location = Some 
-  { long = -78.508000
-  ; lat = 38.033600
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { name = {js|University of Wrocław|js}
-  ; slug = {js|university-of-wrocaw|js}
-  ; description = {js|The University of Wrocław is a public research university located in Wrocław, Poland. 
+    ; url = {js|https://www.virginia.edu/|js}
+    ; logo = Some {js|/academic_institution/virginia.png|js}
+    ; continent = {js|North America|js}
+    ; courses =
+        [ { name = {js|Programming Languages|js}
+          ; acronym = Some {js|CS 4610|js}
+          ; online_resource = None
+          }
+        ]
+    ; location = Some { long = -78.508000; lat = 38.033600 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { name = {js|University of Wrocław|js}
+    ; slug = {js|university-of-wrocaw|js}
+    ; description =
+        {js|The University of Wrocław is a public research university located in Wrocław, Poland. 
 |js}
-  ; url = {js|https://uni.wroc.pl/en/|js}
-  ; logo = Some {js|/academic_institution/wroclaw.jpg|js}
-  ; continent = {js|Europe|js}
-  ; courses = 
- [
-  { name = {js|Functional Programming|js}
-  ; acronym = None
-  ; online_resource  = Some {js|https://ii.uni.wroc.pl/~lukstafi/pmwiki/index.php?n=Functional.Functional|js}
-  }]
-  ; location = Some 
-  { long = 17.034500
-  ; lat = 51.114000
-  }
-  
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  }]
-
+    ; url = {js|https://uni.wroc.pl/en/|js}
+    ; logo = Some {js|/academic_institution/wroclaw.jpg|js}
+    ; continent = {js|Europe|js}
+    ; courses =
+        [ { name = {js|Functional Programming|js}
+          ; acronym = None
+          ; online_resource =
+              Some
+                {js|https://ii.uni.wroc.pl/~lukstafi/pmwiki/index.php?n=Functional.Functional|js}
+          }
+        ]
+    ; location = Some { long = 17.034500; lat = 51.114000 }
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ]

--- a/src/ocamlorg_data/book.ml
+++ b/src/ocamlorg_data/book.ml
@@ -1,7 +1,9 @@
+type link =
+  { description : string
+  ; uri : string
+  }
 
-type link = { description : string; uri : string }
-
-type t = 
+type t =
   { title : string
   ; slug : string
   ; description : string
@@ -15,28 +17,30 @@ type t =
   ; body_html : string
   }
 
-let all = 
-[
-  { title = {js|Algorithmen, Datenstrukturen, Funktionale Programmierung: Eine praktische Einführung mit Caml Light|js}
-  ; slug = {js|algorithmen-datenstrukturen-funktionale-programmierung-eine-praktische-einfhrung-mit-caml-light|js}
-  ; description = {js|In the first part of this book, algorithms are described in a concise and precise manner using Caml Light. The second part provides a tutorial introduction into the language Caml Light and in its last chapter a comprehensive description of the language kernel.
+let all =
+  [ { title =
+        {js|Algorithmen, Datenstrukturen, Funktionale Programmierung: Eine praktische Einführung mit Caml Light|js}
+    ; slug =
+        {js|algorithmen-datenstrukturen-funktionale-programmierung-eine-praktische-einfhrung-mit-caml-light|js}
+    ; description =
+        {js|In the first part of this book, algorithms are described in a concise and precise manner using Caml Light. The second part provides a tutorial introduction into the language Caml Light and in its last chapter a comprehensive description of the language kernel.
 |js}
-  ; authors = 
- [{js|Juergen Wolff von Gudenberg|js}]
-  ; language = {js|german|js}
-  ; published = Some {js|1996|js}
-  ; cover = Some {js|/books/wolff.gif|js}
-  ; isbn = None
-  ; links = 
- []
-  ; body_md = {js|This book gives an introduction to programming where algorithms as well
+    ; authors = [ {js|Juergen Wolff von Gudenberg|js} ]
+    ; language = {js|german|js}
+    ; published = Some {js|1996|js}
+    ; cover = Some {js|/books/wolff.gif|js}
+    ; isbn = None
+    ; links = []
+    ; body_md =
+        {js|This book gives an introduction to programming where algorithms as well
 as data structures are considered functionally. It is intended as an
 accompanying book for basic courses in computer science, but it is also
 suitable for self-studies. In the first part, algorithms are described
 in a concise and precise manner using Caml Light. The second part
 provides a tutorial introduction into the language Caml Light and in its
 last chapter a comprehensive description of the language kernel.|js}
-  ; body_html = {js|<p>This book gives an introduction to programming where algorithms as well
+    ; body_html =
+        {js|<p>This book gives an introduction to programming where algorithms as well
 as data structures are considered functionally. It is intended as an
 accompanying book for basic courses in computer science, but it is also
 suitable for self-studies. In the first part, algorithms are described
@@ -44,28 +48,28 @@ in a concise and precise manner using Caml Light. The second part
 provides a tutorial introduction into the language Caml Light and in its
 last chapter a comprehensive description of the language kernel.</p>
 |js}
-  };
- 
-  { title = {js|Apprendre à programmer avec OCaml|js}
-  ; slug = {js|apprendre--programmer-avec-ocaml|js}
-  ; description = {js|This book is organized into three parts. The first one introduces OCaml and targets beginners, being they programming beginners or simply new to OCaml. Through small programs, the reader is introduced to fundamental concepts of programming and of OCaml. The second and third parts are dedicated to fundamental concepts of algorithmics and should allow the reader to write programs in a structured and efficient way.
+    }
+  ; { title = {js|Apprendre à programmer avec OCaml|js}
+    ; slug = {js|apprendre--programmer-avec-ocaml|js}
+    ; description =
+        {js|This book is organized into three parts. The first one introduces OCaml and targets beginners, being they programming beginners or simply new to OCaml. Through small programs, the reader is introduced to fundamental concepts of programming and of OCaml. The second and third parts are dedicated to fundamental concepts of algorithmics and should allow the reader to write programs in a structured and efficient way.
 |js}
-  ; authors = 
- [{js|Jean-Christophe Filliâtre|js}; {js|Sylvain Conchon|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2014|js}
-  ; cover = Some {js|/books/apprendre_ocaml_cover.png|js}
-  ; isbn = Some {js|2-21213-678-1|js}
-  ; links = 
- [
-      { description = {js|Online|js}
-      ; uri = {js|https://programmer-avec-ocaml.lri.fr/|js}
-      };
-  
-      { description = {js|Order at Amazon.fr|js}
-      ; uri = {js|https://www.amazon.fr/Apprendre-programmer-avec-Ocaml-Algorithmes/dp/2212136781/|js}
-      }]
-  ; body_md = {js|Computer programming is hard to learn. Being a skillful programmer
+    ; authors = [ {js|Jean-Christophe Filliâtre|js}; {js|Sylvain Conchon|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2014|js}
+    ; cover = Some {js|/books/apprendre_ocaml_cover.png|js}
+    ; isbn = Some {js|2-21213-678-1|js}
+    ; links =
+        [ { description = {js|Online|js}
+          ; uri = {js|https://programmer-avec-ocaml.lri.fr/|js}
+          }
+        ; { description = {js|Order at Amazon.fr|js}
+          ; uri =
+              {js|https://www.amazon.fr/Apprendre-programmer-avec-Ocaml-Algorithmes/dp/2212136781/|js}
+          }
+        ]
+    ; body_md =
+        {js|Computer programming is hard to learn. Being a skillful programmer
 requires imagination, anticipation, knowledge in algorithmics, the
 mastery of a programming language, and above all experience, as
 difficulties are often hidden in details.  This book synthesizes our
@@ -86,7 +90,8 @@ should allow the reader to write programs in a structured and
 efficient way. Algorithmic concepts are directly presented in the
 syntax of OCaml and any code snippet from the book is available
 online.|js}
-  ; body_html = {js|<p>Computer programming is hard to learn. Being a skillful programmer
+    ; body_html =
+        {js|<p>Computer programming is hard to learn. Being a skillful programmer
 requires imagination, anticipation, knowledge in algorithmics, the
 mastery of a programming language, and above all experience, as
 difficulties are often hidden in details.  This book synthesizes our
@@ -106,21 +111,20 @@ efficient way. Algorithmic concepts are directly presented in the
 syntax of OCaml and any code snippet from the book is available
 online.</p>
 |js}
-  };
- 
-  { title = {js|Apprentissage de la programmation avec OCaml|js}
-  ; slug = {js|apprentissage-de-la-programmation-avec-ocaml|js}
-  ; description = {js|This book is targeted towards beginner programmers and provides teaching material for all programmers wishing to learn the functional programming style. The programming features introduced in this book are available in all dialects of the ML language, notably Caml-Light, OCaml and Standard ML.
+    }
+  ; { title = {js|Apprentissage de la programmation avec OCaml|js}
+    ; slug = {js|apprentissage-de-la-programmation-avec-ocaml|js}
+    ; description =
+        {js|This book is targeted towards beginner programmers and provides teaching material for all programmers wishing to learn the functional programming style. The programming features introduced in this book are available in all dialects of the ML language, notably Caml-Light, OCaml and Standard ML.
 |js}
-  ; authors = 
- [{js|Catherine Dubois|js}; {js|Valérie Ménissier Morain|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2004|js}
-  ; cover = Some {js|/books/dubois-menissier.gif|js}
-  ; isbn = Some {js|2-7462-0819-9|js}
-  ; links = 
- []
-  ; body_md = {js|Programming is a discipline by which the strengths of computers can be
+    ; authors = [ {js|Catherine Dubois|js}; {js|Valérie Ménissier Morain|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2004|js}
+    ; cover = Some {js|/books/dubois-menissier.gif|js}
+    ; isbn = Some {js|2-7462-0819-9|js}
+    ; links = []
+    ; body_md =
+        {js|Programming is a discipline by which the strengths of computers can be
 harnessed: large amounts of reliable memory, the ability to execute
 repetitive tasks relentlessly, and a high computation speed. In order to
 write correct programs that fulfill their specified needs, it is
@@ -131,7 +135,8 @@ functional programming style. The programming features introduced in
 this book are available in all dialects of the ML language, notably
 Caml-Light, OCaml and Standard ML. The concepts presented therein and
 illustrated in OCaml easily transpose to other programming languages.|js}
-  ; body_html = {js|<p>Programming is a discipline by which the strengths of computers can be
+    ; body_html =
+        {js|<p>Programming is a discipline by which the strengths of computers can be
 harnessed: large amounts of reliable memory, the ability to execute
 repetitive tasks relentlessly, and a high computation speed. In order to
 write correct programs that fulfill their specified needs, it is
@@ -143,23 +148,23 @@ this book are available in all dialects of the ML language, notably
 Caml-Light, OCaml and Standard ML. The concepts presented therein and
 illustrated in OCaml easily transpose to other programming languages.</p>
 |js}
-  };
- 
-  { title = {js|Approche Fonctionnelle de la Programmation|js}
-  ; slug = {js|approche-fonctionnelle-de-la-programmation|js}
-  ; description = {js|This book uses OCaml as a tool to introduce several important programming concepts.|js}
-  ; authors = 
- [{js|Guy Cousineau|js}; {js|Michel Mauny|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1995|js}
-  ; cover = Some {js|/books/cousineau-mauny-fr.gif|js}
-  ; isbn = Some {js|2-84074-114-8|js}
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://pauillac.inria.fr/cousineau-mauny/main-fr.html|js}
-      }]
-  ; body_md = {js|This book uses OCaml as a tool to introduce several important
+    }
+  ; { title = {js|Approche Fonctionnelle de la Programmation|js}
+    ; slug = {js|approche-fonctionnelle-de-la-programmation|js}
+    ; description =
+        {js|This book uses OCaml as a tool to introduce several important programming concepts.|js}
+    ; authors = [ {js|Guy Cousineau|js}; {js|Michel Mauny|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1995|js}
+    ; cover = Some {js|/books/cousineau-mauny-fr.gif|js}
+    ; isbn = Some {js|2-84074-114-8|js}
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri = {js|https://pauillac.inria.fr/cousineau-mauny/main-fr.html|js}
+          }
+        ]
+    ; body_md =
+        {js|This book uses OCaml as a tool to introduce several important
 programming concepts. It is divided in three parts. The first part is an
 introduction to OCaml, which presents the language itself, but also
 introduces evaluation by rewriting, evaluation strategies and proofs of
@@ -169,7 +174,8 @@ interest various types of readers or students. Finally, the third part
 is dedicated to implementation. It describes interpretation then
 compilation, with brief descriptions of memory management and type
 synthesis.|js}
-  ; body_html = {js|<p>This book uses OCaml as a tool to introduce several important
+    ; body_html =
+        {js|<p>This book uses OCaml as a tool to introduce several important
 programming concepts. It is divided in three parts. The first part is an
 introduction to OCaml, which presents the language itself, but also
 introduces evaluation by rewriting, evaluation strategies and proofs of
@@ -180,24 +186,27 @@ is dedicated to implementation. It describes interpretation then
 compilation, with brief descriptions of memory management and type
 synthesis.</p>
 |js}
-  };
- 
-  { title = {js|Concepts et outils de programmation|js}
-  ; slug = {js|concepts-et-outils-de-programmation|js}
-  ; description = {js|The book begins with a functional approach, based on OCaml, and continues with a presentation of an imperative language, namely Ada. It also provides numerous exercises with solutions.
+    }
+  ; { title = {js|Concepts et outils de programmation|js}
+    ; slug = {js|concepts-et-outils-de-programmation|js}
+    ; description =
+        {js|The book begins with a functional approach, based on OCaml, and continues with a presentation of an imperative language, namely Ada. It also provides numerous exercises with solutions.
 |js}
-  ; authors = 
- [{js|Thérèse Accart Hardin|js}; {js|Véronique Donzeau-Gouge Viguié|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1992|js}
-  ; cover = Some {js|/books/hardin-donzeau-gouge.gif|js}
-  ; isbn = Some {js|2-7296-0419-7|js}
-  ; links = 
- [
-      { description = {js|Order at Amazon.fr|js}
-      ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2729604197|js}
-      }]
-  ; body_md = {js|This book presents a new approach to teaching programming concepts to
+    ; authors =
+        [ {js|Thérèse Accart Hardin|js}
+        ; {js|Véronique Donzeau-Gouge Viguié|js}
+        ]
+    ; language = {js|french|js}
+    ; published = Some {js|1992|js}
+    ; cover = Some {js|/books/hardin-donzeau-gouge.gif|js}
+    ; isbn = Some {js|2-7296-0419-7|js}
+    ; links =
+        [ { description = {js|Order at Amazon.fr|js}
+          ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2729604197|js}
+          }
+        ]
+    ; body_md =
+        {js|This book presents a new approach to teaching programming concepts to
 beginners, based on language semantics. A simplified semantic model is
 used to describe in a precise manner the features found in most
 programming languages. This model is powerful enough to explain
@@ -207,7 +216,8 @@ students can actually use it to compute. The book begins with a
 functional approach, based on OCaml, and continues with a presentation
 of an imperative language, namely Ada. It also provides numerous
 exercises with solutions.|js}
-  ; body_html = {js|<p>This book presents a new approach to teaching programming concepts to
+    ; body_html =
+        {js|<p>This book presents a new approach to teaching programming concepts to
 beginners, based on language semantics. A simplified semantic model is
 used to describe in a precise manner the features found in most
 programming languages. This model is powerful enough to explain
@@ -218,116 +228,129 @@ functional approach, based on OCaml, and continues with a presentation
 of an imperative language, namely Ada. It also provides numerous
 exercises with solutions.</p>
 |js}
-  };
- 
-  { title = {js|Cours et exercices d'informatique|js}
-  ; slug = {js|cours-et-exercices-dinformatique|js}
-  ; description = {js|This book was written by teachers at university and in “classes préparatoires”. It is intended for “classes préparatoires” students who study computer science and for students engaged in a computer science cursus up to the masters level. It includes a tutorial of the OCaml language, a course on algorithms, data structures, automata theory, and formal logic, as well as 135 exercises with solutions.
+    }
+  ; { title = {js|Cours et exercices d'informatique|js}
+    ; slug = {js|cours-et-exercices-dinformatique|js}
+    ; description =
+        {js|This book was written by teachers at university and in “classes préparatoires”. It is intended for “classes préparatoires” students who study computer science and for students engaged in a computer science cursus up to the masters level. It includes a tutorial of the OCaml language, a course on algorithms, data structures, automata theory, and formal logic, as well as 135 exercises with solutions.
 |js}
-  ; authors = 
- [{js|Luc Albert|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1997|js}
-  ; cover = Some {js|/books/albert.gif|js}
-  ; isbn = Some {js|2-84180-106-3|js}
-  ; links = 
- []
-  ; body_md = {js|This book was written by teachers at university and in “classes
+    ; authors = [ {js|Luc Albert|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1997|js}
+    ; cover = Some {js|/books/albert.gif|js}
+    ; isbn = Some {js|2-84180-106-3|js}
+    ; links = []
+    ; body_md =
+        {js|This book was written by teachers at university and in “classes
 préparatoires”. It is intended for “classes préparatoires” students who
 study computer science and for students engaged in a computer science
 cursus up to the masters level. It includes a tutorial of the OCaml
 language, a course on algorithms, data structures, automata theory, and
 formal logic, as well as 135 exercises with solutions.|js}
-  ; body_html = {js|<p>This book was written by teachers at university and in “classes
+    ; body_html =
+        {js|<p>This book was written by teachers at university and in “classes
 préparatoires”. It is intended for “classes préparatoires” students who
 study computer science and for students engaged in a computer science
 cursus up to the masters level. It includes a tutorial of the OCaml
 language, a course on algorithms, data structures, automata theory, and
 formal logic, as well as 135 exercises with solutions.</p>
 |js}
-  };
- 
-  { title = {js|Developing Applications with OCaml|js}
-  ; slug = {js|developing-applications-with-ocaml|js}
-  ; description = {js|A comprehensive (742 page) guide to developing application in the OCaml programming language
+    }
+  ; { title = {js|Developing Applications with OCaml|js}
+    ; slug = {js|developing-applications-with-ocaml|js}
+    ; description =
+        {js|A comprehensive (742 page) guide to developing application in the OCaml programming language
 |js}
-  ; authors = 
- [{js|Emmanuel Chailloux|js}; {js|Pascal Manoury|js}; {js|Bruno Pagano|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2002|js}
-  ; cover = Some {js|/books/logocaml-oreilly.gif|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://caml.inria.fr/pub/docs/oreilly-book/index.html|js}
-      };
-  
-      { description = {js|Online|js}
-      ; uri = {js|https://caml.inria.fr/pub/docs/oreilly-book/html/index.html|js}
-      };
-  
-      { description = {js|PDF|js}
-      ; uri = {js|https://caml.inria.fr/pub/docs/oreilly-book/ocaml-ora-book.pdf|js}
-      }]
-  ; body_md = {js|A comprehensive (742 pages) book on OCaml, covering not only the core
+    ; authors =
+        [ {js|Emmanuel Chailloux|js}
+        ; {js|Pascal Manoury|js}
+        ; {js|Bruno Pagano|js}
+        ]
+    ; language = {js|english|js}
+    ; published = Some {js|2002|js}
+    ; cover = Some {js|/books/logocaml-oreilly.gif|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri = {js|https://caml.inria.fr/pub/docs/oreilly-book/index.html|js}
+          }
+        ; { description = {js|Online|js}
+          ; uri =
+              {js|https://caml.inria.fr/pub/docs/oreilly-book/html/index.html|js}
+          }
+        ; { description = {js|PDF|js}
+          ; uri =
+              {js|https://caml.inria.fr/pub/docs/oreilly-book/ocaml-ora-book.pdf|js}
+          }
+        ]
+    ; body_md =
+        {js|A comprehensive (742 pages) book on OCaml, covering not only the core
 language, but also modules, objects and classes, threads and systems
 programming, interoperability with C, and runtime tools. This book is a
 translation of a French book published by OReilly.|js}
-  ; body_html = {js|<p>A comprehensive (742 pages) book on OCaml, covering not only the core
+    ; body_html =
+        {js|<p>A comprehensive (742 pages) book on OCaml, covering not only the core
 language, but also modules, objects and classes, threads and systems
 programming, interoperability with C, and runtime tools. This book is a
 translation of a French book published by OReilly.</p>
 |js}
-  };
- 
-  { title = {js|Développement d'applications avec Objective Caml|js}
-  ; slug = {js|dveloppement-dapplications-avec-objective-caml|js}
-  ; description = {js|"Objective CAML est un langage de programmation : un de plus dira-t-on ! Ils sont en effet déjà nombreux et pourtant il en apparaît constamment de nouveaux. Au delà de leurs disparités, la conception et la genèse de chacun d'eux procèdent d'une motivation partagée : la volonté d'abstraire"
+    }
+  ; { title = {js|Développement d'applications avec Objective Caml|js}
+    ; slug = {js|dveloppement-dapplications-avec-objective-caml|js}
+    ; description =
+        {js|"Objective CAML est un langage de programmation : un de plus dira-t-on ! Ils sont en effet déjà nombreux et pourtant il en apparaît constamment de nouveaux. Au delà de leurs disparités, la conception et la genèse de chacun d'eux procèdent d'une motivation partagée : la volonté d'abstraire"
 |js}
-  ; authors = 
- [{js|Emmanuel Chailloux|js}; {js|Pascal Manoury|js}; {js|Bruno Pagano|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2000|js}
-  ; cover = Some {js|/books/chailloux-manoury-pagano.jpg|js}
-  ; isbn = Some {js|2-84177-121-0|js}
-  ; links = 
- [
-      { description = {js|Online|js}
-      ; uri = {js|https://www.pps.jussieu.fr/Livres/ora/DA-OCAML/index.html|js}
-      };
-  
-      { description = {js|Order at Amazon.fr|js}
-      ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2841771210|js}
-      }]
-  ; body_md = {js|A comprehensive (742 pages) book on OCaml, covering not only the core
+    ; authors =
+        [ {js|Emmanuel Chailloux|js}
+        ; {js|Pascal Manoury|js}
+        ; {js|Bruno Pagano|js}
+        ]
+    ; language = {js|french|js}
+    ; published = Some {js|2000|js}
+    ; cover = Some {js|/books/chailloux-manoury-pagano.jpg|js}
+    ; isbn = Some {js|2-84177-121-0|js}
+    ; links =
+        [ { description = {js|Online|js}
+          ; uri =
+              {js|https://www.pps.jussieu.fr/Livres/ora/DA-OCAML/index.html|js}
+          }
+        ; { description = {js|Order at Amazon.fr|js}
+          ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2841771210|js}
+          }
+        ]
+    ; body_md =
+        {js|A comprehensive (742 pages) book on OCaml, covering not only the core
 language, but also modules, objects and classes, threads and systems
 programming, and interoperability with C.
 
 "Objective CAML est un langage de programmation : un de plus dira-t-on ! Ils sont en effet déjà nombreux et pourtant il en apparaît constamment de nouveaux. Au delà de leurs disparités, la conception et la genèse de chacun d'eux procèdent d'une motivation partagée : la volonté d'abstraire"|js}
-  ; body_html = {js|<p>A comprehensive (742 pages) book on OCaml, covering not only the core
+    ; body_html =
+        {js|<p>A comprehensive (742 pages) book on OCaml, covering not only the core
 language, but also modules, objects and classes, threads and systems
 programming, and interoperability with C.</p>
 <p>&quot;Objective CAML est un langage de programmation : un de plus dira-t-on ! Ils sont en effet déjà nombreux et pourtant il en apparaît constamment de nouveaux. Au delà de leurs disparités, la conception et la genèse de chacun d'eux procèdent d'une motivation partagée : la volonté d'abstraire&quot;</p>
 |js}
-  };
- 
-  { title = {js|Initiation à la programmation fonctionnelle en OCaml|js}
-  ; slug = {js|initiation--la-programmation-fonctionnelle-en-ocaml|js}
-  ; description = {js|Le but de ce livre est d’initier le lecteur au style fonctionnel de programmation en utilisant le langage OCaml.
+    }
+  ; { title = {js|Initiation à la programmation fonctionnelle en OCaml|js}
+    ; slug = {js|initiation--la-programmation-fonctionnelle-en-ocaml|js}
+    ; description =
+        {js|Le but de ce livre est d’initier le lecteur au style fonctionnel de programmation en utilisant le langage OCaml.
 |js}
-  ; authors = 
- [{js|Mohammed-Said Habet|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2015|js}
-  ; cover = Some {js|/books/Initiation_a_la_programmation_fonctionnelle_en_OCaml.jpg|js}
-  ; isbn = Some {js|9782332978400|js}
-  ; links = 
- [
-      { description = {js|Website|js}
-      ; uri = {js|https://www.edilivre.com/initiation-a-la-programmation-fonctionnelle-en-ocaml-mohammed-said-habet.html|js}
-      }]
-  ; body_md = {js|La programmation fonctionnelle est un style de programmation qui
+    ; authors = [ {js|Mohammed-Said Habet|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2015|js}
+    ; cover =
+        Some
+          {js|/books/Initiation_a_la_programmation_fonctionnelle_en_OCaml.jpg|js}
+    ; isbn = Some {js|9782332978400|js}
+    ; links =
+        [ { description = {js|Website|js}
+          ; uri =
+              {js|https://www.edilivre.com/initiation-a-la-programmation-fonctionnelle-en-ocaml-mohammed-said-habet.html|js}
+          }
+        ]
+    ; body_md =
+        {js|La programmation fonctionnelle est un style de programmation qui
 consiste à considérer les programmes informatiques comme des fonctions
 au sens mathématique du terme. Ce style est proposé dans de nombreux
 langages de programmation anciens et récents comme OCaml.
@@ -342,7 +365,8 @@ Le lecteur trouvera une présentation progressive des concepts de
 programmation fonctionnelle dans le langage OCaml, illustrée par des
 exemples, de nombreux exercices corrigés et d’autres laissés à
 l’initiative du lecteur.|js}
-  ; body_html = {js|<p>La programmation fonctionnelle est un style de programmation qui
+    ; body_html =
+        {js|<p>La programmation fonctionnelle est un style de programmation qui
 consiste à considérer les programmes informatiques comme des fonctions
 au sens mathématique du terme. Ce style est proposé dans de nombreux
 langages de programmation anciens et récents comme OCaml.</p>
@@ -356,75 +380,74 @@ programmation fonctionnelle dans le langage OCaml, illustrée par des
 exemples, de nombreux exercices corrigés et d’autres laissés à
 l’initiative du lecteur.</p>
 |js}
-  };
- 
-  { title = {js|Introduction to OCaml|js}
-  ; slug = {js|introduction-to-ocaml|js}
-  ; description = {js|This book is an introduction to ML programming, specifically for the OCaml programming language from INRIA. OCaml is a dialect of the ML family of languages, which derive from the Classic ML language designed by Robin Milner in 1975 for the LCF (Logic of Computable Functions) theorem prover.
+    }
+  ; { title = {js|Introduction to OCaml|js}
+    ; slug = {js|introduction-to-ocaml|js}
+    ; description =
+        {js|This book is an introduction to ML programming, specifically for the OCaml programming language from INRIA. OCaml is a dialect of the ML family of languages, which derive from the Classic ML language designed by Robin Milner in 1975 for the LCF (Logic of Computable Functions) theorem prover.
 |js}
-  ; authors = 
- [{js|Jason Hickey|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2008|js}
-  ; cover = None
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|PDF|js}
-      ; uri = {js|https://courses.cms.caltech.edu/cs134/cs134b/book.pdf|js}
-      }]
-  ; body_md = {js|This book is notoriously much more than just an introduction to OCaml,
+    ; authors = [ {js|Jason Hickey|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2008|js}
+    ; cover = None
+    ; isbn = None
+    ; links =
+        [ { description = {js|PDF|js}
+          ; uri = {js|https://courses.cms.caltech.edu/cs134/cs134b/book.pdf|js}
+          }
+        ]
+    ; body_md =
+        {js|This book is notoriously much more than just an introduction to OCaml,
 it describes most of the language, and is accessible.
 
 Abstract: *This book is an introduction to ML programming, specifically for the OCaml programming language from INRIA. OCaml is a dialect of the ML family of languages, which derive from the Classic ML language designed by Robin Milner in 1975 for the LCF (Logic of Computable Functions) theorem prover.*
 
 [PDF](https://courses.cms.caltech.edu/cs134/cs134b/book.pdf)|js}
-  ; body_html = {js|<p>This book is notoriously much more than just an introduction to OCaml,
+    ; body_html =
+        {js|<p>This book is notoriously much more than just an introduction to OCaml,
 it describes most of the language, and is accessible.</p>
 <p>Abstract: <em>This book is an introduction to ML programming, specifically for the OCaml programming language from INRIA. OCaml is a dialect of the ML family of languages, which derive from the Classic ML language designed by Robin Milner in 1975 for the LCF (Logic of Computable Functions) theorem prover.</em></p>
 <p><a href="https://courses.cms.caltech.edu/cs134/cs134b/book.pdf">PDF</a></p>
 |js}
-  };
- 
-  { title = {js|Introduzione alla programmazione funzionale|js}
-  ; slug = {js|introduzione-alla-programmazione-funzionale|js}
-  ; description = {js|Functional programming introduction with OCaml
+    }
+  ; { title = {js|Introduzione alla programmazione funzionale|js}
+    ; slug = {js|introduzione-alla-programmazione-funzionale|js}
+    ; description = {js|Functional programming introduction with OCaml
 |js}
-  ; authors = 
- [{js|Carla Limongelli|js}; {js|Marta Cialdea|js}]
-  ; language = {js|italian|js}
-  ; published = Some {js|2002|js}
-  ; cover = Some {js|/books/limongelli-cialdea.gif|js}
-  ; isbn = Some {js|88-7488-031-6|js}
-  ; links = 
- []
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { title = {js|Le Langage Caml|js}
-  ; slug = {js|le-langage-caml|js}
-  ; description = {js|This book is a comprehensive introduction to programming in OCaml. Usable as a programming course, it introduces progressively the language features and shows them at work on the fundamental programming problems. In addition to many introductory code samples, this book details the design and implementation of six complete, realistic programs in reputedly difficult application areas: compilation, type inference, automata, etc.
+    ; authors = [ {js|Carla Limongelli|js}; {js|Marta Cialdea|js} ]
+    ; language = {js|italian|js}
+    ; published = Some {js|2002|js}
+    ; cover = Some {js|/books/limongelli-cialdea.gif|js}
+    ; isbn = Some {js|88-7488-031-6|js}
+    ; links = []
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { title = {js|Le Langage Caml|js}
+    ; slug = {js|le-langage-caml|js}
+    ; description =
+        {js|This book is a comprehensive introduction to programming in OCaml. Usable as a programming course, it introduces progressively the language features and shows them at work on the fundamental programming problems. In addition to many introductory code samples, this book details the design and implementation of six complete, realistic programs in reputedly difficult application areas: compilation, type inference, automata, etc.
 |js}
-  ; authors = 
- [{js|Xavier Leroy|js}; {js|Pierre Weis|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1993|js}
-  ; cover = Some {js|/books/le-language-caml-cover.jpg|js}
-  ; isbn = Some {js|2-10-004383-8|js}
-  ; links = 
- [
-      { description = {js|PDF|js}
-      ; uri = {js|https://caml.inria.fr/pub/distrib/books/llc.pdf|js}
-      }]
-  ; body_md = {js|This book is a comprehensive introduction to programming in OCaml.
+    ; authors = [ {js|Xavier Leroy|js}; {js|Pierre Weis|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1993|js}
+    ; cover = Some {js|/books/le-language-caml-cover.jpg|js}
+    ; isbn = Some {js|2-10-004383-8|js}
+    ; links =
+        [ { description = {js|PDF|js}
+          ; uri = {js|https://caml.inria.fr/pub/distrib/books/llc.pdf|js}
+          }
+        ]
+    ; body_md =
+        {js|This book is a comprehensive introduction to programming in OCaml.
 Usable as a programming course, it introduces progressively the language
 features and shows them at work on the fundamental programming problems.
 In addition to many introductory code samples, this book details the
 design and implementation of six complete, realistic programs in
 reputedly difficult application areas: compilation, type inference,
 automata, etc.|js}
-  ; body_html = {js|<p>This book is a comprehensive introduction to programming in OCaml.
+    ; body_html =
+        {js|<p>This book is a comprehensive introduction to programming in OCaml.
 Usable as a programming course, it introduces progressively the language
 features and shows them at work on the fundamental programming problems.
 In addition to many introductory code samples, this book details the
@@ -432,55 +455,56 @@ design and implementation of six complete, realistic programs in
 reputedly difficult application areas: compilation, type inference,
 automata, etc.</p>
 |js}
-  };
- 
-  { title = {js|Manuel de référence du langage Caml|js}
-  ; slug = {js|manuel-de-rfrence-du-langage-caml|js}
-  ; description = {js|"Cet ouvrage contient le manuel de référence du langage Caml et la documentation complète du système Caml Light, un environnement de programmation en Caml distribuée gratuitement. Il s’adresse á des programmeurs Caml expérimentés, et non pas aux d'ébutants. Il vient en complément du livre Le langage Caml, des mêmes auteurs chez le même éditeur, qui fournit une introduction progressive au langage Caml et á l’écriture de programmes dans ce langage."
+    }
+  ; { title = {js|Manuel de référence du langage Caml|js}
+    ; slug = {js|manuel-de-rfrence-du-langage-caml|js}
+    ; description =
+        {js|"Cet ouvrage contient le manuel de référence du langage Caml et la documentation complète du système Caml Light, un environnement de programmation en Caml distribuée gratuitement. Il s’adresse á des programmeurs Caml expérimentés, et non pas aux d'ébutants. Il vient en complément du livre Le langage Caml, des mêmes auteurs chez le même éditeur, qui fournit une introduction progressive au langage Caml et á l’écriture de programmes dans ce langage."
 |js}
-  ; authors = 
- [{js|Xavier Leroy|js}; {js|Pierre Weis|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1993|js}
-  ; cover = Some {js|/books/manuel-de-reference-du-langage-caml-cover.jpg|js}
-  ; isbn = Some {js|2-7296-0492-8|js}
-  ; links = 
- [
-      { description = {js|PDF|js}
-      ; uri = {js|https://caml.inria.fr/pub/distrib/books/manuel-cl.pdf|js}
-      }]
-  ; body_md = {js|Written by two of the implementors of the Caml Light compiler, this
+    ; authors = [ {js|Xavier Leroy|js}; {js|Pierre Weis|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1993|js}
+    ; cover = Some {js|/books/manuel-de-reference-du-langage-caml-cover.jpg|js}
+    ; isbn = Some {js|2-7296-0492-8|js}
+    ; links =
+        [ { description = {js|PDF|js}
+          ; uri = {js|https://caml.inria.fr/pub/distrib/books/manuel-cl.pdf|js}
+          }
+        ]
+    ; body_md =
+        {js|Written by two of the implementors of the Caml Light compiler, this
 comprehensive book describes all constructs of the programming language
 and provides a complete documentation for the Caml Light system.
 
 Intro:  "Cet ouvrage contient le manuel de référence du langage Caml et la documentation complète du système Caml Light, un environnement de programmation en Caml distribuée gratuitement. Il s’adresse á des programmeurs Caml expérimentés, et non pas aux d'ébutants. Il vient en complément du livre Le langage Caml, des mêmes auteurs chez le même éditeur, qui fournit une introduction progressive au langage Caml et á l’écriture de programmes dans ce langage."|js}
-  ; body_html = {js|<p>Written by two of the implementors of the Caml Light compiler, this
+    ; body_html =
+        {js|<p>Written by two of the implementors of the Caml Light compiler, this
 comprehensive book describes all constructs of the programming language
 and provides a complete documentation for the Caml Light system.</p>
 <p>Intro:  &quot;Cet ouvrage contient le manuel de référence du langage Caml et la documentation complète du système Caml Light, un environnement de programmation en Caml distribuée gratuitement. Il s’adresse á des programmeurs Caml expérimentés, et non pas aux d'ébutants. Il vient en complément du livre Le langage Caml, des mêmes auteurs chez le même éditeur, qui fournit une introduction progressive au langage Caml et á l’écriture de programmes dans ce langage.&quot;</p>
 |js}
-  };
- 
-  { title = {js|More OCaml: Algorithms, Methods & Diversions|js}
-  ; slug = {js|more-ocaml-algorithms-methods--diversions|js}
-  ; description = {js|In "More OCaml" John Whitington takes a meandering tour of functional programming with OCaml, introducing various language features and describing some classic algorithms.
+    }
+  ; { title = {js|More OCaml: Algorithms, Methods & Diversions|js}
+    ; slug = {js|more-ocaml-algorithms-methods--diversions|js}
+    ; description =
+        {js|In "More OCaml" John Whitington takes a meandering tour of functional programming with OCaml, introducing various language features and describing some classic algorithms.
 |js}
-  ; authors = 
- [{js|John Whitington|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2014-08-26|js}
-  ; cover = Some {js|/books/more-ocaml-300-376.png|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://ocaml-book.com/more-ocaml-algorithms-methods-diversions/|js}
-      };
-  
-      { description = {js|Amazon|js}
-      ; uri = {js|https://www.amazon.com/gp/product/0957671113|js}
-      }]
-  ; body_md = {js|In "More OCaml" John Whitington takes a meandering tour of functional
+    ; authors = [ {js|John Whitington|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2014-08-26|js}
+    ; cover = Some {js|/books/more-ocaml-300-376.png|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri =
+              {js|https://ocaml-book.com/more-ocaml-algorithms-methods-diversions/|js}
+          }
+        ; { description = {js|Amazon|js}
+          ; uri = {js|https://www.amazon.com/gp/product/0957671113|js}
+          }
+        ]
+    ; body_md =
+        {js|In "More OCaml" John Whitington takes a meandering tour of functional
 programming with OCaml, introducing various language features and describing
 some classic algorithms. The book ends with a large worked example dealing with
 the production of PDF files. There are questions for each chapter together with
@@ -492,7 +516,8 @@ languages such as OCaml. It is hoped that each reader will find something new,
 or see an old thing in a new light. For the more casual reader, or those who are
 used to a different functional language, a summary of basic OCaml is provided at
 the front of the book.|js}
-  ; body_html = {js|<p>In &quot;More OCaml&quot; John Whitington takes a meandering tour of functional
+    ; body_html =
+        {js|<p>In &quot;More OCaml&quot; John Whitington takes a meandering tour of functional
 programming with OCaml, introducing various language features and describing
 some classic algorithms. The book ends with a large worked example dealing with
 the production of PDF files. There are questions for each chapter together with
@@ -504,89 +529,93 @@ or see an old thing in a new light. For the more casual reader, or those who are
 used to a different functional language, a summary of basic OCaml is provided at
 the front of the book.</p>
 |js}
-  };
- 
-  { title = {js|Nouveaux exercices d'algorithmique|js}
-  ; slug = {js|nouveaux-exercices-dalgorithmique|js}
-  ; description = {js|This book presents 103 exercises and 5 problems about algorithms, for masters students. It attempts to address both practical and theoretical questions. Programs are written in OCaml and expressed in a purely functional style.
+    }
+  ; { title = {js|Nouveaux exercices d'algorithmique|js}
+    ; slug = {js|nouveaux-exercices-dalgorithmique|js}
+    ; description =
+        {js|This book presents 103 exercises and 5 problems about algorithms, for masters students. It attempts to address both practical and theoretical questions. Programs are written in OCaml and expressed in a purely functional style.
 |js}
-  ; authors = 
- [{js|Michel Quercia|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2000|js}
-  ; cover = Some {js|/books/quercia.gif|js}
-  ; isbn = Some {js|2-7117-8990|js}
-  ; links = 
- [
-      { description = {js|Order at Amazon.fr|js}
-      ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/3540673873|js}
-      }]
-  ; body_md = {js|This book presents 103 exercises and 5 problems about algorithms, for
+    ; authors = [ {js|Michel Quercia|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2000|js}
+    ; cover = Some {js|/books/quercia.gif|js}
+    ; isbn = Some {js|2-7117-8990|js}
+    ; links =
+        [ { description = {js|Order at Amazon.fr|js}
+          ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/3540673873|js}
+          }
+        ]
+    ; body_md =
+        {js|This book presents 103 exercises and 5 problems about algorithms, for
 masters students. It attempts to address both practical and theoretical
 questions. Programs are written in OCaml and expressed in a purely
 functional style. Problem areas include programming methodology, lists,
 formula evaluation, Boolean logic, algorithmic complexity, trees,
 languages, and automata.|js}
-  ; body_html = {js|<p>This book presents 103 exercises and 5 problems about algorithms, for
+    ; body_html =
+        {js|<p>This book presents 103 exercises and 5 problems about algorithms, for
 masters students. It attempts to address both practical and theoretical
 questions. Programs are written in OCaml and expressed in a purely
 functional style. Problem areas include programming methodology, lists,
 formula evaluation, Boolean logic, algorithmic complexity, trees,
 languages, and automata.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Book|js}
-  ; slug = {js|ocaml-book|js}
-  ; description = {js|Introductory programming textbook based on the OCaml language
+    }
+  ; { title = {js|OCaml Book|js}
+    ; slug = {js|ocaml-book|js}
+    ; description =
+        {js|Introductory programming textbook based on the OCaml language
 |js}
-  ; authors = 
- [{js|Hongbo Zhang|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2011|js}
-  ; cover = None
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|GitHub|js}
-      ; uri = {js|https://github.com/bobzhang/ocaml-book|js}
-      }]
-  ; body_md = {js|This book is a work in progress. It currently includes sections on the
+    ; authors = [ {js|Hongbo Zhang|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2011|js}
+    ; cover = None
+    ; isbn = None
+    ; links =
+        [ { description = {js|GitHub|js}
+          ; uri = {js|https://github.com/bobzhang/ocaml-book|js}
+          }
+        ]
+    ; body_md =
+        {js|This book is a work in progress. It currently includes sections on the
 core OCaml language, Camlp4, parsing, various libraries, the OCaml
 runtime, interoperating with C, and pearls.|js}
-  ; body_html = {js|<p>This book is a work in progress. It currently includes sections on the
+    ; body_html =
+        {js|<p>This book is a work in progress. It currently includes sections on the
 core OCaml language, Camlp4, parsing, various libraries, the OCaml
 runtime, interoperating with C, and pearls.</p>
 |js}
-  };
- 
-  { title = {js|OCaml for Scientists|js}
-  ; slug = {js|ocaml-for-scientists|js}
-  ; description = {js|This book teaches OCaml programming with special emphasis on scientific applications.
+    }
+  ; { title = {js|OCaml for Scientists|js}
+    ; slug = {js|ocaml-for-scientists|js}
+    ; description =
+        {js|This book teaches OCaml programming with special emphasis on scientific applications.
 |js}
-  ; authors = 
- [{js|Jon D. Harrop|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2005|js}
-  ; cover = Some {js|/books/harrop-book.gif|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://www.ffconsultancy.com/products/ocaml_for_scientists/index.html|js}
-      };
-  
-      { description = {js|Ordering Information|js}
-      ; uri = {js|https://www.ffconsultancy.com/products/ocaml_for_scientists/index.html|js}
-      }]
-  ; body_md = {js|This book teaches OCaml programming with special emphasis on scientific
+    ; authors = [ {js|Jon D. Harrop|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2005|js}
+    ; cover = Some {js|/books/harrop-book.gif|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri =
+              {js|https://www.ffconsultancy.com/products/ocaml_for_scientists/index.html|js}
+          }
+        ; { description = {js|Ordering Information|js}
+          ; uri =
+              {js|https://www.ffconsultancy.com/products/ocaml_for_scientists/index.html|js}
+          }
+        ]
+    ; body_md =
+        {js|This book teaches OCaml programming with special emphasis on scientific
 applications. Many examples are given, covering everything from simple
 numerical analysis to sophisticated real-time 3D visualisation using
 OpenGL. This book contains over 800 color syntax-highlighted source code
 examples and dozens of diagrams that elucidate the power of functional
 programming to explain how lightning-fast and yet remarkably-simple
 programs can be constructed in the OCaml programming language.|js}
-  ; body_html = {js|<p>This book teaches OCaml programming with special emphasis on scientific
+    ; body_html =
+        {js|<p>This book teaches OCaml programming with special emphasis on scientific
 applications. Many examples are given, covering everything from simple
 numerical analysis to sophisticated real-time 3D visualisation using
 OpenGL. This book contains over 800 color syntax-highlighted source code
@@ -594,28 +623,27 @@ examples and dozens of diagrams that elucidate the power of functional
 programming to explain how lightning-fast and yet remarkably-simple
 programs can be constructed in the OCaml programming language.</p>
 |js}
-  };
- 
-  { title = {js|OCaml from the very Beginning|js}
-  ; slug = {js|ocaml-from-the-very-beginning|js}
-  ; description = {js|In "OCaml from the Very Beginning" John Whitington takes a no-prerequisites approach to teaching a modern general-purpose programming language.
+    }
+  ; { title = {js|OCaml from the very Beginning|js}
+    ; slug = {js|ocaml-from-the-very-beginning|js}
+    ; description =
+        {js|In "OCaml from the Very Beginning" John Whitington takes a no-prerequisites approach to teaching a modern general-purpose programming language.
 |js}
-  ; authors = 
- [{js|John Whitington|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2013-06-07|js}
-  ; cover = Some {js|/books/OCaml_from_beginning.png|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://ocaml-book.com/|js}
-      };
-  
-      { description = {js|Amazon|js}
-      ; uri = {js|https://www.amazon.com/gp/product/0957671105|js}
-      }]
-  ; body_md = {js|In "OCaml from the Very Beginning" John Whitington takes a
+    ; authors = [ {js|John Whitington|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2013-06-07|js}
+    ; cover = Some {js|/books/OCaml_from_beginning.png|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri = {js|https://ocaml-book.com/|js}
+          }
+        ; { description = {js|Amazon|js}
+          ; uri = {js|https://www.amazon.com/gp/product/0957671105|js}
+          }
+        ]
+    ; body_md =
+        {js|In "OCaml from the Very Beginning" John Whitington takes a
 no-prerequisites approach to teaching a modern general-purpose
 programming language. Each small, self-contained chapter introduces a
 new topic, building until the reader can write quite substantial
@@ -623,7 +651,8 @@ programs. There are plenty of questions and, crucially, worked answers
 and hints.
 
 "OCaml from the Very Beginning" will appeal both to new programmers, and experienced programmers eager to explore functional languages such as OCaml. It is suitable both for formal use within an undergraduate or graduate curriculum, and for the interested amateur.|js}
-  ; body_html = {js|<p>In &quot;OCaml from the Very Beginning&quot; John Whitington takes a
+    ; body_html =
+        {js|<p>In &quot;OCaml from the Very Beginning&quot; John Whitington takes a
 no-prerequisites approach to teaching a modern general-purpose
 programming language. Each small, self-contained chapter introduces a
 new topic, building until the reader can write quite substantial
@@ -631,35 +660,35 @@ programs. There are plenty of questions and, crucially, worked answers
 and hints.</p>
 <p>&quot;OCaml from the Very Beginning&quot; will appeal both to new programmers, and experienced programmers eager to explore functional languages such as OCaml. It is suitable both for formal use within an undergraduate or graduate curriculum, and for the interested amateur.</p>
 |js}
-  };
- 
-  { title = {js|OCaml: Programação Funcional na Prática|js}
-  ; slug = {js|ocaml-programao-funcional-na-prtica|js}
-  ; description = {js|This book is an introduction to functional programming through OCaml, with a pragmatic focus. The goal is to enable the reader to write real programs in OCaml and understand most of the open source code written in the language.
+    }
+  ; { title = {js|OCaml: Programação Funcional na Prática|js}
+    ; slug = {js|ocaml-programao-funcional-na-prtica|js}
+    ; description =
+        {js|This book is an introduction to functional programming through OCaml, with a pragmatic focus. The goal is to enable the reader to write real programs in OCaml and understand most of the open source code written in the language.
 |js}
-  ; authors = 
- [{js|Andrei de Araújo Formiga|js}]
-  ; language = {js|portugese|js}
-  ; published = Some {js|2015|js}
-  ; cover = Some {js|/books/opfp.png|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book site|js}
-      ; uri = {js|https://andreiformiga.com/livro/ocaml/|js}
-      };
-  
-      { description = {js|Order online from Casa do Código|js}
-      ; uri = {js|https://www.casadocodigo.com.br/products/livro-ocaml|js}
-      }]
-  ; body_md = {js|This book is an introduction to functional programming through OCaml, with a pragmatic
+    ; authors = [ {js|Andrei de Araújo Formiga|js} ]
+    ; language = {js|portugese|js}
+    ; published = Some {js|2015|js}
+    ; cover = Some {js|/books/opfp.png|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book site|js}
+          ; uri = {js|https://andreiformiga.com/livro/ocaml/|js}
+          }
+        ; { description = {js|Order online from Casa do Código|js}
+          ; uri = {js|https://www.casadocodigo.com.br/products/livro-ocaml|js}
+          }
+        ]
+    ; body_md =
+        {js|This book is an introduction to functional programming through OCaml, with a pragmatic
 focus. The goal is to enable the reader to write real programs in OCaml and understand
 most of the open source code written in the language. It includes many code examples
 illustrating the topics and a few larger projects written in OCaml that showcase the
 integration of many language features. These larger
 programs include a set of interpreter, compiler and stack machine for a simple
 language, and a decision tree learning program for data analysis.|js}
-  ; body_html = {js|<p>This book is an introduction to functional programming through OCaml, with a pragmatic
+    ; body_html =
+        {js|<p>This book is an introduction to functional programming through OCaml, with a pragmatic
 focus. The goal is to enable the reader to write real programs in OCaml and understand
 most of the open source code written in the language. It includes many code examples
 illustrating the topics and a few larger projects written in OCaml that showcase the
@@ -667,73 +696,79 @@ integration of many language features. These larger
 programs include a set of interpreter, compiler and stack machine for a simple
 language, and a decision tree learning program for data analysis.</p>
 |js}
-  };
- 
-  { title = {js|The OCaml System: Documentation and User's Manual|js}
-  ; slug = {js|the-ocaml-system-documentation-and-users-manual|js}
-  ; description = {js|The official User's Manual for OCaml serving as a complete reference guide|js}
-  ; authors = 
- [{js|Damien Doligez|js}; {js|Alain Frisch|js}; {js|Jacques Garrigue|js};
-  {js|Didier Rémy|js}; {js|Jérôme Vouillon|js}]
-  ; language = {js|english|js}
-  ; published = None
-  ; cover = Some {js|/books/colour-icon-170x148.png|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Online|js}
-      ; uri = {js|https://ocaml.org/releases/latest/manual.html|js}
-      }]
-  ; body_md = {js|This the official User's Manual. It serves as a complete reference guide
+    }
+  ; { title = {js|The OCaml System: Documentation and User's Manual|js}
+    ; slug = {js|the-ocaml-system-documentation-and-users-manual|js}
+    ; description =
+        {js|The official User's Manual for OCaml serving as a complete reference guide|js}
+    ; authors =
+        [ {js|Damien Doligez|js}
+        ; {js|Alain Frisch|js}
+        ; {js|Jacques Garrigue|js}
+        ; {js|Didier Rémy|js}
+        ; {js|Jérôme Vouillon|js}
+        ]
+    ; language = {js|english|js}
+    ; published = None
+    ; cover = Some {js|/books/colour-icon-170x148.png|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Online|js}
+          ; uri = {js|https://ocaml.org/releases/latest/manual.html|js}
+          }
+        ]
+    ; body_md =
+        {js|This the official User's Manual. It serves as a complete reference guide
 to OCaml. Updated for each version of OCaml, it contains the description
 of the language, of its extensions, and the documentation of the tools
 and libraries included in the official distribution.|js}
-  ; body_html = {js|<p>This the official User's Manual. It serves as a complete reference guide
+    ; body_html =
+        {js|<p>This the official User's Manual. It serves as a complete reference guide
 to OCaml. Updated for each version of OCaml, it contains the description
 of the language, of its extensions, and the documentation of the tools
 and libraries included in the official distribution.</p>
 |js}
-  };
- 
-  { title = {js|Option Informatique MP/MP|js}
-  ; slug = {js|option-informatique-mpmp|js}
-  ; description = {js|This books is a follow-up to the previous one and is intended for second year students in “classes préparatoires”. It deals with trees, algebraic expressions, automata and languages, and OCaml streams. The book contains more than 200 OCaml programs.
+    }
+  ; { title = {js|Option Informatique MP/MP|js}
+    ; slug = {js|option-informatique-mpmp|js}
+    ; description =
+        {js|This books is a follow-up to the previous one and is intended for second year students in “classes préparatoires”. It deals with trees, algebraic expressions, automata and languages, and OCaml streams. The book contains more than 200 OCaml programs.
 |js}
-  ; authors = 
- [{js|Denis Monasse|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1997|js}
-  ; cover = Some {js|/books/monasse-2.jpg|js}
-  ; isbn = Some {js|2-7117-8839-3|js}
-  ; links = 
- [
-      { description = {js|Order at Amazon.fr|js}
-      ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2711788393|js}
-      }]
-  ; body_md = {js|This books is a follow-up to the previous one and is intended for second
+    ; authors = [ {js|Denis Monasse|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1997|js}
+    ; cover = Some {js|/books/monasse-2.jpg|js}
+    ; isbn = Some {js|2-7117-8839-3|js}
+    ; links =
+        [ { description = {js|Order at Amazon.fr|js}
+          ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2711788393|js}
+          }
+        ]
+    ; body_md =
+        {js|This books is a follow-up to the previous one and is intended for second
 year students in “classes préparatoires”. It deals with trees, algebraic
 expressions, automata and languages, and OCaml streams. The book
 contains more than 200 OCaml programs.|js}
-  ; body_html = {js|<p>This books is a follow-up to the previous one and is intended for second
+    ; body_html =
+        {js|<p>This books is a follow-up to the previous one and is intended for second
 year students in “classes préparatoires”. It deals with trees, algebraic
 expressions, automata and languages, and OCaml streams. The book
 contains more than 200 OCaml programs.</p>
 |js}
-  };
- 
-  { title = {js|Option Informatique MPSI|js}
-  ; slug = {js|option-informatique-mpsi|js}
-  ; description = {js|This is a computer science course for the first year of “classes préparatoires”. The course begins with an introductory lesson on algorithms and a description of the OCaml language.
+    }
+  ; { title = {js|Option Informatique MPSI|js}
+    ; slug = {js|option-informatique-mpsi|js}
+    ; description =
+        {js|This is a computer science course for the first year of “classes préparatoires”. The course begins with an introductory lesson on algorithms and a description of the OCaml language.
 |js}
-  ; authors = 
- [{js|Denis Monasse|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1996|js}
-  ; cover = Some {js|/books/monasse-1.gif|js}
-  ; isbn = Some {js|2-7117-8831-8|js}
-  ; links = 
- []
-  ; body_md = {js|This is a computer science course for the first year of “classes
+    ; authors = [ {js|Denis Monasse|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1996|js}
+    ; cover = Some {js|/books/monasse-1.gif|js}
+    ; isbn = Some {js|2-7117-8831-8|js}
+    ; links = []
+    ; body_md =
+        {js|This is a computer science course for the first year of “classes
 préparatoires”. The course begins with an introductory lesson on
 algorithms and a description of the OCaml language. Then, several
 fundamental algorithms are described and illustrated using OCaml
@@ -742,7 +777,8 @@ mathematical objects are related to data structures in the programming
 language. This book is suitable for students with some mathematical
 background, and for everyone who wants to learn the bases of computer
 science.|js}
-  ; body_html = {js|<p>This is a computer science course for the first year of “classes
+    ; body_html =
+        {js|<p>This is a computer science course for the first year of “classes
 préparatoires”. The course begins with an introductory lesson on
 algorithms and a description of the OCaml language. Then, several
 fundamental algorithms are described and illustrated using OCaml
@@ -752,50 +788,49 @@ language. This book is suitable for students with some mathematical
 background, and for everyone who wants to learn the bases of computer
 science.</p>
 |js}
-  };
- 
-  { title = {js|Programmation de droite à gauche et vice-versa|js}
-  ; slug = {js|programmation-de-droite--gauche-et-vice-versa|js}
-  ; description = {js|Programming with OCaml
+    }
+  ; { title = {js|Programmation de droite à gauche et vice-versa|js}
+    ; slug = {js|programmation-de-droite--gauche-et-vice-versa|js}
+    ; description = {js|Programming with OCaml
 |js}
-  ; authors = 
- [{js|Pascal Manoury|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2005|js}
-  ; cover = Some {js|/books/manoury.png|js}
-  ; isbn = Some {js|978-2-916466-05-7|js}
-  ; links = 
- [
-      { description = {js|Order Online from Paracamplus|js}
-      ; uri = {js|https://paracamplus.com|js}
-      }]
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { title = {js|Programmation en Caml|js}
-  ; slug = {js|programmation-en-caml|js}
-  ; description = {js|This book is intended for beginners, who will learn basic programming notions. The first part of the book is a programming course that initiates the reader to the OCaml language.
+    ; authors = [ {js|Pascal Manoury|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2005|js}
+    ; cover = Some {js|/books/manoury.png|js}
+    ; isbn = Some {js|978-2-916466-05-7|js}
+    ; links =
+        [ { description = {js|Order Online from Paracamplus|js}
+          ; uri = {js|https://paracamplus.com|js}
+          }
+        ]
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { title = {js|Programmation en Caml|js}
+    ; slug = {js|programmation-en-caml|js}
+    ; description =
+        {js|This book is intended for beginners, who will learn basic programming notions. The first part of the book is a programming course that initiates the reader to the OCaml language.
 |js}
-  ; authors = 
- [{js|Jacques Rouablé|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|1997|js}
-  ; cover = Some {js|/books/rouable.jpg|js}
-  ; isbn = Some {js|2-212-08944-9|js}
-  ; links = 
- [
-      { description = {js|Order at Amazon.fr|js}
-      ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2212089449|js}
-      }]
-  ; body_md = {js|This book is intended for beginners, who will learn basic programming
+    ; authors = [ {js|Jacques Rouablé|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|1997|js}
+    ; cover = Some {js|/books/rouable.jpg|js}
+    ; isbn = Some {js|2-212-08944-9|js}
+    ; links =
+        [ { description = {js|Order at Amazon.fr|js}
+          ; uri = {js|https://www.amazon.fr/exec/obidos/ASIN/2212089449|js}
+          }
+        ]
+    ; body_md =
+        {js|This book is intended for beginners, who will learn basic programming
 notions. The first part of the book is a programming course that
 initiates the reader to the OCaml language. Important notions are
 presented from a practical point of view, and the implementation of some
 of these is analyzed and sketched. The second part, the “OCaml
 workshop”, is a practical application of these notions to other domains
 connected to computer science, logic, automata and grammars.|js}
-  ; body_html = {js|<p>This book is intended for beginners, who will learn basic programming
+    ; body_html =
+        {js|<p>This book is intended for beginners, who will learn basic programming
 notions. The first part of the book is a programming course that
 initiates the reader to the OCaml language. Important notions are
 presented from a practical point of view, and the implementation of some
@@ -803,75 +838,76 @@ of these is analyzed and sketched. The second part, the “OCaml
 workshop”, is a practical application of these notions to other domains
 connected to computer science, logic, automata and grammars.</p>
 |js}
-  };
- 
-  { title = {js|Programmation fonctionnelle, générique et objet: une introduction avec le langage OCaml|js}
-  ; slug = {js|programmation-fonctionnelle-gnrique-et-objet-une-introduction-avec-le-langage-ocaml|js}
-  ; description = {js|Programming with OCaml
+    }
+  ; { title =
+        {js|Programmation fonctionnelle, générique et objet: une introduction avec le langage OCaml|js}
+    ; slug =
+        {js|programmation-fonctionnelle-gnrique-et-objet-une-introduction-avec-le-langage-ocaml|js}
+    ; description = {js|Programming with OCaml
 |js}
-  ; authors = 
- [{js|Philippe Narbel|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2005|js}
-  ; cover = Some {js|/books/narbel.jpg|js}
-  ; isbn = Some {js|2-7117-4843-X|js}
-  ; links = 
- []
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { title = {js|Programmazione funzionale, una semplice introduzione|js}
-  ; slug = {js|programmazione-funzionale-una-semplice-introduzione|js}
-  ; description = {js|Functional programming introduction with OCaml
+    ; authors = [ {js|Philippe Narbel|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2005|js}
+    ; cover = Some {js|/books/narbel.jpg|js}
+    ; isbn = Some {js|2-7117-4843-X|js}
+    ; links = []
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { title = {js|Programmazione funzionale, una semplice introduzione|js}
+    ; slug = {js|programmazione-funzionale-una-semplice-introduzione|js}
+    ; description = {js|Functional programming introduction with OCaml
 |js}
-  ; authors = 
- [{js|Massimo Maria Ghisalberti|js}]
-  ; language = {js|italian|js}
-  ; published = Some {js|2015|js}
-  ; cover = None
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Emacs Org source|js}
-      ; uri = {js|https://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.org|js}
-      };
-  
-      { description = {js|HTML|js}
-      ; uri = {js|https://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.html|js}
-      };
-  
-      { description = {js|PDF|js}
-      ; uri = {js|https://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.pdf|js}
-      }]
-  ; body_md = {js||js}
-  ; body_html = {js||js}
-  };
- 
-  { title = {js|Real World OCaml|js}
-  ; slug = {js|real-world-ocaml|js}
-  ; description = {js|Learn how to solve day-to-day problems in data processing, numerical computation, system scripting, and database-driven web applications with the OCaml multi-paradigm programming language.
+    ; authors = [ {js|Massimo Maria Ghisalberti|js} ]
+    ; language = {js|italian|js}
+    ; published = Some {js|2015|js}
+    ; cover = None
+    ; isbn = None
+    ; links =
+        [ { description = {js|Emacs Org source|js}
+          ; uri =
+              {js|https://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.org|js}
+          }
+        ; { description = {js|HTML|js}
+          ; uri =
+              {js|https://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.html|js}
+          }
+        ; { description = {js|PDF|js}
+          ; uri =
+              {js|https://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.pdf|js}
+          }
+        ]
+    ; body_md = {js||js}
+    ; body_html = {js||js}
+    }
+  ; { title = {js|Real World OCaml|js}
+    ; slug = {js|real-world-ocaml|js}
+    ; description =
+        {js|Learn how to solve day-to-day problems in data processing, numerical computation, system scripting, and database-driven web applications with the OCaml multi-paradigm programming language.
 |js}
-  ; authors = 
- [{js|Jason Hickey|js}; {js|Anil Madhavapeddy|js}; {js|Yaron Minsky|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2013-11-25|js}
-  ; cover = Some {js|/books/real-world-ocaml.jpg|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://dev.realworldocaml.org/|js}
-      };
-  
-      { description = {js|O'Reilly|js}
-      ; uri = {js|https://shop.oreilly.com/product/0636920024743.do|js}
-      };
-  
-      { description = {js|Amazon|js}
-      ; uri = {js|https://www.amazon.com/Real-World-OCaml-Functional-programming/dp/144932391X/ref=tmm_pap_title_0?ie=UTF8&qid=1385006524&sr=8-1|js}
-      }]
-  ; body_md = {js|Learn how to solve day-to-day problems in data processing, numerical
+    ; authors =
+        [ {js|Jason Hickey|js}
+        ; {js|Anil Madhavapeddy|js}
+        ; {js|Yaron Minsky|js}
+        ]
+    ; language = {js|english|js}
+    ; published = Some {js|2013-11-25|js}
+    ; cover = Some {js|/books/real-world-ocaml.jpg|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri = {js|https://dev.realworldocaml.org/|js}
+          }
+        ; { description = {js|O'Reilly|js}
+          ; uri = {js|https://shop.oreilly.com/product/0636920024743.do|js}
+          }
+        ; { description = {js|Amazon|js}
+          ; uri =
+              {js|https://www.amazon.com/Real-World-OCaml-Functional-programming/dp/144932391X/ref=tmm_pap_title_0?ie=UTF8&qid=1385006524&sr=8-1|js}
+          }
+        ]
+    ; body_md =
+        {js|Learn how to solve day-to-day problems in data processing, numerical
 computation, system scripting, and database-driven web applications with
 the OCaml multi-paradigm programming language. This hands-on book shows
 you how to take advantage of OCaml’s functional, imperative, and
@@ -883,7 +919,8 @@ environment, and move toward more advanced topics such as the module
 system, foreign-function interface, macro language, and the OCaml tools.
 Quickly learn how to put OCaml to work for writing succinct and
 readable code.|js}
-  ; body_html = {js|<p>Learn how to solve day-to-day problems in data processing, numerical
+    ; body_html =
+        {js|<p>Learn how to solve day-to-day problems in data processing, numerical
 computation, system scripting, and database-driven web applications with
 the OCaml multi-paradigm programming language. This hands-on book shows
 you how to take advantage of OCaml’s functional, imperative, and
@@ -895,24 +932,25 @@ system, foreign-function interface, macro language, and the OCaml tools.
 Quickly learn how to put OCaml to work for writing succinct and
 readable code.</p>
 |js}
-  };
- 
-  { title = {js|Seize problèmes d'informatique|js}
-  ; slug = {js|seize-problmes-dinformatique|js}
-  ; description = {js|This book offers sixteen problems in computer science, with detailed answers to all questions and complete solutions to algorithmic problems given as OCaml programs.
+    }
+  ; { title = {js|Seize problèmes d'informatique|js}
+    ; slug = {js|seize-problmes-dinformatique|js}
+    ; description =
+        {js|This book offers sixteen problems in computer science, with detailed answers to all questions and complete solutions to algorithmic problems given as OCaml programs.
 |js}
-  ; authors = 
- [{js|Bruno Petazzoni|js}]
-  ; language = {js|french|js}
-  ; published = Some {js|2001|js}
-  ; cover = Some {js|/books/petazzoni.jpg|js}
-  ; isbn = Some {js|3-540-67387-3|js}
-  ; links = 
- [
-      { description = {js|Springer's Catalog Page|js}
-      ; uri = {js|https://www.springeronline.com/sgw/cda/frontpage/0,10735,5-102-22-2042496-0,00.html|js}
-      }]
-  ; body_md = {js|This book offers sixteen problems in computer science, with detailed
+    ; authors = [ {js|Bruno Petazzoni|js} ]
+    ; language = {js|french|js}
+    ; published = Some {js|2001|js}
+    ; cover = Some {js|/books/petazzoni.jpg|js}
+    ; isbn = Some {js|3-540-67387-3|js}
+    ; links =
+        [ { description = {js|Springer's Catalog Page|js}
+          ; uri =
+              {js|https://www.springeronline.com/sgw/cda/frontpage/0,10735,5-102-22-2042496-0,00.html|js}
+          }
+        ]
+    ; body_md =
+        {js|This book offers sixteen problems in computer science, with detailed
 answers to all questions and complete solutions to algorithmic problems
 given as OCaml programs. It deals mainly with automata, finite or
 infinite words, formal language theory, and some classical algorithms
@@ -920,7 +958,8 @@ such as bin-packing. It is intended for students who attend the optional
 computer science curriculum of the “classes préparatoires MPSI/MP”. It
 should also be useful to all teachers and computer science students up
 to a masters degree.|js}
-  ; body_html = {js|<p>This book offers sixteen problems in computer science, with detailed
+    ; body_html =
+        {js|<p>This book offers sixteen problems in computer science, with detailed
 answers to all questions and complete solutions to algorithmic problems
 given as OCaml programs. It deals mainly with automata, finite or
 infinite words, formal language theory, and some classical algorithms
@@ -929,28 +968,27 @@ computer science curriculum of the “classes préparatoires MPSI/MP”. It
 should also be useful to all teachers and computer science students up
 to a masters degree.</p>
 |js}
-  };
- 
-  { title = {js|The Functional Approach to OCaml|js}
-  ; slug = {js|the-functional-approach-to-ocaml|js}
-  ; description = {js|Learning about functional programming using OCaml
+    }
+  ; { title = {js|The Functional Approach to OCaml|js}
+    ; slug = {js|the-functional-approach-to-ocaml|js}
+    ; description = {js|Learning about functional programming using OCaml
 |js}
-  ; authors = 
- [{js|Guy Cousineau|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|1998|js}
-  ; cover = Some {js|/books/cousineau-mauny-en.gif|js}
-  ; isbn = Some {js|0-521-57681-4|js}
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://pauillac.inria.fr/cousineau-mauny/main.html|js}
-      };
-  
-      { description = {js|Order at Amazon.com|js}
-      ; uri = {js|https://www.amazon.com/exec/obidos/ASIN/0521571839/qid%3D911812711/sr%3D1-22/102-8668961-8838559|js}
-      }]
-  ; body_md = {js|This book uses OCaml as a tool to introduce several important
+    ; authors = [ {js|Guy Cousineau|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|1998|js}
+    ; cover = Some {js|/books/cousineau-mauny-en.gif|js}
+    ; isbn = Some {js|0-521-57681-4|js}
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri = {js|https://pauillac.inria.fr/cousineau-mauny/main.html|js}
+          }
+        ; { description = {js|Order at Amazon.com|js}
+          ; uri =
+              {js|https://www.amazon.com/exec/obidos/ASIN/0521571839/qid%3D911812711/sr%3D1-22/102-8668961-8838559|js}
+          }
+        ]
+    ; body_md =
+        {js|This book uses OCaml as a tool to introduce several important
 programming concepts. It is divided in three parts. The first part is an
 introduction to OCaml, which presents the language itself, but also
 introduces evaluation by rewriting, evaluation strategies and proofs of
@@ -960,7 +998,8 @@ interest various types of readers or students. Finally, the third part
 is dedicated to implementation. It describes interpretation and
 compilation, with brief descriptions of memory management and type
 synthesis.|js}
-  ; body_html = {js|<p>This book uses OCaml as a tool to introduce several important
+    ; body_html =
+        {js|<p>This book uses OCaml as a tool to introduce several important
 programming concepts. It is divided in three parts. The first part is an
 introduction to OCaml, which presents the language itself, but also
 introduces evaluation by rewriting, evaluation strategies and proofs of
@@ -971,97 +1010,97 @@ is dedicated to implementation. It describes interpretation and
 compilation, with brief descriptions of memory management and type
 synthesis.</p>
 |js}
-  };
- 
-  { title = {js|Think OCaml: How to think like a Functional Programmer|js}
-  ; slug = {js|think-ocaml-how-to-think-like-a-functional-programmer|js}
-  ; description = {js|Introductory programming textbook based on the OCaml language
+    }
+  ; { title = {js|Think OCaml: How to think like a Functional Programmer|js}
+    ; slug = {js|think-ocaml-how-to-think-like-a-functional-programmer|js}
+    ; description =
+        {js|Introductory programming textbook based on the OCaml language
 |js}
-  ; authors = 
- [{js|Nicholas Monje|js}; {js|Allen Downey|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2008|js}
-  ; cover = Some {js|/books/thinkocaml_cover_web.png|js}
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Book Website|js}
-      ; uri = {js|https://greenteapress.com/thinkocaml/index.html|js}
-      };
-  
-      { description = {js|PDF|js}
-      ; uri = {js|https://greenteapress.com/thinkocaml/thinkocaml.pdf|js}
-      }]
-  ; body_md = {js|This book is a work in progress. It is an introductory programming
+    ; authors = [ {js|Nicholas Monje|js}; {js|Allen Downey|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2008|js}
+    ; cover = Some {js|/books/thinkocaml_cover_web.png|js}
+    ; isbn = None
+    ; links =
+        [ { description = {js|Book Website|js}
+          ; uri = {js|https://greenteapress.com/thinkocaml/index.html|js}
+          }
+        ; { description = {js|PDF|js}
+          ; uri = {js|https://greenteapress.com/thinkocaml/thinkocaml.pdf|js}
+          }
+        ]
+    ; body_md =
+        {js|This book is a work in progress. It is an introductory programming
 textbook based on the OCaml language. It is a modified version of
 Think Python by Allen Downey. It is intended for newcomers to
 programming and also those who know some programming but want to learn
 programming in the function-oriented paradigm, or those who simply
 want to learn OCaml.|js}
-  ; body_html = {js|<p>This book is a work in progress. It is an introductory programming
+    ; body_html =
+        {js|<p>This book is a work in progress. It is an introductory programming
 textbook based on the OCaml language. It is a modified version of
 Think Python by Allen Downey. It is intended for newcomers to
 programming and also those who know some programming but want to learn
 programming in the function-oriented paradigm, or those who simply
 want to learn OCaml.</p>
 |js}
-  };
- 
-  { title = {js|Unix System Programming in OCaml|js}
-  ; slug = {js|unix-system-programming-in-ocaml|js}
-  ; description = {js|Learn Unix system programming in OCaml
+    }
+  ; { title = {js|Unix System Programming in OCaml|js}
+    ; slug = {js|unix-system-programming-in-ocaml|js}
+    ; description = {js|Learn Unix system programming in OCaml
 |js}
-  ; authors = 
- [{js|Xavier Leroy|js}; {js|Didier Rémy|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2010-05-01|js}
-  ; cover = None
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Online|js}
-      ; uri = {js|https://ocaml.github.io/ocamlunix|js}
-      }]
-  ; body_md = {js|This is an excellent book on Unix system programming, with an emphasis
+    ; authors = [ {js|Xavier Leroy|js}; {js|Didier Rémy|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2010-05-01|js}
+    ; cover = None
+    ; isbn = None
+    ; links =
+        [ { description = {js|Online|js}
+          ; uri = {js|https://ocaml.github.io/ocamlunix|js}
+          }
+        ]
+    ; body_md =
+        {js|This is an excellent book on Unix system programming, with an emphasis
 on communications between processes. The main novelty of this work is
 the use of OCaml, instead of the C language that is customary in systems
 programming. This gives an unusual perspective on systems programming
 and on OCaml. It is assumed that the reader is familiar with OCaml and
 Unix shell commands.|js}
-  ; body_html = {js|<p>This is an excellent book on Unix system programming, with an emphasis
+    ; body_html =
+        {js|<p>This is an excellent book on Unix system programming, with an emphasis
 on communications between processes. The main novelty of this work is
 the use of OCaml, instead of the C language that is customary in systems
 programming. This gives an unusual perspective on systems programming
 and on OCaml. It is assumed that the reader is familiar with OCaml and
 Unix shell commands.</p>
 |js}
-  };
- 
-  { title = {js|Using, Understanding and Unraveling OCaml|js}
-  ; slug = {js|using-understanding-and-unraveling-ocaml|js}
-  ; description = {js|This book describes both the OCaml language and the theoretical grounds behind its powerful type system.
+    }
+  ; { title = {js|Using, Understanding and Unraveling OCaml|js}
+    ; slug = {js|using-understanding-and-unraveling-ocaml|js}
+    ; description =
+        {js|This book describes both the OCaml language and the theoretical grounds behind its powerful type system.
 |js}
-  ; authors = 
- [{js|Didier Rémy|js}]
-  ; language = {js|english|js}
-  ; published = Some {js|2002-09-20|js}
-  ; cover = None
-  ; isbn = None
-  ; links = 
- [
-      { description = {js|Online|js}
-      ; uri = {js|https://caml.inria.fr/pub/docs/u3-ocaml/|js}
-      };
-  
-      { description = {js|PDF|js}
-      ; uri = {js|https://caml.inria.fr/pub/docs/u3-ocaml/ocaml.pdf|js}
-      }]
-  ; body_md = {js|This book describes both the OCaml language and the theoretical grounds
+    ; authors = [ {js|Didier Rémy|js} ]
+    ; language = {js|english|js}
+    ; published = Some {js|2002-09-20|js}
+    ; cover = None
+    ; isbn = None
+    ; links =
+        [ { description = {js|Online|js}
+          ; uri = {js|https://caml.inria.fr/pub/docs/u3-ocaml/|js}
+          }
+        ; { description = {js|PDF|js}
+          ; uri = {js|https://caml.inria.fr/pub/docs/u3-ocaml/ocaml.pdf|js}
+          }
+        ]
+    ; body_md =
+        {js|This book describes both the OCaml language and the theoretical grounds
 behind its powerful type system. A good complement to other books on
 OCaml it is addressed to a wide audience of people interested in modern programming languages in general, ML-like languages in particular, or simply in OCaml, whether they are programmers or language designers, beginners or knowledgeable readers — little prerequisite is actually assumed.|js}
-  ; body_html = {js|<p>This book describes both the OCaml language and the theoretical grounds
+    ; body_html =
+        {js|<p>This book describes both the OCaml language and the theoretical grounds
 behind its powerful type system. A good complement to other books on
 OCaml it is addressed to a wide audience of people interested in modern programming languages in general, ML-like languages in particular, or simply in OCaml, whether they are programmers or language designers, beginners or knowledgeable readers — little prerequisite is actually assumed.</p>
 |js}
-  }]
-
+    }
+  ]

--- a/src/ocamlorg_data/event.ml
+++ b/src/ocamlorg_data/event.ml
@@ -1,4 +1,3 @@
-
 type t =
   { title : string
   ; slug : string
@@ -11,41 +10,38 @@ type t =
   ; location : string option
   }
 
-let all = 
-[
-  { title = {js|OCaml Users and Developers Workshop 2021|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2021|js}
-  ; description = {js|The OCaml Workshop 2021 as part of ICFP|js}
-  ; url = {js|https://icfp21.sigplan.org/home/ocaml-2021|js}
-  ; date = {js|2021-08-27T09:00:40.154Z|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; online = true
-  ; textual_location = None
-  ; location = None
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2020|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2020|js}
-  ; description = {js|The OCaml Workshop 2020 as part of ICFP|js}
-  ; url = {js|https://icfp20.sigplan.org/home/ocaml-2020|js}
-  ; date = {js|2020-08-20T09:00:42.358Z|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; online = true
-  ; textual_location = Some {js|Jersey City|js}
-  ; location = Some {js|{"type":"Point","coordinates":[-74.0739787,40.7262413]}|js}
-  };
- 
-  { title = {js|OCaml User and Developer Workshop 2019|js}
-  ; slug = {js|ocaml-user-and-developer-workshop-2019|js}
-  ; description = {js|The OCaml Workshop 2019 as part of ICFP|js}
-  ; url = {js|https://icfp19.sigplan.org/home/ocaml-2019#Call-for-Presentations|js}
-  ; date = {js|2019-08-23T00:00:00.000Z|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; online = false
-  ; textual_location = Some {js|Berlin|js}
-  ; location = Some {js|{"type":"Point","coordinates":[13.4163451,52.4861467]}|js}
-  }]
-
+let all =
+  [ { title = {js|OCaml Users and Developers Workshop 2021|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2021|js}
+    ; description = {js|The OCaml Workshop 2021 as part of ICFP|js}
+    ; url = {js|https://icfp21.sigplan.org/home/ocaml-2021|js}
+    ; date = {js|2021-08-27T09:00:40.154Z|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; online = true
+    ; textual_location = None
+    ; location = None
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2020|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2020|js}
+    ; description = {js|The OCaml Workshop 2020 as part of ICFP|js}
+    ; url = {js|https://icfp20.sigplan.org/home/ocaml-2020|js}
+    ; date = {js|2020-08-20T09:00:42.358Z|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; online = true
+    ; textual_location = Some {js|Jersey City|js}
+    ; location =
+        Some {js|{"type":"Point","coordinates":[-74.0739787,40.7262413]}|js}
+    }
+  ; { title = {js|OCaml User and Developer Workshop 2019|js}
+    ; slug = {js|ocaml-user-and-developer-workshop-2019|js}
+    ; description = {js|The OCaml Workshop 2019 as part of ICFP|js}
+    ; url =
+        {js|https://icfp19.sigplan.org/home/ocaml-2019#Call-for-Presentations|js}
+    ; date = {js|2019-08-23T00:00:00.000Z|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; online = false
+    ; textual_location = Some {js|Berlin|js}
+    ; location =
+        Some {js|{"type":"Point","coordinates":[13.4163451,52.4861467]}|js}
+    }
+  ]

--- a/src/ocamlorg_data/industrial_user.ml
+++ b/src/ocamlorg_data/industrial_user.ml
@@ -1,4 +1,3 @@
-
 type t =
   { name : string
   ; slug : string
@@ -10,597 +9,630 @@ type t =
   ; body_md : string
   ; body_html : string
   }
-  
-let all_en = 
-[
-  { name = {js|Aesthetic Integration|js}
-  ; slug = {js|aesthetic-integration|js}
-  ; description = {js|Aesthetic Integration (AI) is a financial technology startup based in the City of London
+
+let all_en =
+  [ { name = {js|Aesthetic Integration|js}
+    ; slug = {js|aesthetic-integration|js}
+    ; description =
+        {js|Aesthetic Integration (AI) is a financial technology startup based in the City of London
 |js}
-  ; image = Some {js|/users/aesthetic-integration.png|js}
-  ; site = {js|https://www.aestheticintegration.com|js}
-  ; locations = 
- [{js|United Kingdom|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/aesthetic-integration.png|js}
+    ; site = {js|https://www.aestheticintegration.com|js}
+    ; locations = [ {js|United Kingdom|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Aesthetic Integration (AI) is a financial technology startup based in the City of London. AI's patent-pending formal verification technology is revolutionising the safety, stability and transparency of global financial markets.
 |js}
-  ; body_html = {js|<p>Aesthetic Integration (AI) is a financial technology startup based in the City of London. AI's patent-pending formal verification technology is revolutionising the safety, stability and transparency of global financial markets.</p>
+    ; body_html =
+        {js|<p>Aesthetic Integration (AI) is a financial technology startup based in the City of London. AI's patent-pending formal verification technology is revolutionising the safety, stability and transparency of global financial markets.</p>
 |js}
-  };
- 
-  { name = {js|Ahrefs|js}
-  ; slug = {js|ahrefs|js}
-  ; description = {js|Ahrefs develops custom distributed petabyte-scale storage and runs an internet-wide crawler to collect the index of the whole Web
+    }
+  ; { name = {js|Ahrefs|js}
+    ; slug = {js|ahrefs|js}
+    ; description =
+        {js|Ahrefs develops custom distributed petabyte-scale storage and runs an internet-wide crawler to collect the index of the whole Web
 |js}
-  ; image = Some {js|/users/ahrefs.png|js}
-  ; site = {js|https://www.ahrefs.com|js}
-  ; locations = 
- [{js|Singapore|js}; {js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/ahrefs.png|js}
+    ; site = {js|https://www.ahrefs.com|js}
+    ; locations = [ {js|Singapore|js}; {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Ahrefs develops custom distributed petabyte-scale storage and runs an internet-wide crawler to collect the index of the whole Web. On top of that the company is building various analytical services for end-users. OCaml is the main language of the Ahrefs backend, which is currently processing up to 6 billion pages a day. Ahrefs is a multinational team with roots from Ukraine and offices in Singapore and San Francisco.
 |js}
-  ; body_html = {js|<p>Ahrefs develops custom distributed petabyte-scale storage and runs an internet-wide crawler to collect the index of the whole Web. On top of that the company is building various analytical services for end-users. OCaml is the main language of the Ahrefs backend, which is currently processing up to 6 billion pages a day. Ahrefs is a multinational team with roots from Ukraine and offices in Singapore and San Francisco.</p>
+    ; body_html =
+        {js|<p>Ahrefs develops custom distributed petabyte-scale storage and runs an internet-wide crawler to collect the index of the whole Web. On top of that the company is building various analytical services for end-users. OCaml is the main language of the Ahrefs backend, which is currently processing up to 6 billion pages a day. Ahrefs is a multinational team with roots from Ukraine and offices in Singapore and San Francisco.</p>
 |js}
-  };
- 
-  { name = {js|American Museum of Natural History|js}
-  ; slug = {js|american-museum-of-natural-history|js}
-  ; description = {js|The Computational Sciences Department at the AMNH has been using OCaml for almost a decade in their software package POY for phylogenetic inference
+    }
+  ; { name = {js|American Museum of Natural History|js}
+    ; slug = {js|american-museum-of-natural-history|js}
+    ; description =
+        {js|The Computational Sciences Department at the AMNH has been using OCaml for almost a decade in their software package POY for phylogenetic inference
 |js}
-  ; image = Some {js|/users/amnh.png|js}
-  ; site = {js|https://www.amnh.org/our-research/computational-sciences|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/amnh.png|js}
+    ; site = {js|https://www.amnh.org/our-research/computational-sciences|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 The Computational Sciences Department at the AMNH has been using OCaml for almost a decade in their software package [POY](https://github.com/amnh/poy5) for phylogenetic inference. See [AMNH's GitHub page](https://github.com/AMNH) for more projects.
 |js}
-  ; body_html = {js|<p>The Computational Sciences Department at the AMNH has been using OCaml for almost a decade in their software package <a href="https://github.com/amnh/poy5">POY</a> for phylogenetic inference. See <a href="https://github.com/AMNH">AMNH's GitHub page</a> for more projects.</p>
+    ; body_html =
+        {js|<p>The Computational Sciences Department at the AMNH has been using OCaml for almost a decade in their software package <a href="https://github.com/amnh/poy5">POY</a> for phylogenetic inference. See <a href="https://github.com/AMNH">AMNH's GitHub page</a> for more projects.</p>
 |js}
-  };
- 
-  { name = {js|ANSSI|js}
-  ; slug = {js|anssi|js}
-  ; description = {js|The ANSSI core missions are: to detect and react to cyber attacks, to prevent threats, to provide advice and support to governmental entities and operators of critical infrastructure, and to keep companies and the general public informed about information security threats
+    }
+  ; { name = {js|ANSSI|js}
+    ; slug = {js|anssi|js}
+    ; description =
+        {js|The ANSSI core missions are: to detect and react to cyber attacks, to prevent threats, to provide advice and support to governmental entities and operators of critical infrastructure, and to keep companies and the general public informed about information security threats
 |js}
-  ; image = Some {js|/users/anssi.png|js}
-  ; site = {js|https://www.ssi.gouv.fr/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/anssi.png|js}
+    ; site = {js|https://www.ssi.gouv.fr/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 The ANSSI core missions are: to detect and react to cyber attacks, to prevent threats, to provide advice and support to governmental entities and operators of critical infrastructure, and to keep companies and the general public informed about information security threats. See [ANSII's GitHub page](https://github.com/anssi-fr) for some of its OCaml software.
 |js}
-  ; body_html = {js|<p>The ANSSI core missions are: to detect and react to cyber attacks, to prevent threats, to provide advice and support to governmental entities and operators of critical infrastructure, and to keep companies and the general public informed about information security threats. See <a href="https://github.com/anssi-fr">ANSII's GitHub page</a> for some of its OCaml software.</p>
+    ; body_html =
+        {js|<p>The ANSSI core missions are: to detect and react to cyber attacks, to prevent threats, to provide advice and support to governmental entities and operators of critical infrastructure, and to keep companies and the general public informed about information security threats. See <a href="https://github.com/anssi-fr">ANSII's GitHub page</a> for some of its OCaml software.</p>
 |js}
-  };
- 
-  { name = {js|Arena|js}
-  ; slug = {js|arena|js}
-  ; description = {js|Arena helps organizations hire the right people.
+    }
+  ; { name = {js|Arena|js}
+    ; slug = {js|arena|js}
+    ; description = {js|Arena helps organizations hire the right people.
 |js}
-  ; image = Some {js|/users/arena.jpg|js}
-  ; site = {js|https://www.arena.io|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/arena.jpg|js}
+    ; site = {js|https://www.arena.io|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Arena helps organizations hire the right people. We do that by applying big data and predictive analytics to the hiring process. This results in less turnover for our clients and less discrimination for individuals. We use OCaml for all of our backend development.|js}
-  ; body_html = {js|<p>Arena helps organizations hire the right people. We do that by applying big data and predictive analytics to the hiring process. This results in less turnover for our clients and less discrimination for individuals. We use OCaml for all of our backend development.</p>
+    ; body_html =
+        {js|<p>Arena helps organizations hire the right people. We do that by applying big data and predictive analytics to the hiring process. This results in less turnover for our clients and less discrimination for individuals. We use OCaml for all of our backend development.</p>
 |js}
-  };
- 
-  { name = {js|Be Sport|js}
-  ; slug = {js|be-sport|js}
-  ; description = {js|Be Sport's mission is to enhance the value that sport brings to our lives with appropriate use of digital and social media innovations
+    }
+  ; { name = {js|Be Sport|js}
+    ; slug = {js|be-sport|js}
+    ; description =
+        {js|Be Sport's mission is to enhance the value that sport brings to our lives with appropriate use of digital and social media innovations
 |js}
-  ; image = Some {js|/users/besport.png|js}
-  ; site = {js|https://besport.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/besport.png|js}
+    ; site = {js|https://besport.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Be Sport's mission is to enhance the value that sport brings to our lives with appropriate use of digital and social media innovations.
            
 Be Sport is a 100% [OCaml](//ocaml.org/) and [OCsigen](https://ocsigen.org) project, leveraged as the only building blocks to develop the platform. 
 |js}
-  ; body_html = {js|<p>Be Sport's mission is to enhance the value that sport brings to our lives with appropriate use of digital and social media innovations.</p>
+    ; body_html =
+        {js|<p>Be Sport's mission is to enhance the value that sport brings to our lives with appropriate use of digital and social media innovations.</p>
 <p>Be Sport is a 100% <a href="//ocaml.org/">OCaml</a> and <a href="https://ocsigen.org">OCsigen</a> project, leveraged as the only building blocks to develop the platform.</p>
 |js}
-  };
- 
-  { name = {js|Bloomberg L.P.|js}
-  ; slug = {js|bloomberg-lp|js}
-  ; description = {js|Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas
+    }
+  ; { name = {js|Bloomberg L.P.|js}
+    ; slug = {js|bloomberg-lp|js}
+    ; description =
+        {js|Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas
 |js}
-  ; image = Some {js|/users/bloomberg.jpg|js}
-  ; site = {js|https://www.bloomberg.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/bloomberg.jpg|js}
+    ; site = {js|https://www.bloomberg.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas. Bloomberg employs OCaml in an advanced financial derivatives risk management application delivered through its Bloomberg Professional service.|js}
-  ; body_html = {js|<p>Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas. Bloomberg employs OCaml in an advanced financial derivatives risk management application delivered through its Bloomberg Professional service.</p>
+    ; body_html =
+        {js|<p>Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas. Bloomberg employs OCaml in an advanced financial derivatives risk management application delivered through its Bloomberg Professional service.</p>
 |js}
-  };
- 
-  { name = {js|CACAOWEB|js}
-  ; slug = {js|cacaoweb|js}
-  ; description = {js|Cacaoweb is developing an application platform of a new kind. It runs on top of our peer-to-peer network, which happens to be one of the largest in the world
+    }
+  ; { name = {js|CACAOWEB|js}
+    ; slug = {js|cacaoweb|js}
+    ; description =
+        {js|Cacaoweb is developing an application platform of a new kind. It runs on top of our peer-to-peer network, which happens to be one of the largest in the world
 |js}
-  ; image = Some {js|/users/cacaoweb.png|js}
-  ; site = {js|https://cacaoweb.org/|js}
-  ; locations = 
- [{js|United Kingdom|js}; {js|Hong Kong|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/cacaoweb.png|js}
+    ; site = {js|https://cacaoweb.org/|js}
+    ; locations = [ {js|United Kingdom|js}; {js|Hong Kong|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Cacaoweb is developing an application platform of a new kind. It runs on top of our peer-to-peer network, which happens to be one of the largest in the world. The capabilities of the platform are diverse and range from multimedia streaming to social communication, offline storage or data synchronisation. We design and implement massively distributed data stores, programming languages, runtime systems and parallel computation frameworks.
 |js}
-  ; body_html = {js|<p>Cacaoweb is developing an application platform of a new kind. It runs on top of our peer-to-peer network, which happens to be one of the largest in the world. The capabilities of the platform are diverse and range from multimedia streaming to social communication, offline storage or data synchronisation. We design and implement massively distributed data stores, programming languages, runtime systems and parallel computation frameworks.</p>
+    ; body_html =
+        {js|<p>Cacaoweb is developing an application platform of a new kind. It runs on top of our peer-to-peer network, which happens to be one of the largest in the world. The capabilities of the platform are diverse and range from multimedia streaming to social communication, offline storage or data synchronisation. We design and implement massively distributed data stores, programming languages, runtime systems and parallel computation frameworks.</p>
 |js}
-  };
- 
-  { name = {js|CEA|js}
-  ; slug = {js|cea|js}
-  ; description = {js|CEA is a French state company, member of the OCaml Consortium.
+    }
+  ; { name = {js|CEA|js}
+    ; slug = {js|cea|js}
+    ; description =
+        {js|CEA is a French state company, member of the OCaml Consortium.
 |js}
-  ; image = Some {js|/users/cea.png|js}
-  ; site = {js|https://cea.fr/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/cea.png|js}
+    ; site = {js|https://cea.fr/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 CEA is a French state company, member of the OCaml Consortium. It uses OCaml mainly to develop a platform dedicated to source-code analysis of C software, called [Frama-C](https://frama-c.com).
 |js}
-  ; body_html = {js|<p>CEA is a French state company, member of the OCaml Consortium. It uses OCaml mainly to develop a platform dedicated to source-code analysis of C software, called <a href="https://frama-c.com">Frama-C</a>.</p>
+    ; body_html =
+        {js|<p>CEA is a French state company, member of the OCaml Consortium. It uses OCaml mainly to develop a platform dedicated to source-code analysis of C software, called <a href="https://frama-c.com">Frama-C</a>.</p>
 |js}
-  };
- 
-  { name = {js|Citrix|js}
-  ; slug = {js|citrix|js}
-  ; description = {js|Citrix uses OCaml in XenServer, a world-class server virtualization system.
+    }
+  ; { name = {js|Citrix|js}
+    ; slug = {js|citrix|js}
+    ; description =
+        {js|Citrix uses OCaml in XenServer, a world-class server virtualization system.
 |js}
-  ; image = Some {js|/users/citrix.png|js}
-  ; site = {js|https://www.citrix.com|js}
-  ; locations = 
- [{js|United Kingdom|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/citrix.png|js}
+    ; site = {js|https://www.citrix.com|js}
+    ; locations = [ {js|United Kingdom|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Citrix uses OCaml in XenServer, a world-class server virtualization system. Most components of XenServer are released as open source. The open-source XenServer toolstack components implemented in OCaml are bundled in the [XS-opam](https://github.com/xapi-project/xs-opam) repository on GitHub.
 |js}
-  ; body_html = {js|<p>Citrix uses OCaml in XenServer, a world-class server virtualization system. Most components of XenServer are released as open source. The open-source XenServer toolstack components implemented in OCaml are bundled in the <a href="https://github.com/xapi-project/xs-opam">XS-opam</a> repository on GitHub.</p>
+    ; body_html =
+        {js|<p>Citrix uses OCaml in XenServer, a world-class server virtualization system. Most components of XenServer are released as open source. The open-source XenServer toolstack components implemented in OCaml are bundled in the <a href="https://github.com/xapi-project/xs-opam">XS-opam</a> repository on GitHub.</p>
 |js}
-  };
- 
-  { name = {js|Coherent Graphics Ltd|js}
-  ; slug = {js|coherent-graphics-ltd|js}
-  ; description = {js|Coherent Graphics is a developer of both server tools and desktop software for the processing of PDF documents
+    }
+  ; { name = {js|Coherent Graphics Ltd|js}
+    ; slug = {js|coherent-graphics-ltd|js}
+    ; description =
+        {js|Coherent Graphics is a developer of both server tools and desktop software for the processing of PDF documents
 |js}
-  ; image = Some {js|/users/coherent.png|js}
-  ; site = {js|https://www.coherentpdf.com/|js}
-  ; locations = 
- [{js|United Kingdom|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/coherent.png|js}
+    ; site = {js|https://www.coherentpdf.com/|js}
+    ; locations = [ {js|United Kingdom|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Coherent Graphics is a developer of both server tools and desktop software for the processing of PDF documents. We use OCaml as a general-purpose high level language, chosen for its expressiveness and speed.
 |js}
-  ; body_html = {js|<p>Coherent Graphics is a developer of both server tools and desktop software for the processing of PDF documents. We use OCaml as a general-purpose high level language, chosen for its expressiveness and speed.</p>
+    ; body_html =
+        {js|<p>Coherent Graphics is a developer of both server tools and desktop software for the processing of PDF documents. We use OCaml as a general-purpose high level language, chosen for its expressiveness and speed.</p>
 |js}
-  };
- 
-  { name = {js|Cryptosense|js}
-  ; slug = {js|cryptosense|js}
-  ; description = {js|Cryptosense creates security analysis software with a particular focus on cryptographic systems
+    }
+  ; { name = {js|Cryptosense|js}
+    ; slug = {js|cryptosense|js}
+    ; description =
+        {js|Cryptosense creates security analysis software with a particular focus on cryptographic systems
 |js}
-  ; image = Some {js|/users/cryptosense.png|js}
-  ; site = {js|https://www.cryptosense.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/cryptosense.png|js}
+    ; site = {js|https://www.cryptosense.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Based in Paris, France, Cryptosense creates security analysis software with a particular focus on cryptographic systems. A spin-off of the institute for computer science research (Inria), Cryptosense’s founders combine more than 40 years experience in research and industry. Cryptosense provides its solutions to an international clientèle in particular in the financial, industrial and government sectors.
 |js}
-  ; body_html = {js|<p>Based in Paris, France, Cryptosense creates security analysis software with a particular focus on cryptographic systems. A spin-off of the institute for computer science research (Inria), Cryptosense’s founders combine more than 40 years experience in research and industry. Cryptosense provides its solutions to an international clientèle in particular in the financial, industrial and government sectors.</p>
+    ; body_html =
+        {js|<p>Based in Paris, France, Cryptosense creates security analysis software with a particular focus on cryptographic systems. A spin-off of the institute for computer science research (Inria), Cryptosense’s founders combine more than 40 years experience in research and industry. Cryptosense provides its solutions to an international clientèle in particular in the financial, industrial and government sectors.</p>
 |js}
-  };
- 
-  { name = {js|Dassault Systèmes|js}
-  ; slug = {js|dassault-systmes|js}
-  ; description = {js|Dassault Systèmes, the 3DEXPERIENCE Company, provides businesses and people with virtual universes to imagine sustainable innovations.
+    }
+  ; { name = {js|Dassault Systèmes|js}
+    ; slug = {js|dassault-systmes|js}
+    ; description =
+        {js|Dassault Systèmes, the 3DEXPERIENCE Company, provides businesses and people with virtual universes to imagine sustainable innovations.
 |js}
-  ; image = Some {js|/users/dassault.png|js}
-  ; site = {js|https://www.3ds.com/fr/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/dassault.png|js}
+    ; site = {js|https://www.3ds.com/fr/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Dassault Systèmes, the 3DEXPERIENCE Company, provides businesses and people with virtual universes to imagine sustainable innovations.
 |js}
-  ; body_html = {js|<p>Dassault Systèmes, the 3DEXPERIENCE Company, provides businesses and people with virtual universes to imagine sustainable innovations.</p>
+    ; body_html =
+        {js|<p>Dassault Systèmes, the 3DEXPERIENCE Company, provides businesses and people with virtual universes to imagine sustainable innovations.</p>
 |js}
-  };
- 
-  { name = {js|Dernier Cri|js}
-  ; slug = {js|dernier-cri|js}
-  ; description = {js|Dernier Cri is a French company based in Lille and Paris using functional programming to develop web and mobile applications.
+    }
+  ; { name = {js|Dernier Cri|js}
+    ; slug = {js|dernier-cri|js}
+    ; description =
+        {js|Dernier Cri is a French company based in Lille and Paris using functional programming to develop web and mobile applications.
 |js}
-  ; image = Some {js|/users/derniercri.png|js}
-  ; site = {js|https://derniercri.io|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/derniercri.png|js}
+    ; site = {js|https://derniercri.io|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Dernier Cri is a French company based in Lille and Paris using functional programming to develop web and mobile applications. OCaml is principally used to develop internal tools.
 |js}
-  ; body_html = {js|<p>Dernier Cri is a French company based in Lille and Paris using functional programming to develop web and mobile applications. OCaml is principally used to develop internal tools.</p>
+    ; body_html =
+        {js|<p>Dernier Cri is a French company based in Lille and Paris using functional programming to develop web and mobile applications. OCaml is principally used to develop internal tools.</p>
 |js}
-  };
- 
-  { name = {js|Digirati dba Hostnet|js}
-  ; slug = {js|digirati-dba-hostnet|js}
-  ; description = {js|Digirati dba Hostnet is a web hosting company.
+    }
+  ; { name = {js|Digirati dba Hostnet|js}
+    ; slug = {js|digirati-dba-hostnet|js}
+    ; description = {js|Digirati dba Hostnet is a web hosting company.
 |js}
-  ; image = Some {js|/users/hostnet.gif|js}
-  ; site = {js|https://www.hostnet.com.br/|js}
-  ; locations = 
- [{js|Brazil|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/hostnet.gif|js}
+    ; site = {js|https://www.hostnet.com.br/|js}
+    ; locations = [ {js|Brazil|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Digirati dba Hostnet is a web hosting company. We use OCaml mostly for internal systems programming and infrastructure services. We have also contributed to the community by releasing a few open source [OCaml libraries](https://github.com/andrenth).
 |js}
-  ; body_html = {js|<p>Digirati dba Hostnet is a web hosting company. We use OCaml mostly for internal systems programming and infrastructure services. We have also contributed to the community by releasing a few open source <a href="https://github.com/andrenth">OCaml libraries</a>.</p>
+    ; body_html =
+        {js|<p>Digirati dba Hostnet is a web hosting company. We use OCaml mostly for internal systems programming and infrastructure services. We have also contributed to the community by releasing a few open source <a href="https://github.com/andrenth">OCaml libraries</a>.</p>
 |js}
-  };
- 
-  { name = {js|Docker, Inc.|js}
-  ; slug = {js|docker-inc|js}
-  ; description = {js|Docker provides an integrated technology suite that enables development and IT operations teams to build, ship, and run distributed applications anywhere
+    }
+  ; { name = {js|Docker, Inc.|js}
+    ; slug = {js|docker-inc|js}
+    ; description =
+        {js|Docker provides an integrated technology suite that enables development and IT operations teams to build, ship, and run distributed applications anywhere
 |js}
-  ; image = Some {js|/users/docker.png|js}
-  ; site = {js|https://www.docker.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/docker.png|js}
+    ; site = {js|https://www.docker.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Docker provides an integrated technology suite that enables development and IT operations teams to build, ship, and run distributed applications anywhere. Their native [applications for Mac and Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), use OCaml code taken from the [MirageOS](https://mirage.io) library operating system project. |js}
-  ; body_html = {js|<p>Docker provides an integrated technology suite that enables development and IT operations teams to build, ship, and run distributed applications anywhere. Their native <a href="https://blog.docker.com/2016/03/docker-for-mac-windows-beta/">applications for Mac and Windows</a>, use OCaml code taken from the <a href="https://mirage.io">MirageOS</a> library operating system project.</p>
+    ; body_html =
+        {js|<p>Docker provides an integrated technology suite that enables development and IT operations teams to build, ship, and run distributed applications anywhere. Their native <a href="https://blog.docker.com/2016/03/docker-for-mac-windows-beta/">applications for Mac and Windows</a>, use OCaml code taken from the <a href="https://mirage.io">MirageOS</a> library operating system project.</p>
 |js}
-  };
- 
-  { name = {js|Esterel Technologies|js}
-  ; slug = {js|esterel-technologies|js}
-  ; description = {js|Esterel Technologies is a leading provider of critical systems and software development solutions for the aerospace, defense, rail transportation, nuclear, and industrial and automotive domains
+    }
+  ; { name = {js|Esterel Technologies|js}
+    ; slug = {js|esterel-technologies|js}
+    ; description =
+        {js|Esterel Technologies is a leading provider of critical systems and software development solutions for the aerospace, defense, rail transportation, nuclear, and industrial and automotive domains
 |js}
-  ; image = Some {js|/users/esterel.jpg|js}
-  ; site = {js|https://www.esterel-technologies.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/esterel.jpg|js}
+    ; site = {js|https://www.esterel-technologies.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Esterel Technologies is a leading provider of critical systems and software development solutions for the aerospace, defense, rail transportation, nuclear, and industrial and automotive domains.
 |js}
-  ; body_html = {js|<p>Esterel Technologies is a leading provider of critical systems and software development solutions for the aerospace, defense, rail transportation, nuclear, and industrial and automotive domains.</p>
+    ; body_html =
+        {js|<p>Esterel Technologies is a leading provider of critical systems and software development solutions for the aerospace, defense, rail transportation, nuclear, and industrial and automotive domains.</p>
 |js}
-  };
- 
-  { name = {js|Facebook|js}
-  ; slug = {js|facebook|js}
-  ; description = {js|Facebook has built a number of major development tools using OCaml|js}
-  ; image = Some {js|/users/facebook.png|js}
-  ; site = {js|https://www.facebook.com/|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    }
+  ; { name = {js|Facebook|js}
+    ; slug = {js|facebook|js}
+    ; description =
+        {js|Facebook has built a number of major development tools using OCaml|js}
+    ; image = Some {js|/users/facebook.png|js}
+    ; site = {js|https://www.facebook.com/|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Facebook has built a number of major development tools using OCaml. [Hack](https://hacklang.org) is a compiler for a variant of PHP that aims to reconcile the fast development cycle of PHP with the discipline provided by static typing. [Flow](https://flowtype.org) is a similar project that provides static type checking for Javascript.  Both systems are highly responsive, parallel programs that can incorporate source code changes in real time. [Pfff](https://github.com/facebook/pfff/wiki/Main) is a set of tools for code analysis, visualizations, and style-preserving source transformations, written in OCaml, but supporting many languages.|js}
-  ; body_html = {js|<p>Facebook has built a number of major development tools using OCaml. <a href="https://hacklang.org">Hack</a> is a compiler for a variant of PHP that aims to reconcile the fast development cycle of PHP with the discipline provided by static typing. <a href="https://flowtype.org">Flow</a> is a similar project that provides static type checking for Javascript.  Both systems are highly responsive, parallel programs that can incorporate source code changes in real time. <a href="https://github.com/facebook/pfff/wiki/Main">Pfff</a> is a set of tools for code analysis, visualizations, and style-preserving source transformations, written in OCaml, but supporting many languages.</p>
+    ; body_html =
+        {js|<p>Facebook has built a number of major development tools using OCaml. <a href="https://hacklang.org">Hack</a> is a compiler for a variant of PHP that aims to reconcile the fast development cycle of PHP with the discipline provided by static typing. <a href="https://flowtype.org">Flow</a> is a similar project that provides static type checking for Javascript.  Both systems are highly responsive, parallel programs that can incorporate source code changes in real time. <a href="https://github.com/facebook/pfff/wiki/Main">Pfff</a> is a set of tools for code analysis, visualizations, and style-preserving source transformations, written in OCaml, but supporting many languages.</p>
 |js}
-  };
- 
-  { name = {js|Fasoo|js}
-  ; slug = {js|fasoo|js}
-  ; description = {js|Fasoo uses OCaml to develop a static analysis tool.
+    }
+  ; { name = {js|Fasoo|js}
+    ; slug = {js|fasoo|js}
+    ; description = {js|Fasoo uses OCaml to develop a static analysis tool.
 |js}
-  ; image = Some {js|/users/fasoo.png|js}
-  ; site = {js|https://www.fasoo.com|js}
-  ; locations = 
- [{js|Korea|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/fasoo.png|js}
+    ; site = {js|https://www.fasoo.com|js}
+    ; locations = [ {js|Korea|js} ]
+    ; consortium = false
+    ; body_md = {js|
 Fasoo uses OCaml to develop a static analysis tool.
 |js}
-  ; body_html = {js|<p>Fasoo uses OCaml to develop a static analysis tool.</p>
+    ; body_html =
+        {js|<p>Fasoo uses OCaml to develop a static analysis tool.</p>
 |js}
-  };
- 
-  { name = {js|Flying Frog Consultancy|js}
-  ; slug = {js|flying-frog-consultancy|js}
-  ; description = {js|Flying Frog Consultancy Ltd. consult and write books and software on the use of OCaml in the context of scientific computing.
+    }
+  ; { name = {js|Flying Frog Consultancy|js}
+    ; slug = {js|flying-frog-consultancy|js}
+    ; description =
+        {js|Flying Frog Consultancy Ltd. consult and write books and software on the use of OCaml in the context of scientific computing.
 |js}
-  ; image = Some {js|/users/flying-frog.png|js}
-  ; site = {js|https://www.ffconsultancy.com|js}
-  ; locations = 
- [{js|United Kingdom|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/flying-frog.png|js}
+    ; site = {js|https://www.ffconsultancy.com|js}
+    ; locations = [ {js|United Kingdom|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Flying Frog Consultancy Ltd. consult and write books and software on the use of OCaml in the context of scientific computing. OCaml excels in the niche of intrinsically complicated programs between large-scale, array-based programs written in languages such as HPF and small-scale, graphical programs written in languages such as Mathematica.
 |js}
-  ; body_html = {js|<p>Flying Frog Consultancy Ltd. consult and write books and software on the use of OCaml in the context of scientific computing. OCaml excels in the niche of intrinsically complicated programs between large-scale, array-based programs written in languages such as HPF and small-scale, graphical programs written in languages such as Mathematica.</p>
+    ; body_html =
+        {js|<p>Flying Frog Consultancy Ltd. consult and write books and software on the use of OCaml in the context of scientific computing. OCaml excels in the niche of intrinsically complicated programs between large-scale, array-based programs written in languages such as HPF and small-scale, graphical programs written in languages such as Mathematica.</p>
 |js}
-  };
- 
-  { name = {js|ForAllSecure|js}
-  ; slug = {js|forallsecure|js}
-  ; description = {js|ForAllSecure's mission is to test the world's software and provide actionable information to our customers.
+    }
+  ; { name = {js|ForAllSecure|js}
+    ; slug = {js|forallsecure|js}
+    ; description =
+        {js|ForAllSecure's mission is to test the world's software and provide actionable information to our customers.
 |js}
-  ; image = Some {js|/users/forallsecure.svg|js}
-  ; site = {js|https://forallsecure.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/forallsecure.svg|js}
+    ; site = {js|https://forallsecure.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 ForAllSecure's mission is to test the world's software and provide actionable information to our customers. We have started with Linux. Our mission with Linux is to test all programs in current distributions, such as Debian, Ubuntu, and Red Hat. With time, we will cover other platforms, such as Mac, Windows, and mobile. In the meantime, we promise to do one thing well.
 |js}
-  ; body_html = {js|<p>ForAllSecure's mission is to test the world's software and provide actionable information to our customers. We have started with Linux. Our mission with Linux is to test all programs in current distributions, such as Debian, Ubuntu, and Red Hat. With time, we will cover other platforms, such as Mac, Windows, and mobile. In the meantime, we promise to do one thing well.</p>
+    ; body_html =
+        {js|<p>ForAllSecure's mission is to test the world's software and provide actionable information to our customers. We have started with Linux. Our mission with Linux is to test all programs in current distributions, such as Debian, Ubuntu, and Red Hat. With time, we will cover other platforms, such as Mac, Windows, and mobile. In the meantime, we promise to do one thing well.</p>
 |js}
-  };
- 
-  { name = {js|Framtidsforum|js}
-  ; slug = {js|framtidsforum|js}
-  ; description = {js|Framtidsforum I&M sells ExcelEverywhere, which creates web pages that look and function the same as your MS Excel spreadsheet
+    }
+  ; { name = {js|Framtidsforum|js}
+    ; slug = {js|framtidsforum|js}
+    ; description =
+        {js|Framtidsforum I&M sells ExcelEverywhere, which creates web pages that look and function the same as your MS Excel spreadsheet
 |js}
-  ; image = None
-  ; site = {js|https://www.exceleverywhere.com|js}
-  ; locations = 
- [{js|Sweden|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = None
+    ; site = {js|https://www.exceleverywhere.com|js}
+    ; locations = [ {js|Sweden|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Framtidsforum I&M sells ExcelEverywhere, which creates web pages that look and function the same as your MS Excel spreadsheet. JavaScript is used for calculation. Supports 140 Excel-functions. Typically used for expense report, survey, order forms, reservation forms, employment application, financial advisor, ROI. There are also versions that generate ASP, ASP.NET and JSP/Java code. The compiler is written using OCaml.
 |js}
-  ; body_html = {js|<p>Framtidsforum I&amp;M sells ExcelEverywhere, which creates web pages that look and function the same as your MS Excel spreadsheet. JavaScript is used for calculation. Supports 140 Excel-functions. Typically used for expense report, survey, order forms, reservation forms, employment application, financial advisor, ROI. There are also versions that generate ASP, ASP.NET and JSP/Java code. The compiler is written using OCaml.</p>
+    ; body_html =
+        {js|<p>Framtidsforum I&amp;M sells ExcelEverywhere, which creates web pages that look and function the same as your MS Excel spreadsheet. JavaScript is used for calculation. Supports 140 Excel-functions. Typically used for expense report, survey, order forms, reservation forms, employment application, financial advisor, ROI. There are also versions that generate ASP, ASP.NET and JSP/Java code. The compiler is written using OCaml.</p>
 |js}
-  };
- 
-  { name = {js|Galois|js}
-  ; slug = {js|galois|js}
-  ; description = {js|Galois has developed a domain specific declarative language for cryptographic algorithms.
+    }
+  ; { name = {js|Galois|js}
+    ; slug = {js|galois|js}
+    ; description =
+        {js|Galois has developed a domain specific declarative language for cryptographic algorithms.
 |js}
-  ; image = Some {js|/users/galois.png|js}
-  ; site = {js|https://www.galois.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/galois.png|js}
+    ; site = {js|https://www.galois.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Galois has developed a domain specific declarative language for cryptographic algorithms. One of our research compilers is written in OCaml and makes very extensive use of camlp4.
 |js}
-  ; body_html = {js|<p>Galois has developed a domain specific declarative language for cryptographic algorithms. One of our research compilers is written in OCaml and makes very extensive use of camlp4.</p>
+    ; body_html =
+        {js|<p>Galois has developed a domain specific declarative language for cryptographic algorithms. One of our research compilers is written in OCaml and makes very extensive use of camlp4.</p>
 |js}
-  };
- 
-  { name = {js|Incubaid|js}
-  ; slug = {js|incubaid|js}
-  ; description = {js|Incubaid has developed Arakoon, a distributed key-value store that guarantees consistency above anything else.
+    }
+  ; { name = {js|Incubaid|js}
+    ; slug = {js|incubaid|js}
+    ; description =
+        {js|Incubaid has developed Arakoon, a distributed key-value store that guarantees consistency above anything else.
 |js}
-  ; image = Some {js|/users/Incubaid.png|js}
-  ; site = {js|https://incubaid.com|js}
-  ; locations = 
- [{js|Belgium|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/Incubaid.png|js}
+    ; site = {js|https://incubaid.com|js}
+    ; locations = [ {js|Belgium|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Incubaid has developed <a href="https://github.com/Incubaid/arakoon">Arakoon</a>, a distributed key-value store that guarantees consistency above anything else. We created Arakoon due to a lack of existing solutions fitting our requirements, and is available as Open Source software.
 
 |js}
-  ; body_html = {js|<p>Incubaid has developed <a href="https://github.com/Incubaid/arakoon">Arakoon</a>, a distributed key-value store that guarantees consistency above anything else. We created Arakoon due to a lack of existing solutions fitting our requirements, and is available as Open Source software.</p>
+    ; body_html =
+        {js|<p>Incubaid has developed <a href="https://github.com/Incubaid/arakoon">Arakoon</a>, a distributed key-value store that guarantees consistency above anything else. We created Arakoon due to a lack of existing solutions fitting our requirements, and is available as Open Source software.</p>
 |js}
-  };
- 
-  { name = {js|Issuu|js}
-  ; slug = {js|issuu|js}
-  ; description = {js|Issuu is a digital publishing platform delivering exceptional reading experiences of magazines, catalogues, and newspapers
+    }
+  ; { name = {js|Issuu|js}
+    ; slug = {js|issuu|js}
+    ; description =
+        {js|Issuu is a digital publishing platform delivering exceptional reading experiences of magazines, catalogues, and newspapers
 |js}
-  ; image = Some {js|/users/issuu.gif|js}
-  ; site = {js|https://issuu.com|js}
-  ; locations = 
- [{js|Denmark|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/issuu.gif|js}
+    ; site = {js|https://issuu.com|js}
+    ; locations = [ {js|Denmark|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Issuu is a digital publishing platform delivering exceptional reading experiences of magazines, catalogues, and newspapers. Each month Issuu serves over 6 billion page views and 60 million users through their worldwide network. OCaml is used as part of the server-side systems, platforms, and web applications. The backend team is relatively small and the simplicity and scalability of both systems and processes are of vital importance.
 |js}
-  ; body_html = {js|<p>Issuu is a digital publishing platform delivering exceptional reading experiences of magazines, catalogues, and newspapers. Each month Issuu serves over 6 billion page views and 60 million users through their worldwide network. OCaml is used as part of the server-side systems, platforms, and web applications. The backend team is relatively small and the simplicity and scalability of both systems and processes are of vital importance.</p>
+    ; body_html =
+        {js|<p>Issuu is a digital publishing platform delivering exceptional reading experiences of magazines, catalogues, and newspapers. Each month Issuu serves over 6 billion page views and 60 million users through their worldwide network. OCaml is used as part of the server-side systems, platforms, and web applications. The backend team is relatively small and the simplicity and scalability of both systems and processes are of vital importance.</p>
 |js}
-  };
- 
-  { name = {js|Jane Street|js}
-  ; slug = {js|jane-street|js}
-  ; description = {js|Jane Street is a quantitative trading firm that operates around the clock and around the globe
+    }
+  ; { name = {js|Jane Street|js}
+    ; slug = {js|jane-street|js}
+    ; description =
+        {js|Jane Street is a quantitative trading firm that operates around the clock and around the globe
 |js}
-  ; image = Some {js|/users/jane-street.jpg|js}
-  ; site = {js|https://janestreet.com|js}
-  ; locations = 
- [{js|United States|js}; {js|United Kingdom|js}; {js|Hong Kong|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/jane-street.jpg|js}
+    ; site = {js|https://janestreet.com|js}
+    ; locations =
+        [ {js|United States|js}; {js|United Kingdom|js}; {js|Hong Kong|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Jane Street is a quantitative trading firm that operates around the clock and around the globe. They bring a deep understanding of markets, a scientific approach, and innovative technology to bear on the problem of trading profitably in the world's highly competitive financial markets. They're the largest commercial user of OCaml, using it for everything from research tools to trading systems to systems infrastructure to accounting systems. Jane Street has over 400 OCaml programmers and over 15 million lines of OCaml, powering a technology platform that trades billions of dollars every day. Half a million lines of their code are released [open source](https://opensource.janestreet.com), and they've created key parts of the open-source OCaml ecosystem, like [Dune](https://dune.build). You can learn more by checking out their [tech blog](https://blog.janestreet.com).
 |js}
-  ; body_html = {js|<p>Jane Street is a quantitative trading firm that operates around the clock and around the globe. They bring a deep understanding of markets, a scientific approach, and innovative technology to bear on the problem of trading profitably in the world's highly competitive financial markets. They're the largest commercial user of OCaml, using it for everything from research tools to trading systems to systems infrastructure to accounting systems. Jane Street has over 400 OCaml programmers and over 15 million lines of OCaml, powering a technology platform that trades billions of dollars every day. Half a million lines of their code are released <a href="https://opensource.janestreet.com">open source</a>, and they've created key parts of the open-source OCaml ecosystem, like <a href="https://dune.build">Dune</a>. You can learn more by checking out their <a href="https://blog.janestreet.com">tech blog</a>.</p>
+    ; body_html =
+        {js|<p>Jane Street is a quantitative trading firm that operates around the clock and around the globe. They bring a deep understanding of markets, a scientific approach, and innovative technology to bear on the problem of trading profitably in the world's highly competitive financial markets. They're the largest commercial user of OCaml, using it for everything from research tools to trading systems to systems infrastructure to accounting systems. Jane Street has over 400 OCaml programmers and over 15 million lines of OCaml, powering a technology platform that trades billions of dollars every day. Half a million lines of their code are released <a href="https://opensource.janestreet.com">open source</a>, and they've created key parts of the open-source OCaml ecosystem, like <a href="https://dune.build">Dune</a>. You can learn more by checking out their <a href="https://blog.janestreet.com">tech blog</a>.</p>
 |js}
-  };
- 
-  { name = {js|Kernelize|js}
-  ; slug = {js|kernelize|js}
-  ; description = {js|Kernelyze has developed a novel approximation of two-variable functions that achieves the smallest possible worst-case error among all rank-n approximations.
+    }
+  ; { name = {js|Kernelize|js}
+    ; slug = {js|kernelize|js}
+    ; description =
+        {js|Kernelyze has developed a novel approximation of two-variable functions that achieves the smallest possible worst-case error among all rank-n approximations.
 |js}
-  ; image = Some {js|/users/kernelyze-llc-logo.png|js}
-  ; site = {js|https://kernelyze.com/|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/kernelyze-llc-logo.png|js}
+    ; site = {js|https://kernelyze.com/|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 
 Kernelyze has developed a novel approximation of two-variable functions
 that achieves the smallest possible worst-case error among all rank-n
 approximations.|js}
-  ; body_html = {js|<p>Kernelyze has developed a novel approximation of two-variable functions
+    ; body_html =
+        {js|<p>Kernelyze has developed a novel approximation of two-variable functions
 that achieves the smallest possible worst-case error among all rank-n
 approximations.</p>
 |js}
-  };
- 
-  { name = {js|Kong|js}
-  ; slug = {js|kong|js}
-  ; description = {js|Kong makes it easy to distribute, monetize, manage and consume cloud APIs.
+    }
+  ; { name = {js|Kong|js}
+    ; slug = {js|kong|js}
+    ; description =
+        {js|Kong makes it easy to distribute, monetize, manage and consume cloud APIs.
 |js}
-  ; image = Some {js|/users/mashape.png|js}
-  ; site = {js|https://www.konghq.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mashape.png|js}
+    ; site = {js|https://www.konghq.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Kong makes it easy to distribute, monetize, manage and consume cloud APIs. Mashape is building a world-class marketplace for cloud APIs driven by a passionate community of developers from all over the world as well as enterprise API management and analytics products. We use OCaml in our [APIAnalytics](https://apianalytics.com) product — as part of a mission-critical, lightweight HTTP proxy.
 |js}
-  ; body_html = {js|<p>Kong makes it easy to distribute, monetize, manage and consume cloud APIs. Mashape is building a world-class marketplace for cloud APIs driven by a passionate community of developers from all over the world as well as enterprise API management and analytics products. We use OCaml in our <a href="https://apianalytics.com">APIAnalytics</a> product — as part of a mission-critical, lightweight HTTP proxy.</p>
+    ; body_html =
+        {js|<p>Kong makes it easy to distribute, monetize, manage and consume cloud APIs. Mashape is building a world-class marketplace for cloud APIs driven by a passionate community of developers from all over the world as well as enterprise API management and analytics products. We use OCaml in our <a href="https://apianalytics.com">APIAnalytics</a> product — as part of a mission-critical, lightweight HTTP proxy.</p>
 |js}
-  };
- 
-  { name = {js|LexiFi|js}
-  ; slug = {js|lexifi|js}
-  ; description = {js|LexiFi is an innovative provider of software applications and infrastructure technology for the capital markets industry.
+    }
+  ; { name = {js|LexiFi|js}
+    ; slug = {js|lexifi|js}
+    ; description =
+        {js|LexiFi is an innovative provider of software applications and infrastructure technology for the capital markets industry.
 |js}
-  ; image = Some {js|/users/lexifi.png|js}
-  ; site = {js|https://www.lexifi.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/lexifi.png|js}
+    ; site = {js|https://www.lexifi.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 LexiFi is an innovative provider of software applications and infrastructure technology for the capital markets industry. LexiFi Apropos is powered by an original formalism for describing financial contracts, the result of a long-term research and development effort.
 |js}
-  ; body_html = {js|<p>LexiFi is an innovative provider of software applications and infrastructure technology for the capital markets industry. LexiFi Apropos is powered by an original formalism for describing financial contracts, the result of a long-term research and development effort.</p>
+    ; body_html =
+        {js|<p>LexiFi is an innovative provider of software applications and infrastructure technology for the capital markets industry. LexiFi Apropos is powered by an original formalism for describing financial contracts, the result of a long-term research and development effort.</p>
 |js}
-  };
- 
-  { name = {js|Matrix Lead|js}
-  ; slug = {js|matrix-lead|js}
-  ; description = {js|Matrix Lead provides professionals and companies with leading technologies and solutions for spreadsheets. 
+    }
+  ; { name = {js|Matrix Lead|js}
+    ; slug = {js|matrix-lead|js}
+    ; description =
+        {js|Matrix Lead provides professionals and companies with leading technologies and solutions for spreadsheets. 
 |js}
-  ; image = Some {js|/users/matrixlead.png|js}
-  ; site = {js|https://www.matrixlead.com|js}
-  ; locations = 
- [{js|France|js}; {js|China|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/matrixlead.png|js}
+    ; site = {js|https://www.matrixlead.com|js}
+    ; locations = [ {js|France|js}; {js|China|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Matrix Lead provides professionals and companies with leading technologies and solutions for spreadsheets. We create a range of software to help users better build, verify, optimize and manage their spreadsheets. Our flagship product [10 Studio](https://www.10studio.tech) is a Microsoft Excel add-in that combines our several advanced tools, such as formula editor and spreadsheet verificator. The kernel of our tools is an analyzer that analyzes different properties of spreadsheets (including formulas and VBA macros) especially by abstract interpretation-based static analysis. It was initially developed in the Antiques team of Inria and written in OCaml. Then, we wrap web or .NET languages around the analyzer to make ready-to-use tools.
 |js}
-  ; body_html = {js|<p>Matrix Lead provides professionals and companies with leading technologies and solutions for spreadsheets. We create a range of software to help users better build, verify, optimize and manage their spreadsheets. Our flagship product <a href="https://www.10studio.tech">10 Studio</a> is a Microsoft Excel add-in that combines our several advanced tools, such as formula editor and spreadsheet verificator. The kernel of our tools is an analyzer that analyzes different properties of spreadsheets (including formulas and VBA macros) especially by abstract interpretation-based static analysis. It was initially developed in the Antiques team of Inria and written in OCaml. Then, we wrap web or .NET languages around the analyzer to make ready-to-use tools.</p>
+    ; body_html =
+        {js|<p>Matrix Lead provides professionals and companies with leading technologies and solutions for spreadsheets. We create a range of software to help users better build, verify, optimize and manage their spreadsheets. Our flagship product <a href="https://www.10studio.tech">10 Studio</a> is a Microsoft Excel add-in that combines our several advanced tools, such as formula editor and spreadsheet verificator. The kernel of our tools is an analyzer that analyzes different properties of spreadsheets (including formulas and VBA macros) especially by abstract interpretation-based static analysis. It was initially developed in the Antiques team of Inria and written in OCaml. Then, we wrap web or .NET languages around the analyzer to make ready-to-use tools.</p>
 |js}
-  };
- 
-  { name = {js|MEDIT|js}
-  ; slug = {js|medit|js}
-  ; description = {js|MEDIT develops SuMo, an advanced bioinformatic system, for the analysis of protein 3D structures and the identification of drug-design targets. 
+    }
+  ; { name = {js|MEDIT|js}
+    ; slug = {js|medit|js}
+    ; description =
+        {js|MEDIT develops SuMo, an advanced bioinformatic system, for the analysis of protein 3D structures and the identification of drug-design targets. 
 |js}
-  ; image = Some {js|/users/medit.jpg|js}
-  ; site = {js|https://www.medit-pharma.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/medit.jpg|js}
+    ; site = {js|https://www.medit-pharma.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 MEDIT develops [SuMo, an advanced bioinformatic system]("https://mjambon.com/") for the analysis of protein 3D structures and the identification of drug-design targets. SuMo is written entirely in OCaml and provides interfaces to several commercial molecular-modeling packages.
 |js}
-  ; body_html = {js|<p>MEDIT develops <a href="%22https://mjambon.com/%22">SuMo, an advanced bioinformatic system</a> for the analysis of protein 3D structures and the identification of drug-design targets. SuMo is written entirely in OCaml and provides interfaces to several commercial molecular-modeling packages.</p>
+    ; body_html =
+        {js|<p>MEDIT develops <a href="%22https://mjambon.com/%22">SuMo, an advanced bioinformatic system</a> for the analysis of protein 3D structures and the identification of drug-design targets. SuMo is written entirely in OCaml and provides interfaces to several commercial molecular-modeling packages.</p>
 |js}
-  };
- 
-  { name = {js|Microsoft|js}
-  ; slug = {js|microsoft|js}
-  ; description = {js|Microsoft Corporation is an American multinational technology corporation which produces computer software, consumer electronics, personal computers, and related services.
+    }
+  ; { name = {js|Microsoft|js}
+    ; slug = {js|microsoft|js}
+    ; description =
+        {js|Microsoft Corporation is an American multinational technology corporation which produces computer software, consumer electronics, personal computers, and related services.
 |js}
-  ; image = Some {js|/users/microsoft.png|js}
-  ; site = {js|https://www.microsoft.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/microsoft.png|js}
+    ; site = {js|https://www.microsoft.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Microsoft Corporation is an American multinational technology corporation which produces computer software, consumer electronics, personal computers, and related services.
 |js}
-  ; body_html = {js|<p>Microsoft Corporation is an American multinational technology corporation which produces computer software, consumer electronics, personal computers, and related services.</p>
+    ; body_html =
+        {js|<p>Microsoft Corporation is an American multinational technology corporation which produces computer software, consumer electronics, personal computers, and related services.</p>
 |js}
-  };
- 
-  { name = {js|Mount Sinai|js}
-  ; slug = {js|mount-sinai|js}
-  ; description = {js|The Hammer Lab at Mount Sinai develops and uses Ketrew for managing complex bioinformatics workflows.
+    }
+  ; { name = {js|Mount Sinai|js}
+    ; slug = {js|mount-sinai|js}
+    ; description =
+        {js|The Hammer Lab at Mount Sinai develops and uses Ketrew for managing complex bioinformatics workflows.
 |js}
-  ; image = Some {js|/users/mount-sinai.png|js}
-  ; site = {js|https://www.mountsinai.org|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mount-sinai.png|js}
+    ; site = {js|https://www.mountsinai.org|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 The [Hammer Lab]("https://www.hammerlab.org") at Mount Sinai develops and uses [Ketrew]("https://github.com/hammerlab/ketrew") for managing complex bioinformatics workflows. Ketrew includes an embedded domain-specific language to simplify the specification of workflows and an engine for the execution of workflows. Ketrew can be run as a command-line application or as a service.
 |js}
-  ; body_html = {js|<p>The <a href="%22https://www.hammerlab.org%22">Hammer Lab</a> at Mount Sinai develops and uses <a href="%22https://github.com/hammerlab/ketrew%22">Ketrew</a> for managing complex bioinformatics workflows. Ketrew includes an embedded domain-specific language to simplify the specification of workflows and an engine for the execution of workflows. Ketrew can be run as a command-line application or as a service.</p>
+    ; body_html =
+        {js|<p>The <a href="%22https://www.hammerlab.org%22">Hammer Lab</a> at Mount Sinai develops and uses <a href="%22https://github.com/hammerlab/ketrew%22">Ketrew</a> for managing complex bioinformatics workflows. Ketrew includes an embedded domain-specific language to simplify the specification of workflows and an engine for the execution of workflows. Ketrew can be run as a command-line application or as a service.</p>
 |js}
-  };
- 
-  { name = {js|Mr. Number|js}
-  ; slug = {js|mr-number|js}
-  ; description = {js|Mr. Number started as a Silicon Valley startup and developed the Mr. Number app for call blocking, later acquired by WhitePages.
+    }
+  ; { name = {js|Mr. Number|js}
+    ; slug = {js|mr-number|js}
+    ; description =
+        {js|Mr. Number started as a Silicon Valley startup and developed the Mr. Number app for call blocking, later acquired by WhitePages.
 |js}
-  ; image = Some {js|/users/mrnumber.jpg|js}
-  ; site = {js|https://mrnumber.com/|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mrnumber.jpg|js}
+    ; site = {js|https://mrnumber.com/|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Mr. Number started as a Silicon Valley startup and developed the Mr. Number app for call blocking, later [acquired by WhitePages](https://allthingsd.com/20130601/whitepages-scoops-up-mr-number-an-android-app-for-blocking-unwanted-calls/). OCaml is used on the server-side as the glue between the various third-party components and services.</p>
 |js}
-  ; body_html = {js|<p>Mr. Number started as a Silicon Valley startup and developed the Mr. Number app for call blocking, later <a href="https://allthingsd.com/20130601/whitepages-scoops-up-mr-number-an-android-app-for-blocking-unwanted-calls/">acquired by WhitePages</a>. OCaml is used on the server-side as the glue between the various third-party components and services.</p></p>
+    ; body_html =
+        {js|<p>Mr. Number started as a Silicon Valley startup and developed the Mr. Number app for call blocking, later <a href="https://allthingsd.com/20130601/whitepages-scoops-up-mr-number-an-android-app-for-blocking-unwanted-calls/">acquired by WhitePages</a>. OCaml is used on the server-side as the glue between the various third-party components and services.</p></p>
 |js}
-  };
- 
-  { name = {js|MyLife|js}
-  ; slug = {js|mylife|js}
-  ; description = {js|MyLife has developed a powerful people search tool that will empower those in need to find anyone, regardless of years past and the life that was built in between.
+    }
+  ; { name = {js|MyLife|js}
+    ; slug = {js|mylife|js}
+    ; description =
+        {js|MyLife has developed a powerful people search tool that will empower those in need to find anyone, regardless of years past and the life that was built in between.
 |js}
-  ; image = Some {js|/users/mylife.jpg|js}
-  ; site = {js|https://www.mylife.com/|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mylife.jpg|js}
+    ; site = {js|https://www.mylife.com/|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 MyLife has developed a powerful people search tool that will empower those in need to find anyone, regardless of years past and the life that was built in between.|js}
-  ; body_html = {js|<p>MyLife has developed a powerful people search tool that will empower those in need to find anyone, regardless of years past and the life that was built in between.</p>
+    ; body_html =
+        {js|<p>MyLife has developed a powerful people search tool that will empower those in need to find anyone, regardless of years past and the life that was built in between.</p>
 |js}
-  };
- 
-  { name = {js|Narrow Gate Logic|js}
-  ; slug = {js|narrow-gate-logic|js}
-  ; description = {js|Narrow Gate Logic is a company using the OCaml language in business and non-business applications.
+    }
+  ; { name = {js|Narrow Gate Logic|js}
+    ; slug = {js|narrow-gate-logic|js}
+    ; description =
+        {js|Narrow Gate Logic is a company using the OCaml language in business and non-business applications.
 |js}
-  ; image = Some {js|/users/nglogic.png|js}
-  ; site = {js|https://nglogic.com|js}
-  ; locations = 
- [{js|Poland|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/nglogic.png|js}
+    ; site = {js|https://nglogic.com|js}
+    ; locations = [ {js|Poland|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Narrow Gate Logic is a company using the OCaml language in business and non-business applications.
 |js}
-  ; body_html = {js|<p>Narrow Gate Logic is a company using the OCaml language in business and non-business applications.</p>
+    ; body_html =
+        {js|<p>Narrow Gate Logic is a company using the OCaml language in business and non-business applications.</p>
 |js}
-  };
- 
-  { name = {js|Nomadic Labs|js}
-  ; slug = {js|nomadic-labs|js}
-  ; description = {js|Nomadic Labs houses a team focused on Research and Development. Our core competencies are in programming language theory and practice, distributed systems, and formal verification.
+    }
+  ; { name = {js|Nomadic Labs|js}
+    ; slug = {js|nomadic-labs|js}
+    ; description =
+        {js|Nomadic Labs houses a team focused on Research and Development. Our core competencies are in programming language theory and practice, distributed systems, and formal verification.
 |js}
-  ; image = Some {js|/users/nomadic-labs.png|js}
-  ; site = {js|https://www.nomadic-labs.com|js}
-  ; locations = 
- [{js|Paris, France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/nomadic-labs.png|js}
+    ; site = {js|https://www.nomadic-labs.com|js}
+    ; locations = [ {js|Paris, France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Nomadic Labs houses a team focused on Research and Development. Our
 core competencies are in programming language theory and practice,
 distributed systems, and formal verification. Nomadic Labs focuses on
@@ -614,7 +646,8 @@ runtime errors from happening. Safety and correctness are critical for a
 blockchain and we are glad that the OCaml type system allows for a
 form of a lightweight formal method that can be used on a daily basis.
 |js}
-  ; body_html = {js|<p>Nomadic Labs houses a team focused on Research and Development. Our
+    ; body_html =
+        {js|<p>Nomadic Labs houses a team focused on Research and Development. Our
 core competencies are in programming language theory and practice,
 distributed systems, and formal verification. Nomadic Labs focuses on
 contributing to the development of the Tezos core software, including
@@ -626,82 +659,86 @@ runtime errors from happening. Safety and correctness are critical for a
 blockchain and we are glad that the OCaml type system allows for a
 form of a lightweight formal method that can be used on a daily basis.</p>
 |js}
-  };
- 
-  { name = {js|OCamlPro|js}
-  ; slug = {js|ocamlpro|js}
-  ; description = {js|OCamlPro develops and maintains a development environment for the OCaml language.
+    }
+  ; { name = {js|OCamlPro|js}
+    ; slug = {js|ocamlpro|js}
+    ; description =
+        {js|OCamlPro develops and maintains a development environment for the OCaml language.
 |js}
-  ; image = Some {js|/users/ocamlpro.png|js}
-  ; site = {js|https://www.ocamlpro.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/ocamlpro.png|js}
+    ; site = {js|https://www.ocamlpro.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 OCamlPro develops and maintains a development environment for the OCaml language. They provide services for companies deciding to use OCaml. Among these services: trainings, necessary expertise, tools and libraries long-term support, and specific developments to their applicative domains.|js}
-  ; body_html = {js|<p>OCamlPro develops and maintains a development environment for the OCaml language. They provide services for companies deciding to use OCaml. Among these services: trainings, necessary expertise, tools and libraries long-term support, and specific developments to their applicative domains.</p>
+    ; body_html =
+        {js|<p>OCamlPro develops and maintains a development environment for the OCaml language. They provide services for companies deciding to use OCaml. Among these services: trainings, necessary expertise, tools and libraries long-term support, and specific developments to their applicative domains.</p>
 |js}
-  };
- 
-  { name = {js|PRUDENT Technologies and Consulting, Inc.|js}
-  ; slug = {js|prudent-technologies-and-consulting-inc|js}
-  ; description = {js|Prudent Consulting offers IT solutions to large and mid-sized organizations by combining industry experience and technology expertise to help our customers achieve business goals with speed, agility, and great impact.
+    }
+  ; { name = {js|PRUDENT Technologies and Consulting, Inc.|js}
+    ; slug = {js|prudent-technologies-and-consulting-inc|js}
+    ; description =
+        {js|Prudent Consulting offers IT solutions to large and mid-sized organizations by combining industry experience and technology expertise to help our customers achieve business goals with speed, agility, and great impact.
 |js}
-  ; image = Some {js|/users/prudent.jpg|js}
-  ; site = {js|https://www.prudentconsulting.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/prudent.jpg|js}
+    ; site = {js|https://www.prudentconsulting.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Prudent Consulting offers IT solutions to large and mid-sized organizations by combining industry experience and technology expertise to help our customers achieve business goals with speed, agility, and great impact.
 |js}
-  ; body_html = {js|<p>Prudent Consulting offers IT solutions to large and mid-sized organizations by combining industry experience and technology expertise to help our customers achieve business goals with speed, agility, and great impact.</p>
+    ; body_html =
+        {js|<p>Prudent Consulting offers IT solutions to large and mid-sized organizations by combining industry experience and technology expertise to help our customers achieve business goals with speed, agility, and great impact.</p>
 |js}
-  };
- 
-  { name = {js|Psellos|js}
-  ; slug = {js|psellos|js}
-  ; description = {js|Psellos is a small group of computer scientists who became intrigued by the idea of coding iOS apps in OCaml.
+    }
+  ; { name = {js|Psellos|js}
+    ; slug = {js|psellos|js}
+    ; description =
+        {js|Psellos is a small group of computer scientists who became intrigued by the idea of coding iOS apps in OCaml.
 |js}
-  ; image = Some {js|/users/psellos.png|js}
-  ; site = {js|https://www.psellos.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/psellos.png|js}
+    ; site = {js|https://www.psellos.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Psellos is a small group of computer scientists who became intrigued by the idea of coding iOS apps in OCaml. It has worked out better than we expected (you can buy our apps in the iTunes App Store), and at least one other company sells apps built with our tools. Our most recent iOS cross compiler is derived from OCaml 4.00.0.|js}
-  ; body_html = {js|<p>Psellos is a small group of computer scientists who became intrigued by the idea of coding iOS apps in OCaml. It has worked out better than we expected (you can buy our apps in the iTunes App Store), and at least one other company sells apps built with our tools. Our most recent iOS cross compiler is derived from OCaml 4.00.0.</p>
+    ; body_html =
+        {js|<p>Psellos is a small group of computer scientists who became intrigued by the idea of coding iOS apps in OCaml. It has worked out better than we expected (you can buy our apps in the iTunes App Store), and at least one other company sells apps built with our tools. Our most recent iOS cross compiler is derived from OCaml 4.00.0.</p>
 |js}
-  };
- 
-  { name = {js|r2c|js}
-  ; slug = {js|r2c|js}
-  ; description = {js|r2c is a VC-funded security company headquartered in San Francisco and distributed worldwide
+    }
+  ; { name = {js|r2c|js}
+    ; slug = {js|r2c|js}
+    ; description =
+        {js|r2c is a VC-funded security company headquartered in San Francisco and distributed worldwide
 |js}
-  ; image = Some {js|/users/r2c.png|js}
-  ; site = {js|https://r2c.dev|js}
-  ; locations = 
- [{js|California, United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/r2c.png|js}
+    ; site = {js|https://r2c.dev|js}
+    ; locations = [ {js|California, United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 r2c is a VC-funded security company headquartered in San Francisco and distributed worldwide. The main product as of 2021 is [Semgrep](https://semgrep.dev/), an open-source,syntax-aware grep that supports many languages. OCaml is used extensively for parsing and analyzing source code.
 
 Semgrep was originally open-sourced at Facebook and its roots lie in the Linux refactoring tool, [Coccinelle](https://coccinelle.gitlabpages.inria.fr/website/). r2c continues Semgrep’s development and is [hiring software engineers](https://jobs.lever.co/returntocorp) who specialize in program analysis.|js}
-  ; body_html = {js|<p>r2c is a VC-funded security company headquartered in San Francisco and distributed worldwide. The main product as of 2021 is <a href="https://semgrep.dev/">Semgrep</a>, an open-source,syntax-aware grep that supports many languages. OCaml is used extensively for parsing and analyzing source code.</p>
+    ; body_html =
+        {js|<p>r2c is a VC-funded security company headquartered in San Francisco and distributed worldwide. The main product as of 2021 is <a href="https://semgrep.dev/">Semgrep</a>, an open-source,syntax-aware grep that supports many languages. OCaml is used extensively for parsing and analyzing source code.</p>
 <p>Semgrep was originally open-sourced at Facebook and its roots lie in the Linux refactoring tool, <a href="https://coccinelle.gitlabpages.inria.fr/website/">Coccinelle</a>. r2c continues Semgrep’s development and is <a href="https://jobs.lever.co/returntocorp">hiring software engineers</a> who specialize in program analysis.</p>
 |js}
-  };
- 
-  { name = {js|Sakhalin|js}
-  ; slug = {js|sakhalin|js}
-  ; description = {js|Sakhalin develops marine charting apps for Apple iPads and iPhones.
+    }
+  ; { name = {js|Sakhalin|js}
+    ; slug = {js|sakhalin|js}
+    ; description =
+        {js|Sakhalin develops marine charting apps for Apple iPads and iPhones.
 |js}
-  ; image = None
-  ; site = {js|https://www.seaiq.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = None
+    ; site = {js|https://www.seaiq.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Sakhalin develops marine charting apps for Apple iPads and iPhones. The full-featured apps display marine charts, GPS and onboard sensor data, Automatic Identification System, weather data, anchor monitoring, etc. The apps have a wide range of users, from occasional recreational boaters to professional river/harbor pilots that board large freighters. They are free to download and try (with a paid upgrade to enable all features). They are written almost entirely in Ocaml with a minor amount of glue to interface with IOS APIs. Ocaml was chosen because it
 
  1. enables the rapid development of extremely reliable and high-performance software,
@@ -709,7 +746,8 @@ Sakhalin develops marine charting apps for Apple iPads and iPhones. The full-fea
  3. has a wide range of libraries. 
  
 It was made possible by the great work done by Psellos in porting OCaml to the Apple iOS platform. Feel free to contact Sakhalin if you have any questions about using OCaml on iOS.|js}
-  ; body_html = {js|<p>Sakhalin develops marine charting apps for Apple iPads and iPhones. The full-featured apps display marine charts, GPS and onboard sensor data, Automatic Identification System, weather data, anchor monitoring, etc. The apps have a wide range of users, from occasional recreational boaters to professional river/harbor pilots that board large freighters. They are free to download and try (with a paid upgrade to enable all features). They are written almost entirely in Ocaml with a minor amount of glue to interface with IOS APIs. Ocaml was chosen because it</p>
+    ; body_html =
+        {js|<p>Sakhalin develops marine charting apps for Apple iPads and iPhones. The full-featured apps display marine charts, GPS and onboard sensor data, Automatic Identification System, weather data, anchor monitoring, etc. The apps have a wide range of users, from occasional recreational boaters to professional river/harbor pilots that board large freighters. They are free to download and try (with a paid upgrade to enable all features). They are written almost entirely in Ocaml with a minor amount of glue to interface with IOS APIs. Ocaml was chosen because it</p>
 <ol>
 <li>enables the rapid development of extremely reliable and high-performance software,
 </li>
@@ -720,96 +758,101 @@ It was made possible by the great work done by Psellos in porting OCaml to the A
 </ol>
 <p>It was made possible by the great work done by Psellos in porting OCaml to the Apple iOS platform. Feel free to contact Sakhalin if you have any questions about using OCaml on iOS.</p>
 |js}
-  };
- 
-  { name = {js|Shiro Games|js}
-  ; slug = {js|shiro-games|js}
-  ; description = {js|Shiro Games is developing games using Haxe, a language built with a compiler written in OCaml.
+    }
+  ; { name = {js|Shiro Games|js}
+    ; slug = {js|shiro-games|js}
+    ; description =
+        {js|Shiro Games is developing games using Haxe, a language built with a compiler written in OCaml.
 |js}
-  ; image = Some {js|/users/shirogames.png|js}
-  ; site = {js|https://www.shirogames.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/shirogames.png|js}
+    ; site = {js|https://www.shirogames.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Shiro Games is developing games using [Haxe](https://haxe.org/), a language built with a compiler written in OCaml.|js}
-  ; body_html = {js|<p>Shiro Games is developing games using <a href="https://haxe.org/">Haxe</a>, a language built with a compiler written in OCaml.</p>
+    ; body_html =
+        {js|<p>Shiro Games is developing games using <a href="https://haxe.org/">Haxe</a>, a language built with a compiler written in OCaml.</p>
 |js}
-  };
- 
-  { name = {js|SimCorp|js}
-  ; slug = {js|simcorp|js}
-  ; description = {js|Multi-asset platform to support investment decision-making and innovation.
+    }
+  ; { name = {js|SimCorp|js}
+    ; slug = {js|simcorp|js}
+    ; description =
+        {js|Multi-asset platform to support investment decision-making and innovation.
 |js}
-  ; image = Some {js|/users/simcorp.png|js}
-  ; site = {js|https://www.simcorp.com/|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/simcorp.png|js}
+    ; site = {js|https://www.simcorp.com/|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Multi-asset platform to support investment decision-making and innovation.
 |js}
-  ; body_html = {js|<p>Multi-asset platform to support investment decision-making and innovation.</p>
+    ; body_html =
+        {js|<p>Multi-asset platform to support investment decision-making and innovation.</p>
 |js}
-  };
- 
-  { name = {js|Sleekersoft|js}
-  ; slug = {js|sleekersoft|js}
-  ; description = {js|Specialises in functional programming software development, consultation, and training.
+    }
+  ; { name = {js|Sleekersoft|js}
+    ; slug = {js|sleekersoft|js}
+    ; description =
+        {js|Specialises in functional programming software development, consultation, and training.
 |js}
-  ; image = Some {js|/users/sleekersoft.png|js}
-  ; site = {js|https://www.sleekersoft.com|js}
-  ; locations = 
- [{js|Australia|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/sleekersoft.png|js}
+    ; site = {js|https://www.sleekersoft.com|js}
+    ; locations = [ {js|Australia|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Specialises in functional programming software development, consultation, and training.
 |js}
-  ; body_html = {js|<p>Specialises in functional programming software development, consultation, and training.</p>
+    ; body_html =
+        {js|<p>Specialises in functional programming software development, consultation, and training.</p>
 |js}
-  };
- 
-  { name = {js|Solvuu|js}
-  ; slug = {js|solvuu|js}
-  ; description = {js|Solvuu's software allows users to store big and small data sets, share the data with collaborators, execute computationally intensive algorithms and workflows, and visualize results.
+    }
+  ; { name = {js|Solvuu|js}
+    ; slug = {js|solvuu|js}
+    ; description =
+        {js|Solvuu's software allows users to store big and small data sets, share the data with collaborators, execute computationally intensive algorithms and workflows, and visualize results.
 |js}
-  ; image = Some {js|/users/solvuu.jpg|js}
-  ; site = {js|https://www.solvuu.com|js}
-  ; locations = 
- [{js|United States|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/solvuu.jpg|js}
+    ; site = {js|https://www.solvuu.com|js}
+    ; locations = [ {js|United States|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Solvuu's software allows users to store big and small data sets, share the data with collaborators, execute computationally intensive algorithms and workflows, and visualize results. Its initial focus is on genomics data, which has important implications for healthcare, agriculture, and fundamental research. Virtually all of Solvuu's software stack is implemented in OCaml.
 |js}
-  ; body_html = {js|<p>Solvuu's software allows users to store big and small data sets, share the data with collaborators, execute computationally intensive algorithms and workflows, and visualize results. Its initial focus is on genomics data, which has important implications for healthcare, agriculture, and fundamental research. Virtually all of Solvuu's software stack is implemented in OCaml.</p>
+    ; body_html =
+        {js|<p>Solvuu's software allows users to store big and small data sets, share the data with collaborators, execute computationally intensive algorithms and workflows, and visualize results. Its initial focus is on genomics data, which has important implications for healthcare, agriculture, and fundamental research. Virtually all of Solvuu's software stack is implemented in OCaml.</p>
 |js}
-  };
- 
-  { name = {js|Studio Associato 4Sigma|js}
-  ; slug = {js|studio-associato-4sigma|js}
-  ; description = {js|4Sigma is a small firm making websites and some interesting web applications.
+    }
+  ; { name = {js|Studio Associato 4Sigma|js}
+    ; slug = {js|studio-associato-4sigma|js}
+    ; description =
+        {js|4Sigma is a small firm making websites and some interesting web applications.
 |js}
-  ; image = Some {js|/users/4sigma.png|js}
-  ; site = {js|https://www.4sigma.it|js}
-  ; locations = 
- [{js|Italy|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/4sigma.png|js}
+    ; site = {js|https://www.4sigma.it|js}
+    ; locations = [ {js|Italy|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 4Sigma is a small firm making websites and some interesting web applications. OCaml is not the main language used but it is used here and there, particularly in a small server that is a key component of a service we offer our customers.|js}
-  ; body_html = {js|<p>4Sigma is a small firm making websites and some interesting web applications. OCaml is not the main language used but it is used here and there, particularly in a small server that is a key component of a service we offer our customers.</p>
+    ; body_html =
+        {js|<p>4Sigma is a small firm making websites and some interesting web applications. OCaml is not the main language used but it is used here and there, particularly in a small server that is a key component of a service we offer our customers.</p>
 |js}
-  };
- 
-  { name = {js|Tarides|js}
-  ; slug = {js|tarides|js}
-  ; description = {js|Tarides builds and maintains open-source infrastructure tools in OCaml like MirageOS, Irmin and OCaml developer tools.
+    }
+  ; { name = {js|Tarides|js}
+    ; slug = {js|tarides|js}
+    ; description =
+        {js|Tarides builds and maintains open-source infrastructure tools in OCaml like MirageOS, Irmin and OCaml developer tools.
 |js}
-  ; image = Some {js|/users/tarides.png|js}
-  ; site = {js|https://www.tarides.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/tarides.png|js}
+    ; site = {js|https://www.tarides.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 We are building and maintaining open-source infrastructure tools in OCaml:
 
  - [MirageOS](https://mirage.io), the most advanced unikernel project, where we build sandboxes, network and storage protocol implementations as libraries, so we can link them to our applications to run them without the need of an underlying operating system.
@@ -819,7 +862,8 @@ We are building and maintaining open-source infrastructure tools in OCaml:
 Tarides was founded in early 2018 and is mainly based in Paris, France (remote work is possible).
 
 |js}
-  ; body_html = {js|<p>We are building and maintaining open-source infrastructure tools in OCaml:</p>
+    ; body_html =
+        {js|<p>We are building and maintaining open-source infrastructure tools in OCaml:</p>
 <ul>
 <li><a href="https://mirage.io">MirageOS</a>, the most advanced unikernel project, where we build sandboxes, network and storage protocol implementations as libraries, so we can link them to our applications to run them without the need of an underlying operating system.
 </li>
@@ -830,645 +874,685 @@ Tarides was founded in early 2018 and is mainly based in Paris, France (remote w
 </ul>
 <p>Tarides was founded in early 2018 and is mainly based in Paris, France (remote work is possible).</p>
 |js}
-  };
- 
-  { name = {js|TrustInSoft|js}
-  ; slug = {js|trustinsoft|js}
-  ; description = {js|TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis Frama-C platform. 
+    }
+  ; { name = {js|TrustInSoft|js}
+    ; slug = {js|trustinsoft|js}
+    ; description =
+        {js|TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis Frama-C platform. 
 |js}
-  ; image = Some {js|/users/trustinsoft.png|js}
-  ; site = {js|https://trust-in-soft.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/trustinsoft.png|js}
+    ; site = {js|https://trust-in-soft.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis [Frama-C](https://frama-c.com) platform. Our motto is simple: make the formal methods accessible to the majority of software developers.|js}
-  ; body_html = {js|<p>TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis <a href="https://frama-c.com">Frama-C</a> platform. Our motto is simple: make the formal methods accessible to the majority of software developers.</p>
+    ; body_html =
+        {js|<p>TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis <a href="https://frama-c.com">Frama-C</a> platform. Our motto is simple: make the formal methods accessible to the majority of software developers.</p>
 |js}
-  };
- 
-  { name = {js|Wolfram MathCore|js}
-  ; slug = {js|wolfram-mathcore|js}
-  ; description = {js|Wolfram MathCore uses OCaml to implement its SystemModeler kernel.
+    }
+  ; { name = {js|Wolfram MathCore|js}
+    ; slug = {js|wolfram-mathcore|js}
+    ; description =
+        {js|Wolfram MathCore uses OCaml to implement its SystemModeler kernel.
 |js}
-  ; image = Some {js|/users/wolfram-mathcore.gif|js}
-  ; site = {js|https://www.wolframmathcore.com|js}
-  ; locations = 
- [{js|Sweden|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/wolfram-mathcore.gif|js}
+    ; site = {js|https://www.wolframmathcore.com|js}
+    ; locations = [ {js|Sweden|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Wolfram MathCore uses OCaml to implement its SystemModeler kernel. The kernel's main function is to translate models defined in the Modelica language into executable simulation code. This involves parsing and transforming Modelica code, mathematical processing of equations, code generation of C/C++ simulation code, and numerical runtime computations.
 |js}
-  ; body_html = {js|<p>Wolfram MathCore uses OCaml to implement its SystemModeler kernel. The kernel's main function is to translate models defined in the Modelica language into executable simulation code. This involves parsing and transforming Modelica code, mathematical processing of equations, code generation of C/C++ simulation code, and numerical runtime computations.</p>
+    ; body_html =
+        {js|<p>Wolfram MathCore uses OCaml to implement its SystemModeler kernel. The kernel's main function is to translate models defined in the Modelica language into executable simulation code. This involves parsing and transforming Modelica code, mathematical processing of equations, code generation of C/C++ simulation code, and numerical runtime computations.</p>
 |js}
-  };
- 
-  { name = {js|Zeo Agency|js}
-  ; slug = {js|zeo-agency|js}
-  ; description = {js|Zeo is a digital marketing company focused on helping companies to do better in SEO.
+    }
+  ; { name = {js|Zeo Agency|js}
+    ; slug = {js|zeo-agency|js}
+    ; description =
+        {js|Zeo is a digital marketing company focused on helping companies to do better in SEO.
 |js}
-  ; image = None
-  ; site = {js|https://www.zeo.org|js}
-  ; locations = 
- [{js|London, United Kingdom|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = None
+    ; site = {js|https://www.zeo.org|js}
+    ; locations = [ {js|London, United Kingdom|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Zeo is a digital marketing company focused on helping companies to do better in SEO. Due to the nature of our business, we manage billions of lines in our database & create insights by using this data. To utilize our needs effectively, we use OCaml in our data crawling & processing part.
 |js}
-  ; body_html = {js|<p>Zeo is a digital marketing company focused on helping companies to do better in SEO. Due to the nature of our business, we manage billions of lines in our database &amp; create insights by using this data. To utilize our needs effectively, we use OCaml in our data crawling &amp; processing part.</p>
+    ; body_html =
+        {js|<p>Zeo is a digital marketing company focused on helping companies to do better in SEO. Due to the nature of our business, we manage billions of lines in our database &amp; create insights by using this data. To utilize our needs effectively, we use OCaml in our data crawling &amp; processing part.</p>
 |js}
-  }]
+    }
+  ]
 
-let all_fr = 
-[
-  { name = {js|Aesthetic Integration|js}
-  ; slug = {js|aesthetic-integration|js}
-  ; description = {js|Aesthetic Integration (AI) est une startup financière basée dans la City de Londres
+let all_fr =
+  [ { name = {js|Aesthetic Integration|js}
+    ; slug = {js|aesthetic-integration|js}
+    ; description =
+        {js|Aesthetic Integration (AI) est une startup financière basée dans la City de Londres
 |js}
-  ; image = Some {js|/users/aesthetic-integration.png|js}
-  ; site = {js|https://www.aestheticintegration.com|js}
-  ; locations = 
- [{js|Royaume-Uni|js}]
-  ; consortium = true
-  ; body_md = {js|Aesthetic Integration (AI) est une startup financière basée dans la City de Londres. Sa technologie de vérification formelle de brevets déposés révolutionne la sureté, la stabilité et la transparence des marchés financiers globaux.
+    ; image = Some {js|/users/aesthetic-integration.png|js}
+    ; site = {js|https://www.aestheticintegration.com|js}
+    ; locations = [ {js|Royaume-Uni|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|Aesthetic Integration (AI) est une startup financière basée dans la City de Londres. Sa technologie de vérification formelle de brevets déposés révolutionne la sureté, la stabilité et la transparence des marchés financiers globaux.
 |js}
-  ; body_html = {js|<p>Aesthetic Integration (AI) est une startup financière basée dans la City de Londres. Sa technologie de vérification formelle de brevets déposés révolutionne la sureté, la stabilité et la transparence des marchés financiers globaux.</p>
+    ; body_html =
+        {js|<p>Aesthetic Integration (AI) est une startup financière basée dans la City de Londres. Sa technologie de vérification formelle de brevets déposés révolutionne la sureté, la stabilité et la transparence des marchés financiers globaux.</p>
 |js}
-  };
- 
-  { name = {js|Ahrefs|js}
-  ; slug = {js|ahrefs|js}
-  ; description = {js|Ahrefs développe des systèmes de stockages sur mesure allant jusqu'aux pétaoctets et fait tourner un robot d'exploration d'Internet pour indexer le web tout entier
+    }
+  ; { name = {js|Ahrefs|js}
+    ; slug = {js|ahrefs|js}
+    ; description =
+        {js|Ahrefs développe des systèmes de stockages sur mesure allant jusqu'aux pétaoctets et fait tourner un robot d'exploration d'Internet pour indexer le web tout entier
 |js}
-  ; image = Some {js|/users/ahrefs.png|js}
-  ; site = {js|https://www.ahrefs.com|js}
-  ; locations = 
- [{js|Singapour|js}; {js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/ahrefs.png|js}
+    ; site = {js|https://www.ahrefs.com|js}
+    ; locations = [ {js|Singapour|js}; {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Ahrefs développe des systèmes de stockages sur mesure allant jusqu'aux pétaoctets et fait tourner un robot d'exploration d'Internet pour indexer le web tout entier. À partir de cette entreprise sont construits différents services d'analyses pour les utilisateurs finaux. OCaml est le langage principal du backend de Ahrefs, qui traite jusqu'à 6 milliards de pages par jour. Ahrefs est une équipe multinationale ayant des racines en Ukraine et des bureaux à Singapour et San Francisco.
 |js}
-  ; body_html = {js|<p>Ahrefs développe des systèmes de stockages sur mesure allant jusqu'aux pétaoctets et fait tourner un robot d'exploration d'Internet pour indexer le web tout entier. À partir de cette entreprise sont construits différents services d'analyses pour les utilisateurs finaux. OCaml est le langage principal du backend de Ahrefs, qui traite jusqu'à 6 milliards de pages par jour. Ahrefs est une équipe multinationale ayant des racines en Ukraine et des bureaux à Singapour et San Francisco.</p>
+    ; body_html =
+        {js|<p>Ahrefs développe des systèmes de stockages sur mesure allant jusqu'aux pétaoctets et fait tourner un robot d'exploration d'Internet pour indexer le web tout entier. À partir de cette entreprise sont construits différents services d'analyses pour les utilisateurs finaux. OCaml est le langage principal du backend de Ahrefs, qui traite jusqu'à 6 milliards de pages par jour. Ahrefs est une équipe multinationale ayant des racines en Ukraine et des bureaux à Singapour et San Francisco.</p>
 |js}
-  };
- 
-  { name = {js|American Museum of Natural History|js}
-  ; slug = {js|american-museum-of-natural-history|js}
-  ; description = {js|Le Département des Sciences Computationnelles du AMNH utilise OCaml depuis presque une décennie pour leur suite de logiciels POY pour site d'interférence phylogénétique: "https://www.amnh.org/our-research/computational-sciences"
+    }
+  ; { name = {js|American Museum of Natural History|js}
+    ; slug = {js|american-museum-of-natural-history|js}
+    ; description =
+        {js|Le Département des Sciences Computationnelles du AMNH utilise OCaml depuis presque une décennie pour leur suite de logiciels POY pour site d'interférence phylogénétique: "https://www.amnh.org/our-research/computational-sciences"
 |js}
-  ; image = Some {js|/users/amnh.png|js}
-  ; site = {js|https://www.amnh.org/our-research/computational-sciences|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/amnh.png|js}
+    ; site = {js|https://www.amnh.org/our-research/computational-sciences|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Le Département des Sciences Computationnelles du AMNH utilise OCaml depuis presque une décennie pour leur suite de logiciels POY pour site d'interférence phylogénétique: "https://www.amnh.org/our-research/computational-sciences". Voir la [Page GitHub de l'AMNH](https://github.com/AMNH) pour plus de projets.
 |js}
-  ; body_html = {js|<p>Le Département des Sciences Computationnelles du AMNH utilise OCaml depuis presque une décennie pour leur suite de logiciels POY pour site d'interférence phylogénétique: &quot;https://www.amnh.org/our-research/computational-sciences&quot;. Voir la <a href="https://github.com/AMNH">Page GitHub de l'AMNH</a> pour plus de projets.</p>
+    ; body_html =
+        {js|<p>Le Département des Sciences Computationnelles du AMNH utilise OCaml depuis presque une décennie pour leur suite de logiciels POY pour site d'interférence phylogénétique: &quot;https://www.amnh.org/our-research/computational-sciences&quot;. Voir la <a href="https://github.com/AMNH">Page GitHub de l'AMNH</a> pour plus de projets.</p>
 |js}
-  };
- 
-  { name = {js|ANSSI|js}
-  ; slug = {js|anssi|js}
-  ; description = {js|Les missions principales de l'ANSSI sont : de détecter et réagir à des cyberattaques, de prévenir des menaces, de fournir du conseil et du support à des entités gouvernemental et à des opérateurs d'infrastructures critiques, et de garder les entreprises et le grand public informé sur des menaces pour la sécurité des informations
+    }
+  ; { name = {js|ANSSI|js}
+    ; slug = {js|anssi|js}
+    ; description =
+        {js|Les missions principales de l'ANSSI sont : de détecter et réagir à des cyberattaques, de prévenir des menaces, de fournir du conseil et du support à des entités gouvernemental et à des opérateurs d'infrastructures critiques, et de garder les entreprises et le grand public informé sur des menaces pour la sécurité des informations
 |js}
-  ; image = Some {js|/users/anssi.png|js}
-  ; site = {js|https://www.ssi.gouv.fr/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/anssi.png|js}
+    ; site = {js|https://www.ssi.gouv.fr/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Les missions principales de l'ANSSI sont : de détecter et réagir à des cyberattaques, de prévenir des menaces, de fournir du conseil et du support à des entités gouvernemental et à des opérateurs d'infrastructures critiques, et de garder les entreprises et le grand public informé sur des menaces pour la sécurité des informations. Voir [la page Github de l'ANSSI](https://github.com/anssi-fr) pour certains de ses logiciels en OCaml.
 |js}
-  ; body_html = {js|<p>Les missions principales de l'ANSSI sont : de détecter et réagir à des cyberattaques, de prévenir des menaces, de fournir du conseil et du support à des entités gouvernemental et à des opérateurs d'infrastructures critiques, et de garder les entreprises et le grand public informé sur des menaces pour la sécurité des informations. Voir <a href="https://github.com/anssi-fr">la page Github de l'ANSSI</a> pour certains de ses logiciels en OCaml.</p>
+    ; body_html =
+        {js|<p>Les missions principales de l'ANSSI sont : de détecter et réagir à des cyberattaques, de prévenir des menaces, de fournir du conseil et du support à des entités gouvernemental et à des opérateurs d'infrastructures critiques, et de garder les entreprises et le grand public informé sur des menaces pour la sécurité des informations. Voir <a href="https://github.com/anssi-fr">la page Github de l'ANSSI</a> pour certains de ses logiciels en OCaml.</p>
 |js}
-  };
- 
-  { name = {js|Arena|js}
-  ; slug = {js|arena|js}
-  ; description = {js|Arena aide les organisations à embaucher les bonnes personnes.
+    }
+  ; { name = {js|Arena|js}
+    ; slug = {js|arena|js}
+    ; description =
+        {js|Arena aide les organisations à embaucher les bonnes personnes.
 |js}
-  ; image = Some {js|/users/arena.jpg|js}
-  ; site = {js|https://www.arena.io|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/arena.jpg|js}
+    ; site = {js|https://www.arena.io|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Arena aide les organisations à embaucher les bonnes personnes. Nous réalisons cela en appliquant le Big Data et l'analyse prédictive au processus de recrutement. Cela résulte à moins de roulement pour nos clients et à moins de discrimination pour les individus. Nous utilisons OCaml pour tout notre backend de développement.
 |js}
-  ; body_html = {js|<p>Arena aide les organisations à embaucher les bonnes personnes. Nous réalisons cela en appliquant le Big Data et l'analyse prédictive au processus de recrutement. Cela résulte à moins de roulement pour nos clients et à moins de discrimination pour les individus. Nous utilisons OCaml pour tout notre backend de développement.</p>
+    ; body_html =
+        {js|<p>Arena aide les organisations à embaucher les bonnes personnes. Nous réalisons cela en appliquant le Big Data et l'analyse prédictive au processus de recrutement. Cela résulte à moins de roulement pour nos clients et à moins de discrimination pour les individus. Nous utilisons OCaml pour tout notre backend de développement.</p>
 |js}
-  };
- 
-  { name = {js|Be Sport|js}
-  ; slug = {js|be-sport|js}
-  ; description = {js|La mission de Be Sport est d'augmenter la valeur que le sport apporte dans nos vies avec une utilisation appropriée des innovations numériques et des réseaux sociaux.
+    }
+  ; { name = {js|Be Sport|js}
+    ; slug = {js|be-sport|js}
+    ; description =
+        {js|La mission de Be Sport est d'augmenter la valeur que le sport apporte dans nos vies avec une utilisation appropriée des innovations numériques et des réseaux sociaux.
 |js}
-  ; image = Some {js|/users/besport.png|js}
-  ; site = {js|https://besport.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/besport.png|js}
+    ; site = {js|https://besport.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 La mission de Be Sport est d'augmenter la valeur que le sport apporte dans nos vies avec une utilisation appropriée des innovations numériques et des réseaux sociaux.
 
 Be Sport un projet 100% en [OCaml](https://ocaml.org) et [OCsigen](https://ocsigen.org), qui sont les seules briques de base pour développer la plateforme
 |js}
-  ; body_html = {js|<p>La mission de Be Sport est d'augmenter la valeur que le sport apporte dans nos vies avec une utilisation appropriée des innovations numériques et des réseaux sociaux.</p>
+    ; body_html =
+        {js|<p>La mission de Be Sport est d'augmenter la valeur que le sport apporte dans nos vies avec une utilisation appropriée des innovations numériques et des réseaux sociaux.</p>
 <p>Be Sport un projet 100% en <a href="https://ocaml.org">OCaml</a> et <a href="https://ocsigen.org">OCsigen</a>, qui sont les seules briques de base pour développer la plateforme</p>
 |js}
-  };
- 
-  { name = {js|Bloomberg L.P.|js}
-  ; slug = {js|bloomberg-lp|js}
-  ; description = {js|Bloomberg, le leader mondial de l'information et des actualités commerciales et financières, donne aux décideurs influents un avantage décisif en les connectant à un réseau dynamique d'informations, de personnes et d'idées
+    }
+  ; { name = {js|Bloomberg L.P.|js}
+    ; slug = {js|bloomberg-lp|js}
+    ; description =
+        {js|Bloomberg, le leader mondial de l'information et des actualités commerciales et financières, donne aux décideurs influents un avantage décisif en les connectant à un réseau dynamique d'informations, de personnes et d'idées
 |js}
-  ; image = Some {js|/users/bloomberg.jpg|js}
-  ; site = {js|https://www.bloomberg.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/bloomberg.jpg|js}
+    ; site = {js|https://www.bloomberg.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Bloomberg, le leader mondial de l'information et des actualités commerciales et financières, donne aux décideurs influents un avantage décisif en les connectant à un réseau dynamique d'informations, de personnes et d'idées. Bloomberg utilise OCaml dans une application avancée de gestion des risques liés aux produits financiers dérivés, fournie par son service Bloomberg Professional.
 |js}
-  ; body_html = {js|<p>Bloomberg, le leader mondial de l'information et des actualités commerciales et financières, donne aux décideurs influents un avantage décisif en les connectant à un réseau dynamique d'informations, de personnes et d'idées. Bloomberg utilise OCaml dans une application avancée de gestion des risques liés aux produits financiers dérivés, fournie par son service Bloomberg Professional.</p>
+    ; body_html =
+        {js|<p>Bloomberg, le leader mondial de l'information et des actualités commerciales et financières, donne aux décideurs influents un avantage décisif en les connectant à un réseau dynamique d'informations, de personnes et d'idées. Bloomberg utilise OCaml dans une application avancée de gestion des risques liés aux produits financiers dérivés, fournie par son service Bloomberg Professional.</p>
 |js}
-  };
- 
-  { name = {js|CACAOWEB|js}
-  ; slug = {js|cacaoweb|js}
-  ; description = {js|Cacaoweb développe une plateforme d'applications d'un nouveau genre. Elle fonctionne sur notre réseau pair-à-pair, qui se trouve être l'un des plus importants au monde
+    }
+  ; { name = {js|CACAOWEB|js}
+    ; slug = {js|cacaoweb|js}
+    ; description =
+        {js|Cacaoweb développe une plateforme d'applications d'un nouveau genre. Elle fonctionne sur notre réseau pair-à-pair, qui se trouve être l'un des plus importants au monde
 |js}
-  ; image = Some {js|/users/cacaoweb.png|js}
-  ; site = {js|https://cacaoweb.org/|js}
-  ; locations = 
- [{js|Royaume-Uni|js}; {js|Hong Kong|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/cacaoweb.png|js}
+    ; site = {js|https://cacaoweb.org/|js}
+    ; locations = [ {js|Royaume-Uni|js}; {js|Hong Kong|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Cacaoweb développe une plateforme d'applications d'un nouveau genre. Elle fonctionne sur notre réseau pair à pair, qui se trouve être l'un des plus importants au monde. Les capacités de la plateforme sont diverses et vont du streaming multimédia à la communication sociale, en passant par le stockage hors ligne ou la synchronisation des données. Nous concevons et mettons en oeuvre : des systèmes de stockage de données massivement distribuées, des langages de programmation, des systèmes d'exécution et des frameworks de calculs parallèles.
 |js}
-  ; body_html = {js|<p>Cacaoweb développe une plateforme d'applications d'un nouveau genre. Elle fonctionne sur notre réseau pair à pair, qui se trouve être l'un des plus importants au monde. Les capacités de la plateforme sont diverses et vont du streaming multimédia à la communication sociale, en passant par le stockage hors ligne ou la synchronisation des données. Nous concevons et mettons en oeuvre : des systèmes de stockage de données massivement distribuées, des langages de programmation, des systèmes d'exécution et des frameworks de calculs parallèles.</p>
+    ; body_html =
+        {js|<p>Cacaoweb développe une plateforme d'applications d'un nouveau genre. Elle fonctionne sur notre réseau pair à pair, qui se trouve être l'un des plus importants au monde. Les capacités de la plateforme sont diverses et vont du streaming multimédia à la communication sociale, en passant par le stockage hors ligne ou la synchronisation des données. Nous concevons et mettons en oeuvre : des systèmes de stockage de données massivement distribuées, des langages de programmation, des systèmes d'exécution et des frameworks de calculs parallèles.</p>
 |js}
-  };
- 
-  { name = {js|CEA|js}
-  ; slug = {js|cea|js}
-  ; description = {js|CEA est une entreprise publique française, membre du Consortium OCaml
+    }
+  ; { name = {js|CEA|js}
+    ; slug = {js|cea|js}
+    ; description =
+        {js|CEA est une entreprise publique française, membre du Consortium OCaml
 |js}
-  ; image = Some {js|/users/cea.png|js}
-  ; site = {js|https://cea.fr/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/cea.png|js}
+    ; site = {js|https://cea.fr/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Le CEA est une entreprise publique française, membre du Consortium OCaml. Ils utilisent OCaml principalement pour développer une plateforme dédiée à l'analyse du code source des logiciels C, appelée [Frama-C] (https://frama-c.com).
 |js}
-  ; body_html = {js|<p>Le CEA est une entreprise publique française, membre du Consortium OCaml. Ils utilisent OCaml principalement pour développer une plateforme dédiée à l'analyse du code source des logiciels C, appelée [Frama-C] (https://frama-c.com).</p>
+    ; body_html =
+        {js|<p>Le CEA est une entreprise publique française, membre du Consortium OCaml. Ils utilisent OCaml principalement pour développer une plateforme dédiée à l'analyse du code source des logiciels C, appelée [Frama-C] (https://frama-c.com).</p>
 |js}
-  };
- 
-  { name = {js|Citrix|js}
-  ; slug = {js|citrix|js}
-  ; description = {js|Citrix utilise OCaml dans XenServer, un système de virtualisation de serveurs de classe mondiale.
+    }
+  ; { name = {js|Citrix|js}
+    ; slug = {js|citrix|js}
+    ; description =
+        {js|Citrix utilise OCaml dans XenServer, un système de virtualisation de serveurs de classe mondiale.
 |js}
-  ; image = Some {js|/users/citrix.png|js}
-  ; site = {js|https://www.citrix.com|js}
-  ; locations = 
- [{js|United Kingdom|js}; {js|Royaume-Uni|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/citrix.png|js}
+    ; site = {js|https://www.citrix.com|js}
+    ; locations = [ {js|United Kingdom|js}; {js|Royaume-Uni|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Citrix utilise OCaml dans XenServer, un système de virtualisation de serveurs de classe mondiale. La plupart des composants de XenServer sont publiés en open source. Les composants open source de la boîte à outils XenServer implémentés en OCaml sont regroupés dans le dépôt [XS-opam](https://github.com/xapi-project/xs-opam) sur GitHub.
 |js}
-  ; body_html = {js|<p>Citrix utilise OCaml dans XenServer, un système de virtualisation de serveurs de classe mondiale. La plupart des composants de XenServer sont publiés en open source. Les composants open source de la boîte à outils XenServer implémentés en OCaml sont regroupés dans le dépôt <a href="https://github.com/xapi-project/xs-opam">XS-opam</a> sur GitHub.</p>
+    ; body_html =
+        {js|<p>Citrix utilise OCaml dans XenServer, un système de virtualisation de serveurs de classe mondiale. La plupart des composants de XenServer sont publiés en open source. Les composants open source de la boîte à outils XenServer implémentés en OCaml sont regroupés dans le dépôt <a href="https://github.com/xapi-project/xs-opam">XS-opam</a> sur GitHub.</p>
 |js}
-  };
- 
-  { name = {js|Coherent Graphics Ltd|js}
-  ; slug = {js|coherent-graphics-ltd|js}
-  ; description = {js|Coherent Graphics est un développeur d'outils de serveur et de logiciels de bureau pour le traitement des documents PDF
+    }
+  ; { name = {js|Coherent Graphics Ltd|js}
+    ; slug = {js|coherent-graphics-ltd|js}
+    ; description =
+        {js|Coherent Graphics est un développeur d'outils de serveur et de logiciels de bureau pour le traitement des documents PDF
 |js}
-  ; image = Some {js|/users/coherent.png|js}
-  ; site = {js|https://www.coherentpdf.com/|js}
-  ; locations = 
- [{js|Royaume-Uni|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/coherent.png|js}
+    ; site = {js|https://www.coherentpdf.com/|js}
+    ; locations = [ {js|Royaume-Uni|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Coherent Graphics est un développeur d'outils de serveur et de logiciels de bureau pour le traitement des documents PDF. Nous utilisons OCaml comme langage de haut niveau polyvalent, choisi pour son expressivité et sa rapidité.
 |js}
-  ; body_html = {js|<p>Coherent Graphics est un développeur d'outils de serveur et de logiciels de bureau pour le traitement des documents PDF. Nous utilisons OCaml comme langage de haut niveau polyvalent, choisi pour son expressivité et sa rapidité.</p>
+    ; body_html =
+        {js|<p>Coherent Graphics est un développeur d'outils de serveur et de logiciels de bureau pour le traitement des documents PDF. Nous utilisons OCaml comme langage de haut niveau polyvalent, choisi pour son expressivité et sa rapidité.</p>
 |js}
-  };
- 
-  { name = {js|Cryptosense|js}
-  ; slug = {js|cryptosense|js}
-  ; description = {js|Cryptosense crée des logiciels d'analyse de la sécurité avec un accent particulier sur les systèmes cryptographiques
+    }
+  ; { name = {js|Cryptosense|js}
+    ; slug = {js|cryptosense|js}
+    ; description =
+        {js|Cryptosense crée des logiciels d'analyse de la sécurité avec un accent particulier sur les systèmes cryptographiques
 |js}
-  ; image = Some {js|/users/cryptosense.png|js}
-  ; site = {js|https://www.cryptosense.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/cryptosense.png|js}
+    ; site = {js|https://www.cryptosense.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Basée à Paris, en France, Cryptosense crée des logiciels d'analyse de sécurité avec un accent particulier sur les systèmes cryptographiques. Venant de l'Institut de recherche en informatique (INRIA), les fondateurs de Cryptosense combinent plus de 40 ans d'expérience dans la recherche et l'industrie. Cryptosense fournit ses solutions à une clientèle internationale, notamment dans les secteurs financier, industriel et gouvernemental.
 |js}
-  ; body_html = {js|<p>Basée à Paris, en France, Cryptosense crée des logiciels d'analyse de sécurité avec un accent particulier sur les systèmes cryptographiques. Venant de l'Institut de recherche en informatique (INRIA), les fondateurs de Cryptosense combinent plus de 40 ans d'expérience dans la recherche et l'industrie. Cryptosense fournit ses solutions à une clientèle internationale, notamment dans les secteurs financier, industriel et gouvernemental.</p>
+    ; body_html =
+        {js|<p>Basée à Paris, en France, Cryptosense crée des logiciels d'analyse de sécurité avec un accent particulier sur les systèmes cryptographiques. Venant de l'Institut de recherche en informatique (INRIA), les fondateurs de Cryptosense combinent plus de 40 ans d'expérience dans la recherche et l'industrie. Cryptosense fournit ses solutions à une clientèle internationale, notamment dans les secteurs financier, industriel et gouvernemental.</p>
 |js}
-  };
- 
-  { name = {js|Dassault Systèmes|js}
-  ; slug = {js|dassault-systmes|js}
-  ; description = {js|Dassault Systèmes, la société 3DEXPERIENCE, fournit aux entreprises et aux particuliers des univers virtuels pour imaginer des innovations durables
+    }
+  ; { name = {js|Dassault Systèmes|js}
+    ; slug = {js|dassault-systmes|js}
+    ; description =
+        {js|Dassault Systèmes, la société 3DEXPERIENCE, fournit aux entreprises et aux particuliers des univers virtuels pour imaginer des innovations durables
 |js}
-  ; image = Some {js|/users/dassault.png|js}
-  ; site = {js|https://www.3ds.com/fr/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/dassault.png|js}
+    ; site = {js|https://www.3ds.com/fr/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Dassault Systèmes, la société 3DEXPERIENCE, fournit aux entreprises et aux particuliers des univers virtuels pour imaginer des innovations durables.
 |js}
-  ; body_html = {js|<p>Dassault Systèmes, la société 3DEXPERIENCE, fournit aux entreprises et aux particuliers des univers virtuels pour imaginer des innovations durables.</p>
+    ; body_html =
+        {js|<p>Dassault Systèmes, la société 3DEXPERIENCE, fournit aux entreprises et aux particuliers des univers virtuels pour imaginer des innovations durables.</p>
 |js}
-  };
- 
-  { name = {js|Dernier Cri|js}
-  ; slug = {js|dernier-cri|js}
-  ; description = {js|Dernier Cri est une entreprise française basée à Lille et à Paris qui utilise la programmation fonctionnelle pour développer des applications web et mobiles
+    }
+  ; { name = {js|Dernier Cri|js}
+    ; slug = {js|dernier-cri|js}
+    ; description =
+        {js|Dernier Cri est une entreprise française basée à Lille et à Paris qui utilise la programmation fonctionnelle pour développer des applications web et mobiles
 |js}
-  ; image = Some {js|/users/derniercri.png|js}
-  ; site = {js|https://derniercri.io|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/derniercri.png|js}
+    ; site = {js|https://derniercri.io|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Dernier Cri est une entreprise française basée à Lille et à Paris qui utilise la programmation fonctionnelle pour développer des applications web et mobiles. OCaml est principalement utilisé pour développer des outils internes.
 |js}
-  ; body_html = {js|<p>Dernier Cri est une entreprise française basée à Lille et à Paris qui utilise la programmation fonctionnelle pour développer des applications web et mobiles. OCaml est principalement utilisé pour développer des outils internes.</p>
+    ; body_html =
+        {js|<p>Dernier Cri est une entreprise française basée à Lille et à Paris qui utilise la programmation fonctionnelle pour développer des applications web et mobiles. OCaml est principalement utilisé pour développer des outils internes.</p>
 |js}
-  };
- 
-  { name = {js|Digirati dba Hostnet|js}
-  ; slug = {js|digirati-dba-hostnet|js}
-  ; description = {js|Digirati dba Hostnet est une société d'hébergement web
+    }
+  ; { name = {js|Digirati dba Hostnet|js}
+    ; slug = {js|digirati-dba-hostnet|js}
+    ; description =
+        {js|Digirati dba Hostnet est une société d'hébergement web
 |js}
-  ; image = Some {js|/users/hostnet.gif|js}
-  ; site = {js|https://www.hostnet.com.br/|js}
-  ; locations = 
- [{js|Brésil|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/hostnet.gif|js}
+    ; site = {js|https://www.hostnet.com.br/|js}
+    ; locations = [ {js|Brésil|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Digirati dba Hostnet est une société d'hébergement web. Nous utilisons OCaml principalement pour la programmation des systèmes internes et des services d'infrastructure. Nous avons également contribué à la communauté en publiant quelques [bibliothèques OCaml open source](https://github.com/andrenth).
 |js}
-  ; body_html = {js|<p>Digirati dba Hostnet est une société d'hébergement web. Nous utilisons OCaml principalement pour la programmation des systèmes internes et des services d'infrastructure. Nous avons également contribué à la communauté en publiant quelques <a href="https://github.com/andrenth">bibliothèques OCaml open source</a>.</p>
+    ; body_html =
+        {js|<p>Digirati dba Hostnet est une société d'hébergement web. Nous utilisons OCaml principalement pour la programmation des systèmes internes et des services d'infrastructure. Nous avons également contribué à la communauté en publiant quelques <a href="https://github.com/andrenth">bibliothèques OCaml open source</a>.</p>
 |js}
-  };
- 
-  { name = {js|Docker, Inc.|js}
-  ; slug = {js|docker-inc|js}
-  ; description = {js|Docker fournit une suite technologique intégrée qui permet aux équipes de développement et d'exploitation informatique de créer, de distribuer et d'exécuter des applications distribuées partout
+    }
+  ; { name = {js|Docker, Inc.|js}
+    ; slug = {js|docker-inc|js}
+    ; description =
+        {js|Docker fournit une suite technologique intégrée qui permet aux équipes de développement et d'exploitation informatique de créer, de distribuer et d'exécuter des applications distribuées partout
 |js}
-  ; image = Some {js|/users/docker.png|js}
-  ; site = {js|https://www.docker.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/docker.png|js}
+    ; site = {js|https://www.docker.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Docker fournit une suite technologique intégrée qui permet aux équipes de développement et d'exploitation informatique de créer, de distribuer et d'exécuter des applications distribuées partout. Leurs [applications natives pour Mac et Windows](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/) utilisent du code OCaml tiré du projet de système d'exploitation en bibliothèque [MirageOS](https://mirage.io).
 |js}
-  ; body_html = {js|<p>Docker fournit une suite technologique intégrée qui permet aux équipes de développement et d'exploitation informatique de créer, de distribuer et d'exécuter des applications distribuées partout. Leurs <a href="https://blog.docker.com/2016/03/docker-for-mac-windows-beta/">applications natives pour Mac et Windows</a> utilisent du code OCaml tiré du projet de système d'exploitation en bibliothèque <a href="https://mirage.io">MirageOS</a>.</p>
+    ; body_html =
+        {js|<p>Docker fournit une suite technologique intégrée qui permet aux équipes de développement et d'exploitation informatique de créer, de distribuer et d'exécuter des applications distribuées partout. Leurs <a href="https://blog.docker.com/2016/03/docker-for-mac-windows-beta/">applications natives pour Mac et Windows</a> utilisent du code OCaml tiré du projet de système d'exploitation en bibliothèque <a href="https://mirage.io">MirageOS</a>.</p>
 |js}
-  };
- 
-  { name = {js|Esterel Technologies|js}
-  ; slug = {js|esterel-technologies|js}
-  ; description = {js|Esterel Technologies est un des principaux fournisseurs de systèmes critiques et de solutions de développement de logiciels pour les secteurs de l'aérospatiale, de la défense, du transport ferroviaire, du nucléaire, de l'industrie et de l'automobile
+    }
+  ; { name = {js|Esterel Technologies|js}
+    ; slug = {js|esterel-technologies|js}
+    ; description =
+        {js|Esterel Technologies est un des principaux fournisseurs de systèmes critiques et de solutions de développement de logiciels pour les secteurs de l'aérospatiale, de la défense, du transport ferroviaire, du nucléaire, de l'industrie et de l'automobile
 |js}
-  ; image = Some {js|/users/esterel.jpg|js}
-  ; site = {js|https://www.esterel-technologies.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/esterel.jpg|js}
+    ; site = {js|https://www.esterel-technologies.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Esterel Technologies est un des principaux fournisseurs de systèmes critiques et de solutions de développement de logiciels pour les secteurs de l'aérospatiale, de la défense, du transport ferroviaire, du nucléaire, de l'industrie et de l'automobile
 |js}
-  ; body_html = {js|<p>Esterel Technologies est un des principaux fournisseurs de systèmes critiques et de solutions de développement de logiciels pour les secteurs de l'aérospatiale, de la défense, du transport ferroviaire, du nucléaire, de l'industrie et de l'automobile</p>
+    ; body_html =
+        {js|<p>Esterel Technologies est un des principaux fournisseurs de systèmes critiques et de solutions de développement de logiciels pour les secteurs de l'aérospatiale, de la défense, du transport ferroviaire, du nucléaire, de l'industrie et de l'automobile</p>
 |js}
-  };
- 
-  { name = {js|Facebook|js}
-  ; slug = {js|facebook|js}
-  ; description = {js|Facebook a construit un certain nombre d'outils de développement importants en utilisant OCaml|js}
-  ; image = Some {js|/users/facebook.png|js}
-  ; site = {js|https://www.facebook.com/|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    }
+  ; { name = {js|Facebook|js}
+    ; slug = {js|facebook|js}
+    ; description =
+        {js|Facebook a construit un certain nombre d'outils de développement importants en utilisant OCaml|js}
+    ; image = Some {js|/users/facebook.png|js}
+    ; site = {js|https://www.facebook.com/|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Facebook a construit un certain nombre d'outils de développement importants en utilisant OCaml. [Hack](https://hacklang.org) est un compilateur pour une variante de PHP qui vise à concilier le cycle de développement rapide de PHP avec la discipline fournie par le typage statique. [Flow](https://flowtype.org) est un projet similaire qui fournit une vérification statique des types pour JavaScript.  Les deux systèmes sont des programmes fonctionnant en parallèle, très réactifs, capables d'intégrer les modifications du code source en temps réel. [Pfff](https://github.com/facebook/pfff/wiki/Main) est un ensemble d'outils pour l'analyse du code, les visualisations et les transformations de sources préservant le style, écrit en OCaml, mais supportant de nombreux langages.
 |js}
-  ; body_html = {js|<p>Facebook a construit un certain nombre d'outils de développement importants en utilisant OCaml. <a href="https://hacklang.org">Hack</a> est un compilateur pour une variante de PHP qui vise à concilier le cycle de développement rapide de PHP avec la discipline fournie par le typage statique. <a href="https://flowtype.org">Flow</a> est un projet similaire qui fournit une vérification statique des types pour JavaScript.  Les deux systèmes sont des programmes fonctionnant en parallèle, très réactifs, capables d'intégrer les modifications du code source en temps réel. <a href="https://github.com/facebook/pfff/wiki/Main">Pfff</a> est un ensemble d'outils pour l'analyse du code, les visualisations et les transformations de sources préservant le style, écrit en OCaml, mais supportant de nombreux langages.</p>
+    ; body_html =
+        {js|<p>Facebook a construit un certain nombre d'outils de développement importants en utilisant OCaml. <a href="https://hacklang.org">Hack</a> est un compilateur pour une variante de PHP qui vise à concilier le cycle de développement rapide de PHP avec la discipline fournie par le typage statique. <a href="https://flowtype.org">Flow</a> est un projet similaire qui fournit une vérification statique des types pour JavaScript.  Les deux systèmes sont des programmes fonctionnant en parallèle, très réactifs, capables d'intégrer les modifications du code source en temps réel. <a href="https://github.com/facebook/pfff/wiki/Main">Pfff</a> est un ensemble d'outils pour l'analyse du code, les visualisations et les transformations de sources préservant le style, écrit en OCaml, mais supportant de nombreux langages.</p>
 |js}
-  };
- 
-  { name = {js|Fasoo|js}
-  ; slug = {js|fasoo|js}
-  ; description = {js|Fasoo utilise OCaml pour développer un outil d'analyse statique
+    }
+  ; { name = {js|Fasoo|js}
+    ; slug = {js|fasoo|js}
+    ; description =
+        {js|Fasoo utilise OCaml pour développer un outil d'analyse statique
 |js}
-  ; image = Some {js|/users/fasoo.png|js}
-  ; site = {js|https://www.fasoo.com|js}
-  ; locations = 
- [{js|Corée du Sud|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/fasoo.png|js}
+    ; site = {js|https://www.fasoo.com|js}
+    ; locations = [ {js|Corée du Sud|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Fasoo utilise OCaml pour développer un outil d'analyse statique.
 |js}
-  ; body_html = {js|<p>Fasoo utilise OCaml pour développer un outil d'analyse statique.</p>
+    ; body_html =
+        {js|<p>Fasoo utilise OCaml pour développer un outil d'analyse statique.</p>
 |js}
-  };
- 
-  { name = {js|Flying Frog Consultancy|js}
-  ; slug = {js|flying-frog-consultancy|js}
-  ; description = {js|Flying Frog Consultancy Ltd. consulte et écrit des livres et des logiciels sur l'utilisation d'OCaml dans le contexte du calcul scientifique
+    }
+  ; { name = {js|Flying Frog Consultancy|js}
+    ; slug = {js|flying-frog-consultancy|js}
+    ; description =
+        {js|Flying Frog Consultancy Ltd. consulte et écrit des livres et des logiciels sur l'utilisation d'OCaml dans le contexte du calcul scientifique
 |js}
-  ; image = Some {js|/users/flying-frog.png|js}
-  ; site = {js|https://www.ffconsultancy.com|js}
-  ; locations = 
- [{js|Royaume-Uni|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/flying-frog.png|js}
+    ; site = {js|https://www.ffconsultancy.com|js}
+    ; locations = [ {js|Royaume-Uni|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Flying Frog Consultancy Ltd. consulte et écrit des livres et des logiciels sur l'utilisation d'OCaml dans le contexte du calcul scientifique. OCaml excelle dans la niche des programmes intrinsèquement compliqués entre les programmes à grande échelle, basés sur des tableaux, écrits dans des langages tels que HPF et les programmes graphiques à petite échelle écrits dans des langages tels que Mathematica.
 |js}
-  ; body_html = {js|<p>Flying Frog Consultancy Ltd. consulte et écrit des livres et des logiciels sur l'utilisation d'OCaml dans le contexte du calcul scientifique. OCaml excelle dans la niche des programmes intrinsèquement compliqués entre les programmes à grande échelle, basés sur des tableaux, écrits dans des langages tels que HPF et les programmes graphiques à petite échelle écrits dans des langages tels que Mathematica.</p>
+    ; body_html =
+        {js|<p>Flying Frog Consultancy Ltd. consulte et écrit des livres et des logiciels sur l'utilisation d'OCaml dans le contexte du calcul scientifique. OCaml excelle dans la niche des programmes intrinsèquement compliqués entre les programmes à grande échelle, basés sur des tableaux, écrits dans des langages tels que HPF et les programmes graphiques à petite échelle écrits dans des langages tels que Mathematica.</p>
 |js}
-  };
- 
-  { name = {js|ForAllSecure|js}
-  ; slug = {js|forallsecure|js}
-  ; description = {js|La mission de ForAllSecure est de tester les logiciels du monde entier et de fournir des informations exploitables à ses clients
+    }
+  ; { name = {js|ForAllSecure|js}
+    ; slug = {js|forallsecure|js}
+    ; description =
+        {js|La mission de ForAllSecure est de tester les logiciels du monde entier et de fournir des informations exploitables à ses clients
 |js}
-  ; image = Some {js|/users/forallsecure.svg|js}
-  ; site = {js|https://forallsecure.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/forallsecure.svg|js}
+    ; site = {js|https://forallsecure.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 La mission de ForAllSecure est de tester les logiciels du monde entier et de fournir des informations exploitables à ses clients. Nous avons commencé par Linux. Notre mission avec Linux est de tester tous les programmes des distributions actuelles, tels que Debian, Ubuntu et Red Hat. Avec le temps, nous couvrirons d'autres plateformes, comme Mac, Windows et les mobiles. En attendant, nous promettons de bien faire les choses.
 |js}
-  ; body_html = {js|<p>La mission de ForAllSecure est de tester les logiciels du monde entier et de fournir des informations exploitables à ses clients. Nous avons commencé par Linux. Notre mission avec Linux est de tester tous les programmes des distributions actuelles, tels que Debian, Ubuntu et Red Hat. Avec le temps, nous couvrirons d'autres plateformes, comme Mac, Windows et les mobiles. En attendant, nous promettons de bien faire les choses.</p>
+    ; body_html =
+        {js|<p>La mission de ForAllSecure est de tester les logiciels du monde entier et de fournir des informations exploitables à ses clients. Nous avons commencé par Linux. Notre mission avec Linux est de tester tous les programmes des distributions actuelles, tels que Debian, Ubuntu et Red Hat. Avec le temps, nous couvrirons d'autres plateformes, comme Mac, Windows et les mobiles. En attendant, nous promettons de bien faire les choses.</p>
 |js}
-  };
- 
-  { name = {js|Framtidsforum|js}
-  ; slug = {js|framtidsforum|js}
-  ; description = {js|Framtidsforum I&M vend ExcelEverywhere, qui crée des pages web dont l'apparence et le fonctionnement sont identiques à ceux de votre feuille de calcul MS Excel.
+    }
+  ; { name = {js|Framtidsforum|js}
+    ; slug = {js|framtidsforum|js}
+    ; description =
+        {js|Framtidsforum I&M vend ExcelEverywhere, qui crée des pages web dont l'apparence et le fonctionnement sont identiques à ceux de votre feuille de calcul MS Excel.
 |js}
-  ; image = None
-  ; site = {js|https://www.exceleverywhere.com|js}
-  ; locations = 
- [{js|Suède|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = None
+    ; site = {js|https://www.exceleverywhere.com|js}
+    ; locations = [ {js|Suède|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Framtidsforum I&M vend ExcelEverywhere, qui crée des pages web dont l'apparence et le fonctionnement sont identiques à ceux de votre feuille de calcul MS Excel. JavaScript est utilisé pour les calculs. Il supporte 140 fonctions Excel. Généralement utilisé pour les rapports de dépenses, les enquêtes, les formulaires de commande, les formulaires de réservation, les demandes d'emploi, les conseillers financiers, le retour sur investissement. Il existe également des versions qui génèrent du code ASP, ASP.NET et JSP/Java. Le compilateur est écrit en OCaml.
 |js}
-  ; body_html = {js|<p>Framtidsforum I&amp;M vend ExcelEverywhere, qui crée des pages web dont l'apparence et le fonctionnement sont identiques à ceux de votre feuille de calcul MS Excel. JavaScript est utilisé pour les calculs. Il supporte 140 fonctions Excel. Généralement utilisé pour les rapports de dépenses, les enquêtes, les formulaires de commande, les formulaires de réservation, les demandes d'emploi, les conseillers financiers, le retour sur investissement. Il existe également des versions qui génèrent du code ASP, ASP.NET et JSP/Java. Le compilateur est écrit en OCaml.</p>
+    ; body_html =
+        {js|<p>Framtidsforum I&amp;M vend ExcelEverywhere, qui crée des pages web dont l'apparence et le fonctionnement sont identiques à ceux de votre feuille de calcul MS Excel. JavaScript est utilisé pour les calculs. Il supporte 140 fonctions Excel. Généralement utilisé pour les rapports de dépenses, les enquêtes, les formulaires de commande, les formulaires de réservation, les demandes d'emploi, les conseillers financiers, le retour sur investissement. Il existe également des versions qui génèrent du code ASP, ASP.NET et JSP/Java. Le compilateur est écrit en OCaml.</p>
 |js}
-  };
- 
-  { name = {js|Galois|js}
-  ; slug = {js|galois|js}
-  ; description = {js|Galois a développé un langage déclaratif dédié pour les algorithmes cryptographiques
+    }
+  ; { name = {js|Galois|js}
+    ; slug = {js|galois|js}
+    ; description =
+        {js|Galois a développé un langage déclaratif dédié pour les algorithmes cryptographiques
 |js}
-  ; image = Some {js|/users/galois.png|js}
-  ; site = {js|https://www.galois.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/galois.png|js}
+    ; site = {js|https://www.galois.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Galois a développé un langage déclaratif dédié pour les algorithmes cryptographiques. L'un de nos compilateurs de recherche est écrit en OCaml et fait un usage très intensif de camlp4.
 |js}
-  ; body_html = {js|<p>Galois a développé un langage déclaratif dédié pour les algorithmes cryptographiques. L'un de nos compilateurs de recherche est écrit en OCaml et fait un usage très intensif de camlp4.</p>
+    ; body_html =
+        {js|<p>Galois a développé un langage déclaratif dédié pour les algorithmes cryptographiques. L'un de nos compilateurs de recherche est écrit en OCaml et fait un usage très intensif de camlp4.</p>
 |js}
-  };
- 
-  { name = {js|Incubaid|js}
-  ; slug = {js|incubaid|js}
-  ; description = {js|Incubaid a développé Arakoon, un système de stockage distribué, fonctionnant par valeur clé, qui garantit avant tout la cohérence
+    }
+  ; { name = {js|Incubaid|js}
+    ; slug = {js|incubaid|js}
+    ; description =
+        {js|Incubaid a développé Arakoon, un système de stockage distribué, fonctionnant par valeur clé, qui garantit avant tout la cohérence
 |js}
-  ; image = Some {js|/users/Incubaid.png|js}
-  ; site = {js|https://incubaid.com|js}
-  ; locations = 
- [{js|Belgique|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/Incubaid.png|js}
+    ; site = {js|https://incubaid.com|js}
+    ; locations = [ {js|Belgique|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Incubaid a développé <a href="https://github.com/Incubaid/arakoon">Arakoon</a>, un système de stockage distribué, fonctionnant par valeur clé, qui garantit avant tout la cohérence. Nous avons créé Arakoon en raison d'un manque de solutions existantes répondant à nos besoins, et il est disponible en tant que logiciel libre.
 |js}
-  ; body_html = {js|<p>Incubaid a développé <a href="https://github.com/Incubaid/arakoon">Arakoon</a>, un système de stockage distribué, fonctionnant par valeur clé, qui garantit avant tout la cohérence. Nous avons créé Arakoon en raison d'un manque de solutions existantes répondant à nos besoins, et il est disponible en tant que logiciel libre.</p>
+    ; body_html =
+        {js|<p>Incubaid a développé <a href="https://github.com/Incubaid/arakoon">Arakoon</a>, un système de stockage distribué, fonctionnant par valeur clé, qui garantit avant tout la cohérence. Nous avons créé Arakoon en raison d'un manque de solutions existantes répondant à nos besoins, et il est disponible en tant que logiciel libre.</p>
 |js}
-  };
- 
-  { name = {js|Issuu|js}
-  ; slug = {js|issuu|js}
-  ; description = {js|Issuu est une plateforme d'édition numérique offrant des expériences de lecture exceptionnelles de magazines, de catalogues et de journaux
+    }
+  ; { name = {js|Issuu|js}
+    ; slug = {js|issuu|js}
+    ; description =
+        {js|Issuu est une plateforme d'édition numérique offrant des expériences de lecture exceptionnelles de magazines, de catalogues et de journaux
 |js}
-  ; image = Some {js|/users/issuu.gif|js}
-  ; site = {js|https://issuu.com|js}
-  ; locations = 
- [{js|Danemark|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/issuu.gif|js}
+    ; site = {js|https://issuu.com|js}
+    ; locations = [ {js|Danemark|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Issuu est une plateforme d'édition numérique offrant des expériences de lecture exceptionnelle de magazines, catalogues et journaux. Chaque mois, Issuu sert plus de 6 milliards de pages et 60 millions d'utilisateurs à travers son réseau mondial. OCaml est utilisé dans le cadre des systèmes côté serveur, des plateformes et des applications web. L'équipe backend est relativement petite et la simplicité et l'évolutivité des systèmes et des processus sont d'une importance vitale.
 |js}
-  ; body_html = {js|<p>Issuu est une plateforme d'édition numérique offrant des expériences de lecture exceptionnelle de magazines, catalogues et journaux. Chaque mois, Issuu sert plus de 6 milliards de pages et 60 millions d'utilisateurs à travers son réseau mondial. OCaml est utilisé dans le cadre des systèmes côté serveur, des plateformes et des applications web. L'équipe backend est relativement petite et la simplicité et l'évolutivité des systèmes et des processus sont d'une importance vitale.</p>
+    ; body_html =
+        {js|<p>Issuu est une plateforme d'édition numérique offrant des expériences de lecture exceptionnelle de magazines, catalogues et journaux. Chaque mois, Issuu sert plus de 6 milliards de pages et 60 millions d'utilisateurs à travers son réseau mondial. OCaml est utilisé dans le cadre des systèmes côté serveur, des plateformes et des applications web. L'équipe backend est relativement petite et la simplicité et l'évolutivité des systèmes et des processus sont d'une importance vitale.</p>
 |js}
-  };
- 
-  { name = {js|Jane Street|js}
-  ; slug = {js|jane-street|js}
-  ; description = {js|Jane Street est une société de trading quantitatif qui opère 24 heures sur 24 et dans le monde entier
+    }
+  ; { name = {js|Jane Street|js}
+    ; slug = {js|jane-street|js}
+    ; description =
+        {js|Jane Street est une société de trading quantitatif qui opère 24 heures sur 24 et dans le monde entier
 |js}
-  ; image = Some {js|/users/jane-street.jpg|js}
-  ; site = {js|https://janestreet.com|js}
-  ; locations = 
- [{js|États-Unis|js}; {js|Royaume-Uni|js}; {js|Hong Kong|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/jane-street.jpg|js}
+    ; site = {js|https://janestreet.com|js}
+    ; locations = [ {js|États-Unis|js}; {js|Royaume-Uni|js}; {js|Hong Kong|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Jane Street est une société de trading quantitatif qui opère 24 heures sur 24 et dans le monde entier. Elle apporte une profonde compréhension des marchés, une approche scientifique et une technologie innovante pour résoudre le problème de la négociation rentable sur les marchés financiers mondiaux hautement compétitifs. Ils sont le plus grand utilisateur commercial d'OCaml, l'utilisant pour tout, des outils de recherche aux systèmes de négociation en passant par l'infrastructure des systèmes et les systèmes de comptabilité. Jane Street compte plus de 400 programmeurs OCaml et plus de 15 millions de lignes d'OCaml, alimentant une plateforme technologique qui négocie des milliards de dollars chaque jour. Un demi-million de lignes de leur code sont publiées [open source](https://opensource.janestreet.com), et ils ont créé des éléments clés de l'écosystème OCaml open source, comme [Dune](https://dune.build). Vous pouvez en savoir plus en consultant leur [blog technique](https://blog.janestreet.com).
 |js}
-  ; body_html = {js|<p>Jane Street est une société de trading quantitatif qui opère 24 heures sur 24 et dans le monde entier. Elle apporte une profonde compréhension des marchés, une approche scientifique et une technologie innovante pour résoudre le problème de la négociation rentable sur les marchés financiers mondiaux hautement compétitifs. Ils sont le plus grand utilisateur commercial d'OCaml, l'utilisant pour tout, des outils de recherche aux systèmes de négociation en passant par l'infrastructure des systèmes et les systèmes de comptabilité. Jane Street compte plus de 400 programmeurs OCaml et plus de 15 millions de lignes d'OCaml, alimentant une plateforme technologique qui négocie des milliards de dollars chaque jour. Un demi-million de lignes de leur code sont publiées <a href="https://opensource.janestreet.com">open source</a>, et ils ont créé des éléments clés de l'écosystème OCaml open source, comme <a href="https://dune.build">Dune</a>. Vous pouvez en savoir plus en consultant leur <a href="https://blog.janestreet.com">blog technique</a>.</p>
+    ; body_html =
+        {js|<p>Jane Street est une société de trading quantitatif qui opère 24 heures sur 24 et dans le monde entier. Elle apporte une profonde compréhension des marchés, une approche scientifique et une technologie innovante pour résoudre le problème de la négociation rentable sur les marchés financiers mondiaux hautement compétitifs. Ils sont le plus grand utilisateur commercial d'OCaml, l'utilisant pour tout, des outils de recherche aux systèmes de négociation en passant par l'infrastructure des systèmes et les systèmes de comptabilité. Jane Street compte plus de 400 programmeurs OCaml et plus de 15 millions de lignes d'OCaml, alimentant une plateforme technologique qui négocie des milliards de dollars chaque jour. Un demi-million de lignes de leur code sont publiées <a href="https://opensource.janestreet.com">open source</a>, et ils ont créé des éléments clés de l'écosystème OCaml open source, comme <a href="https://dune.build">Dune</a>. Vous pouvez en savoir plus en consultant leur <a href="https://blog.janestreet.com">blog technique</a>.</p>
 |js}
-  };
- 
-  { name = {js|Kernelize|js}
-  ; slug = {js|kernelize|js}
-  ; description = {js|Kernelyze a développé une nouvelle approximation des fonctions à deux variables qui permet d'obtenir la plus petite erreur possible dans le pire des cas parmi toutes les approximations de rang n
+    }
+  ; { name = {js|Kernelize|js}
+    ; slug = {js|kernelize|js}
+    ; description =
+        {js|Kernelyze a développé une nouvelle approximation des fonctions à deux variables qui permet d'obtenir la plus petite erreur possible dans le pire des cas parmi toutes les approximations de rang n
 |js}
-  ; image = Some {js|/users/kernelyze-llc-logo.png|js}
-  ; site = {js|https://kernelyze.com/|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/kernelyze-llc-logo.png|js}
+    ; site = {js|https://kernelyze.com/|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Kernelyze a développé une nouvelle approximation des fonctions à deux variables qui permet d'obtenir la plus petite erreur possible dans le pire des cas parmi toutes les approximations de rang n.
 |js}
-  ; body_html = {js|<p>Kernelyze a développé une nouvelle approximation des fonctions à deux variables qui permet d'obtenir la plus petite erreur possible dans le pire des cas parmi toutes les approximations de rang n.</p>
+    ; body_html =
+        {js|<p>Kernelyze a développé une nouvelle approximation des fonctions à deux variables qui permet d'obtenir la plus petite erreur possible dans le pire des cas parmi toutes les approximations de rang n.</p>
 |js}
-  };
- 
-  { name = {js|Kong|js}
-  ; slug = {js|kong|js}
-  ; description = {js|Kong facilite la distribution, la monétisation, la gestion et la consommation des APIs dans le cloud
+    }
+  ; { name = {js|Kong|js}
+    ; slug = {js|kong|js}
+    ; description =
+        {js|Kong facilite la distribution, la monétisation, la gestion et la consommation des APIs dans le cloud
 |js}
-  ; image = Some {js|/users/mashape.png|js}
-  ; site = {js|https://www.konghq.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mashape.png|js}
+    ; site = {js|https://www.konghq.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Kong facilite la distribution, la monétisation, la gestion et la consommation des API dans le cloud. Mashape construit une place de marché de classe mondiale pour les API dans le cloud, animée par une communauté passionnée de développeurs du monde entier, ainsi que des produits de gestion et d'analyse des API d'entreprise. Nous utilisons OCaml dans notre produit [APIAnalytics](https://apianalytics.com) - dans le cadre d'un proxy HTTP léger et critique.
 |js}
-  ; body_html = {js|<p>Kong facilite la distribution, la monétisation, la gestion et la consommation des API dans le cloud. Mashape construit une place de marché de classe mondiale pour les API dans le cloud, animée par une communauté passionnée de développeurs du monde entier, ainsi que des produits de gestion et d'analyse des API d'entreprise. Nous utilisons OCaml dans notre produit <a href="https://apianalytics.com">APIAnalytics</a> - dans le cadre d'un proxy HTTP léger et critique.</p>
+    ; body_html =
+        {js|<p>Kong facilite la distribution, la monétisation, la gestion et la consommation des API dans le cloud. Mashape construit une place de marché de classe mondiale pour les API dans le cloud, animée par une communauté passionnée de développeurs du monde entier, ainsi que des produits de gestion et d'analyse des API d'entreprise. Nous utilisons OCaml dans notre produit <a href="https://apianalytics.com">APIAnalytics</a> - dans le cadre d'un proxy HTTP léger et critique.</p>
 |js}
-  };
- 
-  { name = {js|LexiFi|js}
-  ; slug = {js|lexifi|js}
-  ; description = {js|LexiFi est un fournisseur innovant d'applications logicielles et de technologies d'infrastructure pour l'industrie des marchés financiers.
+    }
+  ; { name = {js|LexiFi|js}
+    ; slug = {js|lexifi|js}
+    ; description =
+        {js|LexiFi est un fournisseur innovant d'applications logicielles et de technologies d'infrastructure pour l'industrie des marchés financiers.
 |js}
-  ; image = Some {js|/users/lexifi.png|js}
-  ; site = {js|https://www.lexifi.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/lexifi.png|js}
+    ; site = {js|https://www.lexifi.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 LexiFi est un fournisseur innovant d'applications logicielles et de technologies d'infrastructure pour l'industrie des marchés financiers. LexiFi Apropos est alimenté par un formalisme original pour décrire les contrats financiers, résultat d'un effort de recherche et de développement à long terme.
 |js}
-  ; body_html = {js|<p>LexiFi est un fournisseur innovant d'applications logicielles et de technologies d'infrastructure pour l'industrie des marchés financiers. LexiFi Apropos est alimenté par un formalisme original pour décrire les contrats financiers, résultat d'un effort de recherche et de développement à long terme.</p>
+    ; body_html =
+        {js|<p>LexiFi est un fournisseur innovant d'applications logicielles et de technologies d'infrastructure pour l'industrie des marchés financiers. LexiFi Apropos est alimenté par un formalisme original pour décrire les contrats financiers, résultat d'un effort de recherche et de développement à long terme.</p>
 |js}
-  };
- 
-  { name = {js|Matrix Lead|js}
-  ; slug = {js|matrix-lead|js}
-  ; description = {js|Matrix Lead fournit aux professionnels et aux entreprises des technologies des solutions de pointe pour les feuilles de calcul
+    }
+  ; { name = {js|Matrix Lead|js}
+    ; slug = {js|matrix-lead|js}
+    ; description =
+        {js|Matrix Lead fournit aux professionnels et aux entreprises des technologies des solutions de pointe pour les feuilles de calcul
 |js}
-  ; image = Some {js|/users/matrixlead.png|js}
-  ; site = {js|https://www.matrixlead.com|js}
-  ; locations = 
- [{js|France|js}; {js|Chine|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/matrixlead.png|js}
+    ; site = {js|https://www.matrixlead.com|js}
+    ; locations = [ {js|France|js}; {js|Chine|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Matrix Lead fournit aux professionnels et aux entreprises des technologies des solutions de pointe pour les feuilles de calcul. Nous créons une gamme de logiciels pour aider les utilisateurs à mieux construire, vérifier, optimiser et gérer leurs feuilles de calcul. Notre produit phare [10 Studio](https://www.10studio.tech) est un complément de Microsoft Excel qui combine plusieurs outils avancés, tels que l'éditeur de formules et le vérificateur de feuilles de calcul. Le noyau de nos outils est un analyseur qui analyse les différentes propriétés des feuilles de calcul (y compris les formules et les macros VBA), notamment par une analyse statique basée sur l'interprétation abstraite. Il a été initialement développé dans l'équipe Antiques d'INRIA et écrit en OCaml. Ensuite, nous avons enveloppé des langages web ou .NET autour de l'analyseur pour en faire des outils prêts à l'emploi.
 |js}
-  ; body_html = {js|<p>Matrix Lead fournit aux professionnels et aux entreprises des technologies des solutions de pointe pour les feuilles de calcul. Nous créons une gamme de logiciels pour aider les utilisateurs à mieux construire, vérifier, optimiser et gérer leurs feuilles de calcul. Notre produit phare <a href="https://www.10studio.tech">10 Studio</a> est un complément de Microsoft Excel qui combine plusieurs outils avancés, tels que l'éditeur de formules et le vérificateur de feuilles de calcul. Le noyau de nos outils est un analyseur qui analyse les différentes propriétés des feuilles de calcul (y compris les formules et les macros VBA), notamment par une analyse statique basée sur l'interprétation abstraite. Il a été initialement développé dans l'équipe Antiques d'INRIA et écrit en OCaml. Ensuite, nous avons enveloppé des langages web ou .NET autour de l'analyseur pour en faire des outils prêts à l'emploi.</p>
+    ; body_html =
+        {js|<p>Matrix Lead fournit aux professionnels et aux entreprises des technologies des solutions de pointe pour les feuilles de calcul. Nous créons une gamme de logiciels pour aider les utilisateurs à mieux construire, vérifier, optimiser et gérer leurs feuilles de calcul. Notre produit phare <a href="https://www.10studio.tech">10 Studio</a> est un complément de Microsoft Excel qui combine plusieurs outils avancés, tels que l'éditeur de formules et le vérificateur de feuilles de calcul. Le noyau de nos outils est un analyseur qui analyse les différentes propriétés des feuilles de calcul (y compris les formules et les macros VBA), notamment par une analyse statique basée sur l'interprétation abstraite. Il a été initialement développé dans l'équipe Antiques d'INRIA et écrit en OCaml. Ensuite, nous avons enveloppé des langages web ou .NET autour de l'analyseur pour en faire des outils prêts à l'emploi.</p>
 |js}
-  };
- 
-  { name = {js|MEDIT|js}
-  ; slug = {js|medit|js}
-  ; description = {js|MEDIT développe SuMo, un système bio-informatique avancé, pour l'analyse des structures 3D des protéines et l'identification de cibles pour la conception de médicaments
+    }
+  ; { name = {js|MEDIT|js}
+    ; slug = {js|medit|js}
+    ; description =
+        {js|MEDIT développe SuMo, un système bio-informatique avancé, pour l'analyse des structures 3D des protéines et l'identification de cibles pour la conception de médicaments
 |js}
-  ; image = Some {js|/users/medit.jpg|js}
-  ; site = {js|https://www.medit-pharma.com/|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/medit.jpg|js}
+    ; site = {js|https://www.medit-pharma.com/|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 MEDIT développe [SuMo, un système bio-informatique avancé]("https://mjambon.com/") pour l'analyse des structures 3D des protéines et l'identification de cibles pour la conception de médicaments. SuMo est entièrement écrit en OCaml et fournit des interfaces à plusieurs progiciels commerciaux de modélisation moléculaire.
 |js}
-  ; body_html = {js|<p>MEDIT développe <a href="%22https://mjambon.com/%22">SuMo, un système bio-informatique avancé</a> pour l'analyse des structures 3D des protéines et l'identification de cibles pour la conception de médicaments. SuMo est entièrement écrit en OCaml et fournit des interfaces à plusieurs progiciels commerciaux de modélisation moléculaire.</p>
+    ; body_html =
+        {js|<p>MEDIT développe <a href="%22https://mjambon.com/%22">SuMo, un système bio-informatique avancé</a> pour l'analyse des structures 3D des protéines et l'identification de cibles pour la conception de médicaments. SuMo est entièrement écrit en OCaml et fournit des interfaces à plusieurs progiciels commerciaux de modélisation moléculaire.</p>
 |js}
-  };
- 
-  { name = {js|Microsoft|js}
-  ; slug = {js|microsoft|js}
-  ; description = {js|Microsoft Corporation est une société technologique multinationale américaine qui produit des logiciels, de l'électronique grand public, des ordinateurs personnels et des services connexes.
+    }
+  ; { name = {js|Microsoft|js}
+    ; slug = {js|microsoft|js}
+    ; description =
+        {js|Microsoft Corporation est une société technologique multinationale américaine qui produit des logiciels, de l'électronique grand public, des ordinateurs personnels et des services connexes.
 |js}
-  ; image = Some {js|/users/microsoft.png|js}
-  ; site = {js|https://www.microsoft.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/microsoft.png|js}
+    ; site = {js|https://www.microsoft.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Microsoft Corporation est une société technologique multinationale américaine qui produit des logiciels, de l'électronique grand public, des ordinateurs personnels et des services connexes.
 
 |js}
-  ; body_html = {js|<p>Microsoft Corporation est une société technologique multinationale américaine qui produit des logiciels, de l'électronique grand public, des ordinateurs personnels et des services connexes.</p>
+    ; body_html =
+        {js|<p>Microsoft Corporation est une société technologique multinationale américaine qui produit des logiciels, de l'électronique grand public, des ordinateurs personnels et des services connexes.</p>
 |js}
-  };
- 
-  { name = {js|Mount Sinai|js}
-  ; slug = {js|mount-sinai|js}
-  ; description = {js|Le laboratoire Hammer de Mount Sinai développe et utilise Ketrew pour gérer des flux de travail complexes en bio-informatique
+    }
+  ; { name = {js|Mount Sinai|js}
+    ; slug = {js|mount-sinai|js}
+    ; description =
+        {js|Le laboratoire Hammer de Mount Sinai développe et utilise Ketrew pour gérer des flux de travail complexes en bio-informatique
 |js}
-  ; image = Some {js|/users/mount-sinai.png|js}
-  ; site = {js|https://www.mountsinai.org|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mount-sinai.png|js}
+    ; site = {js|https://www.mountsinai.org|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Le [Hammer Lab]("https://www.hammerlab.org") de Mount Sinai développe et utilise [Ketrew]("https://github.com/hammerlab/ketrew") pour gérer des flux de travail complexes en bio-informatique. Ketrew comprend un langage dédié pour simplifier la spécification des flux de travail et un moteur pour l'exécution des flux de travail. Ketrew peut être exécuté comme une application en ligne de commande ou comme un service.
 |js}
-  ; body_html = {js|<p>Le <a href="%22https://www.hammerlab.org%22">Hammer Lab</a> de Mount Sinai développe et utilise <a href="%22https://github.com/hammerlab/ketrew%22">Ketrew</a> pour gérer des flux de travail complexes en bio-informatique. Ketrew comprend un langage dédié pour simplifier la spécification des flux de travail et un moteur pour l'exécution des flux de travail. Ketrew peut être exécuté comme une application en ligne de commande ou comme un service.</p>
+    ; body_html =
+        {js|<p>Le <a href="%22https://www.hammerlab.org%22">Hammer Lab</a> de Mount Sinai développe et utilise <a href="%22https://github.com/hammerlab/ketrew%22">Ketrew</a> pour gérer des flux de travail complexes en bio-informatique. Ketrew comprend un langage dédié pour simplifier la spécification des flux de travail et un moteur pour l'exécution des flux de travail. Ketrew peut être exécuté comme une application en ligne de commande ou comme un service.</p>
 |js}
-  };
- 
-  { name = {js|Mr. Number|js}
-  ; slug = {js|mr-number|js}
-  ; description = {js|Mr. Number est une startup de la Silicon Valley qui a développé l'application Mr. Number pour le blocage des appels, rachetée depuis par WhitePages
+    }
+  ; { name = {js|Mr. Number|js}
+    ; slug = {js|mr-number|js}
+    ; description =
+        {js|Mr. Number est une startup de la Silicon Valley qui a développé l'application Mr. Number pour le blocage des appels, rachetée depuis par WhitePages
 |js}
-  ; image = Some {js|/users/mrnumber.jpg|js}
-  ; site = {js|https://mrnumber.com/|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mrnumber.jpg|js}
+    ; site = {js|https://mrnumber.com/|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Mr. Number a démarré en tant que startup de la Silicon Valley et a développé l'application Mr. Number pour le blocage des appels, qui a ensuite été [rachetée par WhitePages](https://allthingsd.com/20130601/whitepages-scoops-up-mr-number-an-android-app-for-blocking-unwanted-calls/). OCaml est utilisé du côté serveur comme colle entre les divers composants et services tiers.
 |js}
-  ; body_html = {js|<p>Mr. Number a démarré en tant que startup de la Silicon Valley et a développé l'application Mr. Number pour le blocage des appels, qui a ensuite été <a href="https://allthingsd.com/20130601/whitepages-scoops-up-mr-number-an-android-app-for-blocking-unwanted-calls/">rachetée par WhitePages</a>. OCaml est utilisé du côté serveur comme colle entre les divers composants et services tiers.</p>
+    ; body_html =
+        {js|<p>Mr. Number a démarré en tant que startup de la Silicon Valley et a développé l'application Mr. Number pour le blocage des appels, qui a ensuite été <a href="https://allthingsd.com/20130601/whitepages-scoops-up-mr-number-an-android-app-for-blocking-unwanted-calls/">rachetée par WhitePages</a>. OCaml est utilisé du côté serveur comme colle entre les divers composants et services tiers.</p>
 |js}
-  };
- 
-  { name = {js|MyLife|js}
-  ; slug = {js|mylife|js}
-  ; description = {js|MyLife a développé un puissant outil de recherche de personnes qui permettra à ceux qui en ont besoin de trouver n'importe qui, quelles que soient les années passées et la vie qui s'est construite entre-temps
+    }
+  ; { name = {js|MyLife|js}
+    ; slug = {js|mylife|js}
+    ; description =
+        {js|MyLife a développé un puissant outil de recherche de personnes qui permettra à ceux qui en ont besoin de trouver n'importe qui, quelles que soient les années passées et la vie qui s'est construite entre-temps
 |js}
-  ; image = Some {js|/users/mylife.jpg|js}
-  ; site = {js|https://www.mylife.com/|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/mylife.jpg|js}
+    ; site = {js|https://www.mylife.com/|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 MyLife a développé un puissant outil de recherche de personnes qui permettra à ceux qui en ont besoin de trouver n'importe qui, quelles que soient les années passées et la vie qui s'est construite entre-temps.
 |js}
-  ; body_html = {js|<p>MyLife a développé un puissant outil de recherche de personnes qui permettra à ceux qui en ont besoin de trouver n'importe qui, quelles que soient les années passées et la vie qui s'est construite entre-temps.</p>
+    ; body_html =
+        {js|<p>MyLife a développé un puissant outil de recherche de personnes qui permettra à ceux qui en ont besoin de trouver n'importe qui, quelles que soient les années passées et la vie qui s'est construite entre-temps.</p>
 |js}
-  };
- 
-  { name = {js|Narrow Gate Logic|js}
-  ; slug = {js|narrow-gate-logic|js}
-  ; description = {js|Narrow Gate Logic est une entreprise qui utilise le langage OCaml dans des applications commerciales et non commerciales
+    }
+  ; { name = {js|Narrow Gate Logic|js}
+    ; slug = {js|narrow-gate-logic|js}
+    ; description =
+        {js|Narrow Gate Logic est une entreprise qui utilise le langage OCaml dans des applications commerciales et non commerciales
 |js}
-  ; image = Some {js|/users/nglogic.png|js}
-  ; site = {js|https://nglogic.com|js}
-  ; locations = 
- [{js|Pologne|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/nglogic.png|js}
+    ; site = {js|https://nglogic.com|js}
+    ; locations = [ {js|Pologne|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Narrow Gate Logic est une entreprise qui utilise le langage OCaml dans des applications commerciales et non commerciales.
 |js}
-  ; body_html = {js|<p>Narrow Gate Logic est une entreprise qui utilise le langage OCaml dans des applications commerciales et non commerciales.</p>
+    ; body_html =
+        {js|<p>Narrow Gate Logic est une entreprise qui utilise le langage OCaml dans des applications commerciales et non commerciales.</p>
 |js}
-  };
- 
-  { name = {js|Nomadic Labs|js}
-  ; slug = {js|nomadic-labs|js}
-  ; description = {js|Nomadic Labs abrite une équipe axée sur la recherche et le développement. Nos compétences fondamentales sont dans la théorie et la pratique des langages de programmation, les systèmes distribués, et la vérification formelle
+    }
+  ; { name = {js|Nomadic Labs|js}
+    ; slug = {js|nomadic-labs|js}
+    ; description =
+        {js|Nomadic Labs abrite une équipe axée sur la recherche et le développement. Nos compétences fondamentales sont dans la théorie et la pratique des langages de programmation, les systèmes distribués, et la vérification formelle
 |js}
-  ; image = Some {js|/users/nomadic-labs.png|js}
-  ; site = {js|https://www.nomadic-labs.com|js}
-  ; locations = 
- [{js|Paris, France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/nomadic-labs.png|js}
+    ; site = {js|https://www.nomadic-labs.com|js}
+    ; locations = [ {js|Paris, France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Nomadic Labs abrite une équipe axée sur la recherche et le développement. Nos
 compétences fondamentales sont dans la théorie et la pratique des langages de programmation,
 les systèmes distribués, et la vérification formelle. Nomadic Labs se concentre sur
@@ -1482,7 +1566,8 @@ La sécurité et la correction sont essentielles pour une blockchain et nous som
 que le système de types OCaml permette une forme de méthode formelle légère qui peut être
 utilisée quotidiennement.
 |js}
-  ; body_html = {js|<p>Nomadic Labs abrite une équipe axée sur la recherche et le développement. Nos
+    ; body_html =
+        {js|<p>Nomadic Labs abrite une équipe axée sur la recherche et le développement. Nos
 compétences fondamentales sont dans la théorie et la pratique des langages de programmation,
 les systèmes distribués, et la vérification formelle. Nomadic Labs se concentre sur
 la contribution au développement du logiciel de base de Tezos, notamment
@@ -1494,85 +1579,89 @@ La sécurité et la correction sont essentielles pour une blockchain et nous som
 que le système de types OCaml permette une forme de méthode formelle légère qui peut être
 utilisée quotidiennement.</p>
 |js}
-  };
- 
-  { name = {js|OCamlPro|js}
-  ; slug = {js|ocamlpro|js}
-  ; description = {js|OCamlPro développe et maintient un environnement de développement pour le langage OCaml
+    }
+  ; { name = {js|OCamlPro|js}
+    ; slug = {js|ocamlpro|js}
+    ; description =
+        {js|OCamlPro développe et maintient un environnement de développement pour le langage OCaml
 |js}
-  ; image = Some {js|/users/ocamlpro.png|js}
-  ; site = {js|https://www.ocamlpro.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/ocamlpro.png|js}
+    ; site = {js|https://www.ocamlpro.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 OCamlPro développe et maintient un environnement de développement pour le langage OCaml. Ils fournissent des services aux entreprises qui décident d'utiliser OCaml. Parmi ces services : des formations, l'expertise nécessaire, des outils et des bibliothèques, un support à long terme, et des développements spécifiques à leurs domaines d'application.
 |js}
-  ; body_html = {js|<p>OCamlPro développe et maintient un environnement de développement pour le langage OCaml. Ils fournissent des services aux entreprises qui décident d'utiliser OCaml. Parmi ces services : des formations, l'expertise nécessaire, des outils et des bibliothèques, un support à long terme, et des développements spécifiques à leurs domaines d'application.</p>
+    ; body_html =
+        {js|<p>OCamlPro développe et maintient un environnement de développement pour le langage OCaml. Ils fournissent des services aux entreprises qui décident d'utiliser OCaml. Parmi ces services : des formations, l'expertise nécessaire, des outils et des bibliothèques, un support à long terme, et des développements spécifiques à leurs domaines d'application.</p>
 |js}
-  };
- 
-  { name = {js|PRUDENT Technologies and Consulting, Inc.|js}
-  ; slug = {js|prudent-technologies-and-consulting-inc|js}
-  ; description = {js|Prudent Consulting propose des solutions informatiques aux grandes et moyennes entreprises en combinant l'expérience du secteur et l'expertise technologique pour aider nos clients à atteindre leurs objectifs commerciaux avec rapidité, agilité et grand impact.
+    }
+  ; { name = {js|PRUDENT Technologies and Consulting, Inc.|js}
+    ; slug = {js|prudent-technologies-and-consulting-inc|js}
+    ; description =
+        {js|Prudent Consulting propose des solutions informatiques aux grandes et moyennes entreprises en combinant l'expérience du secteur et l'expertise technologique pour aider nos clients à atteindre leurs objectifs commerciaux avec rapidité, agilité et grand impact.
 |js}
-  ; image = Some {js|/users/prudent.jpg|js}
-  ; site = {js|https://www.prudentconsulting.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/prudent.jpg|js}
+    ; site = {js|https://www.prudentconsulting.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Prudent Consulting propose des solutions informatiques aux grandes et moyennes entreprises en combinant l'expérience du secteur et l'expertise technologique pour aider nos clients à atteindre leurs objectifs commerciaux avec rapidité, agilité et grand impact.
 |js}
-  ; body_html = {js|<p>Prudent Consulting propose des solutions informatiques aux grandes et moyennes entreprises en combinant l'expérience du secteur et l'expertise technologique pour aider nos clients à atteindre leurs objectifs commerciaux avec rapidité, agilité et grand impact.</p>
+    ; body_html =
+        {js|<p>Prudent Consulting propose des solutions informatiques aux grandes et moyennes entreprises en combinant l'expérience du secteur et l'expertise technologique pour aider nos clients à atteindre leurs objectifs commerciaux avec rapidité, agilité et grand impact.</p>
 |js}
-  };
- 
-  { name = {js|Psellos|js}
-  ; slug = {js|psellos|js}
-  ; description = {js|Psellos est un petit groupe d'informaticiens qui ont été intrigués par l'idée de coder des applications iOS en OCaml
+    }
+  ; { name = {js|Psellos|js}
+    ; slug = {js|psellos|js}
+    ; description =
+        {js|Psellos est un petit groupe d'informaticiens qui ont été intrigués par l'idée de coder des applications iOS en OCaml
 |js}
-  ; image = Some {js|/users/psellos.png|js}
-  ; site = {js|https://www.psellos.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/psellos.png|js}
+    ; site = {js|https://www.psellos.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Psellos est un petit groupe d'informaticiens qui ont été intrigués par l'idée de coder des applications iOS en OCaml. Cela a fonctionné mieux que prévu (vous pouvez acheter nos applications dans l'App Store d'iTunes), et au moins une autre société vend des applications construites avec nos outils. Notre compilateur croisé iOS le plus récent est dérivé d'OCaml 4.00.0.
 |js}
-  ; body_html = {js|<p>Psellos est un petit groupe d'informaticiens qui ont été intrigués par l'idée de coder des applications iOS en OCaml. Cela a fonctionné mieux que prévu (vous pouvez acheter nos applications dans l'App Store d'iTunes), et au moins une autre société vend des applications construites avec nos outils. Notre compilateur croisé iOS le plus récent est dérivé d'OCaml 4.00.0.</p>
+    ; body_html =
+        {js|<p>Psellos est un petit groupe d'informaticiens qui ont été intrigués par l'idée de coder des applications iOS en OCaml. Cela a fonctionné mieux que prévu (vous pouvez acheter nos applications dans l'App Store d'iTunes), et au moins une autre société vend des applications construites avec nos outils. Notre compilateur croisé iOS le plus récent est dérivé d'OCaml 4.00.0.</p>
 |js}
-  };
- 
-  { name = {js|r2c|js}
-  ; slug = {js|r2c|js}
-  ; description = {js|r2c est une société de sécurité financée par capital-risque, dont le siège est à San Francisco et qui est répartie dans le monde entier
+    }
+  ; { name = {js|r2c|js}
+    ; slug = {js|r2c|js}
+    ; description =
+        {js|r2c est une société de sécurité financée par capital-risque, dont le siège est à San Francisco et qui est répartie dans le monde entier
 |js}
-  ; image = Some {js|/users/r2c.png|js}
-  ; site = {js|https://r2c.dev|js}
-  ; locations = 
- [{js|Californie, États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/r2c.png|js}
+    ; site = {js|https://r2c.dev|js}
+    ; locations = [ {js|Californie, États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 r2c est une société de sécurité financée par VC dont le siège est à San Francisco et qui est répartie dans le monde entier. Son principal produit est [Semgrep](https://semgrep.dev/), un grep open source, sensible à la syntaxe, qui supporte de nombreux langages. OCaml est largement utilisé pour l'analyse syntaxique et l'analyse du code source.
 
 Semgrep était à l'origine un produit open source de chez Facebook et ses racines se trouvent dans l'outil de refactoring de Linux, [Coccinelle](https://coccinelle.gitlabpages.inria.fr/website/). r2c poursuit le développement de Semgrep et [recrute des ingénieurs logiciels](https://jobs.lever.co/returntocorp) spécialisé dans l'analyse de programmes.
 |js}
-  ; body_html = {js|<p>r2c est une société de sécurité financée par VC dont le siège est à San Francisco et qui est répartie dans le monde entier. Son principal produit est <a href="https://semgrep.dev/">Semgrep</a>, un grep open source, sensible à la syntaxe, qui supporte de nombreux langages. OCaml est largement utilisé pour l'analyse syntaxique et l'analyse du code source.</p>
+    ; body_html =
+        {js|<p>r2c est une société de sécurité financée par VC dont le siège est à San Francisco et qui est répartie dans le monde entier. Son principal produit est <a href="https://semgrep.dev/">Semgrep</a>, un grep open source, sensible à la syntaxe, qui supporte de nombreux langages. OCaml est largement utilisé pour l'analyse syntaxique et l'analyse du code source.</p>
 <p>Semgrep était à l'origine un produit open source de chez Facebook et ses racines se trouvent dans l'outil de refactoring de Linux, <a href="https://coccinelle.gitlabpages.inria.fr/website/">Coccinelle</a>. r2c poursuit le développement de Semgrep et <a href="https://jobs.lever.co/returntocorp">recrute des ingénieurs logiciels</a> spécialisé dans l'analyse de programmes.</p>
 |js}
-  };
- 
-  { name = {js|Sakhalin|js}
-  ; slug = {js|sakhalin|js}
-  ; description = {js|Sakhalin développe des applications de cartographie marine pour les iPads et iPhones d'Apple
+    }
+  ; { name = {js|Sakhalin|js}
+    ; slug = {js|sakhalin|js}
+    ; description =
+        {js|Sakhalin développe des applications de cartographie marine pour les iPads et iPhones d'Apple
 |js}
-  ; image = None
-  ; site = {js|https://www.seaiq.com|js}
-  ; locations = 
- [{js|United States|js}; {js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = None
+    ; site = {js|https://www.seaiq.com|js}
+    ; locations = [ {js|United States|js}; {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Sakhalin développe des applications de cartographie marine pour les iPads et iPhones d'Apple. Ces applications affichent des cartes marines, des données GPS et des capteurs embarqués, le système d'identification automatique, des données météorologiques, la surveillance des ancres, etc. Ces applications sont destinées à un large éventail d'utilisateurs, du plaisancier occasionnel au pilote professionnel de rivière ou de port qui monte à bord de gros cargos. Elles sont gratuites à télécharger et à essayer (avec une mise à niveau payante pour activer toutes les fonctionnalités). Elles sont écrites presque entièrement en Ocaml, avec une petite quantité de colle pour l'interface avec les API d'IOS. Ocaml a été choisi parce qu'il
 
  1. permet le développement rapide de logiciels extrêmement fiables et performants,
@@ -1581,7 +1670,8 @@ Sakhalin développe des applications de cartographie marine pour les iPads et iP
 
 Cela a été rendu possible grâce à l'excellent travail effectué par Psellos pour porter OCaml sur la plateforme iOS d'Apple. N'hésitez pas à contacter Sakhalin si vous avez des questions sur l'utilisation d'OCaml sur iOS.
 |js}
-  ; body_html = {js|<p>Sakhalin développe des applications de cartographie marine pour les iPads et iPhones d'Apple. Ces applications affichent des cartes marines, des données GPS et des capteurs embarqués, le système d'identification automatique, des données météorologiques, la surveillance des ancres, etc. Ces applications sont destinées à un large éventail d'utilisateurs, du plaisancier occasionnel au pilote professionnel de rivière ou de port qui monte à bord de gros cargos. Elles sont gratuites à télécharger et à essayer (avec une mise à niveau payante pour activer toutes les fonctionnalités). Elles sont écrites presque entièrement en Ocaml, avec une petite quantité de colle pour l'interface avec les API d'IOS. Ocaml a été choisi parce qu'il</p>
+    ; body_html =
+        {js|<p>Sakhalin développe des applications de cartographie marine pour les iPads et iPhones d'Apple. Ces applications affichent des cartes marines, des données GPS et des capteurs embarqués, le système d'identification automatique, des données météorologiques, la surveillance des ancres, etc. Ces applications sont destinées à un large éventail d'utilisateurs, du plaisancier occasionnel au pilote professionnel de rivière ou de port qui monte à bord de gros cargos. Elles sont gratuites à télécharger et à essayer (avec une mise à niveau payante pour activer toutes les fonctionnalités). Elles sont écrites presque entièrement en Ocaml, avec une petite quantité de colle pour l'interface avec les API d'IOS. Ocaml a été choisi parce qu'il</p>
 <ol>
 <li>permet le développement rapide de logiciels extrêmement fiables et performants,
 </li>
@@ -1592,100 +1682,105 @@ Cela a été rendu possible grâce à l'excellent travail effectué par Psellos 
 </ol>
 <p>Cela a été rendu possible grâce à l'excellent travail effectué par Psellos pour porter OCaml sur la plateforme iOS d'Apple. N'hésitez pas à contacter Sakhalin si vous avez des questions sur l'utilisation d'OCaml sur iOS.</p>
 |js}
-  };
- 
-  { name = {js|Shiro Games|js}
-  ; slug = {js|shiro-games|js}
-  ; description = {js|Shiro Games développe des jeux en utilisant Haxe, un langage construit avec un compilateur écrit en OCaml
+    }
+  ; { name = {js|Shiro Games|js}
+    ; slug = {js|shiro-games|js}
+    ; description =
+        {js|Shiro Games développe des jeux en utilisant Haxe, un langage construit avec un compilateur écrit en OCaml
 |js}
-  ; image = Some {js|/users/shirogames.png|js}
-  ; site = {js|https://www.shirogames.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/shirogames.png|js}
+    ; site = {js|https://www.shirogames.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Shiro Games développe des jeux en utilisant [Haxe](https://haxe.org/), un langage construit avec un compilateur écrit en OCaml.
  
 |js}
-  ; body_html = {js|<p>Shiro Games développe des jeux en utilisant <a href="https://haxe.org/">Haxe</a>, un langage construit avec un compilateur écrit en OCaml.</p>
+    ; body_html =
+        {js|<p>Shiro Games développe des jeux en utilisant <a href="https://haxe.org/">Haxe</a>, un langage construit avec un compilateur écrit en OCaml.</p>
 |js}
-  };
- 
-  { name = {js|SimCorp|js}
-  ; slug = {js|simcorp|js}
-  ; description = {js|Plateforme multiactifs pour soutenir la prise de décision et l'innovation en matière d'investissement
+    }
+  ; { name = {js|SimCorp|js}
+    ; slug = {js|simcorp|js}
+    ; description =
+        {js|Plateforme multiactifs pour soutenir la prise de décision et l'innovation en matière d'investissement
 |js}
-  ; image = Some {js|/users/simcorp.png|js}
-  ; site = {js|https://www.simcorp.com/|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = true
-  ; body_md = {js|
+    ; image = Some {js|/users/simcorp.png|js}
+    ; site = {js|https://www.simcorp.com/|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = true
+    ; body_md =
+        {js|
 Plateforme multiactifs pour soutenir la prise de décision et l'innovation en matière d'investissement.
 
 |js}
-  ; body_html = {js|<p>Plateforme multiactifs pour soutenir la prise de décision et l'innovation en matière d'investissement.</p>
+    ; body_html =
+        {js|<p>Plateforme multiactifs pour soutenir la prise de décision et l'innovation en matière d'investissement.</p>
 |js}
-  };
- 
-  { name = {js|Sleekersoft|js}
-  ; slug = {js|sleekersoft|js}
-  ; description = {js|Spécialisé dans le développement de logiciels de programmation fonctionnelle, la consultation et la formation
+    }
+  ; { name = {js|Sleekersoft|js}
+    ; slug = {js|sleekersoft|js}
+    ; description =
+        {js|Spécialisé dans le développement de logiciels de programmation fonctionnelle, la consultation et la formation
 |js}
-  ; image = Some {js|/users/sleekersoft.png|js}
-  ; site = {js|https://www.sleekersoft.com|js}
-  ; locations = 
- [{js|Australie|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/sleekersoft.png|js}
+    ; site = {js|https://www.sleekersoft.com|js}
+    ; locations = [ {js|Australie|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Spécialisé dans le développement de logiciels de programmation fonctionnelle, la consultation et la formation
 |js}
-  ; body_html = {js|<p>Spécialisé dans le développement de logiciels de programmation fonctionnelle, la consultation et la formation</p>
+    ; body_html =
+        {js|<p>Spécialisé dans le développement de logiciels de programmation fonctionnelle, la consultation et la formation</p>
 |js}
-  };
- 
-  { name = {js|Solvuu|js}
-  ; slug = {js|solvuu|js}
-  ; description = {js|Le logiciel de Solvuu permet aux utilisateurs de stocker des ensembles de données, grands et petits, de partager les données avec des collaborateurs, d'exécuter des algorithmes et des flux de travail à forte intensité de calcul et de visualiser les résultats.
+    }
+  ; { name = {js|Solvuu|js}
+    ; slug = {js|solvuu|js}
+    ; description =
+        {js|Le logiciel de Solvuu permet aux utilisateurs de stocker des ensembles de données, grands et petits, de partager les données avec des collaborateurs, d'exécuter des algorithmes et des flux de travail à forte intensité de calcul et de visualiser les résultats.
 |js}
-  ; image = Some {js|/users/solvuu.jpg|js}
-  ; site = {js|https://www.solvuu.com|js}
-  ; locations = 
- [{js|États-Unis|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/solvuu.jpg|js}
+    ; site = {js|https://www.solvuu.com|js}
+    ; locations = [ {js|États-Unis|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Le logiciel de Solvuu permet aux utilisateurs de stocker des ensembles de données, grands et petits, de partager les données avec des collaborateurs, d'exécuter des algorithmes et des flux de travail à forte intensité de calcul et de visualiser les résultats. L'entreprise se concentre initialement sur les données génomiques, qui ont des implications importantes pour les soins de santé, l'agriculture et la recherche fondamentale. La quasi-totalité de la pile logicielle de Solvuu est implémentée en OCaml.
 |js}
-  ; body_html = {js|<p>Le logiciel de Solvuu permet aux utilisateurs de stocker des ensembles de données, grands et petits, de partager les données avec des collaborateurs, d'exécuter des algorithmes et des flux de travail à forte intensité de calcul et de visualiser les résultats. L'entreprise se concentre initialement sur les données génomiques, qui ont des implications importantes pour les soins de santé, l'agriculture et la recherche fondamentale. La quasi-totalité de la pile logicielle de Solvuu est implémentée en OCaml.</p>
+    ; body_html =
+        {js|<p>Le logiciel de Solvuu permet aux utilisateurs de stocker des ensembles de données, grands et petits, de partager les données avec des collaborateurs, d'exécuter des algorithmes et des flux de travail à forte intensité de calcul et de visualiser les résultats. L'entreprise se concentre initialement sur les données génomiques, qui ont des implications importantes pour les soins de santé, l'agriculture et la recherche fondamentale. La quasi-totalité de la pile logicielle de Solvuu est implémentée en OCaml.</p>
 |js}
-  };
- 
-  { name = {js|Studio Associato 4Sigma|js}
-  ; slug = {js|studio-associato-4sigma|js}
-  ; description = {js|4Sigma est une petite entreprise qui réalise des sites web et quelques applications web intéressantes
+    }
+  ; { name = {js|Studio Associato 4Sigma|js}
+    ; slug = {js|studio-associato-4sigma|js}
+    ; description =
+        {js|4Sigma est une petite entreprise qui réalise des sites web et quelques applications web intéressantes
 |js}
-  ; image = Some {js|/users/4sigma.png|js}
-  ; site = {js|https://www.4sigma.it|js}
-  ; locations = 
- [{js|Italie|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/4sigma.png|js}
+    ; site = {js|https://www.4sigma.it|js}
+    ; locations = [ {js|Italie|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 4Sigma est une petite entreprise qui réalise des sites web et quelques applications web intéressantes. OCaml n'est pas le principal langage utilisé, mais il est utilisé ici et là, notamment dans un petit serveur qui est un élément clé d'un service que nous offrons à nos clients.
 |js}
-  ; body_html = {js|<p>4Sigma est une petite entreprise qui réalise des sites web et quelques applications web intéressantes. OCaml n'est pas le principal langage utilisé, mais il est utilisé ici et là, notamment dans un petit serveur qui est un élément clé d'un service que nous offrons à nos clients.</p>
+    ; body_html =
+        {js|<p>4Sigma est une petite entreprise qui réalise des sites web et quelques applications web intéressantes. OCaml n'est pas le principal langage utilisé, mais il est utilisé ici et là, notamment dans un petit serveur qui est un élément clé d'un service que nous offrons à nos clients.</p>
 |js}
-  };
- 
-  { name = {js|Tarides|js}
-  ; slug = {js|tarides|js}
-  ; description = {js|Tarides construit et maintient des outils d'infrastructure open source en OCaml comme MirageOS, Irmin et des outils de développement d'OCaml
+    }
+  ; { name = {js|Tarides|js}
+    ; slug = {js|tarides|js}
+    ; description =
+        {js|Tarides construit et maintient des outils d'infrastructure open source en OCaml comme MirageOS, Irmin et des outils de développement d'OCaml
 |js}
-  ; image = Some {js|/users/tarides.png|js}
-  ; site = {js|https://www.tarides.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/tarides.png|js}
+    ; site = {js|https://www.tarides.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Nous construisons et maintenons des outils d'infrastructure open source en OCaml :
 
  - [MirageOS](https://mirage.io), le projet unikernel le plus avancé, dans lequel nous construisons des sandboxes, des implémentations de protocoles de réseau et de stockage sous forme de bibliothèques, afin de pouvoir les lier à nos applications pour les exécuter sans avoir besoin d'un système d'exploitation sous-jacent.
@@ -1694,7 +1789,8 @@ Nous construisons et maintenons des outils d'infrastructure open source en OCaml
 
 Tarides a été fondée début 2018 et est principalement basée à Paris, France (le travail à distance est possible).
 |js}
-  ; body_html = {js|<p>Nous construisons et maintenons des outils d'infrastructure open source en OCaml :</p>
+    ; body_html =
+        {js|<p>Nous construisons et maintenons des outils d'infrastructure open source en OCaml :</p>
 <ul>
 <li><a href="https://mirage.io">MirageOS</a>, le projet unikernel le plus avancé, dans lequel nous construisons des sandboxes, des implémentations de protocoles de réseau et de stockage sous forme de bibliothèques, afin de pouvoir les lier à nos applications pour les exécuter sans avoir besoin d'un système d'exploitation sous-jacent.
 </li>
@@ -1705,53 +1801,56 @@ Tarides a été fondée début 2018 et est principalement basée à Paris, Franc
 </ul>
 <p>Tarides a été fondée début 2018 et est principalement basée à Paris, France (le travail à distance est possible).</p>
 |js}
-  };
- 
-  { name = {js|TrustInSoft|js}
-  ; slug = {js|trustinsoft|js}
-  ; description = {js|TrustInSoft est une entreprise qui change les règles de la cybersécurité. TrustInSoft est l'éditeur du logiciel d'analyse de la plateforme Frama-C
+    }
+  ; { name = {js|TrustInSoft|js}
+    ; slug = {js|trustinsoft|js}
+    ; description =
+        {js|TrustInSoft est une entreprise qui change les règles de la cybersécurité. TrustInSoft est l'éditeur du logiciel d'analyse de la plateforme Frama-C
 |js}
-  ; image = Some {js|/users/trustinsoft.png|js}
-  ; site = {js|https://trust-in-soft.com|js}
-  ; locations = 
- [{js|France|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/trustinsoft.png|js}
+    ; site = {js|https://trust-in-soft.com|js}
+    ; locations = [ {js|France|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 TrustInSoft est une entreprise qui change les règles de la cybersécurité. TrustInSoft est l'éditeur de la plateforme d'analyse logicielle [Frama-C](https://frama-c.com). Notre devise est simple : rendre les méthodes formelles accessibles à la majorité des développeurs de logiciels.
 |js}
-  ; body_html = {js|<p>TrustInSoft est une entreprise qui change les règles de la cybersécurité. TrustInSoft est l'éditeur de la plateforme d'analyse logicielle <a href="https://frama-c.com">Frama-C</a>. Notre devise est simple : rendre les méthodes formelles accessibles à la majorité des développeurs de logiciels.</p>
+    ; body_html =
+        {js|<p>TrustInSoft est une entreprise qui change les règles de la cybersécurité. TrustInSoft est l'éditeur de la plateforme d'analyse logicielle <a href="https://frama-c.com">Frama-C</a>. Notre devise est simple : rendre les méthodes formelles accessibles à la majorité des développeurs de logiciels.</p>
 |js}
-  };
- 
-  { name = {js|Wolfram MathCore|js}
-  ; slug = {js|wolfram-mathcore|js}
-  ; description = {js|Wolfram MathCore utilise OCaml pour implémenter son noyau SystemModeler
+    }
+  ; { name = {js|Wolfram MathCore|js}
+    ; slug = {js|wolfram-mathcore|js}
+    ; description =
+        {js|Wolfram MathCore utilise OCaml pour implémenter son noyau SystemModeler
 |js}
-  ; image = Some {js|/users/wolfram-mathcore.gif|js}
-  ; site = {js|https://www.wolframmathcore.com|js}
-  ; locations = 
- [{js|Suède|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = Some {js|/users/wolfram-mathcore.gif|js}
+    ; site = {js|https://www.wolframmathcore.com|js}
+    ; locations = [ {js|Suède|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Wolfram MathCore utilise OCaml pour implémenter son noyau SystemModeler. La fonction principale du noyau est de traduire les modèles définis dans le langage Modelica en code de simulation exécutable. Cela implique l'analyse et la transformation du code Modelica, le traitement mathématique des équations, la génération du code de simulation C/C++ et les calculs numériques d'exécution.
 |js}
-  ; body_html = {js|<p>Wolfram MathCore utilise OCaml pour implémenter son noyau SystemModeler. La fonction principale du noyau est de traduire les modèles définis dans le langage Modelica en code de simulation exécutable. Cela implique l'analyse et la transformation du code Modelica, le traitement mathématique des équations, la génération du code de simulation C/C++ et les calculs numériques d'exécution.</p>
+    ; body_html =
+        {js|<p>Wolfram MathCore utilise OCaml pour implémenter son noyau SystemModeler. La fonction principale du noyau est de traduire les modèles définis dans le langage Modelica en code de simulation exécutable. Cela implique l'analyse et la transformation du code Modelica, le traitement mathématique des équations, la génération du code de simulation C/C++ et les calculs numériques d'exécution.</p>
 |js}
-  };
- 
-  { name = {js|Zeo Agency|js}
-  ; slug = {js|zeo-agency|js}
-  ; description = {js|Zeo est une société de marketing numérique dont l'objectif est d'aider les entreprises à faire mieux en matière de référencement
+    }
+  ; { name = {js|Zeo Agency|js}
+    ; slug = {js|zeo-agency|js}
+    ; description =
+        {js|Zeo est une société de marketing numérique dont l'objectif est d'aider les entreprises à faire mieux en matière de référencement
 |js}
-  ; image = None
-  ; site = {js|https://www.zeo.org|js}
-  ; locations = 
- [{js|Londres, Royaume-Uni|js}]
-  ; consortium = false
-  ; body_md = {js|
+    ; image = None
+    ; site = {js|https://www.zeo.org|js}
+    ; locations = [ {js|Londres, Royaume-Uni|js} ]
+    ; consortium = false
+    ; body_md =
+        {js|
 Zeo est une société de marketing numérique dont l'objectif est d'aider les entreprises à faire mieux en matière de référencement. En raison de la nature de notre activité, nous gérons des milliards de lignes dans notre base de données et créons des informations en utilisant ces données. Pour répondre efficacement à nos besoins, nous utilisons OCaml dans notre partie exploration et traitement des données.
 |js}
-  ; body_html = {js|<p>Zeo est une société de marketing numérique dont l'objectif est d'aider les entreprises à faire mieux en matière de référencement. En raison de la nature de notre activité, nous gérons des milliards de lignes dans notre base de données et créons des informations en utilisant ces données. Pour répondre efficacement à nos besoins, nous utilisons OCaml dans notre partie exploration et traitement des données.</p>
+    ; body_html =
+        {js|<p>Zeo est une société de marketing numérique dont l'objectif est d'aider les entreprises à faire mieux en matière de référencement. En raison de la nature de notre activité, nous gérons des milliards de lignes dans notre base de données et créons des informations en utilisant ces données. Pour répondre efficacement à nos besoins, nous utilisons OCaml dans notre partie exploration et traitement des données.</p>
 |js}
-  }]
-
+    }
+  ]

--- a/src/ocamlorg_data/opam_user.ml
+++ b/src/ocamlorg_data/opam_user.ml
@@ -1,82 +1,69 @@
-
 type t =
   { name : string
   ; email : string option
   ; github_username : string
   ; avatar : string
   }
-  
-let all = 
-[
-  { name = {js|Xavier Leroy|js}
-  ; email = None
-  ; github_username = {js|xavierleroy|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/3845810?v=4|js}
-  };
- 
-  { name = {js|Damien Doligez|js}
-  ; email = None
-  ; github_username = {js|damiendoligez|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/19104?v=4|js}
-  };
- 
-  { name = {js|David Allsopp|js}
-  ; email = None
-  ; github_username = {js|dra27|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/5250680?v=4|js}
-  };
- 
-  { name = {js|Alain Frisch|js}
-  ; email = None
-  ; github_username = {js|alainfrisch|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/3305274?v=4|js}
-  };
- 
-  { name = {js|Gabriel Scherer|js}
-  ; email = None
-  ; github_username = {js|gasche|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/426238?v=4|js}
-  };
- 
-  { name = {js|Jacques Garrigue|js}
-  ; email = None
-  ; github_username = {js|garrigue|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/870242?v=4|js}
-  };
- 
-  { name = {js|Thibaut Mattio|js}
-  ; email = Some {js|thibaut.mattio@gmail.com|js}
-  ; github_username = {js|tmattio|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/6162008?v=4|js}
-  };
- 
-  { name = {js|Anton Bachin|js}
-  ; email = None
-  ; github_username = {js|aantron|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/12073668?v=4|js}
-  };
- 
-  { name = {js|Patrick Ferris|js}
-  ; email = None
-  ; github_username = {js|patricoferris|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/20166594?v=4|js}
-  };
- 
-  { name = {js|Didier Rémy|js}
-  ; email = None
-  ; github_username = {js|diremy|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/1357930?v=4|js}
-  };
- 
-  { name = {js|Gabriel Radanne|js}
-  ; email = None
-  ; github_username = {js|Drup|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/801124?v=4|js}
-  };
- 
-  { name = {js|Daniel Bünzli|js}
-  ; email = None
-  ; github_username = {js|dbuenzli|js}
-  ; avatar = {js|https://avatars.githubusercontent.com/u/485596?v=4|js}
-  }]
 
+let all =
+  [ { name = {js|Xavier Leroy|js}
+    ; email = None
+    ; github_username = {js|xavierleroy|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/3845810?v=4|js}
+    }
+  ; { name = {js|Damien Doligez|js}
+    ; email = None
+    ; github_username = {js|damiendoligez|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/19104?v=4|js}
+    }
+  ; { name = {js|David Allsopp|js}
+    ; email = None
+    ; github_username = {js|dra27|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/5250680?v=4|js}
+    }
+  ; { name = {js|Alain Frisch|js}
+    ; email = None
+    ; github_username = {js|alainfrisch|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/3305274?v=4|js}
+    }
+  ; { name = {js|Gabriel Scherer|js}
+    ; email = None
+    ; github_username = {js|gasche|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/426238?v=4|js}
+    }
+  ; { name = {js|Jacques Garrigue|js}
+    ; email = None
+    ; github_username = {js|garrigue|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/870242?v=4|js}
+    }
+  ; { name = {js|Thibaut Mattio|js}
+    ; email = Some {js|thibaut.mattio@gmail.com|js}
+    ; github_username = {js|tmattio|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/6162008?v=4|js}
+    }
+  ; { name = {js|Anton Bachin|js}
+    ; email = None
+    ; github_username = {js|aantron|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/12073668?v=4|js}
+    }
+  ; { name = {js|Patrick Ferris|js}
+    ; email = None
+    ; github_username = {js|patricoferris|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/20166594?v=4|js}
+    }
+  ; { name = {js|Didier Rémy|js}
+    ; email = None
+    ; github_username = {js|diremy|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/1357930?v=4|js}
+    }
+  ; { name = {js|Gabriel Radanne|js}
+    ; email = None
+    ; github_username = {js|Drup|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/801124?v=4|js}
+    }
+  ; { name = {js|Daniel Bünzli|js}
+    ; email = None
+    ; github_username = {js|dbuenzli|js}
+    ; avatar = {js|https://avatars.githubusercontent.com/u/485596?v=4|js}
+    }
+  ]

--- a/src/ocamlorg_data/paper.ml
+++ b/src/ocamlorg_data/paper.ml
@@ -1,4 +1,3 @@
-
 type t =
   { title : string
   ; slug : string
@@ -9,522 +8,545 @@ type t =
   ; year : int
   ; links : string list
   }
-  
-let all = 
-[
-  { title = {js|A Syntactic Approach to Type Soundness|js}
-  ; slug = {js|a-syntactic-approach-to-type-soundness|js}
-  ; publication = {js|Information & Computation, 115(1):38−94|js}
-  ; authors = 
- [{js|Andrew K. Wright|js}; {js|Matthias Felleisen|js}]
-  ; abstract = {js|This paper describes the semantics and the type system of Core ML,  and uses a simple syntactic technique to prove that well-typed programs cannot go wrong.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}]
-  ; year = 1994
-  ; links = [{js|https://www.cs.rice.edu/CS/PLT/Publications/Scheme/ic94-wf.ps.gz|js}]
-  };
- 
-  { title = {js|The Essence of ML Type Inference|js}
-  ; slug = {js|the-essence-of-ml-type-inference|js}
-  ; publication = {js|Benjamin C. Pierce, editor, Advanced Topics in Types and Programming Languages, MIT Press|js}
-  ; authors = 
- [{js|François Pottier|js}; {js|Didier Rémy|js}]
-  ; abstract = {js|This book chapter gives an in-depth abstract of the Core ML type system, with an emphasis on type inference.  The type inference algorithm is described as the composition of a constraint generator, which produces a system  of type equations, and a constraint solver, which is presented as a set of rewrite rules.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}]
-  ; year = 2005
-  ; links = [{js|https://cristal.inria.fr/attapl/preversion.ps.gz|js}]
-  };
- 
-  { title = {js|Relaxing the value restriction|js}
-  ; slug = {js|relaxing-the-value-restriction|js}
-  ; publication = {js|International Symposium on Functional and Logic Programming|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}]
-  ; abstract = {js|This paper explains why it is sound to generalize certain type variables at a `let` binding, even when the expression that is being `let`-bound is not a value. This relaxed version of Wright's classic “value restriction” was introduced in OCaml 3.07.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}]
-  ; year = 2004
-  ; links = [{js|https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.pdf|js};
-                                                               {js|https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.ps.gz|js}]
-  };
- 
-  { title = {js|Manifest Types, Modules, and Separate Compilation|js}
-  ; slug = {js|manifest-types-modules-and-separate-compilation|js}
-  ; publication = {js|Principles of Programming Languages|js}
-  ; authors = 
- [{js|Xavier Leroy|js}]
-  ; abstract = {js|This paper presents a variant of the Standard ML module system that introduces a strict distinction between abstract  and manifest types. The latter are types whose definitions explicitly appear as part of a module interface. This proposal  is meant to retain most of the expressive power of the Standard ML module system, while providing much better support for  separate compilation. This work sets the formal bases for OCaml's module system.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|modules|js}]
-  ; year = 1994
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.ps.gz|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.dvi.gz|js}]
-  };
- 
-  { title = {js|Applicative Functors and Fully Transparent Higher-order Modules|js}
-  ; slug = {js|applicative-functors-and-fully-transparent-higher-order-modules|js}
-  ; publication = {js|Principles of Programming Languages|js}
-  ; authors = 
- [{js|Xavier Leroy|js}]
-  ; abstract = {js|This work extends the above paper by introducing so-called applicative functors, that is, functors that produce compatible  abstract types when applied to provably equal arguments. Applicative functors are also a feature of OCaml.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|modules|js}]
-  ; year = 1995
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.ps.gz|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.dvi.gz|js}]
-  };
- 
-  { title = {js|A Modular Module System|js}
-  ; slug = {js|a-modular-module-system|js}
-  ; publication = {js|Journal of Functional Programming, 10(3):269-303|js}
-  ; authors = 
- [{js|Xavier Leroy|js}]
-  ; abstract = {js|This accessible paper describes a simplified implementation of the OCaml module system, emphasizing the fact that the module system  is largely independent of the underlying core language. This is a good tutorial to learn both how modules can be used and how  they are typechecked.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|modules|js}]
-  ; year = 2000
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.ps.gz|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.dvi.gz|js}]
-  };
- 
-  { title = {js|A Proposal for Recursive Modules in Objective Caml|js}
-  ; slug = {js|a-proposal-for-recursive-modules-in-objective-caml|js}
-  ; publication = {js|Unpublication|js}
-  ; authors = 
- [{js|Xavier Leroy|js}]
-  ; abstract = {js|This note describes the experimental recursive modules introduced in OCaml 3.07.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|modules|js}]
-  ; year = 2003
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/xleroy-recursive_modules-03.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/xleroy-recursive_modules-03.ps.gz|js}]
-  };
- 
-  { title = {js|Objective ML: An effective object-oriented extension to ML|js}
-  ; slug = {js|objective-ml-an-effective-object-oriented-extension-to-ml|js}
-  ; publication = {js|Theory And Practice of Objects Systems, 4(1):27−50|js}
-  ; authors = 
- [{js|Didier Rémy|js}; {js|Jérôme Vouillon|js}]
-  ; abstract = {js|This paper provides theoretical foundations for OCaml's object-oriented layer, including dynamic and static semantics.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|objects|js}]
-  ; year = 1998
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.ps.gz|js};
-  {js|https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.dvi.gz|js}]
-  };
- 
-  { title = {js|Extending ML with Semi-Explicit Higher-Order Polymorphism|js}
-  ; slug = {js|extending-ml-with-semi-explicit-higher-order-polymorphism|js}
-  ; publication = {js|Information & Computation, 155(1/2):134−169|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}; {js|Didier Rémy|js}]
-  ; abstract = {js|This paper proposes a device for re-introducing first-class polymorphic values into ML while preserving its type inference  mechanism. This technology underlies OCaml's polymorphic methods.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|objects|js}]
-  ; year = 1999
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.ps.gz|js};
-  {js|https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.dvi.gz|js}]
-  };
- 
-  { title = {js|Programming with Polymorphic Variants|js}
-  ; slug = {js|programming-with-polymorphic-variants|js}
-  ; publication = {js|ML Workshop|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}]
-  ; abstract = {js|This paper briefly explains what polymorphic variants are about and how they are compiled.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|polymorphic variants|js}]
-  ; year = 1998
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.ps.gz|js}]
-  };
- 
-  { title = {js|Code Reuse through Polymorphic Variants|js}
-  ; slug = {js|code-reuse-through-polymorphic-variants|js}
-  ; publication = {js|Workshop on Foundations of Software Engineering|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}]
-  ; abstract = {js|This short paper explains how to design a modular, extensible interpreter using polymorphic variants.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|polymorphic variants|js}]
-  ; year = 2000
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/garrigue-variant-reuse-2000.ps.gz|js}]
-  };
- 
-  { title = {js|Simple Type Inference for Structural Polymorphism|js}
-  ; slug = {js|simple-type-inference-for-structural-polymorphism|js}
-  ; publication = {js|Workshop on Foundations of Object-Oriented Languages|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}]
-  ; abstract = {js|This paper explains most of the typechecking machinery behind polymorphic variants.  At its heart is an extension of Core ML's type discipline with so-called local constraints.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|polymorphic variants|js}]
-  ; year = 2002
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/garrigue-structural_poly-fool02.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/garrigue-structural_poly-fool02.ps.gz|js}]
-  };
- 
-  { title = {js|Typing Deep Pattern-matching in Presence of Polymorphic Variants|js}
-  ; slug = {js|typing-deep-pattern-matching-in-presence-of-polymorphic-variants|js}
-  ; publication = {js|JSSST Workshop on Programming and Programming Languages|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}]
-  ; abstract = {js|This paper provides more details about the technical machinery behind polymorphic variants, focusing  on the rules for typechecking deep pattern matching constructs.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}; {js|polymorphic variants|js}]
-  ; year = 2004
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/garrigue-deep-variants-2004.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/garrigue-deep-variants-2004.ps.gz|js}]
-  };
- 
-  { title = {js|Labeled and Optional Arguments for Objective Caml|js}
-  ; slug = {js|labeled-and-optional-arguments-for-objective-caml|js}
-  ; publication = {js|JSSST Workshop on Programming and Programming Languages|js}
-  ; authors = 
- [{js|Jacques Garrigue|js}]
-  ; abstract = {js|This paper offers a dynamic semantics, a static semantics, and a compilation scheme for OCaml's labeled  and optional function parameters.
-|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}]
-  ; year = 2001
-  ; links = [{js|https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.pdf|js};
-                                                               {js|https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.ps.gz|js};
-                                                               {js|https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.dvi.gz|js}]
-  };
- 
-  { title = {js|Meta-programming Tutorial with CamlP4|js}
-  ; slug = {js|meta-programming-tutorial-with-camlp4|js}
-  ; publication = {js|Commercial Users of Functional Programming|js}
-  ; authors = 
- [{js|Jake Donham|js}]
-  ; abstract = {js|Meta-programming tutorial with Camlp4|js}
-  ; tags = 
- [{js|core|js}; {js|language|js}]
-  ; year = 2010
-  ; links = [{js|https://github.com/jaked/cufp-metaprogramming-tutorial|js}]
-  };
- 
-  { title = {js|The ZINC experiment, an Economical Implementation of the ML language|js}
-  ; slug = {js|the-zinc-experiment-an-economical-implementation-of-the-ml-language|js}
-  ; publication = {js|Technical report 117, INRIA|js}
-  ; authors = 
- [{js|Xavier Leroy|js}]
-  ; abstract = {js|This report contains a abstract of the ZINC compiler, which later evolved into Caml Light, then into OCaml. Large parts  of this report are out of date, but it is still valuable as a abstract of the abstract machine used in Caml Light and  (with some further simplifications and speed improvements) in OCaml.
-|js}
-  ; tags = 
- [{js|compiler|js}; {js|runtime|js}]
-  ; year = 1990
-  ; links = [{js|https://caml.inria.fr/pub/papers/xleroy-zinc.pdf|js};
-                                                                  {js|https://caml.inria.fr/pub/papers/xleroy-zinc.ps.gz|js}]
-  };
- 
-  { title = {js|The Effectiveness of Type-based Unboxing|js}
-  ; slug = {js|the-effectiveness-of-type-based-unboxing|js}
-  ; publication = {js|Workshop on Types in Compilation|js}
-  ; authors = 
- [{js|Xavier Leroy|js}]
-  ; abstract = {js|This paper surveys and compares several data representation strategies, including the one used in the OCaml native-code compiler.
-|js}
-  ; tags = 
- [{js|compiler|js}; {js|runtime|js}]
-  ; year = 1997
-  ; links = [{js|https://caml.inria.fr/pub/papers/xleroy-unboxing-tic97.pdf|js};
-                                                                  {js|https://caml.inria.fr/pub/papers/xleroy-unboxing-tic97.ps.gz|js}]
-  };
- 
-  { title = {js|A Concurrent, Generational Garbage Collector for a Multithreaded Implementation of ML|js}
-  ; slug = {js|a-concurrent-generational-garbage-collector-for-a-multithreaded-implementation-of-ml|js}
-  ; publication = {js|Principles of Programming Languages|js}
-  ; authors = 
- [{js|Damien Doligez|js}; {js|Xavier Leroy|js}]
-  ; abstract = {js|Superseded by "Portable, Unobtrusive Garbage Collection for Multiprocessor Systems"
-|js}
-  ; tags = 
- [{js|garbage collection|js}; {js|runtime|js}]
-  ; year = 1993
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/doligez_xleroy-concurrent_gc-popl93.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/doligez_xleroy-concurrent_gc-popl93.ps.gz|js}]
-  };
- 
-  { title = {js|Portable, Unobtrusive Garbage Collection for Multiprocessor Systems|js}
-  ; slug = {js|portable-unobtrusive-garbage-collection-for-multiprocessor-systems|js}
-  ; publication = {js|Principles of Programming Languages|js}
-  ; authors = 
- [{js|Damien Doligez|js}; {js|Georges Gonthier|js}]
-  ; abstract = {js|This paper describes a concurrent version of the garbage collector found in Caml Light and OCaml's runtime system.
-|js}
-  ; tags = 
- [{js|garbage collection|js}; {js|runtime|js}]
-  ; year = 1994
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/doligez_gonthier-gc-popl94.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/doligez_gonthier-gc-popl94.ps.gz|js}]
-  };
- 
-  { title = {js|Conception, réalisation et certification d'un glaneur de cellules concurrent|js}
-  ; slug = {js|conception-ralisation-et-certification-dun-glaneur-de-cellules-concurrent|js}
-  ; publication = {js|Ph.D. thesis, Université Paris 7|js}
-  ; authors = 
- [{js|Damien Doligez|js}; {js|Georges Gonthier|js}]
-  ; abstract = {js|All you ever wanted to know about the garbage collector found in Caml Light and OCaml's runtime system.
-|js}
-  ; tags = 
- [{js|garbage collection|js}; {js|runtime|js}]
-  ; year = 1995
-  ; links = 
- [{js|https://caml.inria.fr/pub/papers/doligez-these.pdf|js};
-  {js|https://caml.inria.fr/pub/papers/doligez-these.ps.gz|js}]
-  };
- 
-  { title = {js|Optimizing Pattern Matching|js}
-  ; slug = {js|optimizing-pattern-matching|js}
-  ; publication = {js|Proceedings of the sixth ACM SIGPLAN International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Fabrice Le Fessant|js}; {js|Luc Maranget|js}]
-  ; abstract = {js|All you ever wanted to know about the garbage collector found in Caml Light and OCaml's runtime system.
-|js}
-  ; tags = 
- [{js|pattern-matching|js}; {js|runtime|js}]
-  ; year = 2001
-  ; links = 
- [{js|https://dl.acm.org/citation.cfm?id=507641|js}]
-  };
- 
-  { title = {js|OCaml for the Masses|js}
-  ; slug = {js|ocaml-for-the-masses|js}
-  ; publication = {js|ACM Queue|js}
-  ; authors = 
- [{js|Yaron Minsky|js}]
-  ; abstract = {js|Why the next language you learn should be functional.
-|js}
-  ; tags = 
- [{js|industrial|js}]
-  ; year = 2011
-  ; links = [{js|https://queue.acm.org/detail.cfm?id=2038036|js}]
-  };
- 
-  { title = {js|Xen and the Art of OCaml|js}
-  ; slug = {js|xen-and-the-art-of-ocaml|js}
-  ; publication = {js|Commercial Users of Functional Programming (CUFP)|js}
-  ; authors = 
- [{js|Anil Madhavapeddy|js}]
-  ; abstract = {js|In this talk, we will firstly describe the architecture of XenServer and the XenAPI and discuss the challenges faced with implementing  an Objective Caml based solution. These challenges range from the low-level concerns of interfacing with Xen and the  Linux kernel, to the high-level algorithmic problems such as distributed failure planning. In addition, we will  discuss the challenges imposed by using OCaml in a commercial environment, such as supporting product upgrades,  enhancing supportability and scaling the development team.
-|js}
-  ; tags = 
- [{js|industrial|js}; {js|application|js}]
-  ; year = 2008
-  ; links = 
- [{js|https://cufp.org/archive/2008/slides/MadhavapeddyAnil.pdf|js}]
-  };
- 
-  { title = {js|Chemoinformatics and Structural Bioinformatics in OCaml|js}
-  ; slug = {js|chemoinformatics-and-structural-bioinformatics-in-ocaml|js}
-  ; publication = {js|Journal of Cheminformatics|js}
-  ; authors = 
- [{js|François Berenger|js}; {js|Kam Y. J. Zhang|js};
-  {js|Yoshihiro Yamanishi|js}]
-  ; abstract = {js|In this article, we share our experience in prototyping chemoinformatics and structural bioinformatics software in OCaml
-|js}
-  ; tags = 
- [{js|industrial|js}; {js|application|js}; {js|bioinformatics|js}]
-  ; year = 2019
-  ; links = 
- [{js|https://jcheminf.biomedcentral.com/articles/10.1186/s13321-019-0332-0|js}]
-  };
- 
-  { title = {js|A Declarative Syntax Definition for OCaml|js}
-  ; slug = {js|a-declarative-syntax-definition-for-ocaml|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Luis Eduardo de Souza Amorim|js}; {js|Eelco Visser|js}]
-  ; abstract = {js|In this talk we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3.  SDF3 supports high-level definition of concrete and abstract syntax through declarative disambiguation and definition of  constructors, enabling a direct mapping to abstract syntax. Based on the SDF3 syntax definition, the Spoofax language  workbench produces a complete syntax aware editor with a parser, syntax checking, parse error recovery, syntax highlighting,  formatting with correct parenthesis insertion, and syntactic completion. The syntax definition should provide a good  basis for experiments with the design of OCaml and the development of further tooling. In the talk we will highlight  interesting aspects the syntax definition, discuss issues we encountered in the syntax of OCaml, and demonstrate the editor.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://eelcovisser.org/talks/2020/08/28/ocaml/|js}]
-  };
- 
-  { title = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
-  ; slug = {js|a-simple-state-machine-framework-for-property-based-testing-in-ocaml|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Jan Midtgaard|js}]
-  ; abstract = {js|Since their inception state-machine frameworks have proven their worth by finding defects in everything  from the underlying AUTOSAR components of Volvo cars to digital invoicing sys- tems. These case studies were carried  out with Erlang’s commercial QuickCheck state-machine framework from Quviq, but such frameworks are now also available  for Haskell, F#, Scala, Elixir, Java, etc. We present a typed state-machine framework for OCaml based on the QCheck  library and illustrate a number concepts common to all such frameworks: state modeling, commands, interpreting commands, preconditions, and agreement checking.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://janmidtgaard.dk/papers/Midtgaard%3AOCaml20.pdf|js}]
-  };
- 
-  { title = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
-  ; slug = {js|ad-ocaml-algorithmic-differentiation-for-ocaml|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Markus Mottl|js}]
-  ; abstract = {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and  deep power series approximations of almost arbitrary OCaml programs via algorithmic  differentiation. Unlike similar frameworks, this includes programs with side effects,  aliasing, and programs with nested derivative operators. The framework also offers implicit  parallelization of both user programs and their transformations. The presentation will provide  a short introduction to the mathematical problem, the difficulties of implementing a solution,  the design of the library, and a demonstration of its capabilities.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/12/AD-OCaml-Algorithmic-Differentiation-for-OCaml|js}]
-  };
- 
-  { title = {js|API migration: compare transformed|js}
-  ; slug = {js|api-migration-compare-transformed|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Joseph Harrison|js}; {js|Steven Varoumas|js}; {js|Simon Thompson|js};
-  {js|Reuben Rowe|js}]
-  ; abstract = {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing  the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on  open source Jane Street libraries by using Rotor to refactor comparison functions so that they return a  more precise variant type rather than an integer. We discuss the difficulties of refactoring the Jane Street  code base, which makes extensive use of ppx macros, and ongoing work implementing new refactorings.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/7/API-migration-compare-transformed|js};
-                                                       {js|https://www.cs.kent.ac.uk/people/staff/sjt/Pubs/OCaml_workshop2020.pdf|js}]
-  };
- 
-  { title = {js|Irmin v2|js}
-  ; slug = {js|irmin-v2|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Clément Pascutto|js}; {js|Ioana Cristescu|js}; {js|Craig Ferguson|js};
-  {js|Thomas Gazagnaire|js}; {js|Romain Liautaud|js}]
-  ; abstract = {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git.  Existing Git users will find many familiar features: branching/merging, immutable causal history for  all changes, and the ability to restore to any previous state. Irmin v2 adds new accessibility methods  to the store: we can now use Irmin from a CLI, or in a browser using irmin-graphql. It also has a new  backend, irmin-pack, which is optimised for space usage and is used by the Tezos blockchain.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/10/Irmin-v2|js};
-                                                       {js|https://tarides.com/blog/2019-11-21-irmin-v2|js}]
-  };
- 
-  { title = {js|LexiFi Runtime Types|js}
-  ; slug = {js|lexifi-runtime-types|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Patrik Keller|js}; {js|Marc Lasson|js}]
-  ; abstract = {js|LexiFi maintains an OCaml compiler extension that enables introspection through runtime type representations.  Recently, we implemented a syntax extension (PPX) that enables the use of LexiFi runtime types on vanilla compilers.  We propose to present our publicly available runtime types and their features. Most notably, we want to present  a mechanism for pattern matching on runtime types with holes.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/9/LexiFi-Runtime-Types|js};
-                                                       {js|https://informationsecurity.uibk.ac.at/pdfs/KL2020_LexiFi_Runtime_Types_OCAML.pdf|js};
-                                                       {js|https://www.lexifi.com/blog/ocaml/runtime-types/|js}]
-  };
- 
-  { title = {js|OCaml Under the Hood: SmartPy|js}
-  ; slug = {js|ocaml-under-the-hood-smartpy|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Sebastien Mondet|js}]
-  ; abstract = {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python  to write contracts and their tests scenarios. It includes an online IDE, a chain explorer, and a command line interface.  Python is used to generate programs in an imperative, type inferred, intermediate language called SmartML. SmartML is  also the name of the OCaml library which provides an interpreter, a compiler to Michelson (the smart-contract language of Tezos),  as well as a scenario “on-chain” interpreter. The IDE uses a mix of OCaml built with js_of_ocaml and pure Javascript.  The command line interface also builds with js_of_ocaml to run on Node.js.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/11/OCaml-Under-The-Hood-SmartPy|js};
-                                                       {js|https://wr.mondet.org/paper/smartpy-ocaml-2020.pdf|js}]
-  };
- 
-  { title = {js|OCaml-CI: A Zero-Configuration CI|js}
-  ; slug = {js|ocaml-ci-a-zero-configuration-ci|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Thomas Leonard|js}; {js|Craig Ferguson|js}; {js|Kate Deplaix|js};
-  {js|Magnus Skjegstad|js}; {js|Anil Madhavapeddy|js}]
-  ; abstract = {js|OCaml-CI is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build,  and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms. The CI has been deployed on around 50 projects so far on GitHub, and many of them see response times an order of magnitude quicker than  with less integrated CI solutions. This talk will introduce the CI service and then look at some of the technologies used to build it.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/6/OCaml-CI-A-Zero-Configuration-CI|js}]
-  };
- 
-  { title = {js|Parallelising your OCaml Code with Multicore OCaml|js}
-  ; slug = {js|parallelising-your-ocaml-code-with-multicore-ocaml|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Sadiq Jaffer|js}; {js|Sudha Parimala|js}; {js|KC Sivaramarkrishnan|js};
-  {js|Tom Kelly|js}; {js|Anil Madhavapeddy|js}]
-  ; abstract = {js|With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that maintain  backwards compatibility with the existing OCaml C-API, there has been increasing interest in the wider  OCaml community for parallelising existing OCaml code.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://github.com/ocaml-multicore/multicore-talks/blob/master/ocaml2020-workshop-parallel/multicore-ocaml20.pdf|js};
-                                                       {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/5/Parallelising-your-OCaml-Code-with-Multicore-OCaml|js}]
-  };
- 
-  { title = {js|The ImpFS Filesystem|js}
-  ; slug = {js|the-impfs-filesystem|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Tom Ridge|js}]
-  ; abstract = {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem,  ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value store  presented at ML’19. In addition, there are a number of other support libraries that may be of interest to the community. ImpFS  represents a single point in the filesystem design space, but we hope that the libraries we have developed will enable others to  build further filesystems with novel features.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/8/The-ImpFS-filesystem|js}]
-  };
- 
-  { title = {js|The final pieces of the OCaml documentation puzzle|js}
-  ; slug = {js|the-final-pieces-of-the-ocaml-documentation-puzzle|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Jonathan Ludlam|js}; {js|Gabriel Radanne|js}; {js|Leo White|js}]
-  ; abstract = {js|Odoc is the latest attempt at creating a documentation tool which handles the full complexity of the OCaml language. It has been a long  time coming as tackling both the module system and rendering into rich documents makes for a difficult task. Nevertheless we believe  the two recent developments provides the final pieces of the OCaml documentation puzzle. This two improvements split odoc in two  layers: a model layer, with a deep understanding of the module system, and a document layer allowing for easy definition of new outputs.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/4/The-final-pieces-of-the-OCaml-documentation-puzzle|js}]
-  };
- 
-  { title = {js|Types in Amber|js}
-  ; slug = {js|types-in-amber|js}
-  ; publication = {js|International Conference on Functional Programming (ICFP)|js}
-  ; authors = 
- [{js|Paul Steckler|js}; {js|Matthew Ryan|js}]
-  ; abstract = {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate  in a format automatically derived from type definitions in OCaml source files. As the Coda software evolves, these formats for sent data may change. We wish to allow nodes running older versions of the software to communicate with newer versions. To achieve that, we identify stable types that  must not change over time, so that their serializations also do not change.
-|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; year = 2020
-  ; links = [{js|https://icfp20.sigplan.org/details/ocaml-2020-papers/3/Types-in-amber|js}]
-  }]
 
+let all =
+  [ { title = {js|A Syntactic Approach to Type Soundness|js}
+    ; slug = {js|a-syntactic-approach-to-type-soundness|js}
+    ; publication = {js|Information & Computation, 115(1):38−94|js}
+    ; authors = [ {js|Andrew K. Wright|js}; {js|Matthias Felleisen|js} ]
+    ; abstract =
+        {js|This paper describes the semantics and the type system of Core ML,  and uses a simple syntactic technique to prove that well-typed programs cannot go wrong.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js} ]
+    ; year = 1994
+    ; links =
+        [ {js|https://www.cs.rice.edu/CS/PLT/Publications/Scheme/ic94-wf.ps.gz|js}
+        ]
+    }
+  ; { title = {js|The Essence of ML Type Inference|js}
+    ; slug = {js|the-essence-of-ml-type-inference|js}
+    ; publication =
+        {js|Benjamin C. Pierce, editor, Advanced Topics in Types and Programming Languages, MIT Press|js}
+    ; authors = [ {js|François Pottier|js}; {js|Didier Rémy|js} ]
+    ; abstract =
+        {js|This book chapter gives an in-depth abstract of the Core ML type system, with an emphasis on type inference.  The type inference algorithm is described as the composition of a constraint generator, which produces a system  of type equations, and a constraint solver, which is presented as a set of rewrite rules.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js} ]
+    ; year = 2005
+    ; links = [ {js|https://cristal.inria.fr/attapl/preversion.ps.gz|js} ]
+    }
+  ; { title = {js|Relaxing the value restriction|js}
+    ; slug = {js|relaxing-the-value-restriction|js}
+    ; publication =
+        {js|International Symposium on Functional and Logic Programming|js}
+    ; authors = [ {js|Jacques Garrigue|js} ]
+    ; abstract =
+        {js|This paper explains why it is sound to generalize certain type variables at a `let` binding, even when the expression that is being `let`-bound is not a value. This relaxed version of Wright's classic “value restriction” was introduced in OCaml 3.07.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js} ]
+    ; year = 2004
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.ps.gz|js}
+        ]
+    }
+  ; { title = {js|Manifest Types, Modules, and Separate Compilation|js}
+    ; slug = {js|manifest-types-modules-and-separate-compilation|js}
+    ; publication = {js|Principles of Programming Languages|js}
+    ; authors = [ {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|This paper presents a variant of the Standard ML module system that introduces a strict distinction between abstract  and manifest types. The latter are types whose definitions explicitly appear as part of a module interface. This proposal  is meant to retain most of the expressive power of the Standard ML module system, while providing much better support for  separate compilation. This work sets the formal bases for OCaml's module system.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|modules|js} ]
+    ; year = 1994
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.ps.gz|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.dvi.gz|js}
+        ]
+    }
+  ; { title =
+        {js|Applicative Functors and Fully Transparent Higher-order Modules|js}
+    ; slug =
+        {js|applicative-functors-and-fully-transparent-higher-order-modules|js}
+    ; publication = {js|Principles of Programming Languages|js}
+    ; authors = [ {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|This work extends the above paper by introducing so-called applicative functors, that is, functors that produce compatible  abstract types when applied to provably equal arguments. Applicative functors are also a feature of OCaml.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|modules|js} ]
+    ; year = 1995
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.ps.gz|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.dvi.gz|js}
+        ]
+    }
+  ; { title = {js|A Modular Module System|js}
+    ; slug = {js|a-modular-module-system|js}
+    ; publication = {js|Journal of Functional Programming, 10(3):269-303|js}
+    ; authors = [ {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|This accessible paper describes a simplified implementation of the OCaml module system, emphasizing the fact that the module system  is largely independent of the underlying core language. This is a good tutorial to learn both how modules can be used and how  they are typechecked.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|modules|js} ]
+    ; year = 2000
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.ps.gz|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.dvi.gz|js}
+        ]
+    }
+  ; { title = {js|A Proposal for Recursive Modules in Objective Caml|js}
+    ; slug = {js|a-proposal-for-recursive-modules-in-objective-caml|js}
+    ; publication = {js|Unpublication|js}
+    ; authors = [ {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|This note describes the experimental recursive modules introduced in OCaml 3.07.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|modules|js} ]
+    ; year = 2003
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/xleroy-recursive_modules-03.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-recursive_modules-03.ps.gz|js}
+        ]
+    }
+  ; { title = {js|Objective ML: An effective object-oriented extension to ML|js}
+    ; slug = {js|objective-ml-an-effective-object-oriented-extension-to-ml|js}
+    ; publication = {js|Theory And Practice of Objects Systems, 4(1):27−50|js}
+    ; authors = [ {js|Didier Rémy|js}; {js|Jérôme Vouillon|js} ]
+    ; abstract =
+        {js|This paper provides theoretical foundations for OCaml's object-oriented layer, including dynamic and static semantics.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|objects|js} ]
+    ; year = 1998
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.ps.gz|js}
+        ; {js|https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.dvi.gz|js}
+        ]
+    }
+  ; { title = {js|Extending ML with Semi-Explicit Higher-Order Polymorphism|js}
+    ; slug = {js|extending-ml-with-semi-explicit-higher-order-polymorphism|js}
+    ; publication = {js|Information & Computation, 155(1/2):134−169|js}
+    ; authors = [ {js|Jacques Garrigue|js}; {js|Didier Rémy|js} ]
+    ; abstract =
+        {js|This paper proposes a device for re-introducing first-class polymorphic values into ML while preserving its type inference  mechanism. This technology underlies OCaml's polymorphic methods.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|objects|js} ]
+    ; year = 1999
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.ps.gz|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.dvi.gz|js}
+        ]
+    }
+  ; { title = {js|Programming with Polymorphic Variants|js}
+    ; slug = {js|programming-with-polymorphic-variants|js}
+    ; publication = {js|ML Workshop|js}
+    ; authors = [ {js|Jacques Garrigue|js} ]
+    ; abstract =
+        {js|This paper briefly explains what polymorphic variants are about and how they are compiled.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|polymorphic variants|js} ]
+    ; year = 1998
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.ps.gz|js}
+        ]
+    }
+  ; { title = {js|Code Reuse through Polymorphic Variants|js}
+    ; slug = {js|code-reuse-through-polymorphic-variants|js}
+    ; publication = {js|Workshop on Foundations of Software Engineering|js}
+    ; authors = [ {js|Jacques Garrigue|js} ]
+    ; abstract =
+        {js|This short paper explains how to design a modular, extensible interpreter using polymorphic variants.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|polymorphic variants|js} ]
+    ; year = 2000
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue-variant-reuse-2000.ps.gz|js}
+        ]
+    }
+  ; { title = {js|Simple Type Inference for Structural Polymorphism|js}
+    ; slug = {js|simple-type-inference-for-structural-polymorphism|js}
+    ; publication = {js|Workshop on Foundations of Object-Oriented Languages|js}
+    ; authors = [ {js|Jacques Garrigue|js} ]
+    ; abstract =
+        {js|This paper explains most of the typechecking machinery behind polymorphic variants.  At its heart is an extension of Core ML's type discipline with so-called local constraints.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|polymorphic variants|js} ]
+    ; year = 2002
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue-structural_poly-fool02.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue-structural_poly-fool02.ps.gz|js}
+        ]
+    }
+  ; { title =
+        {js|Typing Deep Pattern-matching in Presence of Polymorphic Variants|js}
+    ; slug =
+        {js|typing-deep-pattern-matching-in-presence-of-polymorphic-variants|js}
+    ; publication =
+        {js|JSSST Workshop on Programming and Programming Languages|js}
+    ; authors = [ {js|Jacques Garrigue|js} ]
+    ; abstract =
+        {js|This paper provides more details about the technical machinery behind polymorphic variants, focusing  on the rules for typechecking deep pattern matching constructs.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js}; {js|polymorphic variants|js} ]
+    ; year = 2004
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue-deep-variants-2004.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue-deep-variants-2004.ps.gz|js}
+        ]
+    }
+  ; { title = {js|Labeled and Optional Arguments for Objective Caml|js}
+    ; slug = {js|labeled-and-optional-arguments-for-objective-caml|js}
+    ; publication =
+        {js|JSSST Workshop on Programming and Programming Languages|js}
+    ; authors = [ {js|Jacques Garrigue|js} ]
+    ; abstract =
+        {js|This paper offers a dynamic semantics, a static semantics, and a compilation scheme for OCaml's labeled  and optional function parameters.
+|js}
+    ; tags = [ {js|core|js}; {js|language|js} ]
+    ; year = 2001
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.ps.gz|js}
+        ; {js|https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.dvi.gz|js}
+        ]
+    }
+  ; { title = {js|Meta-programming Tutorial with CamlP4|js}
+    ; slug = {js|meta-programming-tutorial-with-camlp4|js}
+    ; publication = {js|Commercial Users of Functional Programming|js}
+    ; authors = [ {js|Jake Donham|js} ]
+    ; abstract = {js|Meta-programming tutorial with Camlp4|js}
+    ; tags = [ {js|core|js}; {js|language|js} ]
+    ; year = 2010
+    ; links = [ {js|https://github.com/jaked/cufp-metaprogramming-tutorial|js} ]
+    }
+  ; { title =
+        {js|The ZINC experiment, an Economical Implementation of the ML language|js}
+    ; slug =
+        {js|the-zinc-experiment-an-economical-implementation-of-the-ml-language|js}
+    ; publication = {js|Technical report 117, INRIA|js}
+    ; authors = [ {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|This report contains a abstract of the ZINC compiler, which later evolved into Caml Light, then into OCaml. Large parts  of this report are out of date, but it is still valuable as a abstract of the abstract machine used in Caml Light and  (with some further simplifications and speed improvements) in OCaml.
+|js}
+    ; tags = [ {js|compiler|js}; {js|runtime|js} ]
+    ; year = 1990
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/xleroy-zinc.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-zinc.ps.gz|js}
+        ]
+    }
+  ; { title = {js|The Effectiveness of Type-based Unboxing|js}
+    ; slug = {js|the-effectiveness-of-type-based-unboxing|js}
+    ; publication = {js|Workshop on Types in Compilation|js}
+    ; authors = [ {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|This paper surveys and compares several data representation strategies, including the one used in the OCaml native-code compiler.
+|js}
+    ; tags = [ {js|compiler|js}; {js|runtime|js} ]
+    ; year = 1997
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/xleroy-unboxing-tic97.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/xleroy-unboxing-tic97.ps.gz|js}
+        ]
+    }
+  ; { title =
+        {js|A Concurrent, Generational Garbage Collector for a Multithreaded Implementation of ML|js}
+    ; slug =
+        {js|a-concurrent-generational-garbage-collector-for-a-multithreaded-implementation-of-ml|js}
+    ; publication = {js|Principles of Programming Languages|js}
+    ; authors = [ {js|Damien Doligez|js}; {js|Xavier Leroy|js} ]
+    ; abstract =
+        {js|Superseded by "Portable, Unobtrusive Garbage Collection for Multiprocessor Systems"
+|js}
+    ; tags = [ {js|garbage collection|js}; {js|runtime|js} ]
+    ; year = 1993
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/doligez_xleroy-concurrent_gc-popl93.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/doligez_xleroy-concurrent_gc-popl93.ps.gz|js}
+        ]
+    }
+  ; { title =
+        {js|Portable, Unobtrusive Garbage Collection for Multiprocessor Systems|js}
+    ; slug =
+        {js|portable-unobtrusive-garbage-collection-for-multiprocessor-systems|js}
+    ; publication = {js|Principles of Programming Languages|js}
+    ; authors = [ {js|Damien Doligez|js}; {js|Georges Gonthier|js} ]
+    ; abstract =
+        {js|This paper describes a concurrent version of the garbage collector found in Caml Light and OCaml's runtime system.
+|js}
+    ; tags = [ {js|garbage collection|js}; {js|runtime|js} ]
+    ; year = 1994
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/doligez_gonthier-gc-popl94.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/doligez_gonthier-gc-popl94.ps.gz|js}
+        ]
+    }
+  ; { title =
+        {js|Conception, réalisation et certification d'un glaneur de cellules concurrent|js}
+    ; slug =
+        {js|conception-ralisation-et-certification-dun-glaneur-de-cellules-concurrent|js}
+    ; publication = {js|Ph.D. thesis, Université Paris 7|js}
+    ; authors = [ {js|Damien Doligez|js}; {js|Georges Gonthier|js} ]
+    ; abstract =
+        {js|All you ever wanted to know about the garbage collector found in Caml Light and OCaml's runtime system.
+|js}
+    ; tags = [ {js|garbage collection|js}; {js|runtime|js} ]
+    ; year = 1995
+    ; links =
+        [ {js|https://caml.inria.fr/pub/papers/doligez-these.pdf|js}
+        ; {js|https://caml.inria.fr/pub/papers/doligez-these.ps.gz|js}
+        ]
+    }
+  ; { title = {js|Optimizing Pattern Matching|js}
+    ; slug = {js|optimizing-pattern-matching|js}
+    ; publication =
+        {js|Proceedings of the sixth ACM SIGPLAN International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Fabrice Le Fessant|js}; {js|Luc Maranget|js} ]
+    ; abstract =
+        {js|All you ever wanted to know about the garbage collector found in Caml Light and OCaml's runtime system.
+|js}
+    ; tags = [ {js|pattern-matching|js}; {js|runtime|js} ]
+    ; year = 2001
+    ; links = [ {js|https://dl.acm.org/citation.cfm?id=507641|js} ]
+    }
+  ; { title = {js|OCaml for the Masses|js}
+    ; slug = {js|ocaml-for-the-masses|js}
+    ; publication = {js|ACM Queue|js}
+    ; authors = [ {js|Yaron Minsky|js} ]
+    ; abstract = {js|Why the next language you learn should be functional.
+|js}
+    ; tags = [ {js|industrial|js} ]
+    ; year = 2011
+    ; links = [ {js|https://queue.acm.org/detail.cfm?id=2038036|js} ]
+    }
+  ; { title = {js|Xen and the Art of OCaml|js}
+    ; slug = {js|xen-and-the-art-of-ocaml|js}
+    ; publication = {js|Commercial Users of Functional Programming (CUFP)|js}
+    ; authors = [ {js|Anil Madhavapeddy|js} ]
+    ; abstract =
+        {js|In this talk, we will firstly describe the architecture of XenServer and the XenAPI and discuss the challenges faced with implementing  an Objective Caml based solution. These challenges range from the low-level concerns of interfacing with Xen and the  Linux kernel, to the high-level algorithmic problems such as distributed failure planning. In addition, we will  discuss the challenges imposed by using OCaml in a commercial environment, such as supporting product upgrades,  enhancing supportability and scaling the development team.
+|js}
+    ; tags = [ {js|industrial|js}; {js|application|js} ]
+    ; year = 2008
+    ; links =
+        [ {js|https://cufp.org/archive/2008/slides/MadhavapeddyAnil.pdf|js} ]
+    }
+  ; { title = {js|Chemoinformatics and Structural Bioinformatics in OCaml|js}
+    ; slug = {js|chemoinformatics-and-structural-bioinformatics-in-ocaml|js}
+    ; publication = {js|Journal of Cheminformatics|js}
+    ; authors =
+        [ {js|François Berenger|js}
+        ; {js|Kam Y. J. Zhang|js}
+        ; {js|Yoshihiro Yamanishi|js}
+        ]
+    ; abstract =
+        {js|In this article, we share our experience in prototyping chemoinformatics and structural bioinformatics software in OCaml
+|js}
+    ; tags = [ {js|industrial|js}; {js|application|js}; {js|bioinformatics|js} ]
+    ; year = 2019
+    ; links =
+        [ {js|https://jcheminf.biomedcentral.com/articles/10.1186/s13321-019-0332-0|js}
+        ]
+    }
+  ; { title = {js|A Declarative Syntax Definition for OCaml|js}
+    ; slug = {js|a-declarative-syntax-definition-for-ocaml|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Luis Eduardo de Souza Amorim|js}; {js|Eelco Visser|js} ]
+    ; abstract =
+        {js|In this talk we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3.  SDF3 supports high-level definition of concrete and abstract syntax through declarative disambiguation and definition of  constructors, enabling a direct mapping to abstract syntax. Based on the SDF3 syntax definition, the Spoofax language  workbench produces a complete syntax aware editor with a parser, syntax checking, parse error recovery, syntax highlighting,  formatting with correct parenthesis insertion, and syntactic completion. The syntax definition should provide a good  basis for experiments with the design of OCaml and the development of further tooling. In the talk we will highlight  interesting aspects the syntax definition, discuss issues we encountered in the syntax of OCaml, and demonstrate the editor.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links = [ {js|https://eelcovisser.org/talks/2020/08/28/ocaml/|js} ]
+    }
+  ; { title =
+        {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
+    ; slug =
+        {js|a-simple-state-machine-framework-for-property-based-testing-in-ocaml|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Jan Midtgaard|js} ]
+    ; abstract =
+        {js|Since their inception state-machine frameworks have proven their worth by finding defects in everything  from the underlying AUTOSAR components of Volvo cars to digital invoicing sys- tems. These case studies were carried  out with Erlang’s commercial QuickCheck state-machine framework from Quviq, but such frameworks are now also available  for Haskell, F#, Scala, Elixir, Java, etc. We present a typed state-machine framework for OCaml based on the QCheck  library and illustrate a number concepts common to all such frameworks: state modeling, commands, interpreting commands, preconditions, and agreement checking.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links = [ {js|https://janmidtgaard.dk/papers/Midtgaard%3AOCaml20.pdf|js} ]
+    }
+  ; { title = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
+    ; slug = {js|ad-ocaml-algorithmic-differentiation-for-ocaml|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Markus Mottl|js} ]
+    ; abstract =
+        {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and  deep power series approximations of almost arbitrary OCaml programs via algorithmic  differentiation. Unlike similar frameworks, this includes programs with side effects,  aliasing, and programs with nested derivative operators. The framework also offers implicit  parallelization of both user programs and their transformations. The presentation will provide  a short introduction to the mathematical problem, the difficulties of implementing a solution,  the design of the library, and a demonstration of its capabilities.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/12/AD-OCaml-Algorithmic-Differentiation-for-OCaml|js}
+        ]
+    }
+  ; { title = {js|API migration: compare transformed|js}
+    ; slug = {js|api-migration-compare-transformed|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors =
+        [ {js|Joseph Harrison|js}
+        ; {js|Steven Varoumas|js}
+        ; {js|Simon Thompson|js}
+        ; {js|Reuben Rowe|js}
+        ]
+    ; abstract =
+        {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing  the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on  open source Jane Street libraries by using Rotor to refactor comparison functions so that they return a  more precise variant type rather than an integer. We discuss the difficulties of refactoring the Jane Street  code base, which makes extensive use of ppx macros, and ongoing work implementing new refactorings.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/7/API-migration-compare-transformed|js}
+        ; {js|https://www.cs.kent.ac.uk/people/staff/sjt/Pubs/OCaml_workshop2020.pdf|js}
+        ]
+    }
+  ; { title = {js|Irmin v2|js}
+    ; slug = {js|irmin-v2|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors =
+        [ {js|Clément Pascutto|js}
+        ; {js|Ioana Cristescu|js}
+        ; {js|Craig Ferguson|js}
+        ; {js|Thomas Gazagnaire|js}
+        ; {js|Romain Liautaud|js}
+        ]
+    ; abstract =
+        {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git.  Existing Git users will find many familiar features: branching/merging, immutable causal history for  all changes, and the ability to restore to any previous state. Irmin v2 adds new accessibility methods  to the store: we can now use Irmin from a CLI, or in a browser using irmin-graphql. It also has a new  backend, irmin-pack, which is optimised for space usage and is used by the Tezos blockchain.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/10/Irmin-v2|js}
+        ; {js|https://tarides.com/blog/2019-11-21-irmin-v2|js}
+        ]
+    }
+  ; { title = {js|LexiFi Runtime Types|js}
+    ; slug = {js|lexifi-runtime-types|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Patrik Keller|js}; {js|Marc Lasson|js} ]
+    ; abstract =
+        {js|LexiFi maintains an OCaml compiler extension that enables introspection through runtime type representations.  Recently, we implemented a syntax extension (PPX) that enables the use of LexiFi runtime types on vanilla compilers.  We propose to present our publicly available runtime types and their features. Most notably, we want to present  a mechanism for pattern matching on runtime types with holes.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/9/LexiFi-Runtime-Types|js}
+        ; {js|https://informationsecurity.uibk.ac.at/pdfs/KL2020_LexiFi_Runtime_Types_OCAML.pdf|js}
+        ; {js|https://www.lexifi.com/blog/ocaml/runtime-types/|js}
+        ]
+    }
+  ; { title = {js|OCaml Under the Hood: SmartPy|js}
+    ; slug = {js|ocaml-under-the-hood-smartpy|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Sebastien Mondet|js} ]
+    ; abstract =
+        {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python  to write contracts and their tests scenarios. It includes an online IDE, a chain explorer, and a command line interface.  Python is used to generate programs in an imperative, type inferred, intermediate language called SmartML. SmartML is  also the name of the OCaml library which provides an interpreter, a compiler to Michelson (the smart-contract language of Tezos),  as well as a scenario “on-chain” interpreter. The IDE uses a mix of OCaml built with js_of_ocaml and pure Javascript.  The command line interface also builds with js_of_ocaml to run on Node.js.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/11/OCaml-Under-The-Hood-SmartPy|js}
+        ; {js|https://wr.mondet.org/paper/smartpy-ocaml-2020.pdf|js}
+        ]
+    }
+  ; { title = {js|OCaml-CI: A Zero-Configuration CI|js}
+    ; slug = {js|ocaml-ci-a-zero-configuration-ci|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors =
+        [ {js|Thomas Leonard|js}
+        ; {js|Craig Ferguson|js}
+        ; {js|Kate Deplaix|js}
+        ; {js|Magnus Skjegstad|js}
+        ; {js|Anil Madhavapeddy|js}
+        ]
+    ; abstract =
+        {js|OCaml-CI is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build,  and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms. The CI has been deployed on around 50 projects so far on GitHub, and many of them see response times an order of magnitude quicker than  with less integrated CI solutions. This talk will introduce the CI service and then look at some of the technologies used to build it.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/6/OCaml-CI-A-Zero-Configuration-CI|js}
+        ]
+    }
+  ; { title = {js|Parallelising your OCaml Code with Multicore OCaml|js}
+    ; slug = {js|parallelising-your-ocaml-code-with-multicore-ocaml|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors =
+        [ {js|Sadiq Jaffer|js}
+        ; {js|Sudha Parimala|js}
+        ; {js|KC Sivaramarkrishnan|js}
+        ; {js|Tom Kelly|js}
+        ; {js|Anil Madhavapeddy|js}
+        ]
+    ; abstract =
+        {js|With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that maintain  backwards compatibility with the existing OCaml C-API, there has been increasing interest in the wider  OCaml community for parallelising existing OCaml code.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://github.com/ocaml-multicore/multicore-talks/blob/master/ocaml2020-workshop-parallel/multicore-ocaml20.pdf|js}
+        ; {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/5/Parallelising-your-OCaml-Code-with-Multicore-OCaml|js}
+        ]
+    }
+  ; { title = {js|The ImpFS Filesystem|js}
+    ; slug = {js|the-impfs-filesystem|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Tom Ridge|js} ]
+    ; abstract =
+        {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem,  ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value store  presented at ML’19. In addition, there are a number of other support libraries that may be of interest to the community. ImpFS  represents a single point in the filesystem design space, but we hope that the libraries we have developed will enable others to  build further filesystems with novel features.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/8/The-ImpFS-filesystem|js}
+        ]
+    }
+  ; { title = {js|The final pieces of the OCaml documentation puzzle|js}
+    ; slug = {js|the-final-pieces-of-the-ocaml-documentation-puzzle|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors =
+        [ {js|Jonathan Ludlam|js}; {js|Gabriel Radanne|js}; {js|Leo White|js} ]
+    ; abstract =
+        {js|Odoc is the latest attempt at creating a documentation tool which handles the full complexity of the OCaml language. It has been a long  time coming as tackling both the module system and rendering into rich documents makes for a difficult task. Nevertheless we believe  the two recent developments provides the final pieces of the OCaml documentation puzzle. This two improvements split odoc in two  layers: a model layer, with a deep understanding of the module system, and a document layer allowing for easy definition of new outputs.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/4/The-final-pieces-of-the-OCaml-documentation-puzzle|js}
+        ]
+    }
+  ; { title = {js|Types in Amber|js}
+    ; slug = {js|types-in-amber|js}
+    ; publication =
+        {js|International Conference on Functional Programming (ICFP)|js}
+    ; authors = [ {js|Paul Steckler|js}; {js|Matthew Ryan|js} ]
+    ; abstract =
+        {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate  in a format automatically derived from type definitions in OCaml source files. As the Coda software evolves, these formats for sent data may change. We wish to allow nodes running older versions of the software to communicate with newer versions. To achieve that, we identify stable types that  must not change over time, so that their serializations also do not change.
+|js}
+    ; tags = [ {js|ocaml-workshop|js} ]
+    ; year = 2020
+    ; links =
+        [ {js|https://icfp20.sigplan.org/details/ocaml-2020-papers/3/Types-in-amber|js}
+        ]
+    }
+  ]

--- a/src/ocamlorg_data/release.ml
+++ b/src/ocamlorg_data/release.ml
@@ -1,4 +1,3 @@
-
 type kind = [ `Compiler ]
 
 type t =
@@ -8,13 +7,13 @@ type t =
   ; body_md : string
   ; body_html : string
   }
-  
-let all = 
-[
-  { kind = `Compiler
-  ; version = {js|3.12.1|js}
-  ; date = {js|2011-07-04|js}
-  ; body_md = {js|
+
+let all =
+  [ { kind = `Compiler
+    ; version = {js|3.12.1|js}
+    ; date = {js|2011-07-04|js}
+    ; body_md =
+        {js|
 # OCaml 3.12.1
 **License**<br />
  The OCaml system is open source software: the compiler is distributed
@@ -131,7 +130,8 @@ The user's manual for OCaml can be:
  [tarball](3.12/ocaml-3.12-refman.info.tar.gz)
  of Emacs `info` files.
 |js}
-  ; body_html = {js|<h1>OCaml 3.12.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 3.12.1</h1>
 <p><strong>License</strong><br />
 The OCaml system is open source software: the compiler is distributed
 under the terms of the Q Public License, and its library is under LGPL;
@@ -265,12 +265,12 @@ of Emacs <code>info</code> files.
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.00.1|js}
-  ; date = {js|2012-10-05|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.00.1|js}
+    ; date = {js|2012-10-05|js}
+    ; body_md =
+        {js|
 # OCaml 4.00.1
 **License**<br />
  The OCaml system is open source software: the compiler is distributed
@@ -394,7 +394,8 @@ The user's manual for OCaml can be:
  of Emacs `info` files.
 
 |js}
-  ; body_html = {js|<h1>OCaml 4.00.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.00.1</h1>
 <p><strong>License</strong><br />
 The OCaml system is open source software: the compiler is distributed
 under the terms of the Q Public License, and its library is under LGPL;
@@ -536,12 +537,12 @@ of Emacs <code>info</code> files.
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.00.1|js}
-  ; date = {js|2013-09-12|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.00.1|js}
+    ; date = {js|2013-09-12|js}
+    ; body_md =
+        {js|
 # OCaml 4.01.0
 **License**<br />
  The OCaml system is open source software: the compiler is distributed
@@ -680,7 +681,8 @@ The user's manual for OCaml can be:
 
 
 |js}
-  ; body_html = {js|<h1>OCaml 4.01.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.01.0</h1>
 <p><strong>License</strong><br />
 The OCaml system is open source software: the compiler is distributed
 under the terms of the Q Public License, and its library is under LGPL;
@@ -832,12 +834,12 @@ of Emacs <code>info</code> files,
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.02.0|js}
-  ; date = {js|2015-07-27|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.02.0|js}
+    ; date = {js|2015-07-27|js}
+    ; body_md =
+        {js|
 # OCaml 4.02.3
 This page describes OCaml version **4.02.3**,
 released on 2015-07-27. Go [here](./) for a list of all releases.
@@ -1025,7 +1027,8 @@ linking). See the full [license](/docs/license.html). Members of the
 [OCaml Consortium](/consortium/) benefit from a
 more liberal license (BSD-like).
 |js}
-  ; body_html = {js|<h1>OCaml 4.02.3</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.02.3</h1>
 <p>This page describes OCaml version <strong>4.02.3</strong>,
 released on 2015-07-27. Go <a href="./">here</a> for a list of all releases.</p>
 <p>Three previous minor versions were released: 4.02.0 on 2014-08-29,
@@ -1222,12 +1225,12 @@ linking). See the full <a href="/docs/license.html">license</a>. Members of the
 <a href="/consortium/">OCaml Consortium</a> benefit from a
 more liberal license (BSD-like).</p>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.03.0|js}
-  ; date = {js|2016-04-25|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.03.0|js}
+    ; date = {js|2016-04-25|js}
+    ; body_md =
+        {js|
 # OCaml 4.03.0
 This page describes OCaml version **4.03.0**, released on
 2016-04-25. Go [here](./) for a list of all releases.
@@ -1383,7 +1386,8 @@ The user's manual for OCaml can be:
   [browsed online](http://www.askra.de/software/ocaml-doc/4.03/).
 
 |js}
-  ; body_html = {js|<h1>OCaml 4.03.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.03.0</h1>
 <p>This page describes OCaml version <strong>4.03.0</strong>, released on
 2016-04-25. Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple OPAM switches:</p>
@@ -1553,12 +1557,12 @@ of Emacs info files,</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.04.0|js}
-  ; date = {js|2017-06-23|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.04.0|js}
+    ; date = {js|2017-06-23|js}
+    ; body_md =
+        {js|
 # OCaml 4.04.2
 This page describes OCaml version **4.04.2**, released on
 2017-06-23. Go [here](./) for a list of all releases.
@@ -1748,7 +1752,8 @@ The user's manual for OCaml can be:
 
 
 |js}
-  ; body_html = {js|<h1>OCaml 4.04.2</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.04.2</h1>
 <p>This page describes OCaml version <strong>4.04.2</strong>, released on
 2017-06-23. Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple OPAM switches:</p>
@@ -1942,12 +1947,12 @@ of Emacs info files,</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.05.0|js}
-  ; date = {js|2017-07-13|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.05.0|js}
+    ; date = {js|2017-07-13|js}
+    ; body_md =
+        {js|
 # OCaml 4.05.0
 This page describes OCaml version **4.05.0**, released on
 2017-07-13. Go [here](./) for a list of all releases.
@@ -2036,7 +2041,8 @@ The user's manual for OCaml can be:
 
 
 |js}
-  ; body_html = {js|<h1>OCaml 4.05.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.05.0</h1>
 <p>This page describes OCaml version <strong>4.05.0</strong>, released on
 2017-07-13. Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple <a href="https://opam.ocaml.org/doc/Usage.html">OPAM</a> switches:</p>
@@ -2137,12 +2143,12 @@ of Emacs info files,</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.06.0|js}
-  ; date = {js|2017-11-03|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.06.0|js}
+    ; date = {js|2017-11-03|js}
+    ; body_md =
+        {js|
 # OCaml 4.06.0
 This page describes OCaml version **4.06.0**, released on
 2017-11-03.  Go [here](./) for a list of all releases.
@@ -3130,7 +3136,8 @@ This is the
 - [GPR#1407](https://github.com/ocaml/ocaml/pull/1407): Fix `raw_spacetime_lib`.  
   (Leo White, review by Gabriel Scherer and Damien Doligez)
 |js}
-  ; body_html = {js|<h1>OCaml 4.06.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.06.0</h1>
 <p>This page describes OCaml version <strong>4.06.0</strong>, released on
 2017-11-03.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -4338,12 +4345,12 @@ types.<br />
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.06.1|js}
-  ; date = {js|2016-02-16|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.06.1|js}
+    ; date = {js|2016-02-16|js}
+    ; body_md =
+        {js|
 # OCaml 4.06.1
 
 This page describe OCaml **4.06.1**, released on Feb 16, 2018.  It is
@@ -4391,7 +4398,8 @@ Changes (Bug fixes)
   Make pattern matching compilation more robust to ill-typed columns
   (Gabriel Scherer and Thomas Refis, review by Luc Maranget)
 |js}
-  ; body_html = {js|<h1>OCaml 4.06.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.06.1</h1>
 <p>This page describe OCaml <strong>4.06.1</strong>, released on Feb 16, 2018.  It is
 a bug-fix release of <a href="4.06.html">OCaml 4.06.0</a>.</p>
 <p>It is available as an OPAM switch and as a source download from:
@@ -4443,12 +4451,12 @@ Make pattern matching compilation more robust to ill-typed columns
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.07.0|js}
-  ; date = {js|2018-07-10|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.07.0|js}
+    ; date = {js|2018-07-10|js}
+    ; body_md =
+        {js|
 # OCaml 4.07.0
 This page describes OCaml version **4.07.0**, released on
 2018-07-10.  Go [here](./) for a list of all releases.
@@ -5339,7 +5347,8 @@ This is the
   that could lead to crashes when `Gc.finalise_last` is used
   (report and fix by Yuriy Vostrikov, review by François Bobot)
 |js}
-  ; body_html = {js|<h1>OCaml 4.07.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.07.0</h1>
 <p>This page describes OCaml version <strong>4.07.0</strong>, released on
 2018-07-10.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -6412,12 +6421,12 @@ that could lead to crashes when <code>Gc.finalise_last</code> is used
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.07.1|js}
-  ; date = {js|2018-10-04|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.07.1|js}
+    ; date = {js|2018-10-04|js}
+    ; body_md =
+        {js|
 # OCaml 4.07.1
 This page describes OCaml version **4.07.1**, released on
 2018-10-04.  Go [here](./) for a list of all releases.
@@ -6561,7 +6570,8 @@ This is the
   -principal causes assertion failure in type checker
   (Jacques Garrigue, report by Markus Mottl, review by Thomas Refis)
 |js}
-  ; body_html = {js|<h1>OCaml 4.07.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.07.1</h1>
 <p>This page describes OCaml version <strong>4.07.1</strong>, released on
 2018-10-04.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -6720,12 +6730,12 @@ Angeletti, review by Jacques Garrigue)</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.08.0|js}
-  ; date = {js|2019-06-14|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.08.0|js}
+    ; date = {js|2019-06-14|js}
+    ; body_md =
+        {js|
 # OCaml 4.08.0
 This page describes OCaml version **4.08.0**, released on
 2019-06-14.  Go [here](./) for a list of all releases.
@@ -8110,7 +8120,8 @@ This is the
   (Jacques Garrigue, review by Leo White and Thomas Refis,
   report by Jeremy Yallop)
 |js}
-  ; body_html = {js|<h1>OCaml 4.08.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.08.0</h1>
 <p>This page describes OCaml version <strong>4.08.0</strong>, released on
 2019-06-14.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -9784,12 +9795,12 @@ report by Jeremy Yallop)</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.08.1|js}
-  ; date = {js|2019-08-05|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.08.1|js}
+    ; date = {js|2019-08-05|js}
+    ; body_md =
+        {js|
 # OCaml 4.08.1
 
 This page describe OCaml **4.08.1**, released on Aug 5, 2019.  It is
@@ -9829,7 +9840,8 @@ a bug-fix release of [OCaml 4.08.0](4.08.0.html).
   fix use of off_t on 32-bit systems.
   (Stephen Dolan, report by Richard Jones, review by Xavier Leroy)
 |js}
-  ; body_html = {js|<h1>OCaml 4.08.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.08.1</h1>
 <p>This page describe OCaml <strong>4.08.1</strong>, released on Aug 5, 2019.  It is
 a bug-fix release of <a href="4.08.0.html">OCaml 4.08.0</a>.</p>
 <h3>Bug fixes:</h3>
@@ -9874,12 +9886,12 @@ fix use of off_t on 32-bit systems.
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.09.0|js}
-  ; date = {js|2019-09-18|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.09.0|js}
+    ; date = {js|2019-09-18|js}
+    ; body_md =
+        {js|
 # OCaml 4.09.0
 This page describes OCaml version **4.09.0**, released on
 2019-09-18.  Go [here](./) for a list of all releases.
@@ -10278,7 +10290,8 @@ This is the
 - [#8944](https://github.com/ocaml/ocaml/issues/8944): Fix "open struct .. end" on clambda backend
   (Thomas Refis, review by Leo White, report by Damon Wang and Mark Shinwell)
 |js}
-  ; body_html = {js|<h1>OCaml 4.09.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.09.0</h1>
 <p>This page describes OCaml version <strong>4.09.0</strong>, released on
 2019-09-18.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -10781,12 +10794,12 @@ report by Aleksandr Kuzmenko)</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.09.1|js}
-  ; date = {js|2020-03-16|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.09.1|js}
+    ; date = {js|2020-03-16|js}
+    ; body_md =
+        {js|
 # OCaml 4.09.1
 
 This page describe OCaml **4.09.1**, released on Mar 16, 2020.  It is
@@ -10836,7 +10849,8 @@ a bug-fix release of [OCaml 4.09.0](4.09.0.html).
   (Jacques-Henri Jourdan, review by Stephen Dolan, Xavier Leroy and
    Gabriel Scherer)
 |js}
-  ; body_html = {js|<h1>OCaml 4.09.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.09.1</h1>
 <p>This page describe OCaml <strong>4.09.1</strong>, released on Mar 16, 2020.  It is
 a bug-fix release of <a href="4.09.0.html">OCaml 4.09.0</a>.</p>
 <h3>Bug fixes:</h3>
@@ -10895,12 +10909,12 @@ Gabriel Scherer)</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.10.0|js}
-  ; date = {js|2020-02-21|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.10.0|js}
+    ; date = {js|2020-02-21|js}
+    ; body_md =
+        {js|
 # OCaml 4.10.0
 This page describes OCaml version **4.10.0**, released on
 2020-02-21.  Go [here](./) for a list of all releases.
@@ -11519,7 +11533,8 @@ This is the
   (Kate Deplaix and David Allsopp, review by Sébastien Hinderer
    and Gabriel Scherer )
 |js}
-  ; body_html = {js|<h1>OCaml 4.10.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.10.0</h1>
 <p>This page describes OCaml version <strong>4.10.0</strong>, released on
 2020-02-21.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -12297,12 +12312,12 @@ and Gabriel Scherer )</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.10.1|js}
-  ; date = {js|2020-08-20|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.10.1|js}
+    ; date = {js|2020-08-20|js}
+    ; body_md =
+        {js|
 # OCaml 4.10.1
 
 This page describe OCaml **4.10.1**, released on Aug 20, 2020.  It is
@@ -12347,7 +12362,8 @@ a bug-fix release of [OCaml 4.10.0](4.10.0.html).
 - [#9552](https://github.com/ocaml/ocaml/issues/9552): restore ocamloptp build and installation
   (Florian Angeletti, review by David Allsopp and Xavier Leroy)
 |js}
-  ; body_html = {js|<h1>OCaml 4.10.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.10.1</h1>
 <p>This page describe OCaml <strong>4.10.1</strong>, released on Aug 20, 2020.  It is
 a bug-fix release of <a href="4.10.0.html">OCaml 4.10.0</a>.</p>
 <h3>Runtime system:</h3>
@@ -12399,12 +12415,12 @@ blue, which was not the case with the best-fit allocator.
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.10.2|js}
-  ; date = {js|2020-12-08|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.10.2|js}
+    ; date = {js|2020-12-08|js}
+    ; body_md =
+        {js|
 # OCaml 4.10.2
 
 This page describes OCaml **4.10.2**, released on Dec 8, 2020.  It is
@@ -12452,7 +12468,8 @@ Backported from OCaml 4.12.0
 - [#9699](https://github.com/ocaml/ocaml/issues/9699), [#9981](https://github.com/ocaml/ocaml/issues/9981): Added mergeable flag tqo ELF sections containing mergeable constants. Fixes compatibility with the integrated assembler in clang 11.0.0.
 Backported from OCaml 4.12.0
 (Jacob Young, review by Nicolás Ojeda Bär)|js}
-  ; body_html = {js|<h1>OCaml 4.10.2</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.10.2</h1>
 <p>This page describes OCaml <strong>4.10.2</strong>, released on Dec 8, 2020.  It is
 an exceptional release making OCaml <strong>4.10</strong> available on macOS/arm64 and
 fixes some compatibility issues for the mingw64 and FreeBSD/amd64 platform.</p>
@@ -12506,12 +12523,12 @@ Backported from OCaml 4.12.0
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.11.0|js}
-  ; date = {js|2020-08-19|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.11.0|js}
+    ; date = {js|2020-08-19|js}
+    ; body_md =
+        {js|
 # OCaml 4.11.0
 This page describes OCaml version **4.11.0**, released on
 2020-08-19.  Go [here](./) for a list of all releases.
@@ -13185,7 +13202,8 @@ Called from Foo.bar in file "foo.ml", line 16, characters 42-53
   to better ensure that members are correctly spaced.
   (Antonin Décimo, review by David Allsopp and Xavier Leroy)
 |js}
-  ; body_html = {js|<h1>OCaml 4.11.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.11.0</h1>
 <p>This page describes OCaml version <strong>4.11.0</strong>, released on
 2020-08-19.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as multiple
@@ -14030,12 +14048,12 @@ to better ensure that members are correctly spaced.
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.11.1|js}
-  ; date = {js|2020-08-31|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.11.1|js}
+    ; date = {js|2020-08-31|js}
+    ; body_md =
+        {js|
 # OCaml 4.11.1
 
 This page describe OCaml **4.11.1**, released on Aug 31, 2020.  It is
@@ -14051,7 +14069,8 @@ a bug-fix release of [OCaml 4.11.0](4.11.0.html).
   appear in the right hand side of an explicit :> coercion
   (Florian Angeletti, report by Jerry James, review by Thomas Refis)
 |js}
-  ; body_html = {js|<h1>OCaml 4.11.1</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.11.1</h1>
 <p>This page describe OCaml <strong>4.11.1</strong>, released on Aug 31, 2020.  It is
 a bug-fix release of <a href="4.11.0.html">OCaml 4.11.0</a>.</p>
 <h3>Bug fixes:</h3>
@@ -14068,12 +14087,12 @@ appear in the right hand side of an explicit :&gt; coercion
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.11.2|js}
-  ; date = {js|2021-02-24|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.11.2|js}
+    ; date = {js|2021-02-24|js}
+    ; body_md =
+        {js|
 # OCaml 4.11.2
 
 This page describes OCaml **4.11.2**, released on Feb 24, 2021.
@@ -14175,7 +14194,8 @@ Changes
   (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
    code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
 |js}
-  ; body_html = {js|<h1>OCaml 4.11.2</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.11.2</h1>
 <p>This page describes OCaml <strong>4.11.2</strong>, released on Feb 24, 2021.
 This is a bug-fix release of <a href="4.11.0.html">OCaml 4.11.0</a>.</p>
 <h2>Opam switches</h2>
@@ -14301,12 +14321,12 @@ code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { kind = `Compiler
-  ; version = {js|4.12.0|js}
-  ; date = {js|2021-02-24|js}
-  ; body_md = {js|
+    }
+  ; { kind = `Compiler
+    ; version = {js|4.12.0|js}
+    ; date = {js|2021-02-24|js}
+    ; body_md =
+        {js|
 # OCaml 4.12.0
 This page describes OCaml version **4.12.0**, released on
 2021-02-24.  Go [here](./) for a list of all releases.
@@ -15138,7 +15158,8 @@ This is the
   (Gabriel Scherer, review by Thomas Refis and Florian Angeletti,
    report by Daniil Baturin)
 |js}
-  ; body_html = {js|<h1>OCaml 4.12.0</h1>
+    ; body_html =
+        {js|<h1>OCaml 4.12.0</h1>
 <p>This page describes OCaml version <strong>4.12.0</strong>, released on
 2021-02-24.  Go <a href="./">here</a> for a list of all releases.</p>
 <p>This release is available as an
@@ -16178,5 +16199,5 @@ report by Daniil Baturin)</p>
 </li>
 </ul>
 |js}
-  }]
-
+    }
+  ]

--- a/src/ocamlorg_data/success_story.ml
+++ b/src/ocamlorg_data/success_story.ml
@@ -1,4 +1,3 @@
-
 type t =
   { title : string
   ; slug : string
@@ -7,14 +6,14 @@ type t =
   ; body_md : string
   ; body_html : string
   }
-  
-let all_en = 
-[
-  { title = {js|The ASTRÉE Static Analyzer|js}
-  ; slug = {js|the-astre-static-analyzer|js}
-  ; image = Some {js|/success-stories/astree-thumb.gif|js}
-  ; url = Some {js|https://www.astree.ens.fr/|js}
-  ; body_md = {js|
+
+let all_en =
+  [ { title = {js|The ASTRÉE Static Analyzer|js}
+    ; slug = {js|the-astre-static-analyzer|js}
+    ; image = Some {js|/success-stories/astree-thumb.gif|js}
+    ; url = Some {js|https://www.astree.ens.fr/|js}
+    ; body_md =
+        {js|
 *[David Monniaux](https://www-verimag.imag.fr/~monniaux/) (CNRS), member
 of the ASTRÉE project, says:* “[ASTRÉE](https://www.astree.ens.fr/) is a
 *static analyzer* based on *[abstract
@@ -44,7 +43,8 @@ support for advanced data structures, and type and memory safety. OCaml
 also allows for modular, clear and compact source code and makes it easy
 to work with recursive structures such as syntax trees.”
 |js}
-  ; body_html = {js|<p><em><a href="https://www-verimag.imag.fr/~monniaux/">David Monniaux</a> (CNRS), member
+    ; body_html =
+        {js|<p><em><a href="https://www-verimag.imag.fr/~monniaux/">David Monniaux</a> (CNRS), member
 of the ASTRÉE project, says:</em> “<a href="https://www.astree.ens.fr/">ASTRÉE</a> is a
 <em>static analyzer</em> based on <em><a href="https://www.di.ens.fr/%7Ecousot/aiintro.shtml">abstract
 interpretation</a></em> that aims
@@ -70,13 +70,13 @@ support for advanced data structures, and type and memory safety. OCaml
 also allows for modular, clear and compact source code and makes it easy
 to work with recursive structures such as syntax trees.”</p>
 |js}
-  };
- 
-  { title = {js|Coq|js}
-  ; slug = {js|coq|js}
-  ; image = Some {js|/success-stories/coq-thumb.jpg|js}
-  ; url = Some {js|https://coq.inria.fr/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Coq|js}
+    ; slug = {js|coq|js}
+    ; image = Some {js|/success-stories/coq-thumb.jpg|js}
+    ; url = Some {js|https://coq.inria.fr/|js}
+    ; body_md =
+        {js|
 *[Jean-Christophe Filliâtre](https://www.lri.fr/~filliatr/) (CNRS), a
 Coq developer, says:* “The [Coq](https://coq.inria.fr/) tool is a system
 for manipulating formal mathematical proofs; a proof carried out in Coq
@@ -95,7 +95,8 @@ quality: errors such as “segmentation faults” cannot occur during
 execution, which is indispensable for a tool whose primary goal is
 precisely rigor.”
 |js}
-  ; body_html = {js|<p><em><a href="https://www.lri.fr/~filliatr/">Jean-Christophe Filliâtre</a> (CNRS), a
+    ; body_html =
+        {js|<p><em><a href="https://www.lri.fr/~filliatr/">Jean-Christophe Filliâtre</a> (CNRS), a
 Coq developer, says:</em> “The <a href="https://coq.inria.fr/">Coq</a> tool is a system
 for manipulating formal mathematical proofs; a proof carried out in Coq
 is mechanically verified by the machine. In addition to its applications
@@ -112,13 +113,13 @@ quality: errors such as “segmentation faults” cannot occur during
 execution, which is indispensable for a tool whose primary goal is
 precisely rigor.”</p>
 |js}
-  };
- 
-  { title = {js|FFTW|js}
-  ; slug = {js|fftw|js}
-  ; image = Some {js|/success-stories/fftw-thumb.png|js}
-  ; url = Some {js|https://www.fftw.org/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|FFTW|js}
+    ; slug = {js|fftw|js}
+    ; image = Some {js|/success-stories/fftw-thumb.png|js}
+    ; url = Some {js|https://www.fftw.org/|js}
+    ; body_md =
+        {js|
 [FFTW](https://www.fftw.org/) is a [very fast](https://www.fftw.org/benchfft/) C
 library for computing Discrete Fourier Transforms (DFT). It uses a powerful
 symbolic optimizer written in OCaml which, given an integer N, generates highly
@@ -134,7 +135,8 @@ the same program will perform well on most architectures without
 modification. Hence the name, “FFTW,” which stands for the somewhat
 whimsical title of “Fastest Fourier Transform in the West.”
 |js}
-  ; body_html = {js|<p><a href="https://www.fftw.org/">FFTW</a> is a <a href="https://www.fftw.org/benchfft/">very fast</a> C
+    ; body_html =
+        {js|<p><a href="https://www.fftw.org/">FFTW</a> is a <a href="https://www.fftw.org/benchfft/">very fast</a> C
 library for computing Discrete Fourier Transforms (DFT). It uses a powerful
 symbolic optimizer written in OCaml which, given an integer N, generates highly
 optimized C code to compute DFTs of size N. FFTW was awarded the 1999
@@ -148,30 +150,31 @@ the same program will perform well on most architectures without
 modification. Hence the name, “FFTW,” which stands for the somewhat
 whimsical title of “Fastest Fourier Transform in the West.”</p>
 |js}
-  };
- 
-  { title = {js|Haxe|js}
-  ; slug = {js|haxe|js}
-  ; image = None
-  ; url = Some {js|https://haxe.org/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Haxe|js}
+    ; slug = {js|haxe|js}
+    ; image = None
+    ; url = Some {js|https://haxe.org/|js}
+    ; body_md =
+        {js|
 [Haxe](https://haxe.org/) is an open source toolkit based on a modern,
 high level, strictly typed programming language, a cross-compiler,
 a complete cross-platform standard library and ways to access each
 platform's native capabilities. The Haxe compiler was entirely written in OCaml.
 |js}
-  ; body_html = {js|<p><a href="https://haxe.org/">Haxe</a> is an open source toolkit based on a modern,
+    ; body_html =
+        {js|<p><a href="https://haxe.org/">Haxe</a> is an open source toolkit based on a modern,
 high level, strictly typed programming language, a cross-compiler,
 a complete cross-platform standard library and ways to access each
 platform's native capabilities. The Haxe compiler was entirely written in OCaml.</p>
 |js}
-  };
- 
-  { title = {js|Jane Street|js}
-  ; slug = {js|jane-street|js}
-  ; image = Some {js|/success-stories/jane-street-thumb.jpg|js}
-  ; url = Some {js|https://janestreet.com/technology/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Jane Street|js}
+    ; slug = {js|jane-street|js}
+    ; image = Some {js|/success-stories/jane-street-thumb.jpg|js}
+    ; url = Some {js|https://janestreet.com/technology/|js}
+    ; body_md =
+        {js|
 Jane Street is a proprietary trading firm that uses OCaml as its primary
 development platform.  Our operation runs at a large scale,
 generating billions of dollars of transactions every day from our offices
@@ -194,7 +197,8 @@ and several syntax extensions like binprot and sexplib.  All of these can
 be found at [https://janestreet.github.io](https://janestreet.github.io).  All in, we've open-sourced
 more than 200k lines of code.
 |js}
-  ; body_html = {js|<p>Jane Street is a proprietary trading firm that uses OCaml as its primary
+    ; body_html =
+        {js|<p>Jane Street is a proprietary trading firm that uses OCaml as its primary
 development platform.  Our operation runs at a large scale,
 generating billions of dollars of transactions every day from our offices
 in Hong Kong, London and New York, with strategies that span many asset classes,
@@ -214,13 +218,13 @@ and several syntax extensions like binprot and sexplib.  All of these can
 be found at <a href="https://janestreet.github.io">https://janestreet.github.io</a>.  All in, we've open-sourced
 more than 200k lines of code.</p>
 |js}
-  };
- 
-  { title = {js|LexiFi's Modeling Language for Finance|js}
-  ; slug = {js|lexifis-modeling-language-for-finance|js}
-  ; image = Some {js|/success-stories/lexifi-thumb.jpg|js}
-  ; url = Some {js|https://www.lexifi.com/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|LexiFi's Modeling Language for Finance|js}
+    ; slug = {js|lexifis-modeling-language-for-finance|js}
+    ; image = Some {js|/success-stories/lexifi-thumb.jpg|js}
+    ; url = Some {js|https://www.lexifi.com/|js}
+    ; body_md =
+        {js|
 Developed by the company [LexiFi](https://www.lexifi.com/), the Modeling
 Language for Finance (MLFi) is the first formal language that accurately
 describes the most sophisticated capital market, credit, and investment
@@ -251,7 +255,8 @@ financial trading and risk management publication. MLFi-based solutions
 are gaining growing acceptance throughout Europe and are contributing to
 spread the use of OCaml in the financial services industry.
 |js}
-  ; body_html = {js|<p>Developed by the company <a href="https://www.lexifi.com/">LexiFi</a>, the Modeling
+    ; body_html =
+        {js|<p>Developed by the company <a href="https://www.lexifi.com/">LexiFi</a>, the Modeling
 Language for Finance (MLFi) is the first formal language that accurately
 describes the most sophisticated capital market, credit, and investment
 products. MLFi is implemented as an extension of OCaml.</p>
@@ -277,13 +282,13 @@ financial trading and risk management publication. MLFi-based solutions
 are gaining growing acceptance throughout Europe and are contributing to
 spread the use of OCaml in the financial services industry.</p>
 |js}
-  };
- 
-  { title = {js|Liquidsoap|js}
-  ; slug = {js|liquidsoap|js}
-  ; image = None
-  ; url = None
-  ; body_md = {js|
+    }
+  ; { title = {js|Liquidsoap|js}
+    ; slug = {js|liquidsoap|js}
+    ; image = None
+    ; url = None
+    ; body_md =
+        {js|
 [Liquidsoap](https://www.liquidsoap.info/) is clearly well established in the
 (internet) radio industry. Liquidsoap is well known as a tool with
 unique abilities, and has lots of users including big commercial ones.
@@ -291,20 +296,21 @@ It is not developed as a business, but companies develop services or
 software on top of it. For example, Sourcefabric develops and sells
 Airtime on top of Liquidsoap.
 |js}
-  ; body_html = {js|<p><a href="https://www.liquidsoap.info/">Liquidsoap</a> is clearly well established in the
+    ; body_html =
+        {js|<p><a href="https://www.liquidsoap.info/">Liquidsoap</a> is clearly well established in the
 (internet) radio industry. Liquidsoap is well known as a tool with
 unique abilities, and has lots of users including big commercial ones.
 It is not developed as a business, but companies develop services or
 software on top of it. For example, Sourcefabric develops and sells
 Airtime on top of Liquidsoap.</p>
 |js}
-  };
- 
-  { title = {js|The MLdonkey peer-to-peer client|js}
-  ; slug = {js|the-mldonkey-peer-to-peer-client|js}
-  ; image = Some {js|/success-stories/mldonkey-thumb.jpg|js}
-  ; url = Some {js|https://mldonkey.sourceforge.net/Main_Page|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|The MLdonkey peer-to-peer client|js}
+    ; slug = {js|the-mldonkey-peer-to-peer-client|js}
+    ; image = Some {js|/success-stories/mldonkey-thumb.jpg|js}
+    ; url = Some {js|https://mldonkey.sourceforge.net/Main_Page|js}
+    ; body_md =
+        {js|
 [MLdonkey](https://mldonkey.sourceforge.net/Main_Page) is a
 multi-platform multi-networks peer-to-peer client. It was the first
 open-source client to access the eDonkey network. Today, MLdonkey
@@ -325,7 +331,8 @@ a daemon, running unattended on the computer, and can be controlled
 remotely using a choice of three different kinds of interfaces: GTK, web
 and telnet.”
 |js}
-  ; body_html = {js|<p><a href="https://mldonkey.sourceforge.net/Main_Page">MLdonkey</a> is a
+    ; body_html =
+        {js|<p><a href="https://mldonkey.sourceforge.net/Main_Page">MLdonkey</a> is a
 multi-platform multi-networks peer-to-peer client. It was the first
 open-source client to access the eDonkey network. Today, MLdonkey
 supports several other large networks, among which Overnet, Bittorrent,
@@ -344,13 +351,13 @@ a daemon, running unattended on the computer, and can be controlled
 remotely using a choice of three different kinds of interfaces: GTK, web
 and telnet.”</p>
 |js}
-  };
- 
-  { title = {js|SLAM|js}
-  ; slug = {js|slam|js}
-  ; image = None
-  ; url = Some {js|https://research.microsoft.com/en-us/projects/slam/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|SLAM|js}
+    ; slug = {js|slam|js}
+    ; image = None
+    ; url = Some {js|https://research.microsoft.com/en-us/projects/slam/|js}
+    ; body_md =
+        {js|
 The [SLAM](https://research.microsoft.com/en-us/projects/slam/) project
 originated in Microsoft Research in early 2000. Its goal was to
 automatically check that a C program correctly uses the interface to an
@@ -369,7 +376,8 @@ T.Ball, B.Cook, V.Levin and S.K.Rajamani, the SLAM developers, write:*
 functional programming language. The expressiveness of this language and
 robustness of its implementation provided a great productivity boost.”
 |js}
-  ; body_html = {js|<p>The <a href="https://research.microsoft.com/en-us/projects/slam/">SLAM</a> project
+    ; body_html =
+        {js|<p>The <a href="https://research.microsoft.com/en-us/projects/slam/">SLAM</a> project
 originated in Microsoft Research in early 2000. Its goal was to
 automatically check that a C program correctly uses the interface to an
 external library. The project used and extended ideas from symbolic
@@ -386,13 +394,13 @@ T.Ball, B.Cook, V.Levin and S.K.Rajamani, the SLAM developers, write:</em>
 functional programming language. The expressiveness of this language and
 robustness of its implementation provided a great productivity boost.”</p>
 |js}
-  };
- 
-  { title = {js|The Unison File Synchronizer|js}
-  ; slug = {js|the-unison-file-synchronizer|js}
-  ; image = Some {js|/success-stories/unison-thumb.jpg|js}
-  ; url = Some {js|https://www.cis.upenn.edu/%7Ebcpierce/unison/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|The Unison File Synchronizer|js}
+    ; slug = {js|the-unison-file-synchronizer|js}
+    ; image = Some {js|/success-stories/unison-thumb.jpg|js}
+    ; url = Some {js|https://www.cis.upenn.edu/%7Ebcpierce/unison/|js}
+    ; body_md =
+        {js|
 [Unison](https://www.cis.upenn.edu/%7Ebcpierce/unison/) is a popular
 file-synchronization tool for Windows and most flavors of Unix. It
 allows two replicas of a collection of files and directories to be
@@ -418,7 +426,8 @@ different programmers. In fact, Unison may be unique among large OCaml
 projects in having been *translated* from Java to OCaml midway through
 its development. Moving to OCaml was like a breath of fresh air.”
 |js}
-  ; body_html = {js|<p><a href="https://www.cis.upenn.edu/%7Ebcpierce/unison/">Unison</a> is a popular
+    ; body_html =
+        {js|<p><a href="https://www.cis.upenn.edu/%7Ebcpierce/unison/">Unison</a> is a popular
 file-synchronization tool for Windows and most flavors of Unix. It
 allows two replicas of a collection of files and directories to be
 stored on different hosts (or different disks on the same host),
@@ -442,15 +451,16 @@ different programmers. In fact, Unison may be unique among large OCaml
 projects in having been <em>translated</em> from Java to OCaml midway through
 its development. Moving to OCaml was like a breath of fresh air.”</p>
 |js}
-  }]
+    }
+  ]
 
-let all_fr = 
-[
-  { title = {js|L'analyseur statique ASTRÉE|js}
-  ; slug = {js|lanalyseur-statique-astre|js}
-  ; image = Some {js|/success-stories/astree-thumb.gif|js}
-  ; url = Some {js|https://www.astree.ens.fr/|js}
-  ; body_md = {js|
+let all_fr =
+  [ { title = {js|L'analyseur statique ASTRÉE|js}
+    ; slug = {js|lanalyseur-statique-astre|js}
+    ; image = Some {js|/success-stories/astree-thumb.gif|js}
+    ; url = Some {js|https://www.astree.ens.fr/|js}
+    ; body_md =
+        {js|
 *[David Monniaux](https://www-verimag.imag.fr/~monniaux/) (CNRS), membre
 du projet ASTRÉE :* « [ASTRÉE](https://www.astree.ens.fr/) est un
 *analyseur statique* basé sur [l'interprétation
@@ -484,7 +494,8 @@ OCaml permet également d'organiser le code source de façon modulaire,
 claire et compacte, et facilite la gestion de structures de données
 récursives comme les arbres de syntaxe abstraite. »
 |js}
-  ; body_html = {js|<p><em><a href="https://www-verimag.imag.fr/~monniaux/">David Monniaux</a> (CNRS), membre
+    ; body_html =
+        {js|<p><em><a href="https://www-verimag.imag.fr/~monniaux/">David Monniaux</a> (CNRS), membre
 du projet ASTRÉE :</em> « <a href="https://www.astree.ens.fr/">ASTRÉE</a> est un
 <em>analyseur statique</em> basé sur <a href="https://www.di.ens.fr/%7Ecousot/aiintro.shtml">l'interprétation
 abstraite</a> et qui vise à
@@ -514,13 +525,13 @@ OCaml permet également d'organiser le code source de façon modulaire,
 claire et compacte, et facilite la gestion de structures de données
 récursives comme les arbres de syntaxe abstraite. »</p>
 |js}
-  };
- 
-  { title = {js|Coq|js}
-  ; slug = {js|coq|js}
-  ; image = Some {js|/success-stories/coq-thumb.jpg|js}
-  ; url = Some {js|https://coq.inria.fr/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Coq|js}
+    ; slug = {js|coq|js}
+    ; image = Some {js|/success-stories/coq-thumb.jpg|js}
+    ; url = Some {js|https://coq.inria.fr/|js}
+    ; body_md =
+        {js|
 *[Jean-Christophe Filliâtre](https://www.lri.fr/%7Efilliatr/) (CNRS), un
 des développeurs de Coq :* « L'outil [Coq](https://coq.inria.fr/) est un
 système de manipulation de preuves mathématiques formelles ; une preuve
@@ -539,7 +550,8 @@ le typage fort de OCaml assure de fait une grande qualité au code de Coq
 fault »), ce qui est indispensable à un outil dont le but premier est
 justement la rigueur. »
 |js}
-  ; body_html = {js|<p><em><a href="https://www.lri.fr/%7Efilliatr/">Jean-Christophe Filliâtre</a> (CNRS), un
+    ; body_html =
+        {js|<p><em><a href="https://www.lri.fr/%7Efilliatr/">Jean-Christophe Filliâtre</a> (CNRS), un
 des développeurs de Coq :</em> « L'outil <a href="https://coq.inria.fr/">Coq</a> est un
 système de manipulation de preuves mathématiques formelles ; une preuve
 réalisée avec Coq est mécaniquement vérifiée par la machine. Outre ses
@@ -556,13 +568,13 @@ le typage fort de OCaml assure de fait une grande qualité au code de Coq
 fault »), ce qui est indispensable à un outil dont le but premier est
 justement la rigueur. »</p>
 |js}
-  };
- 
-  { title = {js|Le système de communication distribuée Ensemble|js}
-  ; slug = {js|le-systme-de-communication-distribue-ensemble|js}
-  ; image = None
-  ; url = Some {js|https://dsl.cs.technion.ac.il/projects/Ensemble/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Le système de communication distribuée Ensemble|js}
+    ; slug = {js|le-systme-de-communication-distribue-ensemble|js}
+    ; image = None
+    ; url = Some {js|https://dsl.cs.technion.ac.il/projects/Ensemble/|js}
+    ; body_md =
+        {js|
 *Ohad Rodeh (IBM Haifa), un des développeurs d'Ensemble :*
 « [Ensemble](https://dsl.cs.technion.ac.il/projects/Ensemble/) est un
 système de communication de groupe écrit en OCaml, développé à Cornell
@@ -581,7 +593,8 @@ algébriques, la récupération automatique de la mémoire et
 l'environnement d'exécution sont les principales raisons de notre
 intérêt pour OCaml. »
 |js}
-  ; body_html = {js|<p><em>Ohad Rodeh (IBM Haifa), un des développeurs d'Ensemble :</em>
+    ; body_html =
+        {js|<p><em>Ohad Rodeh (IBM Haifa), un des développeurs d'Ensemble :</em>
 « <a href="https://dsl.cs.technion.ac.il/projects/Ensemble/">Ensemble</a> est un
 système de communication de groupe écrit en OCaml, développé à Cornell
 et à Hebrew University. À l'auteur d'applications, Ensemble fournit une
@@ -599,13 +612,13 @@ algébriques, la récupération automatique de la mémoire et
 l'environnement d'exécution sont les principales raisons de notre
 intérêt pour OCaml. »</p>
 |js}
-  };
- 
-  { title = {js|FFTW|js}
-  ; slug = {js|fftw|js}
-  ; image = Some {js|/success-stories/fftw-thumb.png|js}
-  ; url = Some {js|https://www.fftw.org/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|FFTW|js}
+    ; slug = {js|fftw|js}
+    ; image = Some {js|/success-stories/fftw-thumb.png|js}
+    ; url = Some {js|https://www.fftw.org/|js}
+    ; body_md =
+        {js|
 [FFTW](https://www.fftw.org/) est une librairie C [très
 rapide](https://www.fftw.org/benchfft/) permettant d'effectuer des
 Transformées de Fourier Discrètes (DFT). Elle emploie un puissant
@@ -624,7 +637,8 @@ sont portables : un même programme donnera de bons résultats sur la
 plupart des architectures sans modification. D'où le nom « FFTW, » qui
 signifie « Fastest Fourier Transform in the West. »
 |js}
-  ; body_html = {js|<p><a href="https://www.fftw.org/">FFTW</a> est une librairie C <a href="https://www.fftw.org/benchfft/">très
+    ; body_html =
+        {js|<p><a href="https://www.fftw.org/">FFTW</a> est une librairie C <a href="https://www.fftw.org/benchfft/">très
 rapide</a> permettant d'effectuer des
 Transformées de Fourier Discrètes (DFT). Elle emploie un puissant
 optimiseur symbolique écrit en OCaml qui, étant donné un entier N,
@@ -641,32 +655,33 @@ sont portables : un même programme donnera de bons résultats sur la
 plupart des architectures sans modification. D'où le nom « FFTW, » qui
 signifie « Fastest Fourier Transform in the West. »</p>
 |js}
-  };
- 
-  { title = {js|Haxe|js}
-  ; slug = {js|haxe|js}
-  ; image = None
-  ; url = Some {js|https://haxe.org/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Haxe|js}
+    ; slug = {js|haxe|js}
+    ; image = None
+    ; url = Some {js|https://haxe.org/|js}
+    ; body_md =
+        {js|
 [Haxe](https://haxe.org/)  est une boîte à outils open source basée sur un 
 langage de programmation moderne, de haut niveau, strictement typé, un 
 compilateur croisé, une bibliothèque standard multiplateforme complète et 
 des moyens d’accéder aux capacités natives de chaque plate-forme.Le compilateur 
 Haxe a été entièrement écrit dans OCaml.
 |js}
-  ; body_html = {js|<p><a href="https://haxe.org/">Haxe</a>  est une boîte à outils open source basée sur un
+    ; body_html =
+        {js|<p><a href="https://haxe.org/">Haxe</a>  est une boîte à outils open source basée sur un
 langage de programmation moderne, de haut niveau, strictement typé, un
 compilateur croisé, une bibliothèque standard multiplateforme complète et
 des moyens d’accéder aux capacités natives de chaque plate-forme.Le compilateur
 Haxe a été entièrement écrit dans OCaml.</p>
 |js}
-  };
- 
-  { title = {js|Jane Street|js}
-  ; slug = {js|jane-street|js}
-  ; image = Some {js|/success-stories/jane-street-thumb.jpg|js}
-  ; url = Some {js|https://janestreet.com/technology/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Jane Street|js}
+    ; slug = {js|jane-street|js}
+    ; image = Some {js|/success-stories/jane-street-thumb.jpg|js}
+    ; url = Some {js|https://janestreet.com/technology/|js}
+    ; body_md =
+        {js|
 Jane Street est une société de négoce propriétaire qui utilise OCaml comme sa 
 plate-forme de développement primaire. Notre exploitation fonctionne à grande 
 échelle, générant des milliards de dollars de transactions chaque jour à partir 
@@ -689,7 +704,8 @@ et sexplib.Tous ces éléments peuvent être trouvés à
 [https://janestreet.github.io](https://janestreet.github.io). Au total, nous avons ouvert
 plus de 200k lignes de code.
 |js}
-  ; body_html = {js|<p>Jane Street est une société de négoce propriétaire qui utilise OCaml comme sa
+    ; body_html =
+        {js|<p>Jane Street est une société de négoce propriétaire qui utilise OCaml comme sa
 plate-forme de développement primaire. Notre exploitation fonctionne à grande
 échelle, générant des milliards de dollars de transactions chaque jour à partir
 de nos bureaux de Hong Kong,Londres et New York, avec des stratégies qui couvrent
@@ -709,13 +725,13 @@ et sexplib.Tous ces éléments peuvent être trouvés à
 <a href="https://janestreet.github.io">https://janestreet.github.io</a>. Au total, nous avons ouvert
 plus de 200k lignes de code.</p>
 |js}
-  };
- 
-  { title = {js|Le Langage de Modélisation Financière de LexiFi|js}
-  ; slug = {js|le-langage-de-modlisation-financire-de-lexifi|js}
-  ; image = Some {js|/success-stories/lexifi-thumb.jpg|js}
-  ; url = Some {js|https://www.lexifi.com/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Le Langage de Modélisation Financière de LexiFi|js}
+    ; slug = {js|le-langage-de-modlisation-financire-de-lexifi|js}
+    ; image = Some {js|/success-stories/lexifi-thumb.jpg|js}
+    ; url = Some {js|https://www.lexifi.com/|js}
+    ; body_md =
+        {js|
 Développé par la société [LexiFi](https://www.lexifi.com/), le Langage de
 Modélisation Financière (MLFi) est le premier langage formel capable de
 décrire les produits d'investissement, de crédit et de marché de
@@ -750,7 +766,8 @@ financiers et de la gestion des risques. Les solutions basées sur MLFi
 gagnent en reconnaissance à travers l'Europe et contribuent à répandre
 l'utilisation d'OCaml dans l'industrie des services financiers.
 |js}
-  ; body_html = {js|<p>Développé par la société <a href="https://www.lexifi.com/">LexiFi</a>, le Langage de
+    ; body_html =
+        {js|<p>Développé par la société <a href="https://www.lexifi.com/">LexiFi</a>, le Langage de
 Modélisation Financière (MLFi) est le premier langage formel capable de
 décrire les produits d'investissement, de crédit et de marché de
 capitaux les plus sophistiqués. MLFi est implanté comme une extension
@@ -780,13 +797,13 @@ financiers et de la gestion des risques. Les solutions basées sur MLFi
 gagnent en reconnaissance à travers l'Europe et contribuent à répandre
 l'utilisation d'OCaml dans l'industrie des services financiers.</p>
 |js}
-  };
- 
-  { title = {js|Liquidsoap|js}
-  ; slug = {js|liquidsoap|js}
-  ; image = None
-  ; url = None
-  ; body_md = {js|
+    }
+  ; { title = {js|Liquidsoap|js}
+    ; slug = {js|liquidsoap|js}
+    ; image = None
+    ; url = None
+    ; body_md =
+        {js|
 [Liquidsoap](https://www.liquidsoap.info/) est clairement bien établie dans 
 l’industrie de la radio (internet).Liquidsoap est bien connu comme un 
 outil avec des capacités uniques, et a beaucoup d’utilisateurs, y compris 
@@ -794,20 +811,21 @@ les grands commerciaux.Il n’est pas développé comme une entreprise, mais les
 entreprises développent des services ou des logiciels sur le dessus de celui-ci.
 Par exemple, Sourcefabric développe et vend du temps d’antenne au-dessus de Liquidsoap.
 |js}
-  ; body_html = {js|<p><a href="https://www.liquidsoap.info/">Liquidsoap</a> est clairement bien établie dans
+    ; body_html =
+        {js|<p><a href="https://www.liquidsoap.info/">Liquidsoap</a> est clairement bien établie dans
 l’industrie de la radio (internet).Liquidsoap est bien connu comme un
 outil avec des capacités uniques, et a beaucoup d’utilisateurs, y compris
 les grands commerciaux.Il n’est pas développé comme une entreprise, mais les
 entreprises développent des services ou des logiciels sur le dessus de celui-ci.
 Par exemple, Sourcefabric développe et vend du temps d’antenne au-dessus de Liquidsoap.</p>
 |js}
-  };
- 
-  { title = {js|Le client pair-à-pair MLdonkey|js}
-  ; slug = {js|le-client-pair--pair-mldonkey|js}
-  ; image = Some {js|/success-stories/mldonkey-thumb.jpg|js}
-  ; url = Some {js|https://mldonkey.sourceforge.net/Main_Page|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Le client pair-à-pair MLdonkey|js}
+    ; slug = {js|le-client-pair--pair-mldonkey|js}
+    ; image = Some {js|/success-stories/mldonkey-thumb.jpg|js}
+    ; url = Some {js|https://mldonkey.sourceforge.net/Main_Page|js}
+    ; body_md =
+        {js|
 [MLdonkey](https://mldonkey.sourceforge.net/Main_Page) est un client
 pair-à-pair multi-plateformes et multi-réseaux. Il a été le premier
 client « open source » à permettre l'accès au réseau eDonkey.
@@ -829,7 +847,8 @@ se connecter à plusieurs réseaux pair-à-pair pour télécharger et
 tâche de fond et sans surveillance humaine, et peut être contrôlé à
 l'aide d'une interface au choix parmi trois : GTK, web et telnet. »
 |js}
-  ; body_html = {js|<p><a href="https://mldonkey.sourceforge.net/Main_Page">MLdonkey</a> est un client
+    ; body_html =
+        {js|<p><a href="https://mldonkey.sourceforge.net/Main_Page">MLdonkey</a> est un client
 pair-à-pair multi-plateformes et multi-réseaux. Il a été le premier
 client « open source » à permettre l'accès au réseau eDonkey.
 Aujourd'hui, MLdonkey autorise également l'accès à plusieurs autres
@@ -849,13 +868,13 @@ se connecter à plusieurs réseaux pair-à-pair pour télécharger et
 tâche de fond et sans surveillance humaine, et peut être contrôlé à
 l'aide d'une interface au choix parmi trois : GTK, web et telnet. »</p>
 |js}
-  };
- 
-  { title = {js|SLAM|js}
-  ; slug = {js|slam|js}
-  ; image = None
-  ; url = Some {js|https://research.microsoft.com/en-us/projects/slam/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|SLAM|js}
+    ; slug = {js|slam|js}
+    ; image = None
+    ; url = Some {js|https://research.microsoft.com/en-us/projects/slam/|js}
+    ; body_md =
+        {js|
 Le projet [SLAM](https://research.microsoft.com/en-us/projects/slam/) a
 débuté à Microsoft Research début 2000. Son but était de vérifier
 automatiquement qu'un programme C utilise correctement l'interface d'une
@@ -877,7 +896,8 @@ OCaml functional programming language. The expressiveness of this
 language and robustness of its implementation provided a great
 productivity boost.”
 |js}
-  ; body_html = {js|<p>Le projet <a href="https://research.microsoft.com/en-us/projects/slam/">SLAM</a> a
+    ; body_html =
+        {js|<p>Le projet <a href="https://research.microsoft.com/en-us/projects/slam/">SLAM</a> a
 débuté à Microsoft Research début 2000. Son but était de vérifier
 automatiquement qu'un programme C utilise correctement l'interface d'une
 bibliothèque extérieure. Pour répondre à cette question, SLAM utilise de
@@ -897,13 +917,13 @@ OCaml functional programming language. The expressiveness of this
 language and robustness of its implementation provided a great
 productivity boost.”</p>
 |js}
-  };
- 
-  { title = {js|Le synchroniseur de fichiers Unison|js}
-  ; slug = {js|le-synchroniseur-de-fichiers-unison|js}
-  ; image = Some {js|/success-stories/unison-thumb.jpg|js}
-  ; url = Some {js|https://www.cis.upenn.edu/%7Ebcpierce/unison/|js}
-  ; body_md = {js|
+    }
+  ; { title = {js|Le synchroniseur de fichiers Unison|js}
+    ; slug = {js|le-synchroniseur-de-fichiers-unison|js}
+    ; image = Some {js|/success-stories/unison-thumb.jpg|js}
+    ; url = Some {js|https://www.cis.upenn.edu/%7Ebcpierce/unison/|js}
+    ; body_md =
+        {js|
 [Unison](https://www.cis.upenn.edu/%7Ebcpierce/unison/) est un outil de
 synchronisation de fichiers populaire, qui fonctionne sous Windows et
 sous la plupart des variantes d'Unix. Il permet de stocker deux
@@ -934,7 +954,8 @@ unique parmi les projets de grande taille écrits en OCaml, d'avoir été
 *traduit* de Java vers OCaml à mi-chemin au cours de son développement.
 L'adoption d'OCaml a été comme une bouffée d'air pur. »
 |js}
-  ; body_html = {js|<p><a href="https://www.cis.upenn.edu/%7Ebcpierce/unison/">Unison</a> est un outil de
+    ; body_html =
+        {js|<p><a href="https://www.cis.upenn.edu/%7Ebcpierce/unison/">Unison</a> est un outil de
 synchronisation de fichiers populaire, qui fonctionne sous Windows et
 sous la plupart des variantes d'Unix. Il permet de stocker deux
 répliques d'une collection de fichiers et de répertoires sur deux
@@ -963,5 +984,5 @@ unique parmi les projets de grande taille écrits en OCaml, d'avoir été
 <em>traduit</em> de Java vers OCaml à mi-chemin au cours de son développement.
 L'adoption d'OCaml a été comme une bouffée d'air pur. »</p>
 |js}
-  }]
-
+    }
+  ]

--- a/src/ocamlorg_data/tool.ml
+++ b/src/ocamlorg_data/tool.ml
@@ -1,4 +1,3 @@
-
 type lifecycle =
   [ `Incubate
   | `Active
@@ -15,164 +14,164 @@ type t =
   ; description : string
   ; lifecycle : lifecycle
   }
-  
-let all = 
-[
-  { name = {js|Bun|js}
-  ; slug = {js|bun|js}
-  ; source = {js|https://github.com/yomimono/ocaml-bun|js}
-  ; license = {js|MIT|js}
-  ; synopsis = {js|Simple management of afl-fuzz processes|js}
-  ; description = {js|<p>A wrapper for OCaml processes using afl-fuzz, intended for easy use in CI environments.</p>
+
+let all =
+  [ { name = {js|Bun|js}
+    ; slug = {js|bun|js}
+    ; source = {js|https://github.com/yomimono/ocaml-bun|js}
+    ; license = {js|MIT|js}
+    ; synopsis = {js|Simple management of afl-fuzz processes|js}
+    ; description =
+        {js|<p>A wrapper for OCaml processes using afl-fuzz, intended for easy use in CI environments.</p>
 |js}
-  ; lifecycle = `Incubate
-  };
- 
-  { name = {js|Mdx|js}
-  ; slug = {js|mdx|js}
-  ; source = {js|https://github.com/realworldocaml/mdx|js}
-  ; license = {js|ISC|js}
-  ; synopsis = {js|Executable code blocks inside markdown files|js}
-  ; description = {js|<p><code>ocaml-mdx</code> allows to execute code blocks inside markdown files. There are (currently) two sub-commands, corresponding to two modes of operations: pre-processing (<code>ocaml-mdx pp</code>) and tests (<code>ocaml-mdx test</code>).
+    ; lifecycle = `Incubate
+    }
+  ; { name = {js|Mdx|js}
+    ; slug = {js|mdx|js}
+    ; source = {js|https://github.com/realworldocaml/mdx|js}
+    ; license = {js|ISC|js}
+    ; synopsis = {js|Executable code blocks inside markdown files|js}
+    ; description =
+        {js|<p><code>ocaml-mdx</code> allows to execute code blocks inside markdown files. There are (currently) two sub-commands, corresponding to two modes of operations: pre-processing (<code>ocaml-mdx pp</code>) and tests (<code>ocaml-mdx test</code>).
 The pre-processor mode allows to mix documentation and code, and to practice &quot;literate programming&quot; using markdown and OCaml.
 The test mode allows to ensure that shell scripts and OCaml fragments in the documentation always stays up-to-date.
 <code>ocaml-mdx</code> is released as two binaries called <code>ocaml-mdx</code> and <code>mdx</code> which are the same, mdx being the deprecate name, kept for now for compatibility.</p>
 |js}
-  ; lifecycle = `Incubate
-  };
- 
-  { name = {js|OCamlFormat|js}
-  ; slug = {js|ocamlformat|js}
-  ; source = {js|https://github.com/ocaml-ppx/ocamlformat|js}
-  ; license = {js|MIT|js}
-  ; synopsis = {js|Auto-formatter for OCaml code|js}
-  ; description = {js|<p>OCamlFormat is a tool to automatically format OCaml code in a uniform style.</p>
+    ; lifecycle = `Incubate
+    }
+  ; { name = {js|OCamlFormat|js}
+    ; slug = {js|ocamlformat|js}
+    ; source = {js|https://github.com/ocaml-ppx/ocamlformat|js}
+    ; license = {js|MIT|js}
+    ; synopsis = {js|Auto-formatter for OCaml code|js}
+    ; description =
+        {js|<p>OCamlFormat is a tool to automatically format OCaml code in a uniform style.</p>
 |js}
-  ; lifecycle = `Incubate
-  };
- 
-  { name = {js|Dune-release|js}
-  ; slug = {js|dune-release|js}
-  ; source = {js|https://github.com/ocamllabs/dune-release|js}
-  ; license = {js|ISC|js}
-  ; synopsis = {js|Release dune packages in opam|js}
-  ; description = {js|<p><code>dune-release</code> is a tool to streamline the release of Dune packages in <a href="https://opam.ocaml.org">opam</a>. It supports projects built with <a href="https://github.com/ocaml/dune">Dune</a> and hosted on <a href="https://github.com">GitHub</a>.</p>
+    ; lifecycle = `Incubate
+    }
+  ; { name = {js|Dune-release|js}
+    ; slug = {js|dune-release|js}
+    ; source = {js|https://github.com/ocamllabs/dune-release|js}
+    ; license = {js|ISC|js}
+    ; synopsis = {js|Release dune packages in opam|js}
+    ; description =
+        {js|<p><code>dune-release</code> is a tool to streamline the release of Dune packages in <a href="https://opam.ocaml.org">opam</a>. It supports projects built with <a href="https://github.com/ocaml/dune">Dune</a> and hosted on <a href="https://github.com">GitHub</a>.</p>
 |js}
-  ; lifecycle = `Incubate
-  };
- 
-  { name = {js|OCaml LSP|js}
-  ; slug = {js|ocaml-lsp|js}
-  ; source = {js|https://github.com/ocaml/ocaml-lsp|js}
-  ; license = {js|ISC|js}
-  ; synopsis = {js|LSP Server for OCaml|js}
-  ; description = {js|<p>An LSP server for OCaml.</p>
+    ; lifecycle = `Incubate
+    }
+  ; { name = {js|OCaml LSP|js}
+    ; slug = {js|ocaml-lsp|js}
+    ; source = {js|https://github.com/ocaml/ocaml-lsp|js}
+    ; license = {js|ISC|js}
+    ; synopsis = {js|LSP Server for OCaml|js}
+    ; description = {js|<p>An LSP server for OCaml.</p>
 |js}
-  ; lifecycle = `Incubate
-  };
- 
-  { name = {js|Merlin|js}
-  ; slug = {js|merlin|js}
-  ; source = {js|https://github.com/ocaml/merlin|js}
-  ; license = {js|MIT|js}
-  ; synopsis = {js|Editor helper, provides completion, typing and source browsing in Vim and Emacs|js}
-  ; description = {js|<p>Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more.</p>
+    ; lifecycle = `Incubate
+    }
+  ; { name = {js|Merlin|js}
+    ; slug = {js|merlin|js}
+    ; source = {js|https://github.com/ocaml/merlin|js}
+    ; license = {js|MIT|js}
+    ; synopsis =
+        {js|Editor helper, provides completion, typing and source browsing in Vim and Emacs|js}
+    ; description =
+        {js|<p>Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more.</p>
 |js}
-  ; lifecycle = `Active
-  };
- 
-  { name = {js|ppxlib|js}
-  ; slug = {js|ppxlib|js}
-  ; source = {js|https://github.com/ocaml-ppx/ppxlib|js}
-  ; license = {js|MIT|js}
-  ; synopsis = {js|Standard library for ppx rewriters|js}
-  ; description = {js|<p>Ppxlib is the standard library for ppx rewriters and other programs that manipulate the in-memory reprensation of OCaml programs, a.k.a the &quot;Parsetree&quot;.
+    ; lifecycle = `Active
+    }
+  ; { name = {js|ppxlib|js}
+    ; slug = {js|ppxlib|js}
+    ; source = {js|https://github.com/ocaml-ppx/ppxlib|js}
+    ; license = {js|MIT|js}
+    ; synopsis = {js|Standard library for ppx rewriters|js}
+    ; description =
+        {js|<p>Ppxlib is the standard library for ppx rewriters and other programs that manipulate the in-memory reprensation of OCaml programs, a.k.a the &quot;Parsetree&quot;.
 It also comes bundled with two ppx rewriters that are commonly used to write tools that manipulate and/or generate Parsetree values; <code>ppxlib.metaquot</code> which allows to construct Parsetree values using the OCaml syntax directly and <code>ppxlib.traverse</code> which provides various ways of automatically traversing values of a given type, in particular allowing to inject a complex structured value into generated code.</p>
 |js}
-  ; lifecycle = `Active
-  };
- 
-  { name = {js|opam-publish|js}
-  ; slug = {js|opam-publish|js}
-  ; source = {js|https://github.com/ocaml-opam/opam-publish|js}
-  ; license = {js|LGPLv2|js}
-  ; synopsis = {js|A tool to ease contributions to opam repositories|js}
-  ; description = {js|<p>opam-publish automates publishing packages to package repositories: it checks that the opam file is complete using <code>opam lint</code>, verifies and adds the archive URL and its checksum and files a GitHub pull request for merging it.</p>
+    ; lifecycle = `Active
+    }
+  ; { name = {js|opam-publish|js}
+    ; slug = {js|opam-publish|js}
+    ; source = {js|https://github.com/ocaml-opam/opam-publish|js}
+    ; license = {js|LGPLv2|js}
+    ; synopsis = {js|A tool to ease contributions to opam repositories|js}
+    ; description =
+        {js|<p>opam-publish automates publishing packages to package repositories: it checks that the opam file is complete using <code>opam lint</code>, verifies and adds the archive URL and its checksum and files a GitHub pull request for merging it.</p>
 |js}
-  ; lifecycle = `Active
-  };
- 
-  { name = {js|utop|js}
-  ; slug = {js|utop|js}
-  ; source = {js|https://github.com/ocaml-community/utop|js}
-  ; license = {js|3 Clause BSD|js}
-  ; synopsis = {js|Universal toplevel for OCaml|js}
-  ; description = {js|<p>utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for OCaml.  It can run in a terminal or in Emacs. It supports line edition, history, real-time and context sensitive completion, colors, and more.  It integrates with the Tuareg mode in Emacs.</p>
+    ; lifecycle = `Active
+    }
+  ; { name = {js|utop|js}
+    ; slug = {js|utop|js}
+    ; source = {js|https://github.com/ocaml-community/utop|js}
+    ; license = {js|3 Clause BSD|js}
+    ; synopsis = {js|Universal toplevel for OCaml|js}
+    ; description =
+        {js|<p>utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for OCaml.  It can run in a terminal or in Emacs. It supports line edition, history, real-time and context sensitive completion, colors, and more.  It integrates with the Tuareg mode in Emacs.</p>
 |js}
-  ; lifecycle = `Active
-  };
- 
-  { name = {js|Dune|js}
-  ; slug = {js|dune|js}
-  ; source = {js|https://github.com/ocaml/dune|js}
-  ; license = {js|MIT|js}
-  ; synopsis = {js|Fast, portable, and opinionated build system|js}
-  ; description = {js|<p>dune is a build system that was designed to simplify the release of Jane Street packages. It reads metadata from &quot;dune&quot; files following a very simple s-expression syntax.
+    ; lifecycle = `Active
+    }
+  ; { name = {js|Dune|js}
+    ; slug = {js|dune|js}
+    ; source = {js|https://github.com/ocaml/dune|js}
+    ; license = {js|MIT|js}
+    ; synopsis = {js|Fast, portable, and opinionated build system|js}
+    ; description =
+        {js|<p>dune is a build system that was designed to simplify the release of Jane Street packages. It reads metadata from &quot;dune&quot; files following a very simple s-expression syntax.
 dune is fast, has very low-overhead, and supports parallel builds on all platforms. It has no system dependencies; all you need to build dune or packages using dune is OCaml. You don't need make or bash as long as the packages themselves don't use bash explicitly.
 dune supports multi-package development by simply dropping multiple repositories into the same directory.
 It also supports multi-context builds, such as building against several opam roots/switches simultaneously. This helps maintaining packages across several versions of OCaml and gives cross-compilation for free.</p>
 |js}
-  ; lifecycle = `Active
-  };
- 
-  { name = {js|omp|js}
-  ; slug = {js|omp|js}
-  ; source = {js|https://github.com/ocaml-ppx/ocaml-migrate-parsetree|js}
-  ; license = {js|LGPLv2|js}
-  ; synopsis = {js|Convert OCaml parsetrees between different versions|js}
-  ; description = {js|<p>Convert OCaml parsetrees between different versions
+    ; lifecycle = `Active
+    }
+  ; { name = {js|omp|js}
+    ; slug = {js|omp|js}
+    ; source = {js|https://github.com/ocaml-ppx/ocaml-migrate-parsetree|js}
+    ; license = {js|LGPLv2|js}
+    ; synopsis = {js|Convert OCaml parsetrees between different versions|js}
+    ; description =
+        {js|<p>Convert OCaml parsetrees between different versions
 This library converts parsetrees, outcometree and ast mappers between different OCaml versions.  High-level functions help making PPX rewriters independent of a compiler version.</p>
 |js}
-  ; lifecycle = `Sustain
-  };
- 
-  { name = {js|ocamlbuild|js}
-  ; slug = {js|ocamlbuild|js}
-  ; source = {js|https://github.com/ocaml/ocamlbuild|js}
-  ; license = {js|LGPLv2|js}
-  ; synopsis = {js|OCamlbuild is a build system with builtin rules to easily build most OCaml projects|js}
-  ; description = {js||js}
-  ; lifecycle = `Sustain
-  };
- 
-  { name = {js|ocamlfind|js}
-  ; slug = {js|ocamlfind|js}
-  ; source = {js|https://github.com/ocaml/ocamlfind|js}
-  ; license = {js|MIT|js}
-  ; synopsis = {js|A library manager for OCaml|js}
-  ; description = {js|<p>Findlib is a library manager for OCaml. It provides a convention how to store libraries, and a file format (&quot;META&quot;) to describe the properties of libraries. There is also a tool (ocamlfind) for interpreting the META files, so that it is very easy to use libraries in programs and scripts.</p>
+    ; lifecycle = `Sustain
+    }
+  ; { name = {js|ocamlbuild|js}
+    ; slug = {js|ocamlbuild|js}
+    ; source = {js|https://github.com/ocaml/ocamlbuild|js}
+    ; license = {js|LGPLv2|js}
+    ; synopsis =
+        {js|OCamlbuild is a build system with builtin rules to easily build most OCaml projects|js}
+    ; description = {js||js}
+    ; lifecycle = `Sustain
+    }
+  ; { name = {js|ocamlfind|js}
+    ; slug = {js|ocamlfind|js}
+    ; source = {js|https://github.com/ocaml/ocamlfind|js}
+    ; license = {js|MIT|js}
+    ; synopsis = {js|A library manager for OCaml|js}
+    ; description =
+        {js|<p>Findlib is a library manager for OCaml. It provides a convention how to store libraries, and a file format (&quot;META&quot;) to describe the properties of libraries. There is also a tool (ocamlfind) for interpreting the META files, so that it is very easy to use libraries in programs and scripts.</p>
 |js}
-  ; lifecycle = `Sustain
-  };
- 
-  { name = {js|ocp-indent|js}
-  ; slug = {js|ocp-indent|js}
-  ; source = {js|https://github.com/OCamlPro/ocp-indent|js}
-  ; license = {js|LGPLv2|js}
-  ; synopsis = {js|A simple tool to indent OCaml programs|js}
-  ; description = {js|<p>Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack machine ; this is much faster and more reliable than using regexps. Presets and configuration options available, with the possibility to set them project-wide. Supports most common syntax extensions, and extensible for others.
+    ; lifecycle = `Sustain
+    }
+  ; { name = {js|ocp-indent|js}
+    ; slug = {js|ocp-indent|js}
+    ; source = {js|https://github.com/OCamlPro/ocp-indent|js}
+    ; license = {js|LGPLv2|js}
+    ; synopsis = {js|A simple tool to indent OCaml programs|js}
+    ; description =
+        {js|<p>Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack machine ; this is much faster and more reliable than using regexps. Presets and configuration options available, with the possibility to set them project-wide. Supports most common syntax extensions, and extensible for others.
 Includes: - An indentor program, callable from the command-line or from within editors - Bindings for popular editors - A library that can be directly used by editor writers, or just for
 fault-tolerant/approximate parsing.</p>
 |js}
-  ; lifecycle = `Sustain
-  };
- 
-  { name = {js|oasis|js}
-  ; slug = {js|oasis|js}
-  ; source = {js|https://github.com/ocaml/oasis|js}
-  ; license = {js|LGPLv2|js}
-  ; synopsis = {js|Tooling for building OCaml libraries and applications|js}
-  ; description = {js|<p>OASIS generates a full configure, build and install system for your application. It starts with a simple _oasis file at the toplevel of your project and creates everything required.
+    ; lifecycle = `Sustain
+    }
+  ; { name = {js|oasis|js}
+    ; slug = {js|oasis|js}
+    ; source = {js|https://github.com/ocaml/oasis|js}
+    ; license = {js|LGPLv2|js}
+    ; synopsis = {js|Tooling for building OCaml libraries and applications|js}
+    ; description =
+        {js|<p>OASIS generates a full configure, build and install system for your application. It starts with a simple _oasis file at the toplevel of your project and creates everything required.
 OASIS leverages existing OCaml tooling to perform most of it's work. In fact, it might be more appropriate to think of it as simply the glue that binds these other subsystems together and coordinates the work that they do. It should support the following tools:</p>
 <ul>
 <li>OCamlbuild - OMake - OCamlMakefile (todo), - ocaml-autoconf (todo)
@@ -181,17 +180,18 @@ It also allows to have standard entry points and description. It helps to integr
 </li>
 </ul>
 |js}
-  ; lifecycle = `Deprecate
-  };
- 
-  { name = {js|camlp4|js}
-  ; slug = {js|camlp4|js}
-  ; source = {js|https://github.com/camlp4/camlp4|js}
-  ; license = {js|LGPLv2|js}
-  ; synopsis = {js|Camlp4 is a system for writing extensible parsers for programming languages|js}
-  ; description = {js|<p>It provides a set of OCaml libraries that are used to define grammars as well as loadable syntax extensions of such grammars. Camlp4 stands for Caml Preprocessor and Pretty-Printer and one of its most important applications is the definition of domain-specific extensions of the syntax of OCaml.
+    ; lifecycle = `Deprecate
+    }
+  ; { name = {js|camlp4|js}
+    ; slug = {js|camlp4|js}
+    ; source = {js|https://github.com/camlp4/camlp4|js}
+    ; license = {js|LGPLv2|js}
+    ; synopsis =
+        {js|Camlp4 is a system for writing extensible parsers for programming languages|js}
+    ; description =
+        {js|<p>It provides a set of OCaml libraries that are used to define grammars as well as loadable syntax extensions of such grammars. Camlp4 stands for Caml Preprocessor and Pretty-Printer and one of its most important applications is the definition of domain-specific extensions of the syntax of OCaml.
 Camlp4 was part of the official OCaml distribution until its version 4.01.0. Since then it has been replaced by a simpler system which is easier to maintain and to learn: ppx rewriters and extension points.</p>
 |js}
-  ; lifecycle = `Deprecate
-  }]
-
+    ; lifecycle = `Deprecate
+    }
+  ]

--- a/src/ocamlorg_data/tutorial.ml
+++ b/src/ocamlorg_data/tutorial.ml
@@ -1,4 +1,3 @@
-
 type difficulty =
   [ `Beginner
   | `Intermediate
@@ -16,18 +15,18 @@ type t =
   ; toc_html : string
   ; body_html : string
   }
-  
-let all = 
-[
-  { title = {js|Up and Running with OCaml|js}
-  ; slug = {js|up-and-running-with-ocaml|js}
-  ; description = {js|Help you install OCaml, the Dune build system, and support for your favourite text editor or IDE.
+
+let all =
+  [ { title = {js|Up and Running with OCaml|js}
+    ; slug = {js|up-and-running-with-ocaml|js}
+    ; description =
+        {js|Help you install OCaml, the Dune build system, and support for your favourite text editor or IDE.
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["getting-started"]
-  ; users = [`Beginner]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "getting-started" ]
+    ; users = [ `Beginner ]
+    ; body_md =
+        {js|
 This page will help you install OCaml, the Dune build system, and support for
 your favourite text editor or IDE. These instructions work on Windows, Unix
 systems like Linux, and macOS.
@@ -251,7 +250,8 @@ Vim:
 let $PATH .= ";".substitute(system('opam config var bin'),'\\n$','','''')
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#installing-ocaml">Installing OCaml</a>
 </li>
@@ -267,7 +267,8 @@ let $PATH .= ";".substitute(system('opam config var bin'),'\\n$','','''')
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This page will help you install OCaml, the Dune build system, and support for
+    ; body_html =
+        {js|<p>This page will help you install OCaml, the Dune build system, and support for
 your favourite text editor or IDE. These instructions work on Windows, Unix
 systems like Linux, and macOS.</p>
 <h2 id="installing-ocaml">Installing OCaml</h2>
@@ -422,17 +423,17 @@ Vim:</p>
 <pre><code>let $PATH .= &quot;;&quot;.substitute(system('opam config var bin'),'\\n$','','''')
 </code></pre>
 |js}
-  };
- 
-  { title = {js|A First Hour with OCaml|js}
-  ; slug = {js|a-first-hour-with-ocaml|js}
-  ; description = {js|Discover the OCaml programming language in this longer tutorial that takes you from absolute beginner to someone who is able to write programs in OCaml.
+    }
+  ; { title = {js|A First Hour with OCaml|js}
+    ; slug = {js|a-first-hour-with-ocaml|js}
+    ; description =
+        {js|Discover the OCaml programming language in this longer tutorial that takes you from absolute beginner to someone who is able to write programs in OCaml.
 |js}
-  ; date = {js|2021-08-06T17:11:00-00:00|js}
-  ; tags = 
- ["getting-started"]
-  ; users = [`Beginner]
-  ; body_md = {js|
+    ; date = {js|2021-08-06T17:11:00-00:00|js}
+    ; tags = [ "getting-started" ]
+    ; users = [ `Beginner ]
+    ; body_md =
+        {js|
 You may follow along with this tutorial with just a basic OCaml installation,
 as described in [Up and Running](up_and_running.html).
 
@@ -1425,7 +1426,8 @@ like to explore it further. Elsewhere on [ocaml.org](/index.html) there are
 pointers to [books on OCaml](/learn/books.html) and
 [other tutorials](/learn/tutorials/index.html).
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#running-ocaml-programs">Running OCaml programs</a>
 </li>
@@ -1459,7 +1461,8 @@ pointers to [books on OCaml](/learn/books.html) and
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>You may follow along with this tutorial with just a basic OCaml installation,
+    ; body_html =
+        {js|<p>You may follow along with this tutorial with just a basic OCaml installation,
 as described in <a href="up_and_running.html">Up and Running</a>.</p>
 <p>Alternatively, you may follow almost all of it by running OCaml in your browser
 using <a href="http://try.ocamlpro.com">TryOCaml</a>, with no installation required.</p>
@@ -2197,17 +2200,16 @@ like to explore it further. Elsewhere on <a href="/index.html">ocaml.org</a> the
 pointers to <a href="/learn/books.html">books on OCaml</a> and
 <a href="/learn/tutorials/index.html">other tutorials</a>.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Programming Guidelines|js}
-  ; slug = {js|ocaml-programming-guidelines|js}
-  ; description = {js|Opinionated guidelines for writing OCaml code
+    }
+  ; { title = {js|OCaml Programming Guidelines|js}
+    ; slug = {js|ocaml-programming-guidelines|js}
+    ; description = {js|Opinionated guidelines for writing OCaml code
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["getting-started"]
-  ; users = [`Beginner; `Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "getting-started" ]
+    ; users = [ `Beginner; `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 This is a set of reasonable guidelines for formatting OCaml
 programs—guidelines which reflect the consensus among veteran OCaml
 programmers. Nevertheless, all detailed notifications of possible errors
@@ -3974,7 +3976,8 @@ look of an algorithm that performs pattern matching and recursive
 calls to handle an argument that belongs to a recursive sum data type.
 
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#general-guidelines-to-write-programs">General guidelines to write programs</a>
 </li>
@@ -3992,7 +3995,8 @@ calls to handle an argument that belongs to a recursive sum data type.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This is a set of reasonable guidelines for formatting OCaml
+    ; body_html =
+        {js|<p>This is a set of reasonable guidelines for formatting OCaml
 programs—guidelines which reflect the consensus among veteran OCaml
 programmers. Nevertheless, all detailed notifications of possible errors
 or omissions will be noted with pleasure. To send your comments using
@@ -5516,17 +5520,17 @@ as the imperative program with the additional clarity and natural
 look of an algorithm that performs pattern matching and recursive
 calls to handle an argument that belongs to a recursive sum data type.</p>
 |js}
-  };
- 
-  { title = {js|Compiling OCaml Projects|js}
-  ; slug = {js|compiling-ocaml-projects|js}
-  ; description = {js|An introduction to the OCaml compiler tools for building OCaml projects as well as the most common build tools
+    }
+  ; { title = {js|Compiling OCaml Projects|js}
+    ; slug = {js|compiling-ocaml-projects|js}
+    ; description =
+        {js|An introduction to the OCaml compiler tools for building OCaml projects as well as the most common build tools
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["getting-started"]
-  ; users = [`Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "getting-started" ]
+    ; users = [ `Intermediate ]
+    ; body_md =
+        {js|
 This tutorial explains how to compile your OCaml programs into executable form.
 It addresses, in turn:
 
@@ -5698,7 +5702,8 @@ structure, build, and run dune projects.
 - [GNU make](https://www.gnu.org/software/make/) GNU make can build anything, including OCaml. May be used in conjunction with [OCamlmakefile](https://github.com/mmottl/ocaml-makefile)
 - [Oasis](https://github.com/ocaml/oasis) Generates a configure, build, and install system from a specification.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#compilation-basics">Compilation basics</a>
 </li>
@@ -5712,7 +5717,8 @@ structure, build, and run dune projects.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This tutorial explains how to compile your OCaml programs into executable form.
+    ; body_html =
+        {js|<p>This tutorial explains how to compile your OCaml programs into executable form.
 It addresses, in turn:</p>
 <ol>
 <li>
@@ -5854,17 +5860,17 @@ structure, build, and run dune projects.</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { title = {js|Data Types and Matching|js}
-  ; slug = {js|data-types-and-matching|js}
-  ; description = {js|Learn to build custom types and write function to process this data
+    }
+  ; { title = {js|Data Types and Matching|js}
+    ; slug = {js|data-types-and-matching|js}
+    ; description =
+        {js|Learn to build custom types and write function to process this data
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 In this tutorial we learn how to build our own types in OCaml, and how to write
 functions which process this new data.
 
@@ -6405,7 +6411,8 @@ Traditionally, we name the type `t`. In the program using this library, it
 would then be `Png.t` which is shorter, reads better than `Png.png`, and avoids
 confusion if the library also defines other types.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#built-in-compound-types">Built-in compound types</a>
 </li>
@@ -6427,7 +6434,8 @@ confusion if the library also defines other types.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>In this tutorial we learn how to build our own types in OCaml, and how to write
+    ; body_html =
+        {js|<p>In this tutorial we learn how to build our own types in OCaml, and how to write
 functions which process this new data.</p>
 <h2 id="built-in-compound-types">Built-in compound types</h2>
 <p>We have already seen simple data types such as <code>int</code>, <code>float</code>, <code>string</code>, and
@@ -6850,17 +6858,17 @@ val rotate : float -&gt; t -&gt; t
 would then be <code>Png.t</code> which is shorter, reads better than <code>Png.png</code>, and avoids
 confusion if the library also defines other types.</p>
 |js}
-  };
- 
-  { title = {js|Lists|js}
-  ; slug = {js|lists|js}
-  ; description = {js|Learn about one of OCaml's must used, built-in data types
+    }
+  ; { title = {js|Lists|js}
+    ; slug = {js|lists|js}
+    ; description =
+        {js|Learn about one of OCaml's must used, built-in data types
 |js}
-  ; date = {js|2021-08-06T17:28:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-08-06T17:28:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 A list is an ordered sequence of elements. All elements of a list in OCaml must
 be the same type. Lists are built into the language and have a special syntax.
 Here is a list of three integers:
@@ -7364,7 +7372,8 @@ val length : 'a list -> int = <fun>
 In the standard library documentation, functions which are not tail-recursive
 are marked.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#the-standard-library-list-module">The standard library List module</a>
 </li>
@@ -7374,7 +7383,8 @@ are marked.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>A list is an ordered sequence of elements. All elements of a list in OCaml must
+    ; body_html =
+        {js|<p>A list is an ordered sequence of elements. All elements of a list in OCaml must
 be the same type. Lists are built into the language and have a special syntax.
 Here is a list of three integers:</p>
 <pre><code class="language-ocaml"># [1; 2; 3]
@@ -7749,17 +7759,16 @@ val length : 'a list -&gt; int = &lt;fun&gt;
 <p>In the standard library documentation, functions which are not tail-recursive
 are marked.</p>
 |js}
-  };
- 
-  { title = {js|Functional Programming|js}
-  ; slug = {js|functional-programming|js}
-  ; description = {js|A guide to functional programming in OCaml
+    }
+  ; { title = {js|Functional Programming|js}
+    ; slug = {js|functional-programming|js}
+    ; description = {js|A guide to functional programming in OCaml
 |js}
-  ; date = {js|2021-08-06T17:16:00-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-08-06T17:16:00-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 ## What is functional programming?
 We've got quite far into the tutorial, yet we haven't really considered
 **functional programming**. All of the features given so far - rich data
@@ -8232,7 +8241,8 @@ let print_string = output_string stdout
 we have only supplied one, it is partially applied. So `print_string` is
 a function, expecting one string argument.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#what-is-functional-programming">What is functional programming?</a>
 </li>
@@ -8252,7 +8262,8 @@ a function, expecting one string argument.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="what-is-functional-programming">What is functional programming?</h2>
+    ; body_html =
+        {js|<h2 id="what-is-functional-programming">What is functional programming?</h2>
 <p>We've got quite far into the tutorial, yet we haven't really considered
 <strong>functional programming</strong>. All of the features given so far - rich data
 types, pattern matching, type inference, nested functions - you could
@@ -8625,17 +8636,16 @@ can be thought of as a kind of alias for a function name plus arguments:</p>
 we have only supplied one, it is partially applied. So <code>print_string</code> is
 a function, expecting one string argument.</p>
 |js}
-  };
- 
-  { title = {js|If Statements, Loops and Recursions|js}
-  ; slug = {js|if-statements-loops-and-recursions|js}
-  ; description = {js|Learn basic control-flow and recursion in OCaml
+    }
+  ; { title = {js|If Statements, Loops and Recursions|js}
+    ; slug = {js|if-statements-loops-and-recursions|js}
+    ; description = {js|Learn basic control-flow and recursion in OCaml
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 ## If statements (actually, these are if expressions)
 OCaml has an `if` statement with two variations, and the obvious meaning:
 
@@ -9887,7 +9897,8 @@ You can also
 use similar syntax for writing mutually recursive class definitions and
 modules.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#if-statements-actually-these-are-if-expressions">If statements (actually, these are if expressions)</a>
 </li>
@@ -9909,7 +9920,8 @@ modules.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="if-statements-actually-these-are-if-expressions">If statements (actually, these are if expressions)</h2>
+    ; body_html =
+        {js|<h2 id="if-statements-actually-these-are-if-expressions">If statements (actually, these are if expressions)</h2>
 <p>OCaml has an <code>if</code> statement with two variations, and the obvious meaning:</p>
 <!-- $MDX skip -->
 <pre><code class="language-ocaml">if boolean-condition then expression
@@ -10930,17 +10942,17 @@ Error: Unbound value odd
 use similar syntax for writing mutually recursive class definitions and
 modules.</p>
 |js}
-  };
- 
-  { title = {js|Modules|js}
-  ; slug = {js|modules|js}
-  ; description = {js|Learn about OCaml modules and how they can be used to cleanly separate distinct parts of your program
+    }
+  ; { title = {js|Modules|js}
+    ; slug = {js|modules|js}
+    ; description =
+        {js|Learn about OCaml modules and how they can be used to cleanly separate distinct parts of your program
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 ## Basic usage
 
 In OCaml, every piece of code is wrapped into a module. Optionally, a module
@@ -11397,7 +11409,8 @@ open Extensions
 List.optmap ...
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#basic-usage">Basic usage</a>
 </li>
@@ -11413,7 +11426,8 @@ List.optmap ...
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="basic-usage">Basic usage</h2>
+    ; body_html =
+        {js|<h2 id="basic-usage">Basic usage</h2>
 <p>In OCaml, every piece of code is wrapped into a module. Optionally, a module
 itself can be a submodule of another module, pretty much like directories in a
 file system - but we don't do this very often.</p>
@@ -11788,17 +11802,16 @@ the .ml file:</p>
 List.optmap ...
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Labels|js}
-  ; slug = {js|labels|js}
-  ; description = {js|Provide labels to your functions arguments
+    }
+  ; { title = {js|Labels|js}
+    ; slug = {js|labels|js}
+    ; description = {js|Provide labels to your functions arguments
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Labelled and optional arguments to functions
 
 Python has a nice syntax for writing arguments to functions. Here's
@@ -12423,7 +12436,8 @@ your code. You will, however, see them in advanced OCaml code quite a
 lot precisely because advanced programmers will sometimes want to weaken
 the type system to write advanced idioms.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#labelled-and-optional-arguments-to-functions">Labelled and optional arguments to functions</a>
 </li>
@@ -12433,7 +12447,8 @@ the type system to write advanced idioms.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="labelled-and-optional-arguments-to-functions">Labelled and optional arguments to functions</h2>
+    ; body_html =
+        {js|<h2 id="labelled-and-optional-arguments-to-functions">Labelled and optional arguments to functions</h2>
 <p>Python has a nice syntax for writing arguments to functions. Here's
 an example (from the Python tutorial, since I'm not a Python
 programmer):</p>
@@ -12909,17 +12924,16 @@ your code. You will, however, see them in advanced OCaml code quite a
 lot precisely because advanced programmers will sometimes want to weaken
 the type system to write advanced idioms.</p>
 |js}
-  };
- 
-  { title = {js|Pointers in OCaml|js}
-  ; slug = {js|pointers-in-ocaml|js}
-  ; description = {js|Use OCaml's explicit pointers with references
+    }
+  ; { title = {js|Pointers in OCaml|js}
+    ; slug = {js|pointers-in-ocaml|js}
+    ; description = {js|Use OCaml's explicit pointers with references
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Status of pointers in OCaml
 Pointers exist in OCaml, and in fact they spread all over the place.
 They are used either implicitly (in the most cases), or explicitly (in
@@ -13223,7 +13237,8 @@ val tl : 'a lists -> 'a lists = <fun>
 val append : 'a lists -> 'a lists -> unit = <fun>
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#status-of-pointers-in-ocaml">Status of pointers in OCaml</a>
 </li>
@@ -13237,7 +13252,8 @@ val append : 'a lists -> 'a lists -> unit = <fun>
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="status-of-pointers-in-ocaml">Status of pointers in OCaml</h2>
+    ; body_html =
+        {js|<h2 id="status-of-pointers-in-ocaml">Status of pointers in OCaml</h2>
 <p>Pointers exist in OCaml, and in fact they spread all over the place.
 They are used either implicitly (in the most cases), or explicitly (in
 the rare occasions where implicit pointers are not more handy). The vast
@@ -13488,17 +13504,17 @@ val tl : 'a lists -&gt; 'a lists = &lt;fun&gt;
 val append : 'a lists -&gt; 'a lists -&gt; unit = &lt;fun&gt;
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Null Pointers, Asserts and Warnings|js}
-  ; slug = {js|null-pointers-asserts-and-warnings|js}
-  ; description = {js|Handling warnings and asserting invariants for your code
+    }
+  ; { title = {js|Null Pointers, Asserts and Warnings|js}
+    ; slug = {js|null-pointers-asserts-and-warnings|js}
+    ; description =
+        {js|Handling warnings and asserting invariants for your code
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Null pointers
 So you've got a survey on your website which asks your readers for their
 names and ages. Only problem is that for some reason a few of your
@@ -13641,7 +13657,8 @@ let () =
   ignore(read_line ())
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#null-pointers">Null pointers</a>
 </li>
@@ -13651,7 +13668,8 @@ let () =
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="null-pointers">Null pointers</h2>
+    ; body_html =
+        {js|<h2 id="null-pointers">Null pointers</h2>
 <p>So you've got a survey on your website which asks your readers for their
 names and ages. Only problem is that for some reason a few of your
 readers don't want to give you their age - they stubbornly refuse to
@@ -13761,17 +13779,17 @@ let () =
   ignore(read_line ())
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Functors|js}
-  ; slug = {js|functors|js}
-  ; description = {js|Learn about functors, modules parameterised by other modules
+    }
+  ; { title = {js|Functors|js}
+    ; slug = {js|functors|js}
+    ; description =
+        {js|Learn about functors, modules parameterised by other modules
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 Functors are probably one of the most complex features of OCaml, but you don't
 have to use them extensively to be a successful OCaml programmer.  Actually,
 you may never have to define a functor yourself, but you will surely encounter
@@ -13953,7 +13971,8 @@ the source files
 [`map.ml`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/map.ml) of the
 standard library.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#what-are-functors-and-why-do-we-need-them">What are functors and why do we need them?</a>
 </li>
@@ -13965,7 +13984,8 @@ standard library.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>Functors are probably one of the most complex features of OCaml, but you don't
+    ; body_html =
+        {js|<p>Functors are probably one of the most complex features of OCaml, but you don't
 have to use them extensively to be a successful OCaml programmer.  Actually,
 you may never have to define a functor yourself, but you will surely encounter
 them in the standard library. They are the only way of using the Set and Map
@@ -14122,17 +14142,17 @@ the source files
 <a href="https://github.com/ocaml/ocaml/blob/trunk/stdlib/map.ml"><code>map.ml</code></a> of the
 standard library.</p>
 |js}
-  };
- 
-  { title = {js|Objects|js}
-  ; slug = {js|objects|js}
-  ; description = {js|OCaml is an object-oriented, imperative, functional programming language
+    }
+  ; { title = {js|Objects|js}
+    ; slug = {js|objects|js}
+    ; description =
+        {js|OCaml is an object-oriented, imperative, functional programming language
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Objects and classes
 OCaml is an object-oriented, imperative, functional programming language
 :-) It mixes all these paradigms and lets you use the most appropriate
@@ -14832,7 +14852,8 @@ Error: This expression has type < get : int; special : string >
 val l : t list = [<obj>; <obj>]
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#objects-and-classes">Objects and classes</a>
 </li>
@@ -14842,7 +14863,8 @@ val l : t list = [<obj>; <obj>]
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="objects-and-classes">Objects and classes</h2>
+    ; body_html =
+        {js|<h2 id="objects-and-classes">Objects and classes</h2>
 <p>OCaml is an object-oriented, imperative, functional programming language
 :-) It mixes all these paradigms and lets you use the most appropriate
 (or most familiar) programming paradigm for the task at hand. In this
@@ -15444,17 +15466,17 @@ Error: This expression has type &lt; get : int; special : string &gt;
 val l : t list = [&lt;obj&gt;; &lt;obj&gt;]
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Error Handling|js}
-  ; slug = {js|error-handling|js}
-  ; description = {js|Discover the different ways you can manage errors in your OCaml programs
+    }
+  ; { title = {js|Error Handling|js}
+    ; slug = {js|error-handling|js}
+    ; description =
+        {js|Discover the different ways you can manage errors in your OCaml programs
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["errors"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "errors" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 ## Exceptions
 
 One way of handling errors in OCaml is exceptions. The
@@ -15607,7 +15629,8 @@ are:
 For easy combination of functions that can fail, many alternative standard
 libraries provide useful combinators on the `result` type: `map`, `>>=`, etc.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#exceptions">Exceptions</a>
 </li>
@@ -15617,7 +15640,8 @@ libraries provide useful combinators on the `result` type: `map`, `>>=`, etc.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="exceptions">Exceptions</h2>
+    ; body_html =
+        {js|<h2 id="exceptions">Exceptions</h2>
 <p>One way of handling errors in OCaml is exceptions. The
 standard library relies heavily upon them.</p>
 <p>Exceptions belong to the type <code>exn</code> (an extensible sum type):</p>
@@ -15737,17 +15761,17 @@ sometimes make error messages hard to read.
 <p>For easy combination of functions that can fail, many alternative standard
 libraries provide useful combinators on the <code>result</code> type: <code>map</code>, <code>&gt;&gt;=</code>, etc.</p>
 |js}
-  };
- 
-  { title = {js|Common Error Messages|js}
-  ; slug = {js|common-error-messages|js}
-  ; description = {js|Understand the most common error messages the OCaml compiler can throw at you
+    }
+  ; { title = {js|Common Error Messages|js}
+    ; slug = {js|common-error-messages|js}
+    ; description =
+        {js|Understand the most common error messages the OCaml compiler can throw at you
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["errors"; "debugging"]
-  ; users = [`Beginner]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "errors"; "debugging" ]
+    ; users = [ `Beginner ]
+    ; body_md =
+        {js|
 This page gives a list of quick explanations for some error or warning
 messages that are emitted by the OCaml compilers. Longer explanations
 are usually given in dedicated sections of this tutorial.
@@ -15978,7 +16002,8 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 - : string = "\\\\e\\n"
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#type-errors">Type errors</a>
 </li>
@@ -15990,7 +16015,8 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This page gives a list of quick explanations for some error or warning
+    ; body_html =
+        {js|<p>This page gives a list of quick explanations for some error or warning
 messages that are emitted by the OCaml compilers. Longer explanations
 are usually given in dedicated sections of this tutorial.</p>
 <h2 id="type-errors">Type errors</h2>
@@ -16174,17 +16200,17 @@ Warning 14 [illegal-backslash]: illegal backslash escape in string.
 - : string = &quot;\\\\e\\n&quot;
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Debug|js}
-  ; slug = {js|debug|js}
-  ; description = {js|Learn to build custom types and write function to process this data
+    }
+  ; { title = {js|Debug|js}
+    ; slug = {js|debug|js}
+    ; description =
+        {js|Learn to build custom types and write function to process this data
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["debugging"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "debugging" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 This tutorial presents two techniques for debugging OCaml programs:
 
 * [Tracing functions calls](#Tracingfunctionscallsinthetoplevel),
@@ -16509,7 +16535,8 @@ will send you directly to the file and character reported by the debugger, and
 you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
 points using `CTRL-X space`, and so on...
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#tracing-functions-calls-in-the-toplevel">Tracing functions calls in the toplevel</a>
 </li>
@@ -16519,7 +16546,8 @@ points using `CTRL-X space`, and so on...
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This tutorial presents two techniques for debugging OCaml programs:</p>
+    ; body_html =
+        {js|<p>This tutorial presents two techniques for debugging OCaml programs:</p>
 <ul>
 <li><a href="#Tracingfunctionscallsinthetoplevel">Tracing functions calls</a>,
 which works in the interactive toplevel.
@@ -16778,17 +16806,17 @@ will send you directly to the file and character reported by the debugger, and
 you can step back and forth using <code>ESC-b</code> and <code>ESC-s</code>, you can set up break
 points using <code>CTRL-X space</code>, and so on...</p>
 |js}
-  };
- 
-  { title = {js|Map|js}
-  ; slug = {js|map|js}
-  ; description = {js|Create a mapping using the standard library's Map module
+    }
+  ; { title = {js|Map|js}
+    ; slug = {js|map|js}
+    ; description =
+        {js|Create a mapping using the standard library's Map module
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["stdlib"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "stdlib" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 ## Module Map
 
 Map creates a "mapping". For instance, let's say I have some data that is
@@ -16921,7 +16949,8 @@ quickly find the data. Let's actually show how to do a find.
 This should quickly and efficiently return Fred's password: "sugarplums".
 
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#module-map">Module Map</a>
 </li>
@@ -16929,7 +16958,8 @@ This should quickly and efficiently return Fred's password: "sugarplums".
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="module-map">Module Map</h2>
+    ; body_html =
+        {js|<h2 id="module-map">Module Map</h2>
 <p>Map creates a &quot;mapping&quot;. For instance, let's say I have some data that is
 users and their associated passwords. I could with the Map module create
 a mapping from user names to their passwords. The mapping module not
@@ -17037,17 +17067,16 @@ quickly find the data. Let's actually show how to do a find.</p>
 </code></pre>
 <p>This should quickly and efficiently return Fred's password: &quot;sugarplums&quot;.</p>
 |js}
-  };
- 
-  { title = {js|Sets|js}
-  ; slug = {js|sets|js}
-  ; description = {js|The standard library's Set module
+    }
+  ; { title = {js|Sets|js}
+    ; slug = {js|sets|js}
+    ; description = {js|The standard library's Set module
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["stdlib"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "stdlib" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 ## Module Set
 To make a set of strings:
 
@@ -17184,7 +17213,8 @@ returns a new set that is very similar to (and shares much of its
 internals with) the original set.
 
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#module-set">Module Set</a>
 </li>
@@ -17192,7 +17222,8 @@ internals with) the original set.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="module-set">Module Set</h2>
+    ; body_html =
+        {js|<h2 id="module-set">Module Set</h2>
 <p>To make a set of strings:</p>
 <pre><code class="language-ocaml"># module SS = Set.Make(String)
 module SS :
@@ -17299,17 +17330,17 @@ removing an element from a set does not alter that set but, rather,
 returns a new set that is very similar to (and shares much of its
 internals with) the original set.</p>
 |js}
-  };
- 
-  { title = {js|Hashtables|js}
-  ; slug = {js|hashtables|js}
-  ; description = {js|Discover efficient and mutable lookup tables with OCaml's Hashtbl module
+    }
+  ; { title = {js|Hashtables|js}
+    ; slug = {js|hashtables|js}
+    ; description =
+        {js|Discover efficient and mutable lookup tables with OCaml's Hashtbl module
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["stdlib"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "stdlib" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Module Hashtbl
 
 The Hashtbl module implements an efficient, mutable lookup table. To
@@ -17415,7 +17446,8 @@ entry in `my_hash` for a letter we would do:
 - : bool = true
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#module-hashtbl">Module Hashtbl</a>
 </li>
@@ -17423,7 +17455,8 @@ entry in `my_hash` for a letter we would do:
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="module-hashtbl">Module Hashtbl</h2>
+    ; body_html =
+        {js|<h2 id="module-hashtbl">Module Hashtbl</h2>
 <p>The Hashtbl module implements an efficient, mutable lookup table. To
 create a hash table we could write:</p>
 <pre><code class="language-ocaml"># let my_hash = Hashtbl.create 123456
@@ -17500,17 +17533,17 @@ entry in <code>my_hash</code> for a letter we would do:</p>
 - : bool = true
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Streams|js}
-  ; slug = {js|streams|js}
-  ; description = {js|Streams offer an abstraction over consuming items from sequences
+    }
+  ; { title = {js|Streams|js}
+    ; slug = {js|streams|js}
+    ; description =
+        {js|Streams offer an abstraction over consuming items from sequences
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["stdlib"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "stdlib" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 Suppose you need to process each line of a text file. One way to do this
 is to read the file in as a single large string and use something like
 `Str.split` to turn it into a list. This works when the file is small,
@@ -18237,7 +18270,8 @@ In addition, there are a few undocumented functions: `iapp`, `icons`,
 are visible in the interface with the caveat: "For system use only, not
 for the casual user".
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#constructing-streams">Constructing streams</a>
 </li>
@@ -18261,7 +18295,8 @@ for the casual user".
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>Suppose you need to process each line of a text file. One way to do this
+    ; body_html =
+        {js|<p>Suppose you need to process each line of a text file. One way to do this
 is to read the file in as a single large string and use something like
 <code>Str.split</code> to turn it into a list. This works when the file is small,
 but because the entire file is loaded into memory, it does not scale
@@ -18895,17 +18930,17 @@ elements)
 are visible in the interface with the caveat: &quot;For system use only, not
 for the casual user&quot;.</p>
 |js}
-  };
- 
-  { title = {js|Format|js}
-  ; slug = {js|format|js}
-  ; description = {js|The Format module of Caml Light and OCaml's standard libraries provides pretty-printing facilities to get a fancy display for printing routines
+    }
+  ; { title = {js|Format|js}
+    ; slug = {js|format|js}
+    ; description =
+        {js|The Format module of Caml Light and OCaml's standard libraries provides pretty-printing facilities to get a fancy display for printing routines
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["stdlib"; "common"]
-  ; users = [`Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "stdlib"; "common" ]
+    ; users = [ `Intermediate ]
+    ; body_md =
+        {js|
 The `Format` module of Caml Light and OCaml's standard libraries
 provides pretty-printing facilities to get a fancy display for printing
 routines. This module implements a “pretty-printing engine” that is
@@ -19326,7 +19361,8 @@ let print_lambda = pr_lambda std_formatter
 let eprint_lambda = pr_lambda err_formatter
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#principles">Principles</a>
 </li>
@@ -19348,7 +19384,8 @@ let eprint_lambda = pr_lambda err_formatter
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>The <code>Format</code> module of Caml Light and OCaml's standard libraries
+    ; body_html =
+        {js|<p>The <code>Format</code> module of Caml Light and OCaml's standard libraries
 provides pretty-printing facilities to get a fancy display for printing
 routines. This module implements a “pretty-printing engine” that is
 intended to break lines in a nice way (let's say “automatically when it
@@ -19741,17 +19778,17 @@ or <code>stderr</code> is just a matter of partial application:</p>
 let eprint_lambda = pr_lambda err_formatter
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Calling C Libraries|js}
-  ; slug = {js|calling-c-libraries|js}
-  ; description = {js|Cross the divide and call C code from your OCaml program
+    }
+  ; { title = {js|Calling C Libraries|js}
+    ; slug = {js|calling-c-libraries|js}
+    ; description =
+        {js|Cross the divide and call C code from your OCaml program
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["interoperability"]
-  ; users = [`Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "interoperability" ]
+    ; users = [ `Advanced ]
+    ; body_md =
+        {js|
 ## MiniGtk
 While the structure of lablgtk outlined in [Introduction to
 Gtk](introduction_to_gtk.html "Introduction to Gtk") seems perhaps
@@ -20164,7 +20201,8 @@ convert it to a `value`. Luckily we can quite easily use the C API to
 create `value` blocks which the OCaml garbage collector *won't* examine
 too closely ......
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#minigtk">MiniGtk</a>
 </li>
@@ -20172,7 +20210,8 @@ too closely ......
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="minigtk">MiniGtk</h2>
+    ; body_html =
+        {js|<h2 id="minigtk">MiniGtk</h2>
 <p>While the structure of lablgtk outlined in <a href="introduction_to_gtk.html" title="Introduction to Gtk">Introduction to
 Gtk</a> seems perhaps
 over-complex, it's worth considering exactly why the author chose two
@@ -20522,17 +20561,17 @@ convert it to a <code>value</code>. Luckily we can quite easily use the C API to
 create <code>value</code> blocks which the OCaml garbage collector <em>won't</em> examine
 too closely ......</p>
 |js}
-  };
- 
-  { title = {js|Calling Fortran Libraries|js}
-  ; slug = {js|calling-fortran-libraries|js}
-  ; description = {js|Cross the divide and call Fortran code from your OCaml program
+    }
+  ; { title = {js|Calling Fortran Libraries|js}
+    ; slug = {js|calling-fortran-libraries|js}
+    ; description =
+        {js|Cross the divide and call Fortran code from your OCaml program
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["interoperability"]
-  ; users = [`Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "interoperability" ]
+    ; users = [ `Advanced ]
+    ; body_md =
+        {js|
 Fortran isn't a language the many people write new code in but it still
 is in extensive use in the scientific communities. Many, many libraries
 exist for doing numerical calculation that will never be written in C or
@@ -20674,8 +20713,9 @@ prompt> ocamlc -c gtd6.ml prompt> ocamlc -o test gtd6.cmo wrapper.so
 ```
 And voila, we've called the fortran function from OCaml.
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<p>Fortran isn't a language the many people write new code in but it still
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<p>Fortran isn't a language the many people write new code in but it still
 is in extensive use in the scientific communities. Many, many libraries
 exist for doing numerical calculation that will never be written in C or
 C++. It is quite possible though to call Fortran routines from OCaml as
@@ -20791,17 +20831,17 @@ let some else help out (or wait until I learn how to do it).</p>
 </code></pre>
 <p>And voila, we've called the fortran function from OCaml.</p>
 |js}
-  };
- 
-  { title = {js|Command-line Arguments|js}
-  ; slug = {js|command-line-arguments|js}
-  ; description = {js|The Arg module that comes with the compiler can help you write command line interfaces
+    }
+  ; { title = {js|Command-line Arguments|js}
+    ; slug = {js|command-line-arguments|js}
+    ; description =
+        {js|The Arg module that comes with the compiler can help you write command line interfaces
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["common"]
-  ; users = [`Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "common" ]
+    ; users = [ `Intermediate ]
+    ; body_md =
+        {js|
 In this tutorial we learn how to read command line arguments directly, using
 OCaml's `Sys.argv` array, and then how to do so more easily using the standard
 library's `Arg` module.
@@ -20989,7 +21029,8 @@ built-in `Arg` module:
 * [Getopt](https://opam.ocaml.org/packages/getopt/) for OCaml is similar to
   [GNU getopt](https://www.gnu.org/software/libc/manual/html_node/Getopt.html).
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#sysargv">Sys.argv</a>
 </li>
@@ -21001,7 +21042,8 @@ built-in `Arg` module:
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>In this tutorial we learn how to read command line arguments directly, using
+    ; body_html =
+        {js|<p>In this tutorial we learn how to read command line arguments directly, using
 OCaml's <code>Sys.argv</code> array, and then how to do so more easily using the standard
 library's <code>Arg</code> module.</p>
 <h2 id="sysargv">Sys.argv</h2>
@@ -21153,17 +21195,17 @@ rejecting malformed command lines which others might sliently accept.</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { title = {js|File Manipulation|js}
-  ; slug = {js|file-manipulation|js}
-  ; description = {js|A guide to basic file manipulation in OCaml with the standard library
+    }
+  ; { title = {js|File Manipulation|js}
+    ; slug = {js|file-manipulation|js}
+    ; description =
+        {js|A guide to basic file manipulation in OCaml with the standard library
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["common"]
-  ; users = [`Beginner; `Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "common" ]
+    ; users = [ `Beginner; `Intermediate ]
+    ; body_md =
+        {js|
 This is a guide to basic file manipulation in OCaml using only the
 standard library.
 
@@ -21286,7 +21328,8 @@ $ ./file_manip
 Hello!
 ```
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#buffered-channels">Buffered channels</a>
 </li>
@@ -21294,7 +21337,8 @@ Hello!
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This is a guide to basic file manipulation in OCaml using only the
+    ; body_html =
+        {js|<p>This is a guide to basic file manipulation in OCaml using only the
 standard library.</p>
 <!-- TODO: links to new API locations -->
 <p>Official documentation for the modules of interest:
@@ -21418,17 +21462,17 @@ $ ./file_manip
 Hello!
 </code></pre>
 |js}
-  };
- 
-  { title = {js|Garbage Collection|js}
-  ; slug = {js|garbage-collection|js}
-  ; description = {js|OCaml is a garbage collected language meaning you don't have to worry about allocating and freeing memory
+    }
+  ; { title = {js|Garbage Collection|js}
+    ; slug = {js|garbage-collection|js}
+    ; description =
+        {js|OCaml is a garbage collected language meaning you don't have to worry about allocating and freeing memory
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["advanced"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "advanced" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Garbage collection, reference counting, explicit allocation
 
 As with all modern languages, OCaml provides a garbage collector so that
@@ -21798,7 +21842,8 @@ increasing order of difficulty:
 1. Provide a general-purpose cache fronting a "users" table in your
  choice of **relational database** (with locking).
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#garbage-collection-reference-counting-explicit-allocation">Garbage collection, reference counting, explicit allocation</a>
 </li>
@@ -21812,7 +21857,8 @@ increasing order of difficulty:
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="garbage-collection-reference-counting-explicit-allocation">Garbage collection, reference counting, explicit allocation</h2>
+    ; body_html =
+        {js|<h2 id="garbage-collection-reference-counting-explicit-allocation">Garbage collection, reference counting, explicit allocation</h2>
 <p>As with all modern languages, OCaml provides a garbage collector so that
 you don't need to explicitly allocate and free memory as in C/C++.</p>
 <p>The OCaml garbage collector is a modern hybrid generational/incremental
@@ -22129,17 +22175,17 @@ choice of <strong>relational database</strong> (with locking).
 </li>
 </ol>
 |js}
-  };
- 
-  { title = {js|Performance and Profiling|js}
-  ; slug = {js|performance-and-profiling|js}
-  ; description = {js|Understand how to profile your OCaml code to analyse its performance and produce faster programs
+    }
+  ; { title = {js|Performance and Profiling|js}
+    ; slug = {js|performance-and-profiling|js}
+    ; description =
+        {js|Understand how to profile your OCaml code to analyse its performance and produce faster programs
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["advanced"]
-  ; users = [`Intermediate; `Advanced]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "advanced" ]
+    ; users = [ `Intermediate; `Advanced ]
+    ; body_md =
+        {js|
 ## Speed
 Why is OCaml fast? Indeed, step back and ask *is OCaml fast?* How can we
 make programs faster? In this chapter we'll look at what actually
@@ -23059,7 +23105,8 @@ looking at the `mlvalues.h` header file.
 * In Java is a dynamic type check (aka cast) much more expensive than
  a dynamic method dispatch. -->
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#speed">Speed</a>
 </li>
@@ -23071,7 +23118,8 @@ looking at the `mlvalues.h` header file.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2 id="speed">Speed</h2>
+    ; body_html =
+        {js|<h2 id="speed">Speed</h2>
 <p>Why is OCaml fast? Indeed, step back and ask <em>is OCaml fast?</em> How can we
 make programs faster? In this chapter we'll look at what actually
 happens when you compile your OCaml programs down to machine code. This
@@ -23848,17 +23896,17 @@ looking at the <code>mlvalues.h</code> header file.</p>
 * In Java is a dynamic type check (aka cast) much more expensive than
  a dynamic method dispatch. -->
 |js}
-  };
- 
-  { title = {js|Comparison of Standard Containers|js}
-  ; slug = {js|comparison-of-standard-containers|js}
-  ; description = {js|A comparison of some core data-structures including lists, queues and arrays
+    }
+  ; { title = {js|Comparison of Standard Containers|js}
+    ; slug = {js|comparison-of-standard-containers|js}
+    ; description =
+        {js|A comparison of some core data-structures including lists, queues and arrays
 |js}
-  ; date = {js|2021-05-27T21:07:30-00:00|js}
-  ; tags = 
- ["language"]
-  ; users = [`Intermediate]
-  ; body_md = {js|
+    ; date = {js|2021-05-27T21:07:30-00:00|js}
+    ; tags = [ "language" ]
+    ; users = [ `Intermediate ]
+    ; body_md =
+        {js|
 This is a rough comparison of the different container types that are
 provided by the OCaml language or by the OCaml standard library. In each
 case, n is the number of valid elements in the container.
@@ -23953,7 +24001,8 @@ element doesn't create a new stack but simply adds it to the stack.
 * taking an element: O(1)
 * length: O(1)
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li><a href="#lists-immutable-singly-linked-lists">Lists: immutable singly-linked lists</a>
 </li>
@@ -23975,7 +24024,8 @@ element doesn't create a new stack but simply adds it to the stack.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>This is a rough comparison of the different container types that are
+    ; body_html =
+        {js|<p>This is a rough comparison of the different container types that are
 provided by the OCaml language or by the OCaml standard library. In each
 case, n is the number of valid elements in the container.</p>
 <p>Note that the big-O cost given for some operations reflects the current
@@ -24092,5 +24142,5 @@ element doesn't create a new stack but simply adds it to the stack.</p>
 </li>
 </ul>
 |js}
-  }]
-
+    }
+  ]

--- a/src/ocamlorg_data/video.ml
+++ b/src/ocamlorg_data/video.ml
@@ -1,4 +1,3 @@
-
 type kind =
   [ `Conference
   | `Mooc
@@ -17,190 +16,222 @@ type t =
   ; embed : string option
   ; year : int
   }
-  
-let all = 
-[
-  { title = {js|A Declarative Syntax Definition for OCaml|js}
-  ; slug = {js|a-declarative-syntax-definition-for-ocaml|js}
-  ; description = {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of constructors, enabling a direct mapping to abstract syntax. Based on the SDF3 syntax definition, the Spoofax language workbench produces a complete syntax aware editor with a parser, syntax checking, parse error recovery, syntax highlighting, formatting with correct parenthesis insertion, and syntactic completion. The syntax definition should provide a good basis for experiments with the design of OCaml and the development of further tooling. In the talk, we will highlight interesting aspects of the syntax definition, discuss issues we encountered in the syntax of OCaml, and demonstrate the editor.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|A Declarative Syntax Definition for OCaml|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
-  ; year = 2020
-  };
- 
-  { title = {js|The Final Pieces of the OCaml Documentation Puzzle|js}
-  ; slug = {js|the-final-pieces-of-the-ocaml-documentation-puzzle|js}
-  ; description = {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. Its tasks are even harder than the typechecker as it also needs to keep track of documentation comments precisely and efficiently. As an example, signatures such as include F(X).T and destructive substitutions were never handled properly by any documentation generator.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|The final pieces of the OCaml documentation puzzle|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/2acebff9-25fa-4733-83cc-620a65b12251|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
-  ; year = 2020
-  };
- 
-  { title = {js|OCaml-CI: A Zero-Configuration CI|js}
-  ; slug = {js|ocaml-ci-a-zero-configuration-ci|js}
-  ; description = {js|OCaml-CI is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms. The CI has been deployed on around 50 projects so far on GitHub, and many of them see response times an order of magnitude quicker than with less integrated CI solutions. This talk will introduce the CI service and then look at some of the technologies used to build it.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|OCaml-CI: A Zero-Configuration CI|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
-  ; year = 2020
-  };
- 
-  { title = {js|State of the OCaml Platform 2020|js}
-  ; slug = {js|state-of-the-ocaml-platform-2020|js}
-  ; description = {js|This talk covers: integrated development environments, next steps for the OCaml Platform and plans for 2020-2021|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"; "ocaml-platform"]
-  ; paper = None
-  ; link = {js|https://watch.ocaml.org/videos/watch/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
-  ; year = 2020
-  };
- 
-  { title = {js|Parallelising your OCaml Code with Multicore OCaml|js}
-  ; slug = {js|parallelising-your-ocaml-code-with-multicore-ocaml|js}
-  ; description = {js|This presentation will take the attendees through the following steps aimed at developing parallel programs with Multicore OCaml: installing the latest Multicore OCaml compiler, brief overview of the low-level API for parallel programming, a tour of domainslib – a high-level parallel programming library for Multicore OCaml, common pitfalls when parallelising and tools for diagnosing Multicore OCaml performance.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"; "multicore-ocaml"]
-  ; paper = Some {js|Parallelising your OCaml Code with Multicore OCaml|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
-  ; year = 2020
-  };
- 
-  { title = {js|Types in Amber|js}
-  ; slug = {js|types-in-amber|js}
-  ; description = {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software evolves, these formats for sent data may change. We wish to allow nodes running older versions of the software to communicate with newer versions. To achieve that, we identify stable types that must not change over time, so that their serializations also do not change.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|Types in Amber|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/99b3dc75-9f93-4677-9f8b-076546725512|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
-  ; year = 2020
-  };
- 
-  { title = {js|OCaml under the Hood: SmartPy|js}
-  ; slug = {js|ocaml-under-the-hood-smartpy|js}
-  ; description = {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is used to generate programs in an imperative, type-inferred, intermediate language called SmartML. SmartML is also the name of the OCaml library which provides an interpreter, a compiler to Michelson (the smart-contract language of Tezos), as well as a scenario “on-chain” interpreter. The IDE uses a mix of OCaml built with js_of_ocaml and pure Javascript. The command-line interface also builds with js_of_ocaml to run on Node.js.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|OCaml Under the Hood: SmartPy|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
-  ; year = 2020
-  };
- 
-  { title = {js|LexiFi Runtime Types|js}
-  ; slug = {js|lexifi-runtime-types|js}
-  ; description = {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Being no longer relevant, the type information is discarded after compilation. The resulting performance is a key feature of the OCaml language.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|LexiFi Runtime Types|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
-  ; year = 2020
-  };
- 
-  { title = {js|The ImpFS Filesystem|js}
-  ; slug = {js|the-impfs-filesystem|js}
-  ; description = {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value store presented at ML’19. In addition, there are a number of other support libraries that may be of interest to the community. ImpFS represents a single point in the filesystem design space, but we hope that the libraries we have developed will enable others to build further filesystems with novel features.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|The ImpFS Filesystem|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/28545b27-4637-47a5-8edd-6b904daef19c|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
-  ; year = 2020
-  };
- 
-  { title = {js|Irmin v2|js}
-  ; slug = {js|irmin-v2|js}
-  ; description = {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to any previous state. It has been extensively used by major software projects over the past few years such as Docker for Mac/Windows, and noticeably through DataKit, which powers hundreds of thousands monthly builds on the opam-repository CI contributors may be familiar with.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"; "irmin"]
-  ; paper = Some {js|Irmin v2|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
-  ; year = 2020
-  };
- 
-  { title = {js|Why OCaml|js}
-  ; slug = {js|why-ocaml|js}
-  ; description = {js|A summary of why Jane Street uses OCaml, including a discussion of how OCaml fits into the broader space of programming languages. Given to our summer interns.|js}
-  ; people = 
- []
-  ; kind = `Lecture
-  ; tags = ["jane-street"]
-  ; paper = None
-  ; link = {js|https://watch.ocaml.org/videos/watch/3abacf08-a3a1-405c-975b-a4efb54f0dd0|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/3abacf08-a3a1-405c-975b-a4efb54f0dd0|js}
-  ; year = 2015
-  };
- 
-  { title = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
-  ; slug = {js|ad-ocaml-algorithmic-differentiation-for-ocaml|js}
-  ; description = {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side effects, aliasing, and programs with nested derivative operators. The framework also offers implicit parallelization of both user programs and their transformations.
+
+let all =
+  [ { title = {js|A Declarative Syntax Definition for OCaml|js}
+    ; slug = {js|a-declarative-syntax-definition-for-ocaml|js}
+    ; description =
+        {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of constructors, enabling a direct mapping to abstract syntax. Based on the SDF3 syntax definition, the Spoofax language workbench produces a complete syntax aware editor with a parser, syntax checking, parse error recovery, syntax highlighting, formatting with correct parenthesis insertion, and syntactic completion. The syntax definition should provide a good basis for experiments with the design of OCaml and the development of further tooling. In the talk, we will highlight interesting aspects of the syntax definition, discuss issues we encountered in the syntax of OCaml, and demonstrate the editor.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|A Declarative Syntax Definition for OCaml|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
+    ; year = 2020
+    }
+  ; { title = {js|The Final Pieces of the OCaml Documentation Puzzle|js}
+    ; slug = {js|the-final-pieces-of-the-ocaml-documentation-puzzle|js}
+    ; description =
+        {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. Its tasks are even harder than the typechecker as it also needs to keep track of documentation comments precisely and efficiently. As an example, signatures such as include F(X).T and destructive substitutions were never handled properly by any documentation generator.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|The final pieces of the OCaml documentation puzzle|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/2acebff9-25fa-4733-83cc-620a65b12251|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
+    ; year = 2020
+    }
+  ; { title = {js|OCaml-CI: A Zero-Configuration CI|js}
+    ; slug = {js|ocaml-ci-a-zero-configuration-ci|js}
+    ; description =
+        {js|OCaml-CI is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms. The CI has been deployed on around 50 projects so far on GitHub, and many of them see response times an order of magnitude quicker than with less integrated CI solutions. This talk will introduce the CI service and then look at some of the technologies used to build it.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|OCaml-CI: A Zero-Configuration CI|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
+    ; year = 2020
+    }
+  ; { title = {js|State of the OCaml Platform 2020|js}
+    ; slug = {js|state-of-the-ocaml-platform-2020|js}
+    ; description =
+        {js|This talk covers: integrated development environments, next steps for the OCaml Platform and plans for 2020-2021|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop"; "ocaml-platform" ]
+    ; paper = None
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
+    ; year = 2020
+    }
+  ; { title = {js|Parallelising your OCaml Code with Multicore OCaml|js}
+    ; slug = {js|parallelising-your-ocaml-code-with-multicore-ocaml|js}
+    ; description =
+        {js|This presentation will take the attendees through the following steps aimed at developing parallel programs with Multicore OCaml: installing the latest Multicore OCaml compiler, brief overview of the low-level API for parallel programming, a tour of domainslib – a high-level parallel programming library for Multicore OCaml, common pitfalls when parallelising and tools for diagnosing Multicore OCaml performance.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop"; "multicore-ocaml" ]
+    ; paper = Some {js|Parallelising your OCaml Code with Multicore OCaml|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
+    ; year = 2020
+    }
+  ; { title = {js|Types in Amber|js}
+    ; slug = {js|types-in-amber|js}
+    ; description =
+        {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software evolves, these formats for sent data may change. We wish to allow nodes running older versions of the software to communicate with newer versions. To achieve that, we identify stable types that must not change over time, so that their serializations also do not change.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|Types in Amber|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/99b3dc75-9f93-4677-9f8b-076546725512|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
+    ; year = 2020
+    }
+  ; { title = {js|OCaml under the Hood: SmartPy|js}
+    ; slug = {js|ocaml-under-the-hood-smartpy|js}
+    ; description =
+        {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is used to generate programs in an imperative, type-inferred, intermediate language called SmartML. SmartML is also the name of the OCaml library which provides an interpreter, a compiler to Michelson (the smart-contract language of Tezos), as well as a scenario “on-chain” interpreter. The IDE uses a mix of OCaml built with js_of_ocaml and pure Javascript. The command-line interface also builds with js_of_ocaml to run on Node.js.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|OCaml Under the Hood: SmartPy|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
+    ; year = 2020
+    }
+  ; { title = {js|LexiFi Runtime Types|js}
+    ; slug = {js|lexifi-runtime-types|js}
+    ; description =
+        {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Being no longer relevant, the type information is discarded after compilation. The resulting performance is a key feature of the OCaml language.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|LexiFi Runtime Types|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
+    ; year = 2020
+    }
+  ; { title = {js|The ImpFS Filesystem|js}
+    ; slug = {js|the-impfs-filesystem|js}
+    ; description =
+        {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value store presented at ML’19. In addition, there are a number of other support libraries that may be of interest to the community. ImpFS represents a single point in the filesystem design space, but we hope that the libraries we have developed will enable others to build further filesystems with novel features.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|The ImpFS Filesystem|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/28545b27-4637-47a5-8edd-6b904daef19c|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
+    ; year = 2020
+    }
+  ; { title = {js|Irmin v2|js}
+    ; slug = {js|irmin-v2|js}
+    ; description =
+        {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to any previous state. It has been extensively used by major software projects over the past few years such as Docker for Mac/Windows, and noticeably through DataKit, which powers hundreds of thousands monthly builds on the opam-repository CI contributors may be familiar with.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop"; "irmin" ]
+    ; paper = Some {js|Irmin v2|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
+    ; year = 2020
+    }
+  ; { title = {js|Why OCaml|js}
+    ; slug = {js|why-ocaml|js}
+    ; description =
+        {js|A summary of why Jane Street uses OCaml, including a discussion of how OCaml fits into the broader space of programming languages. Given to our summer interns.|js}
+    ; people = []
+    ; kind = `Lecture
+    ; tags = [ "jane-street" ]
+    ; paper = None
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/3abacf08-a3a1-405c-975b-a4efb54f0dd0|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/3abacf08-a3a1-405c-975b-a4efb54f0dd0|js}
+    ; year = 2015
+    }
+  ; { title = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
+    ; slug = {js|ad-ocaml-algorithmic-differentiation-for-ocaml|js}
+    ; description =
+        {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side effects, aliasing, and programs with nested derivative operators. The framework also offers implicit parallelization of both user programs and their transformations.
 
 The presentation will provide a short introduction to the mathematical problem, the difficulties of implementing a solution, the design of the library, and a demonstration of its capabilities.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
-  ; year = 2020
-  };
- 
-  { title = {js|API migration: compare transformed|js}
-  ; slug = {js|api-migration-compare-transformed|js}
-  ; description = {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries by using Rotor to refactor comparison functions so that they return a more precise variant type rather than an integer. We discuss the difficulties of refactoring the Jane Street code base, which makes extensive use of ppx macros, and ongoing work implementing new refactorings.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|API migration: compare transformed|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/c46b925b-bd77-404f-ac5d-5dab65047529|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
-  ; year = 2020
-  };
- 
-  { title = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
-  ; slug = {js|a-simple-state-machine-framework-for-property-based-testing-in-ocaml|js}
-  ; description = {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercial QuickCheck state-machine framework from Quviq, but such frameworks are now also available for Haskell, F#, Scala, Elixir, Java, etc. We present a typed state-machine framework for OCaml based on the QCheck library and illustrate a number of concepts common to all such frameworks: state modeling, commands, interpreting commands, preconditions, and agreement checking.|js}
-  ; people = 
- []
-  ; kind = `Conference
-  ; tags = ["ocaml-workshop"]
-  ; paper = Some {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
-  ; link = {js|https://watch.ocaml.org/videos/watch/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
-  ; embed = Some {js|https://watch.ocaml.org/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
-  ; year = 2020
-  }]
-
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
+    ; year = 2020
+    }
+  ; { title = {js|API migration: compare transformed|js}
+    ; slug = {js|api-migration-compare-transformed|js}
+    ; description =
+        {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries by using Rotor to refactor comparison functions so that they return a more precise variant type rather than an integer. We discuss the difficulties of refactoring the Jane Street code base, which makes extensive use of ppx macros, and ongoing work implementing new refactorings.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper = Some {js|API migration: compare transformed|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/c46b925b-bd77-404f-ac5d-5dab65047529|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
+    ; year = 2020
+    }
+  ; { title =
+        {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
+    ; slug =
+        {js|a-simple-state-machine-framework-for-property-based-testing-in-ocaml|js}
+    ; description =
+        {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercial QuickCheck state-machine framework from Quviq, but such frameworks are now also available for Haskell, F#, Scala, Elixir, Java, etc. We present a typed state-machine framework for OCaml based on the QCheck library and illustrate a number of concepts common to all such frameworks: state modeling, commands, interpreting commands, preconditions, and agreement checking.|js}
+    ; people = []
+    ; kind = `Conference
+    ; tags = [ "ocaml-workshop" ]
+    ; paper =
+        Some
+          {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
+    ; link =
+        {js|https://watch.ocaml.org/videos/watch/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
+    ; embed =
+        Some
+          {js|https://watch.ocaml.org/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
+    ; year = 2020
+    }
+  ]

--- a/src/ocamlorg_data/watch.ml
+++ b/src/ocamlorg_data/watch.ml
@@ -1,521 +1,592 @@
-
-
-  type t =
-  { name: string;
-    embed_path : string;
-    thumbnail_path : string;
-    description : string option;
-    published_at : string;
-    updated_at : string;
-    language : string;
-    category : string;
+type t =
+  { name : string
+  ; embed_path : string
+  ; thumbnail_path : string
+  ; description : string option
+  ; published_at : string
+  ; updated_at : string
+  ; language : string
+  ; category : string
   }
-  
-let all = 
-[
-  { name = {js|25 Years of OCaml: Xavier Leroy|js}
-  ; embed_path = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
-  ; thumbnail_path = {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
-  ; description = Some {js|Professor Xavier Leroy -- the primary original author and leader of the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop 2021 keynote speech.|js}
-  ; published_at = {js|2021-08-27T13:23:10.199Z|js}
-  ; updated_at = {js|2021-09-08T10:02:00.187Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|A Declarative Syntax Definition for OCaml|js}
-  ; embed_path = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
-  ; thumbnail_path = {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
-  ; description = Some {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-01T04:02:00.070Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|A Multiverse of Glorious Documentation|js}
-  ; embed_path = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
-  ; thumbnail_path = {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
-  ; description = Some {js|This talk describes the process of generating documentation for every version of every package that can be built from the opam repository, and how it is presented as a single coherent website that is continuously updated as new packages are releas...|js}
-  ; published_at = {js|2021-08-27T11:23:36.000Z|js}
-  ; updated_at = {js|2021-09-07T21:02:00.188Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
-  ; embed_path = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
-  ; thumbnail_path = {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
-  ; description = Some {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-05-21T15:08:00.099Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|A review of the growth of the OCaml community|js}
-  ; embed_path = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
-  ; thumbnail_path = {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T17:05:33.471Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
-  ; embed_path = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
-  ; thumbnail_path = {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
-  ; description = Some {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-04-19T19:24:10.203Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|API migration: compare transformed|js}
-  ; embed_path = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
-  ; thumbnail_path = {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
-  ; description = Some {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-01T14:02:00.083Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Adapting the OCaml ecosystem for Multicore OCaml|js}
-  ; embed_path = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
-  ; thumbnail_path = {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
-  ; description = Some {js|OCaml 5.0 with support for shared-memory parallelism being around the corner, there’s increasing interest in the community to port existing libraries to Multicore. This talk will take the attendees through what the arrival of Multicore means to th...|js}
-  ; published_at = {js|2021-08-27T10:18:38.000Z|js}
-  ; updated_at = {js|2021-09-08T10:02:00.087Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Binary Analysis Platform|js}
-  ; embed_path = {js|/videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988|js}
-  ; thumbnail_path = {js|/static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg|js}
-  ; description = Some {js|We present Binary Analysis Platform (BAP), a representation-agnostic program analysis framework for binaries that can leverage existing tools, libraries, and frameworks, no matter which intermediate representation (IR) they use. In BAP, a new IR c...|js}
-  ; published_at = {js|2021-08-31T08:39:55.774Z|js}
-  ; updated_at = {js|2021-09-04T14:02:00.212Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Continuous Benchmarking for OCaml Projects|js}
-  ; embed_path = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
-  ; thumbnail_path = {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
-  ; description = Some {js|Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.
+
+let all =
+  [ { name = {js|25 Years of OCaml: Xavier Leroy|js}
+    ; embed_path = {js|/videos/embed/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/94ead657-79a0-4c10-8435-9e13906a6c44.jpg|js}
+    ; description =
+        Some
+          {js|Professor Xavier Leroy -- the primary original author and leader of the OCaml project -- reflects on 25 years of the OCaml language at his OCaml Workshop 2021 keynote speech.|js}
+    ; published_at = {js|2021-08-27T13:23:10.199Z|js}
+    ; updated_at = {js|2021-09-08T10:02:00.187Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|A Declarative Syntax Definition for OCaml|js}
+    ; embed_path = {js|/videos/embed/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/92c0a0e3-5326-42aa-86a3-6adb3927e111.jpg|js}
+    ; description =
+        Some
+          {js|In this talk, we present our work on a syntax definition for the OCaml language in the syntax definition formalism SDF3. SDF3 supports the high-level definition of concrete and abstract syntax through declarative disambiguation and definition of c...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-01T04:02:00.070Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|A Multiverse of Glorious Documentation|js}
+    ; embed_path = {js|/videos/embed/9bb452d6-1829-4dac-a6a2-46b31050c931|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/6a0a8291-4626-4820-8071-904b3c508345.jpg|js}
+    ; description =
+        Some
+          {js|This talk describes the process of generating documentation for every version of every package that can be built from the opam repository, and how it is presented as a single coherent website that is continuously updated as new packages are releas...|js}
+    ; published_at = {js|2021-08-27T11:23:36.000Z|js}
+    ; updated_at = {js|2021-09-07T21:02:00.188Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name =
+        {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
+    ; embed_path = {js|/videos/embed/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/316ddad9-dbc3-4d46-9f43-5da72689e93b.jpg|js}
+    ; description =
+        Some
+          {js|Since their inception, state-machine frameworks have proven their worth by finding defects in everything from the underlying AUTOSAR components of Volvo cars to digital invoicing systems. These case studies were carried out with Erlang’s commercia...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-05-21T15:08:00.099Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|A review of the growth of the OCaml community|js}
+    ; embed_path = {js|/videos/embed/f9d0b637-8aec-4bff-8c32-cd16b58023b6|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/e573402b-1350-4aa7-a9ba-0e1c51198fb4.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T17:05:33.471Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
+    ; embed_path = {js|/videos/embed/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/eb972fd2-668e-4998-a798-e9fbdcadba20.jpg|js}
+    ; description =
+        Some
+          {js|AD-OCaml is a library framework for calculating mathematically exact derivatives and deep power series approximations of almost arbitrary OCaml programs via algorithmic differentiation. Unlike similar frameworks, this includes programs with side e...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-04-19T19:24:10.203Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|API migration: compare transformed|js}
+    ; embed_path = {js|/videos/embed/c46b925b-bd77-404f-ac5d-5dab65047529|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/eef64419-3c34-4c15-9419-edcbc455e54d.jpg|js}
+    ; description =
+        Some
+          {js|In this talk we describe our experience in using an automatic API-migration strategy dedicated at changing the signatures of OCaml functions, using the Rotor refactoring tool for OCaml. We perform a case study on open source Jane Street libraries ...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-01T14:02:00.083Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Adapting the OCaml ecosystem for Multicore OCaml|js}
+    ; embed_path = {js|/videos/embed/629b89a8-bbd5-490d-98b0-d0c740912b02|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/41212c84-36d6-44fa-b884-2ced79505929.jpg|js}
+    ; description =
+        Some
+          {js|OCaml 5.0 with support for shared-memory parallelism being around the corner, there’s increasing interest in the community to port existing libraries to Multicore. This talk will take the attendees through what the arrival of Multicore means to th...|js}
+    ; published_at = {js|2021-08-27T10:18:38.000Z|js}
+    ; updated_at = {js|2021-09-08T10:02:00.087Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Binary Analysis Platform|js}
+    ; embed_path = {js|/videos/embed/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/390cd7dd-4578-4162-bae0-6c218cb5ebde.jpg|js}
+    ; description =
+        Some
+          {js|We present Binary Analysis Platform (BAP), a representation-agnostic program analysis framework for binaries that can leverage existing tools, libraries, and frameworks, no matter which intermediate representation (IR) they use. In BAP, a new IR c...|js}
+    ; published_at = {js|2021-08-31T08:39:55.774Z|js}
+    ; updated_at = {js|2021-09-04T14:02:00.212Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Continuous Benchmarking for OCaml Projects|js}
+    ; embed_path = {js|/videos/embed/1c994370-1aaa-4db6-b901-d762786e4904|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/33ab36c3-3650-4c13-9fea-9b5907cf8c0f.jpg|js}
+    ; description =
+        Some
+          {js|Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.
 
 current-bench provides a predictable environment for performance benchmarks and a UI...|js}
-  ; published_at = {js|2021-08-27T11:20:09.000Z|js}
-  ; updated_at = {js|2021-09-06T12:02:00.082Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Core Time stamp counter: A fast high resolution time source|js}
-  ; embed_path = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
-  ; thumbnail_path = {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:29:56.317Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Deductive Verification of Realistic OCaml Code|js}
-  ; embed_path = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
-  ; thumbnail_path = {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
-  ; description = Some {js|We present the formal verification of a subset of the Set module from the OCaml standard library. The proof is conducted using Cameleer, a new tool for the deductive verification of OCaml code. Cameleer takes as input an OCaml program, annotated u...|js}
-  ; published_at = {js|2021-08-27T10:33:38.000Z|js}
-  ; updated_at = {js|2021-09-07T04:02:00.301Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Digodoc and Docs|js}
-  ; embed_path = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
-  ; thumbnail_path = {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
-  ; description = Some {js|In this talk, we will introduce a new tool called digodoc, that builds a graph of an opam switch, associating files, libraries and opam packages into a cyclic graph of inclusions and dependencies. We will then explain how we used that tool to buil...|js}
-  ; published_at = {js|2021-08-27T12:09:56.000Z|js}
-  ; updated_at = {js|2021-09-07T20:02:00.180Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Effective Concurrency through Algebraic Effects|js}
-  ; embed_path = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
-  ; thumbnail_path = {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-07T10:02:00.076Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Experiences with Effects in OCaml|js}
-  ; embed_path = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
-  ; thumbnail_path = {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
-  ; description = Some {js|The multicore branch of OCaml adds support for effect handlers. In this talk, we report our experiences with effects, both from converting existing code, and from writing new code. Converting the Angstrom parser from a callback style to effects gr...|js}
-  ; published_at = {js|2021-08-27T14:41:07.000Z|js}
-  ; updated_at = {js|2021-09-08T05:02:00.187Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|From 2n+1 to n|js}
-  ; embed_path = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
-  ; thumbnail_path = {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
-  ; description = Some {js|
+    ; published_at = {js|2021-08-27T11:20:09.000Z|js}
+    ; updated_at = {js|2021-09-06T12:02:00.082Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Core Time stamp counter: A fast high resolution time source|js}
+    ; embed_path = {js|/videos/embed/75b4d60f-3e37-40bd-b025-f39dcce0c42c|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/43248673-6478-4e96-b8ac-cd415d85569b.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:29:56.317Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Deductive Verification of Realistic OCaml Code|js}
+    ; embed_path = {js|/videos/embed/92309d92-8cbf-4545-980c-209c96e42a79|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/db29d3bf-784c-47f1-bf90-f13fd2a9d530.jpg|js}
+    ; description =
+        Some
+          {js|We present the formal verification of a subset of the Set module from the OCaml standard library. The proof is conducted using Cameleer, a new tool for the deductive verification of OCaml code. Cameleer takes as input an OCaml program, annotated u...|js}
+    ; published_at = {js|2021-08-27T10:33:38.000Z|js}
+    ; updated_at = {js|2021-09-07T04:02:00.301Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Digodoc and Docs|js}
+    ; embed_path = {js|/videos/embed/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/43a418d6-56ec-48f4-852b-0a18ec0789aa.jpg|js}
+    ; description =
+        Some
+          {js|In this talk, we will introduce a new tool called digodoc, that builds a graph of an opam switch, associating files, libraries and opam packages into a cyclic graph of inclusions and dependencies. We will then explain how we used that tool to buil...|js}
+    ; published_at = {js|2021-08-27T12:09:56.000Z|js}
+    ; updated_at = {js|2021-09-07T20:02:00.180Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Effective Concurrency through Algebraic Effects|js}
+    ; embed_path = {js|/videos/embed/e9f6c837-1435-4349-af0f-07d22d1c11ea|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/1de58bd2-d2f9-428c-8b8c-97b48d6d2c7e.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-07T10:02:00.076Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Experiences with Effects in OCaml|js}
+    ; embed_path = {js|/videos/embed/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/d48bf7bb-8c46-4d49-a3a6-734bf339343b.jpg|js}
+    ; description =
+        Some
+          {js|The multicore branch of OCaml adds support for effect handlers. In this talk, we report our experiences with effects, both from converting existing code, and from writing new code. Converting the Angstrom parser from a callback style to effects gr...|js}
+    ; published_at = {js|2021-08-27T14:41:07.000Z|js}
+    ; updated_at = {js|2021-09-08T05:02:00.187Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|From 2n+1 to n|js}
+    ; embed_path = {js|/videos/embed/74b32dae-11c6-4713-be1b-946260196e50|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/a2042ab9-9025-421a-9eae-176462ac594b.jpg|js}
+    ; description =
+        Some
+          {js|
 OCaml relies on a type-agnostic object representation centred around values which unify odd integers and aligned pointers. The last bit of a value distinguishes the two variants: zero indicates a pointer on the OCaml heap, while one encodes a ta...|js}
-  ; published_at = {js|2021-08-31T08:30:23.211Z|js}
-  ; updated_at = {js|2021-09-06T14:02:00.190Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Global Semantic Analysis on OCaml programs|js}
-  ; embed_path = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
-  ; thumbnail_path = {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:55:20.938Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|GopCaml: A Structural Editor for OCaml|js}
-  ; embed_path = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
-  ; thumbnail_path = {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
-  ; description = Some {js|This talk presents GopCaml-mode, the first structural editing plugin for OCaml. We will give a tour of the main plugin features, discussing the plugin’s internal design and its integration with existing OCaml and GNU Emacs toolchains.
+    ; published_at = {js|2021-08-31T08:30:23.211Z|js}
+    ; updated_at = {js|2021-09-06T14:02:00.190Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Global Semantic Analysis on OCaml programs|js}
+    ; embed_path = {js|/videos/embed/51e4bdf0-50f7-4b13-8514-2d62b5341066|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/8255d370-e621-44bc-b7c3-6dd39fab4d1d.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:55:20.938Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|GopCaml: A Structural Editor for OCaml|js}
+    ; embed_path = {js|/videos/embed/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/729cda51-abb3-4c8d-9d0e-b922e81be518.jpg|js}
+    ; description =
+        Some
+          {js|This talk presents GopCaml-mode, the first structural editing plugin for OCaml. We will give a tour of the main plugin features, discussing the plugin’s internal design and its integration with existing OCaml and GNU Emacs toolchains.
 
 Kiran Gop...|js}
-  ; published_at = {js|2021-08-27T10:12:58.000Z|js}
-  ; updated_at = {js|2021-09-07T15:02:00.164Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Inline Assembly in OCaml|js}
-  ; embed_path = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
-  ; thumbnail_path = {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:39:42.613Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Irmin v2|js}
-  ; embed_path = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
-  ; thumbnail_path = {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
-  ; description = Some {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-07T15:02:00.070Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Ketrew and Biokepi|js}
-  ; embed_path = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
-  ; thumbnail_path = {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T22:36:42.344Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js}
-  ; embed_path = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
-  ; thumbnail_path = {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
-  ; description = Some {js|When testing a library, developers typically first have to capture the semantics they want to check. They then write the code implementing these tests and find relevant test cases that expose possible misbehaviours.
+    ; published_at = {js|2021-08-27T10:12:58.000Z|js}
+    ; updated_at = {js|2021-09-07T15:02:00.164Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Inline Assembly in OCaml|js}
+    ; embed_path = {js|/videos/embed/632f520f-8f83-4b6f-89f1-5cde088436c7|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/5d2f65d1-6129-4206-832b-c3d4bab410df.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:39:42.613Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Irmin v2|js}
+    ; embed_path = {js|/videos/embed/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/138e7c05-185b-4e54-95d0-d15018905a39.jpg|js}
+    ; description =
+        Some
+          {js|Irmin is an OCaml library for building distributed databases with the same design principles as Git. Existing Git users will find many familiar features: branching/merging, immutable causal history for all changes, and the ability to restore to an...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-07T15:02:00.070Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Ketrew and Biokepi|js}
+    ; embed_path = {js|/videos/embed/f3dcee35-bc04-453a-ba35-7aec90599661|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/0a36e8ce-c415-4191-ad5b-6ef2eb23db4e.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T22:36:42.344Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js}
+    ; embed_path = {js|/videos/embed/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/e5d18bd4-b482-463c-80f8-35d9fbb46b23.jpg|js}
+    ; description =
+        Some
+          {js|When testing a library, developers typically first have to capture the semantics they want to check. They then write the code implementing these tests and find relevant test cases that expose possible misbehaviours.
 
 In this work, we present a t...|js}
-  ; published_at = {js|2021-08-27T10:40:06.000Z|js}
-  ; updated_at = {js|2021-09-07T04:02:00.442Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|LexiFi Runtime Types|js}
-  ; embed_path = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
-  ; thumbnail_path = {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
-  ; description = Some {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-29T09:02:00.090Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Love: a readable language interpreted by a blockchain|js}
-  ; embed_path = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
-  ; thumbnail_path = {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
-  ; description = Some {js|We present Love, a smart contract language embedded in the Dune Network blockchain. It benefits from an OCaml-like syntax and a system-F inspired type system. Love has been used for deploying complex services such as games, ERC20s, atomic swaps, e...|js}
-  ; published_at = {js|2021-08-27T15:10:17.000Z|js}
-  ; updated_at = {js|2021-09-02T23:02:00.323Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|OCaml Under The Hood: SmartPy|js}
-  ; embed_path = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
-  ; thumbnail_path = {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
-  ; description = Some {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-05-19T17:08:00.226Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|OCaml and Python: Getting the Best of Both Worlds|js}
-  ; embed_path = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
-  ; thumbnail_path = {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
-  ; description = Some {js|In this talk we present how we expose a wide variety of OCaml libraries and services so that they can be accessed from Python. Our initial use case on the Python side consisted in Jupyter notebooks used to analyse various datasets, these datasets ...|js}
-  ; published_at = {js|2021-08-27T10:16:54.000Z|js}
-  ; updated_at = {js|2021-09-07T15:02:00.247Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|OCaml-CI : A Zero-Configuration CI|js}
-  ; embed_path = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
-  ; thumbnail_path = {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
-  ; description = Some {js|OCaml-CI
+    ; published_at = {js|2021-08-27T10:40:06.000Z|js}
+    ; updated_at = {js|2021-09-07T04:02:00.442Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|LexiFi Runtime Types|js}
+    ; embed_path = {js|/videos/embed/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/1d43d8b4-87d1-4398-b925-10a42460b8dc.jpg|js}
+    ; description =
+        Some
+          {js|OCaml programmers make deliberate use of abstract data types for composing safe and reliable software systems. The OCaml compiler relies on the invariants imposed by the type system to produce efficient and compact runtime data representations. Be...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-29T09:02:00.090Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Love: a readable language interpreted by a blockchain|js}
+    ; embed_path = {js|/videos/embed/d3b2b31e-1739-406e-8de7-d5f21bc01836|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/93a6e9ac-2266-408a-81e7-1ebf239233f8.jpg|js}
+    ; description =
+        Some
+          {js|We present Love, a smart contract language embedded in the Dune Network blockchain. It benefits from an OCaml-like syntax and a system-F inspired type system. Love has been used for deploying complex services such as games, ERC20s, atomic swaps, e...|js}
+    ; published_at = {js|2021-08-27T15:10:17.000Z|js}
+    ; updated_at = {js|2021-09-02T23:02:00.323Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|OCaml Under The Hood: SmartPy|js}
+    ; embed_path = {js|/videos/embed/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/e1ac5b07-3648-40c1-b62c-5e88471741dc.jpg|js}
+    ; description =
+        Some
+          {js|SmartPy is a complete system to develop smart-contracts for the Tezos blockchain. It is an embedded EDSL in python to write contracts and their test scenarios. It includes an online IDE, a chain explorer, and a command-line interface. Python is us...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-05-19T17:08:00.226Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|OCaml and Python: Getting the Best of Both Worlds|js}
+    ; embed_path = {js|/videos/embed/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/53db83d1-0763-4dfa-a087-cce3cad1b581.jpg|js}
+    ; description =
+        Some
+          {js|In this talk we present how we expose a wide variety of OCaml libraries and services so that they can be accessed from Python. Our initial use case on the Python side consisted in Jupyter notebooks used to analyse various datasets, these datasets ...|js}
+    ; published_at = {js|2021-08-27T10:16:54.000Z|js}
+    ; updated_at = {js|2021-09-07T15:02:00.247Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|OCaml-CI : A Zero-Configuration CI|js}
+    ; embed_path = {js|/videos/embed/0fee79e8-715a-400b-bfcc-34c3610f4890|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/596f39a9-8654-4922-8bec-6e7ac5dcc319.jpg|js}
+    ; description =
+        Some
+          {js|OCaml-CI
 
 is a CI service for OCaml projects. It
 uses metadata from the project’s opam and dune
 files to work out what to build, and uses caching
 to make builds fast. It automatically tests projects
 against multiple OCaml versions and OS platforms...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-04T20:02:00.100Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|OCaml-CI : A Zero-Configuration CI|js}
-  ; embed_path = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
-  ; thumbnail_path = {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
-  ; description = Some {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-05-27T16:35:41.085Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Opam-bin: Binary Packages with Opam|js}
-  ; embed_path = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
-  ; thumbnail_path = {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
-  ; description = Some {js|In this talk, we will present opam-bin, an Opam plugin that builds Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin also creates Opam Repositories for these binary pack- ages, to make them easy to share with othe...|js}
-  ; published_at = {js|2021-08-27T15:01:40.000Z|js}
-  ; updated_at = {js|2021-09-08T06:02:00.094Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Operf: Benchmarking the OCaml Compiler|js}
-  ; embed_path = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
-  ; thumbnail_path = {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:23:23.889Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js}
-  ; embed_path = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
-  ; thumbnail_path = {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
-  ; description = Some {js|We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey box fuzzing with QuickCheck and extends it to handle parallelism.
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-04T20:02:00.100Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|OCaml-CI : A Zero-Configuration CI|js}
+    ; embed_path = {js|/videos/embed/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/1c22a14e-f067-4d4e-8e26-027cc6d8a491.jpg|js}
+    ; description =
+        Some
+          {js|OCaml-CI1 is a CI service for OCaml projects. It uses metadata from the project’s opam and dune files to work out what to build, and uses caching to make builds fast. It automatically tests projects against multiple OCaml versions and OS platforms...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-05-27T16:35:41.085Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Opam-bin: Binary Packages with Opam|js}
+    ; embed_path = {js|/videos/embed/a889e4d3-0508-4734-b667-7060b0a253cd|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/b2325a24-f068-473b-961e-a0b783ae5c39.jpg|js}
+    ; description =
+        Some
+          {js|In this talk, we will present opam-bin, an Opam plugin that builds Binary Opam packages on the fly, to speed-up reinstallation of pack- ages. opam-bin also creates Opam Repositories for these binary pack- ages, to make them easy to share with othe...|js}
+    ; published_at = {js|2021-08-27T15:01:40.000Z|js}
+    ; updated_at = {js|2021-09-08T06:02:00.094Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Operf: Benchmarking the OCaml Compiler|js}
+    ; embed_path = {js|/videos/embed/5a4a6c12-3cb1-40d2-a663-25f294e12555|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/c2b5c90a-9c9e-4058-94a1-15525795a01a.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:23:23.889Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name =
+        {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js}
+    ; embed_path = {js|/videos/embed/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/b1a67c0a-2eb9-4c9d-97ce-b4dc039da59b.jpg|js}
+    ; description =
+        Some
+          {js|We develop ParaFuzz, an input and concurrency fuzzing tool for Multicore OCaml programs. ParaFuzz builds on top of Crowbar which combines AFL-based grey box fuzzing with QuickCheck and extends it to handle parallelism.
 
 Sumit Padhiyar
 Indian In...|js}
-  ; published_at = {js|2021-08-27T10:36:13.000Z|js}
-  ; updated_at = {js|2021-09-07T04:02:00.349Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Parallelising your OCaml Code with Multicore OCaml|js}
-  ; embed_path = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
-  ; thumbnail_path = {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
-  ; description = Some {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
+    ; published_at = {js|2021-08-27T10:36:13.000Z|js}
+    ; updated_at = {js|2021-09-07T04:02:00.349Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Parallelising your OCaml Code with Multicore OCaml|js}
+    ; embed_path = {js|/videos/embed/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/30bc6019-ecab-40e5-a7b6-c294ac9a7344.jpg|js}
+    ; description =
+        Some
+          {js|Slides, speaker notes and runnable examples mentioned in this talk are available at: https://github.com/ocaml-multicore/ocaml2020-workshop-parallel
 
 With the availability of multicore variants of the recent OCaml versions (4.10 and 4.11) that main...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-05T03:02:00.936Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Persistent Networking with Irmin and MirageOS|js}
-  ; embed_path = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
-  ; thumbnail_path = {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T17:09:03.939Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Probabilistic resource limits using StatMemprof|js}
-  ; embed_path = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
-  ; thumbnail_path = {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
-  ; description = Some {js|The goal of this talk is two-fold. First, we present memprof-limits, a probabilistic implementation of per-thread global memory limits, and per-thread allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs in the pre...|js}
-  ; published_at = {js|2021-08-27T11:08:12.000Z|js}
-  ; updated_at = {js|2021-09-06T04:02:01.770Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Property-Based Testing for OCaml through Coq|js}
-  ; embed_path = {js|/videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a|js}
-  ; thumbnail_path = {js|/static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg|js}
-  ; description = Some {js|We will present a property-based testing framework for OCaml that leverages the power of QuickChick, a popular and mature testing plugin for the Coq proof assistant, by automatically constructing a extraction-based shim between OCaml and Coq. That...|js}
-  ; published_at = {js|2021-08-31T08:37:00.571Z|js}
-  ; updated_at = {js|2021-09-06T10:02:00.283Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Safe Protocol Updates via Propositional Logic|js}
-  ; embed_path = {js|/videos/embed/c6176f51-0277-46f0-937b-1e2721044492|js}
-  ; thumbnail_path = {js|/static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg|js}
-  ; description = Some {js|If values of a given type are stored on disk, or are sent between different executables, then changing that type or its serialization can result in versioning issues.
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-05T03:02:00.936Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Persistent Networking with Irmin and MirageOS|js}
+    ; embed_path = {js|/videos/embed/97dd9634-28e4-4066-96e4-9c2036ee4bb2|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/46ba8c5d-0f4a-427e-8e76-0c58cb0e70a7.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T17:09:03.939Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Probabilistic resource limits using StatMemprof|js}
+    ; embed_path = {js|/videos/embed/bc297e85-82dd-4baf-8556-4a3a934978f9|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/9b4dc06e-1d07-45b8-a21a-1e4f39897fef.jpg|js}
+    ; description =
+        Some
+          {js|The goal of this talk is two-fold. First, we present memprof-limits, a probabilistic implementation of per-thread global memory limits, and per-thread allocation limits, for OCaml 4.12. Then, we will discuss the reasoning about programs in the pre...|js}
+    ; published_at = {js|2021-08-27T11:08:12.000Z|js}
+    ; updated_at = {js|2021-09-06T04:02:01.770Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Property-Based Testing for OCaml through Coq|js}
+    ; embed_path = {js|/videos/embed/9324fba4-2482-4bab-bfdd-b8881b3ed94a|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/d7e22bba-cda1-4c2b-9368-9b2c1643e751.jpg|js}
+    ; description =
+        Some
+          {js|We will present a property-based testing framework for OCaml that leverages the power of QuickChick, a popular and mature testing plugin for the Coq proof assistant, by automatically constructing a extraction-based shim between OCaml and Coq. That...|js}
+    ; published_at = {js|2021-08-31T08:37:00.571Z|js}
+    ; updated_at = {js|2021-09-06T10:02:00.283Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Safe Protocol Updates via Propositional Logic|js}
+    ; embed_path = {js|/videos/embed/c6176f51-0277-46f0-937b-1e2721044492|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/a89a3483-274a-44f1-9a38-c679f6b12196.jpg|js}
+    ; description =
+        Some
+          {js|If values of a given type are stored on disk, or are sent between different executables, then changing that type or its serialization can result in versioning issues.
 Often such issues are resolved by either making the deserializer more permissiv...|js}
-  ; published_at = {js|2021-08-31T08:34:54.707Z|js}
-  ; updated_at = {js|2021-09-04T14:02:00.088Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs|js}
-  ; embed_path = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
-  ; thumbnail_path = {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
-  ; description = Some {js|Semgrep, which stands for “semantic grep,” is a fast, lightweight, polyglot, open source static analysis tool to find bugs and enforce code standards. It is used internally by many companies including Dropbox and Snowflake. Semgrep is also now use...|js}
-  ; published_at = {js|2021-08-31T08:41:15.492Z|js}
-  ; updated_at = {js|2021-09-05T16:02:01.373Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Specialization of Generic Array Accesses After Inlining|js}
-  ; embed_path = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
-  ; thumbnail_path = {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:34:23.463Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|State of the OCaml Platform|js}
-  ; embed_path = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
-  ; thumbnail_path = {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
-  ; description = None
-  ; published_at = {js|2018-01-12T00:00:00.000Z|js}
-  ; updated_at = {js|2021-07-27T12:08:00.264Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|State of the OCaml Platform 2020|js}
-  ; embed_path = {js|/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
-  ; thumbnail_path = {js|/static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg|js}
-  ; description = Some {js|This talk covers:
+    ; published_at = {js|2021-08-31T08:34:54.707Z|js}
+    ; updated_at = {js|2021-09-04T14:02:00.088Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name =
+        {js|Semgrep : a fast, lightweight, polyglot static analysis tool to find bugs|js}
+    ; embed_path = {js|/videos/embed/c0d07213-1426-46a1-98e0-0b0c4515c841|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/2ab3961f-4e66-4ec9-b20e-72e25dfbebe4.jpg|js}
+    ; description =
+        Some
+          {js|Semgrep, which stands for “semantic grep,” is a fast, lightweight, polyglot, open source static analysis tool to find bugs and enforce code standards. It is used internally by many companies including Dropbox and Snowflake. Semgrep is also now use...|js}
+    ; published_at = {js|2021-08-31T08:41:15.492Z|js}
+    ; updated_at = {js|2021-09-05T16:02:01.373Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Specialization of Generic Array Accesses After Inlining|js}
+    ; embed_path = {js|/videos/embed/80553916-b90a-4641-93c8-35b000df04c1|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/1f81fbbf-6fb0-4047-93a1-57759431166a.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:34:23.463Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|State of the OCaml Platform|js}
+    ; embed_path = {js|/videos/embed/390ce74c-f85f-477d-8f20-504437409add|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/33258292-009b-42ee-83d3-9eb4bfb4e048.jpg|js}
+    ; description = None
+    ; published_at = {js|2018-01-12T00:00:00.000Z|js}
+    ; updated_at = {js|2021-07-27T12:08:00.264Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|State of the OCaml Platform 2020|js}
+    ; embed_path = {js|/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/4fd6a51f-686c-4f6f-8026-83692304b432.jpg|js}
+    ; description =
+        Some
+          {js|This talk covers:
 
 - Integrated Development Environments
 - Next Steps for the OCaml Platform
 - Plans for 2020-2021|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-30T08:02:00.086Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|The ImpFS filesystem|js}
-  ; embed_path = {js|/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
-  ; thumbnail_path = {js|/static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg|js}
-  ; description = Some {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value ...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-04T20:02:00.472Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|The OCaml Platform 1.0 - Reason ML|js}
-  ; embed_path = {js|/videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e|js}
-  ; thumbnail_path = {js|/static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg|js}
-  ; description = Some {js|Presented by Anil Madhavapeddy (@avsm)
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-30T08:02:00.086Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|The ImpFS filesystem|js}
+    ; embed_path = {js|/videos/embed/28545b27-4637-47a5-8edd-6b904daef19c|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/dde19660-653d-4dc3-9e81-54b2e3ab22a2.jpg|js}
+    ; description =
+        Some
+          {js|This proposal describes a presentation to be given at the OCaml’20 workshop. The presentation will cover a new OCaml filesystem, ImpFS, and the related libraries. The filesystem makes use of a B-tree library presented at OCaml’17, and a key-value ...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-04T20:02:00.472Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|The OCaml Platform 1.0 - Reason ML|js}
+    ; embed_path = {js|/videos/embed/bd9a8e54-6ca5-4036-a08c-6a47cee6619e|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/ddc1e6fb-9999-4e79-b458-31c7e3ec1108.jpg|js}
+    ; description =
+        Some
+          {js|Presented by Anil Madhavapeddy (@avsm)
 
 We keep being told ReasonML can compile to native and do interop with OCaml, and that there's a wealth of existing code and tools we can draw into our applications - but how do we get there?
 This video will ...|js}
-  ; published_at = {js|2018-12-11T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-03T14:02:00.094Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|The State of OCaml|js}
-  ; embed_path = {js|/videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3|js}
-  ; thumbnail_path = {js|/static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-02T10:02:00.083Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|The State of the OCaml Platform|js}
-  ; embed_path = {js|/videos/embed/32475a83-b455-455b-937f-28e7185f4fc2|js}
-  ; thumbnail_path = {js|/static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:47:54.414Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|The final pieces of the OCaml documentation puzzle|js}
-  ; embed_path = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
-  ; thumbnail_path = {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
-  ; description = Some {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-09-05T03:02:00.455Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Towards A Debugger for Native Code OCaml|js}
-  ; embed_path = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
-  ; thumbnail_path = {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
-  ; description = None
-  ; published_at = {js|2015-09-18T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-03T16:20:17.728Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  };
- 
-  { name = {js|Types in Amber|js}
-  ; embed_path = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
-  ; thumbnail_path = {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
-  ; description = Some {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
-  ; published_at = {js|2020-08-28T00:00:00.000Z|js}
-  ; updated_at = {js|2021-08-29T09:02:00.201Z|js}
-  ; language = {js|Unknown|js}
-  ; category = {js|Misc|js}
-  };
- 
-  { name = {js|Wibbily Wobbly Timey Camly|js}
-  ; embed_path = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
-  ; thumbnail_path = {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
-  ; description = Some {js|Time handling is commonly considered a difficult problem by programmers due to myriad standards and complexity of time zone definitions. This also complicates scheduling across multiple time zones especially when one takes Daylight Saving Time int...|js}
-  ; published_at = {js|2021-08-27T10:37:18.000Z|js}
-  ; updated_at = {js|2021-09-07T04:02:00.396Z|js}
-  ; language = {js|English|js}
-  ; category = {js|Science & Technology|js}
-  }]
-
+    ; published_at = {js|2018-12-11T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-03T14:02:00.094Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|The State of OCaml|js}
+    ; embed_path = {js|/videos/embed/60a2ecfb-86ea-4881-a279-0a928452a3c3|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/a5e5f630-2df9-4691-8ddf-a8137001ab4c.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-02T10:02:00.083Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|The State of the OCaml Platform|js}
+    ; embed_path = {js|/videos/embed/32475a83-b455-455b-937f-28e7185f4fc2|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/7eb8af05-a6d5-4a88-89f3-146673a87cf0.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:47:54.414Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|The final pieces of the OCaml documentation puzzle|js}
+    ; embed_path = {js|/videos/embed/2acebff9-25fa-4733-83cc-620a65b12251|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/c877a501-c705-44f7-8826-e7ce846a5e42.jpg|js}
+    ; description =
+        Some
+          {js|Rendering OCaml document is widely known as a very difficult task: The ever-evolving OCaml module system is extremely rich and can include complex set of inter-dependencies that are both difficult to compute and to render in a concise document. It...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-09-05T03:02:00.455Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Towards A Debugger for Native Code OCaml|js}
+    ; embed_path = {js|/videos/embed/b76f3301-261d-44f3-97ec-1910b45f6969|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/93ea327e-5e8b-4844-b237-75719a7256b9.jpg|js}
+    ; description = None
+    ; published_at = {js|2015-09-18T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-03T16:20:17.728Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ; { name = {js|Types in Amber|js}
+    ; embed_path = {js|/videos/embed/99b3dc75-9f93-4677-9f8b-076546725512|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/acd50ed1-43cf-45fd-a55e-9c40a6bf58ba.jpg|js}
+    ; description =
+        Some
+          {js|Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce the size of data needed by nodes running its protocol. Nodes communicate in a format automatically derived from type definitions in OCaml source files. As the Coda software ev...|js}
+    ; published_at = {js|2020-08-28T00:00:00.000Z|js}
+    ; updated_at = {js|2021-08-29T09:02:00.201Z|js}
+    ; language = {js|Unknown|js}
+    ; category = {js|Misc|js}
+    }
+  ; { name = {js|Wibbily Wobbly Timey Camly|js}
+    ; embed_path = {js|/videos/embed/ec641446-823b-40ec-a207-85157a18f88e|js}
+    ; thumbnail_path =
+        {js|/static/thumbnails/2300474a-7615-4c92-9489-9ff5117d8bc7.jpg|js}
+    ; description =
+        Some
+          {js|Time handling is commonly considered a difficult problem by programmers due to myriad standards and complexity of time zone definitions. This also complicates scheduling across multiple time zones especially when one takes Daylight Saving Time int...|js}
+    ; published_at = {js|2021-08-27T10:37:18.000Z|js}
+    ; updated_at = {js|2021-09-07T04:02:00.396Z|js}
+    ; language = {js|English|js}
+    ; category = {js|Science & Technology|js}
+    }
+  ]

--- a/src/ocamlorg_data/workshop.ml
+++ b/src/ocamlorg_data/workshop.ml
@@ -1,139 +1,123 @@
-
 type role =
   [ `Chair
   | `Co_chair
   ]
 
-  type important_date = { date : string; info : string }
+type important_date =
+  { date : string
+  ; info : string
+  }
 
-  type committee_member = {
-    name : string;
-    role : role option;
-    affiliation : string option;
+type committee_member =
+  { name : string
+  ; role : role option
+  ; affiliation : string option
   }
-  
-  type presentation = {
-    title : string;
-    authors : string list;
-    link : string option;
-    video : string option;
-    slides : string option;
-    poster : bool option;
-    additional_links : string list option;
+
+type presentation =
+  { title : string
+  ; authors : string list
+  ; link : string option
+  ; video : string option
+  ; slides : string option
+  ; poster : bool option
+  ; additional_links : string list option
   }
-  
-  type metadata = {
-    title : string;
-    location : string option;
-    date : string;
-    online : bool;
-    important_dates : important_date list;
-    presentations : presentation list;
-    program_committee : committee_member list;
-    organising_committee : committee_member list;
+
+type metadata =
+  { title : string
+  ; location : string option
+  ; date : string
+  ; online : bool
+  ; important_dates : important_date list
+  ; presentations : presentation list
+  ; program_committee : committee_member list
+  ; organising_committee : committee_member list
   }
-  
-  type t = {
-    title : string;
-    slug : string;
-    location : string option;
-    date : string;
-    online : bool;
-    important_dates : important_date list;
-    presentations : presentation list;
-    program_committee : committee_member list;
-    organising_committee : committee_member list;
-    toc_html : string;
-    body_md : string;
-    body_html : string;
+
+type t =
+  { title : string
+  ; slug : string
+  ; location : string option
+  ; date : string
+  ; online : bool
+  ; important_dates : important_date list
+  ; presentations : presentation list
+  ; program_committee : committee_member list
+  ; organising_committee : committee_member list
+  ; toc_html : string
+  ; body_md : string
+  ; body_html : string
   }
-  
-let all = 
-[
-  { title = {js|OCaml Users and Developers Workshop 2008|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2008|js}
-  ; location = Some {js|Paris, France|js}
-  ; date = {js|2008-01-26|js}
-  ; online = false
-  ; important_dates = 
- []
-  ; presentations = [
-  { title = {js|The core Caml system: status report and challenges|js};
-    authors = 
-                         ["Xavier Leroy"];
-    link = Some {js|https://www.youtube.com/watch?v=YdAcmMLwd_U|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Ocsigen: Exploiting the full power of OCaml in Web Programming|js};
-    authors = 
-                         ["Vincent Balat"];
-    link = Some {js|https://www.youtube.com/watch?v=WnGbGq4ETj0 http://www.ocsigen.org/|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|GODI|js};
-    authors = ["Gerd Stolpmann"];
-    link = Some {js|https://www.youtube.com/watch?v=SiF9CD5CK_k|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|ocamlbuild|js};
-    authors = 
-                         ["Nicolas Pouillard"];
-    link = Some {js|https://www.youtube.com/watch?v=4HPlX6wdmTI|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OCaml in Debian|js};
-    authors = 
-                         ["Sylvain Le Gall"];
-    link = Some {js|https://www.youtube.com/watch?v=-kBprJFFfsc|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OCaml on a JVM using OCaml-Java|js};
-    authors = 
-                         ["Xavier Clerc"];
-    link = Some {js|https://www.youtube.com/watch?v=v0zBMVABYXo|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- []
-  ; organising_committee = [
-  { name = {js|Sylvain Le Gall|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Vincent Balat|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Gabriel Kerneis|js};
-    role = None;
-    affiliation = None;
-  }]
-  ; body_md = {js|
+
+let all =
+  [ { title = {js|OCaml Users and Developers Workshop 2008|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2008|js}
+    ; location = Some {js|Paris, France|js}
+    ; date = {js|2008-01-26|js}
+    ; online = false
+    ; important_dates = []
+    ; presentations =
+        [ { title = {js|The core Caml system: status report and challenges|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link = Some {js|https://www.youtube.com/watch?v=YdAcmMLwd_U|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Ocsigen: Exploiting the full power of OCaml in Web Programming|js}
+          ; authors = [ "Vincent Balat" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=WnGbGq4ETj0 http://www.ocsigen.org/|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|GODI|js}
+          ; authors = [ "Gerd Stolpmann" ]
+          ; link = Some {js|https://www.youtube.com/watch?v=SiF9CD5CK_k|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|ocamlbuild|js}
+          ; authors = [ "Nicolas Pouillard" ]
+          ; link = Some {js|https://www.youtube.com/watch?v=4HPlX6wdmTI|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml in Debian|js}
+          ; authors = [ "Sylvain Le Gall" ]
+          ; link = Some {js|https://www.youtube.com/watch?v=-kBprJFFfsc|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml on a JVM using OCaml-Java|js}
+          ; authors = [ "Xavier Clerc" ]
+          ; link = Some {js|https://www.youtube.com/watch?v=v0zBMVABYXo|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee = []
+    ; organising_committee =
+        [ { name = {js|Sylvain Le Gall|js}; role = None; affiliation = None }
+        ; { name = {js|Vincent Balat|js}; role = None; affiliation = None }
+        ; { name = {js|Gabriel Kerneis|js}; role = None; affiliation = None }
+        ]
+    ; body_md =
+        {js|
 ### Call for Presentations
 
 Please consider submitting a presentation! See here the call for presentations.
@@ -141,107 +125,87 @@ Please consider submitting a presentation! See here the call for presentations.
 
 
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<h3>Call for Presentations</h3>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<h3>Call for Presentations</h3>
 <p>Please consider submitting a presentation! See here the call for presentations.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2009|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2009|js}
-  ; location = Some {js|Grenoble, France|js}
-  ; date = {js|2009-09-23|js}
-  ; online = false
-  ; important_dates = 
- []
-  ; presentations = [
-  { title = {js|OCamlCore.org news and projects|js};
-    authors = 
-                         ["Stefano Zacchiroli"; "Sylvain Le Gall"];
-    link = Some {js|http://www.ocamlcore.org/|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OCaml Batteries Included|js};
-    authors = 
-                         ["David Teller"];
-    link = Some {js|http://batteries.forge.ocamlcore.org/|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Cameleon/Chamo|js};
-    authors = 
-                         ["Maxence Guesdon"];
-    link = Some {js|http://home.gna.org/cameleon/chamo.en.html|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Delimited overloading|js};
-    authors = 
-                         ["Christophe Troestler"];
-    link = Some {js|http://pa-do.forge.ocamlcore.org/|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OCaml as fast as C!|js};
-    authors = 
-                         ["Sylvain Le Gall"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2009/slides/OCamlAsFastAsC.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|VHDL symbolic simulation in OCaml|js};
-    authors = 
-                         ["Florent Ouchet"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Parsing technology for OCaml: from stream matching to dypgen|js};
-    authors = 
-                         ["Christophe Raffalli"];
-    link = Some {js|http://dypgen.free.fr/|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- []
-  ; organising_committee = [
-  { name = {js|Sylvain Le Gall|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Alan Schmitt|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Serge Leblanc|js};
-    role = None;
-    affiliation = None;
-  }]
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2009|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2009|js}
+    ; location = Some {js|Grenoble, France|js}
+    ; date = {js|2009-09-23|js}
+    ; online = false
+    ; important_dates = []
+    ; presentations =
+        [ { title = {js|OCamlCore.org news and projects|js}
+          ; authors = [ "Stefano Zacchiroli"; "Sylvain Le Gall" ]
+          ; link = Some {js|http://www.ocamlcore.org/|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml Batteries Included|js}
+          ; authors = [ "David Teller" ]
+          ; link = Some {js|http://batteries.forge.ocamlcore.org/|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Cameleon/Chamo|js}
+          ; authors = [ "Maxence Guesdon" ]
+          ; link = Some {js|http://home.gna.org/cameleon/chamo.en.html|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Delimited overloading|js}
+          ; authors = [ "Christophe Troestler" ]
+          ; link = Some {js|http://pa-do.forge.ocamlcore.org/|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml as fast as C!|js}
+          ; authors = [ "Sylvain Le Gall" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2009/slides/OCamlAsFastAsC.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|VHDL symbolic simulation in OCaml|js}
+          ; authors = [ "Florent Ouchet" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Parsing technology for OCaml: from stream matching to dypgen|js}
+          ; authors = [ "Christophe Raffalli" ]
+          ; link = Some {js|http://dypgen.free.fr/|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee = []
+    ; organising_committee =
+        [ { name = {js|Sylvain Le Gall|js}; role = None; affiliation = None }
+        ; { name = {js|Alan Schmitt|js}; role = None; affiliation = None }
+        ; { name = {js|Serge Leblanc|js}; role = None; affiliation = None }
+        ]
+    ; body_md =
+        {js|
 ### Call for Presentations
 
 Please consider submitting a presentation! See here the call for presentations.
@@ -249,145 +213,128 @@ Please consider submitting a presentation! See here the call for presentations.
 
 
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<h3>Call for Presentations</h3>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<h3>Call for Presentations</h3>
 <p>Please consider submitting a presentation! See here the call for presentations.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2010|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2010|js}
-  ; location = Some {js|Paris, France|js}
-  ; date = {js|2010-04-23|js}
-  ; online = false
-  ; important_dates = 
- []
-  ; presentations = [
-  { title = {js|Foreword|js};
-    authors = 
-                         ["Xavier Leroy"];
-    link = Some {js|https://youtu.be/2_eVOy8w1tc|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OCamlCore.org news and projects|js};
-    authors = 
-                         ["Sylvain Le Gall"];
-    link = Some {js|https://youtu.be/jGkBLivoML0|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Enforcing Type-Safe Linking using Inter-Package Relationships for OCaml Debian packages|js};
-    authors = 
-                         ["Stefano Zacchiroli"];
-    link = Some {js|https://youtu.be/9WOyYrMz3F0|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OASIS, a Cabal like system for OCaml|js};
-    authors = 
-                         ["Sylvain Le Gall"];
-    link = Some {js|https://youtu.be/VHmMD2u9iRU|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Cluster computing in Ocaml|js};
-    authors = 
-                         ["Gerd Stolpmann"];
-    link = Some {js|https://youtu.be/XkBFZ1W89fs|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Ocaml in a web startup|js};
-    authors = 
-                         ["Dario Teixeira"];
-    link = Some {js|https://youtu.be/0r6Y-38lh1s|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|React, functional reactive programming for OCaml|js};
-    authors = 
-                         ["Daniel Bünzli"];
-    link = Some {js|https://youtu.be/0-tVf9BFTMY|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Ocamlviz|js};
-    authors = 
-                         ["Sylvain Conchon"; "Julien Robert";
-                          "Guillaume Von Tokarski";
-                          "Jean-Christophe Filliâtre"; "Fabrice Le Fessant"];
-    link = Some {js|https://youtu.be/NOY5CyTteFc|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OC4MC : Objective Caml for MultiCore|js};
-    authors = 
-                         ["Benjamin Canou"];
-    link = Some {js|https://youtu.be/soOaUFzbXyQ|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|Cooperative Light-Weight Threads|js};
-    authors = 
-                         ["Jérémie Dimino"];
-    link = Some {js|https://youtu.be/C7Z0HduWGx8|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|The collaborative rendering farm: a JoCaml-powered desktop grid|js};
-    authors = 
-                         ["William Le Ferrand"];
-    link = Some {js|https://youtu.be/Iae81LS8sWY|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-                         
-  { title = {js|OCaml in the clouds|js};
-    authors = 
-                         ["Anil Madhavapeddy"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- []
-  ; organising_committee = []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2010|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2010|js}
+    ; location = Some {js|Paris, France|js}
+    ; date = {js|2010-04-23|js}
+    ; online = false
+    ; important_dates = []
+    ; presentations =
+        [ { title = {js|Foreword|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link = Some {js|https://youtu.be/2_eVOy8w1tc|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCamlCore.org news and projects|js}
+          ; authors = [ "Sylvain Le Gall" ]
+          ; link = Some {js|https://youtu.be/jGkBLivoML0|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Enforcing Type-Safe Linking using Inter-Package Relationships for OCaml Debian packages|js}
+          ; authors = [ "Stefano Zacchiroli" ]
+          ; link = Some {js|https://youtu.be/9WOyYrMz3F0|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OASIS, a Cabal like system for OCaml|js}
+          ; authors = [ "Sylvain Le Gall" ]
+          ; link = Some {js|https://youtu.be/VHmMD2u9iRU|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Cluster computing in Ocaml|js}
+          ; authors = [ "Gerd Stolpmann" ]
+          ; link = Some {js|https://youtu.be/XkBFZ1W89fs|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Ocaml in a web startup|js}
+          ; authors = [ "Dario Teixeira" ]
+          ; link = Some {js|https://youtu.be/0r6Y-38lh1s|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|React, functional reactive programming for OCaml|js}
+          ; authors = [ "Daniel Bünzli" ]
+          ; link = Some {js|https://youtu.be/0-tVf9BFTMY|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Ocamlviz|js}
+          ; authors =
+              [ "Sylvain Conchon"
+              ; "Julien Robert"
+              ; "Guillaume Von Tokarski"
+              ; "Jean-Christophe Filliâtre"
+              ; "Fabrice Le Fessant"
+              ]
+          ; link = Some {js|https://youtu.be/NOY5CyTteFc|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OC4MC : Objective Caml for MultiCore|js}
+          ; authors = [ "Benjamin Canou" ]
+          ; link = Some {js|https://youtu.be/soOaUFzbXyQ|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Cooperative Light-Weight Threads|js}
+          ; authors = [ "Jérémie Dimino" ]
+          ; link = Some {js|https://youtu.be/C7Z0HduWGx8|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|The collaborative rendering farm: a JoCaml-powered desktop grid|js}
+          ; authors = [ "William Le Ferrand" ]
+          ; link = Some {js|https://youtu.be/Iae81LS8sWY|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml in the clouds|js}
+          ; authors = [ "Anil Madhavapeddy" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee = []
+    ; organising_committee = []
+    ; body_md =
+        {js|
 ### Call for Presentations
 
 Please consider submitting a presentation! See here the call for presentations.
@@ -395,162 +342,134 @@ Please consider submitting a presentation! See here the call for presentations.
 
 
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<h3>Call for Presentations</h3>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<h3>Call for Presentations</h3>
 <p>Please consider submitting a presentation! See here the call for presentations.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2011|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2011|js}
-  ; location = Some {js|Paris, France|js}
-  ; date = {js|2011-04-15|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2011-04-15|js};
-    info = {js|Workshop Date|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|OCamlCore.org news and projects|js};
-    authors = 
-  ["Sylvain Le Gall"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Compiling Ocaml bytecode to Javascript|js};
-    authors = 
-  ["Jérôme Vouillon"];
-    link = Some {js|https://youtu.be/rJNCUFZokNI|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCAPIC: programming PIC microcontrollers with Objective Caml|js};
-    authors = 
-  ["Benoît Vaugon"; "Philippe Wang"];
-    link = Some {js|http://www.algo-prog.info/ocaml_for_pic/ https://youtu.be/ZLTWLrTCd4s|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Developing Frama-C Plug-ins in OCaml|js};
-    authors = 
-  ["Julien Signoles"];
-    link = Some {js|https://youtu.be/TgaWYzHW33s|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Client/server Web applications with Eliom|js};
-    authors = 
-  ["Vincent Balat"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|MirageOS|js};
-    authors = ["Anil Madhavapeddy"];
-    link = Some {js|https://youtu.be/GEkxyA2FwW0|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Using OCaml to generate 198,278 lines of C|js};
-    authors = 
-  ["Richard Jones"];
-    link = Some {js|https://youtu.be/FbgRsFpfHJI|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCaml annual report|js};
-    authors = ["Xavier Leroy"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|JoCaml|js};
-    authors = ["Luc Maranget"];
-    link = Some {js|https://youtu.be/dQl0BUE1WGw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The Eternal Solution for Memoisation: Ephemerons|js};
-    authors = 
-  ["François Bobot"];
-    link = Some {js|https://youtu.be/i8U3Y7C6eIs|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OASIS-DB: a CPAN for OCaml|js};
-    authors = ["Sylvain Le Gall"];
-    link = Some {js|https://github.com/ocaml/oasis https://youtu.be/njkP5EZ8uAo|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Ideas for a Modern OCaml Web Portal|js};
-    authors = 
-  ["Ashish Agarwal"];
-    link = Some {js|https://youtu.be/W7_wIjvg_is|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- []
-  ; organising_committee = [
-  { name = {js|Sylvain Le Gall|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Dario Teixeira|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Pierre Chambart (chambart AT crans.org)|js};
-    role = None;
-    affiliation = None;
-  };
-                                
-  { name = {js|Paolo Herms|js};
-    role = None;
-    affiliation = None;
-  }]
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2011|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2011|js}
+    ; location = Some {js|Paris, France|js}
+    ; date = {js|2011-04-15|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2011-04-15|js}; info = {js|Workshop Date|js} } ]
+    ; presentations =
+        [ { title = {js|OCamlCore.org news and projects|js}
+          ; authors = [ "Sylvain Le Gall" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Compiling Ocaml bytecode to Javascript|js}
+          ; authors = [ "Jérôme Vouillon" ]
+          ; link = Some {js|https://youtu.be/rJNCUFZokNI|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|OCAPIC: programming PIC microcontrollers with Objective Caml|js}
+          ; authors = [ "Benoît Vaugon"; "Philippe Wang" ]
+          ; link =
+              Some
+                {js|http://www.algo-prog.info/ocaml_for_pic/ https://youtu.be/ZLTWLrTCd4s|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Developing Frama-C Plug-ins in OCaml|js}
+          ; authors = [ "Julien Signoles" ]
+          ; link = Some {js|https://youtu.be/TgaWYzHW33s|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Client/server Web applications with Eliom|js}
+          ; authors = [ "Vincent Balat" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|MirageOS|js}
+          ; authors = [ "Anil Madhavapeddy" ]
+          ; link = Some {js|https://youtu.be/GEkxyA2FwW0|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Using OCaml to generate 198,278 lines of C|js}
+          ; authors = [ "Richard Jones" ]
+          ; link = Some {js|https://youtu.be/FbgRsFpfHJI|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml annual report|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|JoCaml|js}
+          ; authors = [ "Luc Maranget" ]
+          ; link = Some {js|https://youtu.be/dQl0BUE1WGw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The Eternal Solution for Memoisation: Ephemerons|js}
+          ; authors = [ "François Bobot" ]
+          ; link = Some {js|https://youtu.be/i8U3Y7C6eIs|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OASIS-DB: a CPAN for OCaml|js}
+          ; authors = [ "Sylvain Le Gall" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/oasis https://youtu.be/njkP5EZ8uAo|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Ideas for a Modern OCaml Web Portal|js}
+          ; authors = [ "Ashish Agarwal" ]
+          ; link = Some {js|https://youtu.be/W7_wIjvg_is|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee = []
+    ; organising_committee =
+        [ { name = {js|Sylvain Le Gall|js}; role = None; affiliation = None }
+        ; { name = {js|Dario Teixeira|js}; role = None; affiliation = None }
+        ; { name = {js|Pierre Chambart (chambart AT crans.org)|js}
+          ; role = None
+          ; affiliation = None
+          }
+        ; { name = {js|Paolo Herms|js}; role = None; affiliation = None }
+        ]
+    ; body_md =
+        {js|
 This event will take place in Paris. The venue is in Telecom ParisTech (former ENST, the place of the first OCaml Meeting).
 
 ### Questions and contact
@@ -559,281 +478,275 @@ If you have any queries or suggestions for the workshop, please contact Didier R
 
 
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<p>This event will take place in Paris. The venue is in Telecom ParisTech (former ENST, the place of the first OCaml Meeting).</p>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<p>This event will take place in Paris. The venue is in Telecom ParisTech (former ENST, the place of the first OCaml Meeting).</p>
 <h3>Questions and contact</h3>
 <p>If you have any queries or suggestions for the workshop, please contact Didier Remy (first.last@inria.fr) or Anil Madhavapeddy (first.last@cl.cam.ac.uk).</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2012|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2012|js}
-  ; location = Some {js|Copenhagen, Denmark|js}
-  ; date = {js|2012-09-14|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2012-07-08|js};
-    info = {js|Abstract Submission Deadline|js};
-  };
-  
-  { date = {js|2012-07-06|js};
-    info = {js|Notification to Speakers|js};
-  };
-  
-  { date = {js|2012-08-09|js};
-    info = {js|Early Registration Deadline|js};
-  };
-  
-  { date = {js|2012-07-14|js};
-    info = {js|Workshop Date|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Welcome|js};
-    authors = ["Didier Remy";
-                                               "Anil Madhavapeddy"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Presenting Core|js};
-    authors = ["Yaron Minsky"];
-    link = Some {js|http://www.youtube.com/watch?v=qFfS6-XKp9A&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Ocsigen/Eliom: The state of the art, and the prospects|js};
-    authors = 
-  ["Benedikt Becker"; "Vincent Balat"];
-    link = Some {js|http://www.youtube.com/watch?v=kk_o1QV9tQc&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Experiments in Generic Programming|js};
-    authors = 
-  ["Pierre Chambart"; "Grégoire Henry"];
-    link = Some {js|http://www.youtube.com/watch?v=2EcucepyIyw&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Async|js};
-    authors = ["Mark Shinwell"; "David House"];
-    link = Some {js|http://www.youtube.com/watch?v=XhNBp46CpOk&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCamlCC -- Raising Low-Level Bytecode to High-Level C|js};
-    authors = 
-  ["Michel Mauny"; "Benoit Vaugon"];
-    link = Some {js|http://www.youtube.com/watch?v=aHHKeWA88Xo&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of OCaml|js};
-    authors = ["Xavier Leroy"];
-    link = Some {js|http://www.youtube.com/watch?v=ANwpbkSxHZs&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCamlPro: promoting OCaml use in industry|js};
-    authors = 
-  ["Fabrice le Fessant"];
-    link = Some {js|http://www.youtube.com/watch?v=DXr8Lr3z7wY&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Towards an OCaml Platform|js};
-    authors = ["Yaron Minsky"];
-    link = Some {js|http://www.youtube.com/watch?v=ZosM-KFOZ9s&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OPAM: an OCaml Package Manager|js};
-    authors = 
-  ["Frederic Tuong"; "Fabrice le Fessant"; "Thomas Gazagnaire"];
-    link = Some {js|http://www.youtube.com/watch?v=ivLqeRZJTGs&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|An LLVM Backend for OCaml|js};
-    authors = ["Colin Benner"];
-    link = Some {js|http://www.youtube.com/watch?v=wFsgHH297JE&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|DragonKit: an extensible language oriented compiler|js};
-    authors = 
-  ["Wojciech Meyer"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Programming the Xen cloud using OCaml|js};
-    authors = 
-  ["David Scott"; "Richard Mortier"; "Anil Madhavapeddy"];
-    link = Some {js|http://www.youtube.com/watch?v=dJlHBS7sP_c&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Arakoon: a consistent distributed key value store|js};
-    authors = 
-  ["Romain Slootmaekers"; "Nicolas Trangez"];
-    link = Some {js|http://www.youtube.com/watch?v=9PFXV9OAN-s&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|gloc: Metaprogramming WebGL Shaders with OCaml|js};
-    authors = 
-  ["David Sheets"];
-    link = Some {js|http://www.youtube.com/watch?v=ll9z1ULtgqo&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Real-world debugging in OCaml|js};
-    authors = ["Mark Shinwell"];
-    link = Some {js|http://www.youtube.com/watch?v=NF2WpWnB-nk&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCaml Companion Tools|js};
-    authors = ["Xavier Clerc"];
-    link = Some {js|http://www.youtube.com/watch?v=V5MLwkrLfs8&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Study of OCaml programs' memory behavior|js};
-    authors = 
-  ["Çagdas Bozman"; "Thomas Gazagnaire"; "Fabrice Le Fessant";
-   "Michel Mauny"];
-    link = Some {js|http://www.youtube.com/watch?v=C2bZa6EYRyk&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Implementing an interval computation library for OCaml|js};
-    authors = 
-  ["Jean-Marc Alliot"; "Charlie Vanaret"; "Jean-Baptiste Gotteland";
-   "Nicolas Durand"; "David Gianazza"];
-    link = Some {js|http://www.youtube.com/watch?v=Bn0xSTmzZLA&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Automatic Analysis of Industrial Robot Programs|js};
-    authors = 
-  ["Markus Weißmann"];
-    link = Some {js|http://www.youtube.com/watch?v=2bURV8fh_v8&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Biocaml: The OCaml Bioinformatics Library|js};
-    authors = 
-  ["Ashish Agarwal"; "Sebastien Mondet"; "Philippe Veber";
-   "Christophe Troestler"; "Francois Berenger"];
-    link = Some {js|http://www.youtube.com/watch?v=rzrqcTWc2V8&feature=plcp|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Didier Remy (co-chair)|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Anil Madhavapeddy (co-chair)|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Alain Frisch|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Jacques Garrigue|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Richard Jones|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Thomas Gazagnaire|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Martin Jambon|js};
-    role = None;
-    affiliation = None;
-  }]
-  ; organising_committee = 
- []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2012|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2012|js}
+    ; location = Some {js|Copenhagen, Denmark|js}
+    ; date = {js|2012-09-14|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2012-07-08|js}
+          ; info = {js|Abstract Submission Deadline|js}
+          }
+        ; { date = {js|2012-07-06|js}; info = {js|Notification to Speakers|js} }
+        ; { date = {js|2012-08-09|js}
+          ; info = {js|Early Registration Deadline|js}
+          }
+        ; { date = {js|2012-07-14|js}; info = {js|Workshop Date|js} }
+        ]
+    ; presentations =
+        [ { title = {js|Welcome|js}
+          ; authors = [ "Didier Remy"; "Anil Madhavapeddy" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Presenting Core|js}
+          ; authors = [ "Yaron Minsky" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=qFfS6-XKp9A&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Ocsigen/Eliom: The state of the art, and the prospects|js}
+          ; authors = [ "Benedikt Becker"; "Vincent Balat" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=kk_o1QV9tQc&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Experiments in Generic Programming|js}
+          ; authors = [ "Pierre Chambart"; "Grégoire Henry" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=2EcucepyIyw&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Async|js}
+          ; authors = [ "Mark Shinwell"; "David House" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=XhNBp46CpOk&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|OCamlCC -- Raising Low-Level Bytecode to High-Level C|js}
+          ; authors = [ "Michel Mauny"; "Benoit Vaugon" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=aHHKeWA88Xo&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of OCaml|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=ANwpbkSxHZs&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCamlPro: promoting OCaml use in industry|js}
+          ; authors = [ "Fabrice le Fessant" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=DXr8Lr3z7wY&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Towards an OCaml Platform|js}
+          ; authors = [ "Yaron Minsky" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=ZosM-KFOZ9s&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OPAM: an OCaml Package Manager|js}
+          ; authors =
+              [ "Frederic Tuong"; "Fabrice le Fessant"; "Thomas Gazagnaire" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=ivLqeRZJTGs&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|An LLVM Backend for OCaml|js}
+          ; authors = [ "Colin Benner" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=wFsgHH297JE&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|DragonKit: an extensible language oriented compiler|js}
+          ; authors = [ "Wojciech Meyer" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Programming the Xen cloud using OCaml|js}
+          ; authors = [ "David Scott"; "Richard Mortier"; "Anil Madhavapeddy" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=dJlHBS7sP_c&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Arakoon: a consistent distributed key value store|js}
+          ; authors = [ "Romain Slootmaekers"; "Nicolas Trangez" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=9PFXV9OAN-s&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|gloc: Metaprogramming WebGL Shaders with OCaml|js}
+          ; authors = [ "David Sheets" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=ll9z1ULtgqo&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Real-world debugging in OCaml|js}
+          ; authors = [ "Mark Shinwell" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=NF2WpWnB-nk&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml Companion Tools|js}
+          ; authors = [ "Xavier Clerc" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=V5MLwkrLfs8&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Study of OCaml programs' memory behavior|js}
+          ; authors =
+              [ "Çagdas Bozman"
+              ; "Thomas Gazagnaire"
+              ; "Fabrice Le Fessant"
+              ; "Michel Mauny"
+              ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=C2bZa6EYRyk&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Implementing an interval computation library for OCaml|js}
+          ; authors =
+              [ "Jean-Marc Alliot"
+              ; "Charlie Vanaret"
+              ; "Jean-Baptiste Gotteland"
+              ; "Nicolas Durand"
+              ; "David Gianazza"
+              ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=Bn0xSTmzZLA&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Automatic Analysis of Industrial Robot Programs|js}
+          ; authors = [ "Markus Weißmann" ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=2bURV8fh_v8&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Biocaml: The OCaml Bioinformatics Library|js}
+          ; authors =
+              [ "Ashish Agarwal"
+              ; "Sebastien Mondet"
+              ; "Philippe Veber"
+              ; "Christophe Troestler"
+              ; "Francois Berenger"
+              ]
+          ; link =
+              Some
+                {js|http://www.youtube.com/watch?v=rzrqcTWc2V8&feature=plcp|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Didier Remy (co-chair)|js}
+          ; role = None
+          ; affiliation = None
+          }
+        ; { name = {js|Anil Madhavapeddy (co-chair)|js}
+          ; role = None
+          ; affiliation = None
+          }
+        ; { name = {js|Alain Frisch|js}; role = None; affiliation = None }
+        ; { name = {js|Jacques Garrigue|js}; role = None; affiliation = None }
+        ; { name = {js|Richard Jones|js}; role = None; affiliation = None }
+        ; { name = {js|Thomas Gazagnaire|js}; role = None; affiliation = None }
+        ; { name = {js|Martin Jambon|js}; role = None; affiliation = None }
+        ]
+    ; organising_committee = []
+    ; body_md =
+        {js|
 ### Scope
 
 The OCaml Users and Developers Workshop will bring together industrial users of OCaml with academics and hackers who are working on extending the language, type system and tools. Discussion will focus on the practical aspects of OCaml programming and the nitty gritty of the tool-chain and upcoming improvements and changes. Thus, we aim to solicit talks on all aspects related to improving the use or development of the language, including, for example:
@@ -857,8 +770,9 @@ If you have any queries or suggestions for the workshop, please contact Didier R
 There is also an ASCII version of this information available, suitable for dissemination on mailing lists. Please help spread the word about this meeting!
 
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<h3>Scope</h3>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<h3>Scope</h3>
 <p>The OCaml Users and Developers Workshop will bring together industrial users of OCaml with academics and hackers who are working on extending the language, type system and tools. Discussion will focus on the practical aspects of OCaml programming and the nitty gritty of the tool-chain and upcoming improvements and changes. Thus, we aim to solicit talks on all aspects related to improving the use or development of the language, including, for example:</p>
 <ul>
 <li>
@@ -882,261 +796,267 @@ There is also an ASCII version of this information available, suitable for disse
 <p>If you have any queries or suggestions for the workshop, please contact Didier Remy (first.last@inria.fr) or Anil Madhavapeddy (first.last@cl.cam.ac.uk).</p>
 <p>There is also an ASCII version of this information available, suitable for dissemination on mailing lists. Please help spread the word about this meeting!</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2016|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2016|js}
-  ; location = Some {js|Boston (MA,USA)|js}
-  ; date = {js|2013-09-23|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2013-10-07|js};
-    info = {js|The final program, with links to papers and slides is available.|js};
-  };
-  
-  { date = {js|2013-07-11|js};
-    info = {js|The preliminary program is available.|js};
-  };
-  
-  { date = {js|2016-05-07|js};
-    info = {js|The submission site is now open! Please submit a presentation before June 18|js};
-  };
-  
-  { date = {js|2016-04-16|js};
-    info = {js|workshop announcement. The submission site should open in the next days.|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Accessing and using weather-related data in OCaml|js};
-    authors = 
-  ["Hezekiah Carty"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/weather-related-data.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The Frenetic Network Controller|js};
-    authors = 
-  ["Nate Foster"; "Arjun Guha"; "Frenetic Contributors"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/frenetic.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Pfff: PHP Program analysis at Facebook|js};
-    authors = 
-  ["Yoann Padioleau"];
-    link = Some {js|https://github.com/facebook/pfff/wiki/Main https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/padioleau.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The design of the wxOCaml library|js};
-    authors = 
-  ["jjjjj"];
-    link = Some {js|xxxxx|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Goji: an Automated Tool for Building High Level OCaml-JavaScript Interfaces|js};
-    authors = 
-  ["Benjamin Canou"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/wxocaml.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/lefessant.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|ctypes: foreign calls in your native language|js};
-    authors = 
-  ["Jeremy Yallop"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ctypes.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of OCaml|js};
-    authors = ["Xavier Leroy"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/leroy.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The OCaml Platform v0.1|js};
-    authors = ["Anil Madhavapeddy";
-                                                               "Amir Chaudhry";
-                                                               "Thomas Gazagnaire";
-                                                               "David Sheets";
-                                                               "Philippe Wang";
-                                                               "Leo White";
-                                                               "Jeremy Yallop"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/platform.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/madhavapeddy.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Extensions points for OCaml|js};
-    authors = ["Leo White"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/white.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|High-Performance GPGPU Programming with OCaml|js};
-    authors = 
-  ["Mathias Bourgoin"; "Emmmanuel Chailloux"; "Jean-Luc Lamotte"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/gpgpu.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bourgoin.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Improving OCaml high level optimisations|js};
-    authors = 
-  ["Pierre Chambart"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|A new implementation of OCaml formats based on GADTs|js};
-    authors = 
-  ["Benoît Vaugon"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/formats-as-gadts.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/vaugon.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Runtime types in OCaml|js};
-    authors = ["Grégoire Henry";
-                                                              "Jacques Garrigue"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/runtime-types.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/henry.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|On variance, injectivity, and abstraction|js};
-    authors = 
-  ["Jacques Garrigue"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/injectivity.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/garrigue.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Ocamlot: OCaml Online Testing|js};
-    authors = ["David Sheets";
-                                                                    "Anil Madhavapeddy";
-                                                                    "Amir Chaudhry";
-                                                                    "Thomas Gazagnaire"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Merlin, an assistant for editing OCaml code|js};
-    authors = 
-  ["Frédéric Bour"; "Thomas Refis"; "Simon Castellan"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/merlin.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Profiling the Memory Usage of OCaml Applications without Changing their Behavior|js};
-    authors = 
-  ["Çagdas Bozman"; "Michel Mauny"; "Fabrice Le Fessant";
-   "Thomas Gazagnaire"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/profiling-memory.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Core bench: micro-benchmarking for OCaml|js};
-    authors = 
-  ["Christopher Hardin"; "James Roshan"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/core-bench.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/james.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Mark Shinwell|js};
-    role = None;
-    affiliation = Some {js|Jane Street Europe, UK|js};
-  };
-  
-  { name = {js|Damien Doligez|js};
-    role = None;
-    affiliation = Some {js|INRIA Paris-Rocquencourt, France|js};
-  };
-  
-  { name = {js|Jun Furuse|js};
-    role = None;
-    affiliation = Some {js|Standard Chartered Bank, Singapore|js};
-  };
-  
-  { name = {js|Jacques Le Normand|js};
-    role = None;
-    affiliation = Some {js|Google, USA|js};
-  };
-  
-  { name = {js|Michel Mauny|js};
-    role = None;
-    affiliation = Some {js|ENSTA-ParisTech, France (chair)|js};
-  };
-  
-  { name = {js|David Walker|js};
-    role = None;
-    affiliation = Some {js|Princeton University, USA|js};
-  };
-  
-  { name = {js|Jeremy Yallop|js};
-    role = None;
-    affiliation = Some {js|University of Cambridge, UK|js};
-  };
-  
-  { name = {js|Sarah Zennou|js};
-    role = None;
-    affiliation = Some {js|EADS IW, France|js};
-  }]
-  ; organising_committee = 
- []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2016|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2016|js}
+    ; location = Some {js|Boston (MA,USA)|js}
+    ; date = {js|2013-09-23|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2013-10-07|js}
+          ; info =
+              {js|The final program, with links to papers and slides is available.|js}
+          }
+        ; { date = {js|2013-07-11|js}
+          ; info = {js|The preliminary program is available.|js}
+          }
+        ; { date = {js|2016-05-07|js}
+          ; info =
+              {js|The submission site is now open! Please submit a presentation before June 18|js}
+          }
+        ; { date = {js|2016-04-16|js}
+          ; info =
+              {js|workshop announcement. The submission site should open in the next days.|js}
+          }
+        ]
+    ; presentations =
+        [ { title = {js|Accessing and using weather-related data in OCaml|js}
+          ; authors = [ "Hezekiah Carty" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/weather-related-data.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The Frenetic Network Controller|js}
+          ; authors = [ "Nate Foster"; "Arjun Guha"; "Frenetic Contributors" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/frenetic.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Pfff: PHP Program analysis at Facebook|js}
+          ; authors = [ "Yoann Padioleau" ]
+          ; link =
+              Some
+                {js|https://github.com/facebook/pfff/wiki/Main https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/padioleau.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The design of the wxOCaml library|js}
+          ; authors = [ "jjjjj" ]
+          ; link = Some {js|xxxxx|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Goji: an Automated Tool for Building High Level OCaml-JavaScript Interfaces|js}
+          ; authors = [ "Benjamin Canou" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/wxocaml.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/lefessant.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|ctypes: foreign calls in your native language|js}
+          ; authors = [ "Jeremy Yallop" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ctypes.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of OCaml|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/leroy.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The OCaml Platform v0.1|js}
+          ; authors =
+              [ "Anil Madhavapeddy"
+              ; "Amir Chaudhry"
+              ; "Thomas Gazagnaire"
+              ; "David Sheets"
+              ; "Philippe Wang"
+              ; "Leo White"
+              ; "Jeremy Yallop"
+              ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/platform.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/madhavapeddy.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Extensions points for OCaml|js}
+          ; authors = [ "Leo White" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/white.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|High-Performance GPGPU Programming with OCaml|js}
+          ; authors =
+              [ "Mathias Bourgoin"; "Emmmanuel Chailloux"; "Jean-Luc Lamotte" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/gpgpu.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bourgoin.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Improving OCaml high level optimisations|js}
+          ; authors = [ "Pierre Chambart" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|A new implementation of OCaml formats based on GADTs|js}
+          ; authors = [ "Benoît Vaugon" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/formats-as-gadts.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/vaugon.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Runtime types in OCaml|js}
+          ; authors = [ "Grégoire Henry"; "Jacques Garrigue" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/runtime-types.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/henry.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|On variance, injectivity, and abstraction|js}
+          ; authors = [ "Jacques Garrigue" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/injectivity.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/garrigue.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Ocamlot: OCaml Online Testing|js}
+          ; authors =
+              [ "David Sheets"
+              ; "Anil Madhavapeddy"
+              ; "Amir Chaudhry"
+              ; "Thomas Gazagnaire"
+              ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Merlin, an assistant for editing OCaml code|js}
+          ; authors = [ "Frédéric Bour"; "Thomas Refis"; "Simon Castellan" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/merlin.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Profiling the Memory Usage of OCaml Applications without Changing their Behavior|js}
+          ; authors =
+              [ "Çagdas Bozman"
+              ; "Michel Mauny"
+              ; "Fabrice Le Fessant"
+              ; "Thomas Gazagnaire"
+              ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/profiling-memory.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Core bench: micro-benchmarking for OCaml|js}
+          ; authors = [ "Christopher Hardin"; "James Roshan" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/core-bench.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/james.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Mark Shinwell|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street Europe, UK|js}
+          }
+        ; { name = {js|Damien Doligez|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA Paris-Rocquencourt, France|js}
+          }
+        ; { name = {js|Jun Furuse|js}
+          ; role = None
+          ; affiliation = Some {js|Standard Chartered Bank, Singapore|js}
+          }
+        ; { name = {js|Jacques Le Normand|js}
+          ; role = None
+          ; affiliation = Some {js|Google, USA|js}
+          }
+        ; { name = {js|Michel Mauny|js}
+          ; role = None
+          ; affiliation = Some {js|ENSTA-ParisTech, France (chair)|js}
+          }
+        ; { name = {js|David Walker|js}
+          ; role = None
+          ; affiliation = Some {js|Princeton University, USA|js}
+          }
+        ; { name = {js|Jeremy Yallop|js}
+          ; role = None
+          ; affiliation = Some {js|University of Cambridge, UK|js}
+          }
+        ; { name = {js|Sarah Zennou|js}
+          ; role = None
+          ; affiliation = Some {js|EADS IW, France|js}
+          }
+        ]
+    ; organising_committee = []
+    ; body_md =
+        {js|
 ### Call for Presentations
 
 Please consider submitting a presentation, and/or join us in Boston! See here the call for presentations.
@@ -1148,305 +1068,309 @@ Michel Mauny <michel.mauny AT ensta-paristech DOT fr>
 
 
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<h3>Call for Presentations</h3>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<h3>Call for Presentations</h3>
 <p>Please consider submitting a presentation, and/or join us in Boston! See here the call for presentations.</p>
 <h3>Submission</h3>
 <p>If you have any questions, please e-mail:
 Michel Mauny &lt;michel.mauny AT ensta-paristech DOT fr&gt;</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2014|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2014|js}
-  ; location = Some {js|Gothenburg, Sweden|js}
-  ; date = {js|2014-09-05|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2014-09-09|js};
-    info = {js|Add links to slides|js};
-  };
-  
-  { date = {js|2014-09-07|js};
-    info = {js|Links to videos of the talks added to the program|js};
-  };
-  
-  { date = {js|2014-08-24|js};
-    info = {js|Add abstracts to the program|js};
-  };
-  
-  { date = {js|2014-07-04|js};
-    info = {js|preliminary program|js};
-  };
-  
-  { date = {js|2014-05-20|js};
-    info = {js|Extended deadline is Friday May 23, 23:59 UTC-11|js};
-  };
-  
-  { date = {js|2014-05-16|js};
-    info = {js|Precise deadline is May 19, 23:59 UTC-11 (i.e. May 20 10:59 UTC)|js};
-  };
-  
-  { date = {js|2014-05-07|js};
-    info = {js|Sent the last CFP. Deadline is May 19|js};
-  };
-  
-  { date = {js|2014-04-24|js};
-    info = {js|The submission site is now open|js};
-  };
-  
-  { date = {js|2014-02-10|js};
-    info = {js|workshop announcement|js};
-  };
-  
-  { date = {js|2014-09-05|js};
-    info = {js|Workshop|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Multicore OCaml|js};
-    authors = ["Stephen Dolan";
-                                                       "Leo White";
-                                                       "Anil Madhavapeddy"];
-    link = Some {js|https://www.youtube.com/watch?v=FzmQTC_X5R4&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Ephemerons meet OCaml GC|js};
-    authors = ["François Bobot"];
-    link = Some {js|https://www.youtube.com/watch?v=2fzjoxLMOXA&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Introduction to 0install|js};
-    authors = ["Thomas Leonard"];
-    link = Some {js|https://www.youtube.com/watch?v=dYRT6z0NGII&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Transport Layer Security purely in OCaml|js};
-    authors = 
-  ["Hannes Mehnert"; "David Kaloper Meršinjak"];
-    link = Some {js|https://www.youtube.com/watch?v=hJk2lQXbkNk&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCamlOScope: a New OCaml API Search|js};
-    authors = 
-  ["Jun Furuse"];
-    link = Some {js|https://www.youtube.com/watch?v=zRwXIGs42iY&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of OCaml (invited)|js};
-    authors = ["Xavier Leroy"];
-    link = Some {js|https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The OCaml Platform v1.0|js};
-    authors = ["Anil Madhavapeddy";
-                                                               "Amir Chaudhry";
-                                                               "Jeremie Diminio";
-                                                               "Thomas Gazagnaire";
-                                                               "Louis Gesbert";
-                                                               "Thomas Leonard";
-                                                               "David Sheets";
-                                                               "Mark Shinwell";
-                                                               "Leo White";
-                                                               "Jeremy Yallop"];
-    link = Some {js|https://www.youtube.com/watch?v=jxhtpQ5nJHg&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|A Proposal for Non-Intrusive Namespaces in OCaml|js};
-    authors = 
-  ["Pierrick Couderc"; "Fabrice Le Fessant"; "Benjamin Canou";
-   "Pierre Chambart"];
-    link = Some {js|https://www.youtube.com/watch?v=ltkBqVMVQeo&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Improving Type Error Messages in OCaml|js};
-    authors = 
-  ["Arthur Charguéraud"];
-    link = Some {js|https://www.youtube.com/watch?v=V_ipQZeBueg&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Github Pull Requests for OCaml development: a field report|js};
-    authors = 
-  ["Gabriel Scherer"];
-    link = Some {js|https://www.youtube.com/watch?v=PGgAsnxlt4U&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Irminsule; a branch-consistent distributed library database|js};
-    authors = 
-  ["Thomas Gazagnaire"; "Amir Chaudhry"; "Anil Madhavapeddy";
-   "Richard Mortier"; "David Scott"; "David Sheets"; "Gregory Tsipenyuk";
-   "Jon Crowcroft"];
-    link = Some {js|https://www.youtube.com/watch?v=_RzF1mAHUAA&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|A Case for Multi-Switch Constraints in OPAM|js};
-    authors = 
-  ["Fabrice Le Fessant"];
-    link = Some {js|https://www.youtube.com/watch?v=uMCnThFtDA4&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|LibreS3: design, challenges, and steps toward reusable libraries|js};
-    authors = 
-  ["Edwin Török"];
-    link = Some {js|https://www.youtube.com/watch?v=vedtdREomTw&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Nullable Type Inference|js};
-    authors = ["Michel Mauny";
-                                                               "Benoit Vaugon"];
-    link = Some {js|https://www.youtube.com/watch?v=0xOQTv88v5o&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Coq of OCaml|js};
-    authors = ["Guillaume Claret"];
-    link = Some {js|https://www.youtube.com/watch?v=2t9-ZtYTu1Q&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|High Performance Client-Side Web Programming with SPOC and Js of ocaml|js};
-    authors = 
-  ["Mathias Bourgoin"; "Emmmanuel Chailloux"];
-    link = Some {js|https://www.youtube.com/watch?v=xRw2m5V1avI&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Using Preferences to Tame your Package Manager|js};
-    authors = 
-  ["Roberto Di Cosmo"; "Pietro Abate"; "Stefano Zacchiroli";
-   "Fabrice Le Fessant"; "Louis Gesbert"];
-    link = Some {js|https://www.youtube.com/watch?v=E-gtFnbHcv0&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Simple, efficient, sound-and-complete combinator parsing for all context-free grammars, using an oracle|js};
-    authors = 
-  ["Tom Ridge"];
-    link = Some {js|https://www.youtube.com/watch?v=qEqB755feLY&list=UUP9g4dLR7xt6KzCYntNqYcw|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Esther Baruk|js};
-    role = None;
-    affiliation = Some {js|LexiFi, France|js};
-  };
-  
-  { name = {js|Jacques Garrigue|js};
-    role = None;
-    affiliation = Some {js|Nagoya University, Japan (chair)|js};
-  };
-  
-  { name = {js|Oleg Kiselyov|js};
-    role = None;
-    affiliation = Some {js|Monterey, CA, USA|js};
-  };
-  
-  { name = {js|Pierre Letouzey|js};
-    role = None;
-    affiliation = Some {js|Universite Paris 7, France|js};
-  };
-  
-  { name = {js|Luc Maranget|js};
-    role = None;
-    affiliation = Some {js|INRIA Paris-Rocquencourt, France|js};
-  };
-  
-  { name = {js|Keisuke Nakano|js};
-    role = None;
-    affiliation = Some {js|University of Electro-Communications, Japan|js};
-  };
-  
-  { name = {js|Yoann Padioleau|js};
-    role = None;
-    affiliation = Some {js|Facebook, USA|js};
-  };
-  
-  { name = {js|Andreas Rossberg|js};
-    role = None;
-    affiliation = Some {js|Google, Germany|js};
-  };
-  
-  { name = {js|Julien Signoles|js};
-    role = None;
-    affiliation = Some {js|CEA LIST, France|js};
-  };
-  
-  { name = {js|Leo White|js};
-    role = None;
-    affiliation = Some {js|University of Cambridge, UK|js};
-  }]
-  ; organising_committee = 
- []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2014|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2014|js}
+    ; location = Some {js|Gothenburg, Sweden|js}
+    ; date = {js|2014-09-05|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2014-09-09|js}; info = {js|Add links to slides|js} }
+        ; { date = {js|2014-09-07|js}
+          ; info = {js|Links to videos of the talks added to the program|js}
+          }
+        ; { date = {js|2014-08-24|js}
+          ; info = {js|Add abstracts to the program|js}
+          }
+        ; { date = {js|2014-07-04|js}; info = {js|preliminary program|js} }
+        ; { date = {js|2014-05-20|js}
+          ; info = {js|Extended deadline is Friday May 23, 23:59 UTC-11|js}
+          }
+        ; { date = {js|2014-05-16|js}
+          ; info =
+              {js|Precise deadline is May 19, 23:59 UTC-11 (i.e. May 20 10:59 UTC)|js}
+          }
+        ; { date = {js|2014-05-07|js}
+          ; info = {js|Sent the last CFP. Deadline is May 19|js}
+          }
+        ; { date = {js|2014-04-24|js}
+          ; info = {js|The submission site is now open|js}
+          }
+        ; { date = {js|2014-02-10|js}; info = {js|workshop announcement|js} }
+        ; { date = {js|2014-09-05|js}; info = {js|Workshop|js} }
+        ]
+    ; presentations =
+        [ { title = {js|Multicore OCaml|js}
+          ; authors = [ "Stephen Dolan"; "Leo White"; "Anil Madhavapeddy" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=FzmQTC_X5R4&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Ephemerons meet OCaml GC|js}
+          ; authors = [ "François Bobot" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=2fzjoxLMOXA&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Introduction to 0install|js}
+          ; authors = [ "Thomas Leonard" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=dYRT6z0NGII&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Transport Layer Security purely in OCaml|js}
+          ; authors = [ "Hannes Mehnert"; "David Kaloper Meršinjak" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=hJk2lQXbkNk&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCamlOScope: a New OCaml API Search|js}
+          ; authors = [ "Jun Furuse" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=zRwXIGs42iY&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of OCaml (invited)|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The OCaml Platform v1.0|js}
+          ; authors =
+              [ "Anil Madhavapeddy"
+              ; "Amir Chaudhry"
+              ; "Jeremie Diminio"
+              ; "Thomas Gazagnaire"
+              ; "Louis Gesbert"
+              ; "Thomas Leonard"
+              ; "David Sheets"
+              ; "Mark Shinwell"
+              ; "Leo White"
+              ; "Jeremy Yallop"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=jxhtpQ5nJHg&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|A Proposal for Non-Intrusive Namespaces in OCaml|js}
+          ; authors =
+              [ "Pierrick Couderc"
+              ; "Fabrice Le Fessant"
+              ; "Benjamin Canou"
+              ; "Pierre Chambart"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=ltkBqVMVQeo&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Improving Type Error Messages in OCaml|js}
+          ; authors = [ "Arthur Charguéraud" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=V_ipQZeBueg&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Github Pull Requests for OCaml development: a field report|js}
+          ; authors = [ "Gabriel Scherer" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=PGgAsnxlt4U&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Irminsule; a branch-consistent distributed library database|js}
+          ; authors =
+              [ "Thomas Gazagnaire"
+              ; "Amir Chaudhry"
+              ; "Anil Madhavapeddy"
+              ; "Richard Mortier"
+              ; "David Scott"
+              ; "David Sheets"
+              ; "Gregory Tsipenyuk"
+              ; "Jon Crowcroft"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=_RzF1mAHUAA&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|A Case for Multi-Switch Constraints in OPAM|js}
+          ; authors = [ "Fabrice Le Fessant" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=uMCnThFtDA4&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|LibreS3: design, challenges, and steps toward reusable libraries|js}
+          ; authors = [ "Edwin Török" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=vedtdREomTw&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Nullable Type Inference|js}
+          ; authors = [ "Michel Mauny"; "Benoit Vaugon" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=0xOQTv88v5o&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Coq of OCaml|js}
+          ; authors = [ "Guillaume Claret" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=2t9-ZtYTu1Q&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|High Performance Client-Side Web Programming with SPOC and Js of ocaml|js}
+          ; authors = [ "Mathias Bourgoin"; "Emmmanuel Chailloux" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=xRw2m5V1avI&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Using Preferences to Tame your Package Manager|js}
+          ; authors =
+              [ "Roberto Di Cosmo"
+              ; "Pietro Abate"
+              ; "Stefano Zacchiroli"
+              ; "Fabrice Le Fessant"
+              ; "Louis Gesbert"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=E-gtFnbHcv0&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Simple, efficient, sound-and-complete combinator parsing for all context-free grammars, using an oracle|js}
+          ; authors = [ "Tom Ridge" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=qEqB755feLY&list=UUP9g4dLR7xt6KzCYntNqYcw|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Esther Baruk|js}
+          ; role = None
+          ; affiliation = Some {js|LexiFi, France|js}
+          }
+        ; { name = {js|Jacques Garrigue|js}
+          ; role = None
+          ; affiliation = Some {js|Nagoya University, Japan (chair)|js}
+          }
+        ; { name = {js|Oleg Kiselyov|js}
+          ; role = None
+          ; affiliation = Some {js|Monterey, CA, USA|js}
+          }
+        ; { name = {js|Pierre Letouzey|js}
+          ; role = None
+          ; affiliation = Some {js|Universite Paris 7, France|js}
+          }
+        ; { name = {js|Luc Maranget|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA Paris-Rocquencourt, France|js}
+          }
+        ; { name = {js|Keisuke Nakano|js}
+          ; role = None
+          ; affiliation =
+              Some {js|University of Electro-Communications, Japan|js}
+          }
+        ; { name = {js|Yoann Padioleau|js}
+          ; role = None
+          ; affiliation = Some {js|Facebook, USA|js}
+          }
+        ; { name = {js|Andreas Rossberg|js}
+          ; role = None
+          ; affiliation = Some {js|Google, Germany|js}
+          }
+        ; { name = {js|Julien Signoles|js}
+          ; role = None
+          ; affiliation = Some {js|CEA LIST, France|js}
+          }
+        ; { name = {js|Leo White|js}
+          ; role = None
+          ; affiliation = Some {js|University of Cambridge, UK|js}
+          }
+        ]
+    ; organising_committee = []
+    ; body_md =
+        {js|
 
 
 ## Call for presentations (past)
@@ -1510,7 +1434,8 @@ As another form of cooperation, combined post-proceedings of selected papers fro
 ### Questions and contact
 
 If you have any questions, please e-mail: Jacques Garrigue|js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li>Call for presentations (past)
 </li>
@@ -1518,7 +1443,8 @@ If you have any questions, please e-mail: Jacques Garrigue|js}
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2>Call for presentations (past)</h2>
+    ; body_html =
+        {js|<h2>Call for presentations (past)</h2>
 <h3>Scope</h3>
 <p>Presentations and discussions will focus on the OCaml
 programming language and its community. We aim to solicit talks
@@ -1574,237 +1500,250 @@ submitted PDF or the text version.</p>
 <h3>Questions and contact</h3>
 <p>If you have any questions, please e-mail: Jacques Garrigue</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2015|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2015|js}
-  ; location = Some {js|Vancouver, British Columbia, Canada|js}
-  ; date = {js|2015-09-08|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2015-09-19|js};
-    info = {js|Videos of the talks are online|js};
-  };
-  
-  { date = {js|2015-07-31|js};
-    info = {js|programme and call for participation|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Towards A Debugger for Native-Code OCaml|js};
-    authors = 
-  ["Fabrice Le Fessant"; "Pierre Chambart"];
-    link = Some {js|https://www.youtube.com/watch?v=VJJBSE5DzkQ&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS&index=2|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Operf: Benchmarking the OCaml Compiler|js};
-    authors = 
-  ["Pierre Chambart"; "Fabrice Le Fessant"; "Vincent Bernardoff"];
-    link = Some {js|https://www.youtube.com/watch?v=U5hWHTBIRh0&index=2&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Core.Time_stamp_counter: A fast high resolution time source|js};
-    authors = 
-  ["Roshan James"; "Christopher Hardin"];
-    link = Some {js|https://www.youtube.com/watch?v=pEO1GgO-D3I&index=3&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Specialization of Generic Array Accesses After Inlining|js};
-    authors = 
-  ["Ryohei Tokuda"; "Eijiro Sumii"; "Akinori Abe"];
-    link = Some {js|https://www.youtube.com/watch?v=CAHAQLEtklM&index=4&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Inline Assembly in OCaml|js};
-    authors = ["Vladimir Brankov"];
-    link = Some {js|https://www.youtube.com/watch?v=9BklvtQjZzY&index=5&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of OCaml (invited talk)|js};
-    authors = 
-  ["Xavier Leroy"];
-    link = Some {js|https://www.youtube.com/watch?v=dEUMNuE4rxc&index=7&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of the OCaml Platform: September 2015|js};
-    authors = 
-  ["Anil Madhavapeddy"; "Amir Chaudhry"; "Thomas Gazagnaire";
-   "Jeremy Yallop"; "David Sheets"];
-    link = Some {js|https://www.youtube.com/watch?v=dEUMNuE4rxc&index=7&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Modular macros|js};
-    authors = ["Jeremy Yallop";
-                                                      "Leo White"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Typeful PPX and Value Implicits|js};
-    authors = 
-  ["Jun Furuse"];
-    link = Some {js|https://www.youtube.com/watch?v=QMh7Kz8VOMU&index=8&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Global Semantic Analysis on OCaml programs|js};
-    authors = 
-  ["Thomas Blanc"; "Pierre Chambart"; "Michel Mauny"; "Fabrice Le Fessant"];
-    link = Some {js|https://www.youtube.com/watch?v=wkaLd4wWZdo&index=9&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Effective Concurrency through Algebraic Effects|js};
-    authors = 
-  ["Stephen Dolan"; "Leo White"; "Kc Sivaramakrishnan"; "Jeremy Yallop";
-   "Anil Madhavapeddy"];
-    link = Some {js|https://www.youtube.com/watch?v=jZB8CZRRuEo&index=10&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|A review of the growth of the OCaml community|js};
-    authors = 
-  ["Amir Chaudhry"];
-    link = Some {js|https://www.youtube.com/watch?v=L4bRNN-HEIU&index=11&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Persistent Networking with Irmin and MirageOS|js};
-    authors = 
-  ["Mindy Preston"; "Magnus Skjegstad"; "Thomas Gazagnaire";
-   "Richard Mortier"; "Anil Madhavapeddy"];
-    link = Some {js|https://www.youtube.com/watch?v=nUJYGFJDVVo&index=12&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Ketrew and Biokepi|js};
-    authors = ["Sebastien Mondet"];
-    link = Some {js|https://www.youtube.com/watch?v=ef2CFHLDelI&index=13&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Four years of OCaml in production|js};
-    authors = 
-  ["Anders Fugmann"; "Jonas B. Jensen"; "Mads Hartmann Jensen"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Ashish AGARWAL|js};
-    role = None;
-    affiliation = Some {js|Solvuu, USA|js};
-  };
-  
-  { name = {js|Sandrine BLAZY|js};
-    role = None;
-    affiliation = Some {js|U. Rennes 1, France|js};
-  };
-  
-  { name = {js|Cristiano CALCAGNO|js};
-    role = None;
-    affiliation = Some {js|Facebook, USA|js};
-  };
-  
-  { name = {js|Emmanuel CHAILLOUX|js};
-    role = None;
-    affiliation = Some {js|U. Paris 6, France|js};
-  };
-  
-  { name = {js|Pierre CHAMBART|js};
-    role = None;
-    affiliation = Some {js|OCamlPro, France|js};
-  };
-  
-  { name = {js|Damien DOLIGEZ|js};
-    role = None;
-    affiliation = Some {js|Jane Street, USA and Inria, France (chair)|js};
-  };
-  
-  { name = {js|Martin JAMBON|js};
-    role = None;
-    affiliation = Some {js|Esper, USA|js};
-  };
-  
-  { name = {js|Keigo IMAI|js};
-    role = None;
-    affiliation = Some {js|Kyoto University, Japan|js};
-  };
-  
-  { name = {js|Julien VERLAGUET|js};
-    role = None;
-    affiliation = Some {js|Facebook, USA|js};
-  };
-  
-  { name = {js|Markus WEISSMAN|js};
-    role = None;
-    affiliation = Some {js|TU. Muenchen, Germany|js};
-  };
-  
-  { name = {js|Jeremy YALLOP|js};
-    role = None;
-    affiliation = Some {js|OCaml Labs, UK|js};
-  }]
-  ; organising_committee = 
- [
-  { name = {js|Mark Shinwell|js};
-    role = None;
-    affiliation = Some {js|Jane Street Europe, UK (chair)|js};
-  }]
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2015|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2015|js}
+    ; location = Some {js|Vancouver, British Columbia, Canada|js}
+    ; date = {js|2015-09-08|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2015-09-19|js}
+          ; info = {js|Videos of the talks are online|js}
+          }
+        ; { date = {js|2015-07-31|js}
+          ; info = {js|programme and call for participation|js}
+          }
+        ]
+    ; presentations =
+        [ { title = {js|Towards A Debugger for Native-Code OCaml|js}
+          ; authors = [ "Fabrice Le Fessant"; "Pierre Chambart" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=VJJBSE5DzkQ&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS&index=2|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Operf: Benchmarking the OCaml Compiler|js}
+          ; authors =
+              [ "Pierre Chambart"; "Fabrice Le Fessant"; "Vincent Bernardoff" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=U5hWHTBIRh0&index=2&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Core.Time_stamp_counter: A fast high resolution time source|js}
+          ; authors = [ "Roshan James"; "Christopher Hardin" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=pEO1GgO-D3I&index=3&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Specialization of Generic Array Accesses After Inlining|js}
+          ; authors = [ "Ryohei Tokuda"; "Eijiro Sumii"; "Akinori Abe" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=CAHAQLEtklM&index=4&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Inline Assembly in OCaml|js}
+          ; authors = [ "Vladimir Brankov" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=9BklvtQjZzY&index=5&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of OCaml (invited talk)|js}
+          ; authors = [ "Xavier Leroy" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=dEUMNuE4rxc&index=7&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of the OCaml Platform: September 2015|js}
+          ; authors =
+              [ "Anil Madhavapeddy"
+              ; "Amir Chaudhry"
+              ; "Thomas Gazagnaire"
+              ; "Jeremy Yallop"
+              ; "David Sheets"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=dEUMNuE4rxc&index=7&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Modular macros|js}
+          ; authors = [ "Jeremy Yallop"; "Leo White" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Typeful PPX and Value Implicits|js}
+          ; authors = [ "Jun Furuse" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=QMh7Kz8VOMU&index=8&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Global Semantic Analysis on OCaml programs|js}
+          ; authors =
+              [ "Thomas Blanc"
+              ; "Pierre Chambart"
+              ; "Michel Mauny"
+              ; "Fabrice Le Fessant"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=wkaLd4wWZdo&index=9&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Effective Concurrency through Algebraic Effects|js}
+          ; authors =
+              [ "Stephen Dolan"
+              ; "Leo White"
+              ; "Kc Sivaramakrishnan"
+              ; "Jeremy Yallop"
+              ; "Anil Madhavapeddy"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=jZB8CZRRuEo&index=10&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|A review of the growth of the OCaml community|js}
+          ; authors = [ "Amir Chaudhry" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=L4bRNN-HEIU&index=11&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Persistent Networking with Irmin and MirageOS|js}
+          ; authors =
+              [ "Mindy Preston"
+              ; "Magnus Skjegstad"
+              ; "Thomas Gazagnaire"
+              ; "Richard Mortier"
+              ; "Anil Madhavapeddy"
+              ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=nUJYGFJDVVo&index=12&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Ketrew and Biokepi|js}
+          ; authors = [ "Sebastien Mondet" ]
+          ; link =
+              Some
+                {js|https://www.youtube.com/watch?v=ef2CFHLDelI&index=13&list=PLnqUlCo055hU46uoONmhYGUbYAK27Y6rS|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Four years of OCaml in production|js}
+          ; authors =
+              [ "Anders Fugmann"; "Jonas B. Jensen"; "Mads Hartmann Jensen" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Ashish AGARWAL|js}
+          ; role = None
+          ; affiliation = Some {js|Solvuu, USA|js}
+          }
+        ; { name = {js|Sandrine BLAZY|js}
+          ; role = None
+          ; affiliation = Some {js|U. Rennes 1, France|js}
+          }
+        ; { name = {js|Cristiano CALCAGNO|js}
+          ; role = None
+          ; affiliation = Some {js|Facebook, USA|js}
+          }
+        ; { name = {js|Emmanuel CHAILLOUX|js}
+          ; role = None
+          ; affiliation = Some {js|U. Paris 6, France|js}
+          }
+        ; { name = {js|Pierre CHAMBART|js}
+          ; role = None
+          ; affiliation = Some {js|OCamlPro, France|js}
+          }
+        ; { name = {js|Damien DOLIGEZ|js}
+          ; role = None
+          ; affiliation =
+              Some {js|Jane Street, USA and Inria, France (chair)|js}
+          }
+        ; { name = {js|Martin JAMBON|js}
+          ; role = None
+          ; affiliation = Some {js|Esper, USA|js}
+          }
+        ; { name = {js|Keigo IMAI|js}
+          ; role = None
+          ; affiliation = Some {js|Kyoto University, Japan|js}
+          }
+        ; { name = {js|Julien VERLAGUET|js}
+          ; role = None
+          ; affiliation = Some {js|Facebook, USA|js}
+          }
+        ; { name = {js|Markus WEISSMAN|js}
+          ; role = None
+          ; affiliation = Some {js|TU. Muenchen, Germany|js}
+          }
+        ; { name = {js|Jeremy YALLOP|js}
+          ; role = None
+          ; affiliation = Some {js|OCaml Labs, UK|js}
+          }
+        ]
+    ; organising_committee =
+        [ { name = {js|Mark Shinwell|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street Europe, UK (chair)|js}
+          }
+        ]
+    ; body_md =
+        {js|
 
 
 ## Call for presentations (past)
@@ -1841,7 +1780,8 @@ The ML family workshop, held on the previous day, deals with general issues of t
 ### Questions and contact
 
 If you have any questions, please e-mail: Damien Doligez <ocaml2015 AT easychair DOT org>|js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li>Call for presentations (past)
 </li>
@@ -1849,7 +1789,8 @@ If you have any questions, please e-mail: Damien Doligez <ocaml2015 AT easychair
 </li>
 </ul>
 |js}
-  ; body_html = {js|<h2>Call for presentations (past)</h2>
+    ; body_html =
+        {js|<h2>Call for presentations (past)</h2>
 <h3>Scope</h3>
 <p>Discussions will focus on the practical aspects of OCaml programming and the nitty gritty of the tool-chain and upcoming improvements and changes. Thus, we aim to solicit talks on all aspects related to improving the use or development of the language and of its programming environment, including, for example:</p>
 <ul>
@@ -1881,231 +1822,205 @@ deployments in unusual situations.</p>
 <h3>Questions and contact</h3>
 <p>If you have any questions, please e-mail: Damien Doligez <ocaml2015 AT easychair DOT org></p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2016|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2016|js}
-  ; location = Some {js|Nara, Japan|js}
-  ; date = {js|2016-09-08|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2016-06-20|js};
-    info = {js|Talk proposal submission deadline|js};
-  };
-  
-  { date = {js|2016-07-18|js};
-    info = {js|Author notification|js};
-  };
-  
-  { date = {js|2016-09-23|js};
-    info = {js|OCaml workshop|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Conex - establishing trust into data repositories|js};
-    authors = 
-  ["Hannes Mehnert"; "Louis Gesbert"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Generic Programming in OCaml|js};
-    authors = ["Florent Balestrieri";
-                                                                    "Michel Mauny"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Improving the OCaml Web Stack: Motivations and Progress|js};
-    authors = 
-  ["Spiridon Eliopoulos"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Learn OCaml: An Online Learning Center for OCaml|js};
-    authors = 
-  ["Benjamin Canou"; "Grégoire Henry"; "Çagdas Bozman";
-   "Fabrice Le Fessant"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Lock-free programming for the masses|js};
-    authors = 
-  ["Kc Sivaramakrishnan"; "Theo Laurent"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCaml inside: a drop-in replacement for libtls|js};
-    authors = 
-  ["Enguerrand Decorne"; "Jeremy Yallop"; "David Kaloper Meršinjak"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OPAM-builder: Continuous Monitoring of OPAM Repositories|js};
-    authors = 
-  ["Fabrice Le Fessant"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Semantics of the Lambda intermediate language|js};
-    authors = 
-  ["Pierre Chambart"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Statistically profiling memory in OCaml|js};
-    authors = 
-  ["Jacques-Henri Jourdan"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Sundials/ML: interfacing with numerical solvers|js};
-    authors = 
-  ["Timothy Bourke"; "Jun Inoue"; "Marc Pouzet"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of the OCaml Platform: September 2016|js};
-    authors = 
-  ["Louis Gesbert, on behalf of the OCaml Platform team"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Who's got your Mail? Mr. Mime|js};
-    authors = ["Romain Calascibetta"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Inuit library: from printf to interactive user-interfaces|js};
-    authors = 
-  ["Frédéric Bour"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  };
-  
-  { title = {js|ocp-lint, A Plugin-based Style-Checker with Semantic Patches|js};
-    authors = 
-  ["Çagdas Bozman"; "Théophane Hufschmitt"; "Michael Laporte";
-   "Fabrice Le Fessant"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  };
-  
-  { title = {js|Partial evaluation and metaprogramming|js};
-    authors = 
-  ["Pierre Chambart"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Kenichi Asai|js};
-    role = None;
-    affiliation = Some {js|Ochanomizu University, Japan|js};
-  };
-  
-  { name = {js|Oleg Kiselyov|js};
-    role = None;
-    affiliation = Some {js|Tohoku University, Japan|js};
-  };
-  
-  { name = {js|Igor Pikovets|js};
-    role = None;
-    affiliation = Some {js|Ahrefs Research, USA|js};
-  };
-  
-  { name = {js|Mindy Preston|js};
-    role = None;
-    affiliation = Some {js|Docker, UK|js};
-  };
-  
-  { name = {js|Gabriel Scherer|js};
-    role = None;
-    affiliation = Some {js|Northeastern University, USA|js};
-  };
-  
-  { name = {js|Mark Shinwell|js};
-    role = None;
-    affiliation = Some {js|Jane Street Europe, UK (chair)|js};
-  };
-  
-  { name = {js|KC Sivaramakrishnan|js};
-    role = None;
-    affiliation = Some {js|University of Cambridge, UK|js};
-  };
-  
-  { name = {js|Jerome Vouillon|js};
-    role = None;
-    affiliation = Some {js|PPS, France|js};
-  };
-  
-  { name = {js|Jordan Walke|js};
-    role = None;
-    affiliation = Some {js|Facebook, USA|js};
-  }]
-  ; organising_committee = 
- [
-  { name = {js|Mark Shinwell|js};
-    role = None;
-    affiliation = Some {js|Jane Street Europe, UK (chair)|js};
-  }]
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2016|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2016|js}
+    ; location = Some {js|Nara, Japan|js}
+    ; date = {js|2016-09-08|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2016-06-20|js}
+          ; info = {js|Talk proposal submission deadline|js}
+          }
+        ; { date = {js|2016-07-18|js}; info = {js|Author notification|js} }
+        ; { date = {js|2016-09-23|js}; info = {js|OCaml workshop|js} }
+        ]
+    ; presentations =
+        [ { title = {js|Conex - establishing trust into data repositories|js}
+          ; authors = [ "Hannes Mehnert"; "Louis Gesbert" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Generic Programming in OCaml|js}
+          ; authors = [ "Florent Balestrieri"; "Michel Mauny" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Improving the OCaml Web Stack: Motivations and Progress|js}
+          ; authors = [ "Spiridon Eliopoulos" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Learn OCaml: An Online Learning Center for OCaml|js}
+          ; authors =
+              [ "Benjamin Canou"
+              ; "Grégoire Henry"
+              ; "Çagdas Bozman"
+              ; "Fabrice Le Fessant"
+              ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Lock-free programming for the masses|js}
+          ; authors = [ "Kc Sivaramakrishnan"; "Theo Laurent" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml inside: a drop-in replacement for libtls|js}
+          ; authors =
+              [ "Enguerrand Decorne"
+              ; "Jeremy Yallop"
+              ; "David Kaloper Meršinjak"
+              ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|OPAM-builder: Continuous Monitoring of OPAM Repositories|js}
+          ; authors = [ "Fabrice Le Fessant" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Semantics of the Lambda intermediate language|js}
+          ; authors = [ "Pierre Chambart" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Statistically profiling memory in OCaml|js}
+          ; authors = [ "Jacques-Henri Jourdan" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Sundials/ML: interfacing with numerical solvers|js}
+          ; authors = [ "Timothy Bourke"; "Jun Inoue"; "Marc Pouzet" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of the OCaml Platform: September 2016|js}
+          ; authors = [ "Louis Gesbert, on behalf of the OCaml Platform team" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Who's got your Mail? Mr. Mime|js}
+          ; authors = [ "Romain Calascibetta" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Inuit library: from printf to interactive user-interfaces|js}
+          ; authors = [ "Frédéric Bour" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ; { title =
+              {js|ocp-lint, A Plugin-based Style-Checker with Semantic Patches|js}
+          ; authors =
+              [ "Çagdas Bozman"
+              ; "Théophane Hufschmitt"
+              ; "Michael Laporte"
+              ; "Fabrice Le Fessant"
+              ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ; { title = {js|Partial evaluation and metaprogramming|js}
+          ; authors = [ "Pierre Chambart" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Kenichi Asai|js}
+          ; role = None
+          ; affiliation = Some {js|Ochanomizu University, Japan|js}
+          }
+        ; { name = {js|Oleg Kiselyov|js}
+          ; role = None
+          ; affiliation = Some {js|Tohoku University, Japan|js}
+          }
+        ; { name = {js|Igor Pikovets|js}
+          ; role = None
+          ; affiliation = Some {js|Ahrefs Research, USA|js}
+          }
+        ; { name = {js|Mindy Preston|js}
+          ; role = None
+          ; affiliation = Some {js|Docker, UK|js}
+          }
+        ; { name = {js|Gabriel Scherer|js}
+          ; role = None
+          ; affiliation = Some {js|Northeastern University, USA|js}
+          }
+        ; { name = {js|Mark Shinwell|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street Europe, UK (chair)|js}
+          }
+        ; { name = {js|KC Sivaramakrishnan|js}
+          ; role = None
+          ; affiliation = Some {js|University of Cambridge, UK|js}
+          }
+        ; { name = {js|Jerome Vouillon|js}
+          ; role = None
+          ; affiliation = Some {js|PPS, France|js}
+          }
+        ; { name = {js|Jordan Walke|js}
+          ; role = None
+          ; affiliation = Some {js|Facebook, USA|js}
+          }
+        ]
+    ; organising_committee =
+        [ { name = {js|Mark Shinwell|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street Europe, UK (chair)|js}
+          }
+        ]
+    ; body_md =
+        {js|
 
 ### Scope
 
@@ -2168,8 +2083,9 @@ There may be a combined post-conference proceedings of selected papers from the 
 
 Please send any questions to the chair:
 mshinwell -at- janestreet.com|js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<h3>Scope</h3>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<h3>Scope</h3>
 <p>Presentations and discussions will focus on the OCaml
 programming language and its community. We aim to solicit talks
 on all aspects related to improving the use or development of
@@ -2225,248 +2141,251 @@ submitted PDF or the text version.</p>
 <p>Please send any questions to the chair:
 mshinwell -at- janestreet.com</p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2017|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2017|js}
-  ; location = Some {js|Oxford, UK|js}
-  ; date = {js|2017-09-08|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2017-05-31|js};
-    info = {js|Abstract submission deadline (any timezone)|js};
-  };
-  
-  { date = {js|2017-06-28|js};
-    info = {js|Author notification|js};
-  };
-  
-  { date = {js|2017-09-08|js};
-    info = {js|OCaml Workshop|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|A B-tree library for OCaml|js};
-    authors = ["Tom Ridge"];
-    link = Some {js|workshop/2017/extended-abstract__2017__tom-ridge__a-b-tree-library-for-ocaml.pdf|js};
-    video = None;
-    slides = Some {js|workshop/2017/slides__2017__tom-ridge__a-b-tree-library-for-ocaml.pdf|js};
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|A memory model for multicore OCaml|js};
-    authors = 
-  ["Stephen Dolan"; "KC Sivaramakrishnan"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__stephen-dolan_kc-sivaramakrishnan__a-memory-model-for-multicore-ocaml.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Component-based Program Synthesis in OCaml|js};
-    authors = 
-  ["Zhanpeng Liang"; "Kanae Tsushima"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__zhanpeng-liang_kanae-tsushima__component-based-program-synthesis-in-ocaml.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Extending OCaml's open|js};
-    authors = ["Runhang Li";
-                                                              "Jeremy Yallop"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__runhang-li_jeremy-yallop__extending-ocaml-s-open.pdf|js};
-    video = Some {js|https://www.youtube.com/watch?v=rxCMop-dTuc&index=4&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js};
-    slides = None;
-    poster = None;
-    additional_links = Some 
-  ["https://github.com/objmagic/ocaml-workshop-17-open-ext-talk"];
-  };
-  
-  { title = {js|Genspio: Generating Shell Phrases In OCaml|js};
-    authors = 
-  ["Sebastien Mondet"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__sebastien-mondet__genspio-generating-shell-phrases-in-ocaml.pdf|js};
-    video = Some {js|https://www.youtube.com/watch?v=prwLcBUoYiA&index=3&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js};
-    slides = Some {js|http://wr.mondet.org/slides/OCaml2017-Genspio/|js};
-    poster = None;
-    additional_links = Some 
-  ["https://github.com/hammerlab/genspio"];
-  };
-  
-  { title = {js|Owl: A General-Purpose Numerical Library in OCaml|js};
-    authors = 
-  ["Liang Wang"];
-    link = Some {js|https://arxiv.org/abs/1707.09616|js};
-    video = Some {js|https://www.youtube.com/watch?v=Jyv3tJD1N3o&index=7&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js};
-    slides = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__liang_wang__owl-a-general-purpose-numerical-library-in-ocaml.pdf|js};
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|ROTOR: First Steps Towards a Refactoring Tool for OCaml|js};
-    authors = 
-  ["Reuben N. S. Rowe"; "Simon Thompson"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__reuben-rowe_simon-thompson__rotor-first-steps-towards-a-refactoring-tool-for-ocaml.pdf|js};
-    video = None;
-    slides = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__reuben-rowe_simon-thompson__rotor-first-steps-towards-a-refactoring-tool-for-ocaml.pdf|js};
-    poster = None;
-    additional_links = Some 
-  ["https://gitlab.com/trustworthy-refactoring/";
-   "https://hub.docker.com/r/reubenrowe/ocaml-rotor"];
-  };
-  
-  { title = {js|Testing with Crowbar|js};
-    authors = ["Stephen Dolan";
-                                                            "Mindy Preston"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__stephen-dolan_mindy-preston__testing-with-crowbar.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Tezos: the OCaml Crypto-Ledger|js};
-    authors = 
-  ["Benjamin Canou"; "Grégoire Henry"; "Pierre Chambart";
-   "Fabrice Le Fessant"; "Arthur Breitman"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__benjamin-canou_gregoire-henry_pierre-chambart_fabrice-le-fessant_arthur-breitman__tezos-the-ocaml-crypto-ledger.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The State of the OCaml Platform: September 2017|js};
-    authors = 
-  ["Anil Madhavapeddy"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__anil-madhavapeddy__the-state-of-the-ocaml-platform-september-2017.pdf|js};
-    video = Some {js|https://www.youtube.com/watch?v=y-1Zrzdd9KM&index=6&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js};
-    slides = Some {js|https://speakerdeck.com/avsm/ocaml-platform-2017|js};
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Wodan: a pure OCaml, flash-aware filesystem library|js};
-    authors = 
-  ["Gabriel de Perthuis"];
-    link = Some {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__gabriel-de-perthuis__wodan-a-pure-ocaml-flash-aware-filesystem-library.pdf|js};
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|ocamli: interpreted OCaml|js};
-    authors = ["John Whitington"];
-    link = Some {js|http://www.cs.le.ac.uk/people/jw642/ocamlworkshop.pdf extended-abstract__2017__john_whitington__ocamli-interpreted-ocaml.pdf|js};
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  };
-  
-  { title = {js|mSAT: An OCaml SAT Solver|js};
-    authors = ["Bury Guillaume"];
-    link = Some {js|https://gbury.eu/public/papers/icfp2017_msat.pdf|js};
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  };
-  
-  { title = {js|Tyre – Typed Regular Expressions|js};
-    authors = 
-  ["Gabriel Radanne"];
-    link = Some {js|https://www.irif.fr/~gradanne/papers/tyre/abstract.pdf|js};
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  };
-  
-  { title = {js|Jbuilder: a modern approach to OCaml development|js};
-    authors = 
-  ["Jeremie Dimino"; "Mark Shinwell"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = Some true;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Ashish Agarwal|js};
-    role = None;
-    affiliation = Some {js|Solvuu, USA|js};
-  };
-  
-  { name = {js|François Bobot|js};
-    role = None;
-    affiliation = Some {js|CEA, France|js};
-  };
-  
-  { name = {js|Frédéric Bour|js};
-    role = None;
-    affiliation = Some {js|OCaml Labs, France|js};
-  };
-  
-  { name = {js|Cristiano Calcagno|js};
-    role = None;
-    affiliation = Some {js|Facebook, UK|js};
-  };
-  
-  { name = {js|Louis Gesbert|js};
-    role = None;
-    affiliation = Some {js|OcamlPro, France|js};
-  };
-  
-  { name = {js|Sébastien Hinderer|js};
-    role = None;
-    affiliation = Some {js|INRIA, France|js};
-  };
-  
-  { name = {js|Atsushi Igarashi|js};
-    role = None;
-    affiliation = Some {js|Kyoto University, Japan|js};
-  };
-  
-  { name = {js|Oleg Kiselyov|js};
-    role = None;
-    affiliation = Some {js|Tohoku University, Japan|js};
-  };
-  
-  { name = {js|Julia Lawall|js};
-    role = None;
-    affiliation = Some {js|INRIA/LIP6, France|js};
-  };
-  
-  { name = {js|Sam Lindley|js};
-    role = None;
-    affiliation = Some {js|The University of Edinburgh, UK|js};
-  };
-  
-  { name = {js|Louis Mandel|js};
-    role = None;
-    affiliation = Some {js|IBM Research, USA|js};
-  };
-  
-  { name = {js|Zoe Paraskevopoulou|js};
-    role = None;
-    affiliation = Some {js|Princeton University, USA|js};
-  };
-  
-  { name = {js|Gabriel Scherer|js};
-    role = None;
-    affiliation = Some {js|Northeastern University, USA|js};
-  }]
-  ; organising_committee = 
- []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2017|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2017|js}
+    ; location = Some {js|Oxford, UK|js}
+    ; date = {js|2017-09-08|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2017-05-31|js}
+          ; info = {js|Abstract submission deadline (any timezone)|js}
+          }
+        ; { date = {js|2017-06-28|js}; info = {js|Author notification|js} }
+        ; { date = {js|2017-09-08|js}; info = {js|OCaml Workshop|js} }
+        ]
+    ; presentations =
+        [ { title = {js|A B-tree library for OCaml|js}
+          ; authors = [ "Tom Ridge" ]
+          ; link =
+              Some
+                {js|workshop/2017/extended-abstract__2017__tom-ridge__a-b-tree-library-for-ocaml.pdf|js}
+          ; video = None
+          ; slides =
+              Some
+                {js|workshop/2017/slides__2017__tom-ridge__a-b-tree-library-for-ocaml.pdf|js}
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|A memory model for multicore OCaml|js}
+          ; authors = [ "Stephen Dolan"; "KC Sivaramakrishnan" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__stephen-dolan_kc-sivaramakrishnan__a-memory-model-for-multicore-ocaml.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Component-based Program Synthesis in OCaml|js}
+          ; authors = [ "Zhanpeng Liang"; "Kanae Tsushima" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__zhanpeng-liang_kanae-tsushima__component-based-program-synthesis-in-ocaml.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Extending OCaml's open|js}
+          ; authors = [ "Runhang Li"; "Jeremy Yallop" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__runhang-li_jeremy-yallop__extending-ocaml-s-open.pdf|js}
+          ; video =
+              Some
+                {js|https://www.youtube.com/watch?v=rxCMop-dTuc&index=4&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links =
+              Some
+                [ "https://github.com/objmagic/ocaml-workshop-17-open-ext-talk"
+                ]
+          }
+        ; { title = {js|Genspio: Generating Shell Phrases In OCaml|js}
+          ; authors = [ "Sebastien Mondet" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__sebastien-mondet__genspio-generating-shell-phrases-in-ocaml.pdf|js}
+          ; video =
+              Some
+                {js|https://www.youtube.com/watch?v=prwLcBUoYiA&index=3&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js}
+          ; slides = Some {js|http://wr.mondet.org/slides/OCaml2017-Genspio/|js}
+          ; poster = None
+          ; additional_links = Some [ "https://github.com/hammerlab/genspio" ]
+          }
+        ; { title = {js|Owl: A General-Purpose Numerical Library in OCaml|js}
+          ; authors = [ "Liang Wang" ]
+          ; link = Some {js|https://arxiv.org/abs/1707.09616|js}
+          ; video =
+              Some
+                {js|https://www.youtube.com/watch?v=Jyv3tJD1N3o&index=7&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js}
+          ; slides =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__liang_wang__owl-a-general-purpose-numerical-library-in-ocaml.pdf|js}
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|ROTOR: First Steps Towards a Refactoring Tool for OCaml|js}
+          ; authors = [ "Reuben N. S. Rowe"; "Simon Thompson" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__reuben-rowe_simon-thompson__rotor-first-steps-towards-a-refactoring-tool-for-ocaml.pdf|js}
+          ; video = None
+          ; slides =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__reuben-rowe_simon-thompson__rotor-first-steps-towards-a-refactoring-tool-for-ocaml.pdf|js}
+          ; poster = None
+          ; additional_links =
+              Some
+                [ "https://gitlab.com/trustworthy-refactoring/"
+                ; "https://hub.docker.com/r/reubenrowe/ocaml-rotor"
+                ]
+          }
+        ; { title = {js|Testing with Crowbar|js}
+          ; authors = [ "Stephen Dolan"; "Mindy Preston" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__stephen-dolan_mindy-preston__testing-with-crowbar.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Tezos: the OCaml Crypto-Ledger|js}
+          ; authors =
+              [ "Benjamin Canou"
+              ; "Grégoire Henry"
+              ; "Pierre Chambart"
+              ; "Fabrice Le Fessant"
+              ; "Arthur Breitman"
+              ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__benjamin-canou_gregoire-henry_pierre-chambart_fabrice-le-fessant_arthur-breitman__tezos-the-ocaml-crypto-ledger.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The State of the OCaml Platform: September 2017|js}
+          ; authors = [ "Anil Madhavapeddy" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__anil-madhavapeddy__the-state-of-the-ocaml-platform-september-2017.pdf|js}
+          ; video =
+              Some
+                {js|https://www.youtube.com/watch?v=y-1Zrzdd9KM&index=6&list=TLGGpj_CrU7rr7MxMjAxMjAxOA|js}
+          ; slides =
+              Some {js|https://speakerdeck.com/avsm/ocaml-platform-2017|js}
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Wodan: a pure OCaml, flash-aware filesystem library|js}
+          ; authors = [ "Gabriel de Perthuis" ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__gabriel-de-perthuis__wodan-a-pure-ocaml-flash-aware-filesystem-library.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|ocamli: interpreted OCaml|js}
+          ; authors = [ "John Whitington" ]
+          ; link =
+              Some
+                {js|http://www.cs.le.ac.uk/people/jw642/ocamlworkshop.pdf extended-abstract__2017__john_whitington__ocamli-interpreted-ocaml.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ; { title = {js|mSAT: An OCaml SAT Solver|js}
+          ; authors = [ "Bury Guillaume" ]
+          ; link = Some {js|https://gbury.eu/public/papers/icfp2017_msat.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ; { title = {js|Tyre – Typed Regular Expressions|js}
+          ; authors = [ "Gabriel Radanne" ]
+          ; link =
+              Some
+                {js|https://www.irif.fr/~gradanne/papers/tyre/abstract.pdf|js}
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ; { title = {js|Jbuilder: a modern approach to OCaml development|js}
+          ; authors = [ "Jeremie Dimino"; "Mark Shinwell" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = Some true
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Ashish Agarwal|js}
+          ; role = None
+          ; affiliation = Some {js|Solvuu, USA|js}
+          }
+        ; { name = {js|François Bobot|js}
+          ; role = None
+          ; affiliation = Some {js|CEA, France|js}
+          }
+        ; { name = {js|Frédéric Bour|js}
+          ; role = None
+          ; affiliation = Some {js|OCaml Labs, France|js}
+          }
+        ; { name = {js|Cristiano Calcagno|js}
+          ; role = None
+          ; affiliation = Some {js|Facebook, UK|js}
+          }
+        ; { name = {js|Louis Gesbert|js}
+          ; role = None
+          ; affiliation = Some {js|OcamlPro, France|js}
+          }
+        ; { name = {js|Sébastien Hinderer|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA, France|js}
+          }
+        ; { name = {js|Atsushi Igarashi|js}
+          ; role = None
+          ; affiliation = Some {js|Kyoto University, Japan|js}
+          }
+        ; { name = {js|Oleg Kiselyov|js}
+          ; role = None
+          ; affiliation = Some {js|Tohoku University, Japan|js}
+          }
+        ; { name = {js|Julia Lawall|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA/LIP6, France|js}
+          }
+        ; { name = {js|Sam Lindley|js}
+          ; role = None
+          ; affiliation = Some {js|The University of Edinburgh, UK|js}
+          }
+        ; { name = {js|Louis Mandel|js}
+          ; role = None
+          ; affiliation = Some {js|IBM Research, USA|js}
+          }
+        ; { name = {js|Zoe Paraskevopoulou|js}
+          ; role = None
+          ; affiliation = Some {js|Princeton University, USA|js}
+          }
+        ; { name = {js|Gabriel Scherer|js}
+          ; role = None
+          ; affiliation = Some {js|Northeastern University, USA|js}
+          }
+        ]
+    ; organising_committee = []
+    ; body_md =
+        {js|
 OCaml 2017 will open with an invited talk by three frequent
 contributors that recently became maintainers of the OCaml
 implementation: David Allsopp
@@ -2552,7 +2471,8 @@ their abstracts for inclusion.
 
 Please send any questions to the chair:
 `Gabriel Scherer <gabriel.scherer@gmail.com>`|js}
-  ; toc_html = {js|<ul>
+    ; toc_html =
+        {js|<ul>
 <li><ul>
 <li>Call for presentations (past)
 </li>
@@ -2560,7 +2480,8 @@ Please send any questions to the chair:
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>OCaml 2017 will open with an invited talk by three frequent
+    ; body_html =
+        {js|<p>OCaml 2017 will open with an invited talk by three frequent
 contributors that recently became maintainers of the OCaml
 implementation: David Allsopp
 (<a href="https://www.youtube.com/watch?v=10OQHsnyg64&amp;index=2&amp;list=TLGGpj_CrU7rr7MxMjAxMjAxOA">video</a>),
@@ -2637,669 +2558,575 @@ their abstracts for inclusion.</p>
 <p>Please send any questions to the chair:
 <code>Gabriel Scherer &lt;gabriel.scherer@gmail.com&gt;</code></p>
 |js}
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2018|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2018|js}
-  ; location = Some {js|St. Louis, Missouri, USA|js}
-  ; date = {js|2018-08-23|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2018-05-31|js};
-    info = {js|Abstract submission deadline (any timezone)|js};
-  };
-  
-  { date = {js|2018-09-27|js};
-    info = {js|OCaml Workshop|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Abusing Format for fun and profits|js};
-    authors = 
-  ["Gabriel Radanne"; "Frédéric Bour"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|MLExplain|js};
-    authors = ["Kévin Le Bon";
-                                                 "Alan Schmitt"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCaml on the ESP32 chip: Well-Typed Lightbulbs Await|js};
-    authors = 
-  ["Lucas Pluvinage"; "Sadiq Jaffer"; "Anil Madhavapeddy"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|R&B: Towards bringing functional programming to everyday's web programmer|js};
-    authors = 
-  ["Hongbo Zhang"; "Cristiano Calcagno"; "Jordan Walke"; "Cheng Lou";
-   "Rick Vetter"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|RFCs, all the way down!|js};
-    authors = ["Romain Calascibetta"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Relit: Implementing Typed Literal Macros in Reason|js};
-    authors = 
-  ["Charles Chamberlain"; "Cyrus Omar"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The OCaml Platform 1.0|js};
-    authors = ["Anil Madhavapeddy";
-                                                              "Gemma Gordon"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The OCaml Software Foundation|js};
-    authors = ["Michel Mauny";
-                                                                    "Yann Régis-Gianas"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The Vecosek Ecosystem|js};
-    authors = ["Sebastien Mondet"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|This PDF is an OCaml bytecode|js};
-    authors = ["Gabriel Radanne"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Wall: rendering vector graphics with OCaml and OpenGL|js};
-    authors = 
-  ["Frédéric Bour"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Winning on Windows: porting the OCaml Platform|js};
-    authors = 
-  ["David Allsopp"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Andrew Kennedy|js};
-    role = Some `Chair;
-    affiliation = Some {js|Facebook, London|js};
-  };
-  
-  { name = {js|Stephen Dolan|js};
-    role = None;
-    affiliation = Some {js|University of Cambridge, UK|js};
-  };
-  
-  { name = {js|Clark Gaebel|js};
-    role = None;
-    affiliation = Some {js|Jane Street|js};
-  };
-  
-  { name = {js|Nicolás Ojeda Bär|js};
-    role = None;
-    affiliation = Some {js|LexiFi|js};
-  };
-  
-  { name = {js|Jonathan Protzenko|js};
-    role = None;
-    affiliation = Some {js|Microsoft Research Redmond, USA|js};
-  };
-  
-  { name = {js|Gabriel Scherer|js};
-    role = None;
-    affiliation = Some {js|INRIA Saclay, France|js};
-  };
-  
-  { name = {js|Kanae Tsushima|js};
-    role = None;
-    affiliation = Some {js|National Institute of Informatics, Japan|js};
-  };
-  
-  { name = {js|John Whitington|js};
-    role = None;
-    affiliation = Some {js|University of Leicester, UK|js};
-  }]
-  ; organising_committee = 
- []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Users and Developers Workshop 2018|js}
+    ; slug = {js|ocaml-users-and-developers-workshop-2018|js}
+    ; location = Some {js|St. Louis, Missouri, USA|js}
+    ; date = {js|2018-08-23|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2018-05-31|js}
+          ; info = {js|Abstract submission deadline (any timezone)|js}
+          }
+        ; { date = {js|2018-09-27|js}; info = {js|OCaml Workshop|js} }
+        ]
+    ; presentations =
+        [ { title = {js|Abusing Format for fun and profits|js}
+          ; authors = [ "Gabriel Radanne"; "Frédéric Bour" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|MLExplain|js}
+          ; authors = [ "Kévin Le Bon"; "Alan Schmitt" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml on the ESP32 chip: Well-Typed Lightbulbs Await|js}
+          ; authors = [ "Lucas Pluvinage"; "Sadiq Jaffer"; "Anil Madhavapeddy" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|R&B: Towards bringing functional programming to everyday's web programmer|js}
+          ; authors =
+              [ "Hongbo Zhang"
+              ; "Cristiano Calcagno"
+              ; "Jordan Walke"
+              ; "Cheng Lou"
+              ; "Rick Vetter"
+              ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|RFCs, all the way down!|js}
+          ; authors = [ "Romain Calascibetta" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Relit: Implementing Typed Literal Macros in Reason|js}
+          ; authors = [ "Charles Chamberlain"; "Cyrus Omar" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The OCaml Platform 1.0|js}
+          ; authors = [ "Anil Madhavapeddy"; "Gemma Gordon" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The OCaml Software Foundation|js}
+          ; authors = [ "Michel Mauny"; "Yann Régis-Gianas" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The Vecosek Ecosystem|js}
+          ; authors = [ "Sebastien Mondet" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|This PDF is an OCaml bytecode|js}
+          ; authors = [ "Gabriel Radanne" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Wall: rendering vector graphics with OCaml and OpenGL|js}
+          ; authors = [ "Frédéric Bour" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Winning on Windows: porting the OCaml Platform|js}
+          ; authors = [ "David Allsopp" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Andrew Kennedy|js}
+          ; role = Some `Chair
+          ; affiliation = Some {js|Facebook, London|js}
+          }
+        ; { name = {js|Stephen Dolan|js}
+          ; role = None
+          ; affiliation = Some {js|University of Cambridge, UK|js}
+          }
+        ; { name = {js|Clark Gaebel|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street|js}
+          }
+        ; { name = {js|Nicolás Ojeda Bär|js}
+          ; role = None
+          ; affiliation = Some {js|LexiFi|js}
+          }
+        ; { name = {js|Jonathan Protzenko|js}
+          ; role = None
+          ; affiliation = Some {js|Microsoft Research Redmond, USA|js}
+          }
+        ; { name = {js|Gabriel Scherer|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA Saclay, France|js}
+          }
+        ; { name = {js|Kanae Tsushima|js}
+          ; role = None
+          ; affiliation = Some {js|National Institute of Informatics, Japan|js}
+          }
+        ; { name = {js|John Whitington|js}
+          ; role = None
+          ; affiliation = Some {js|University of Leicester, UK|js}
+          }
+        ]
+    ; organising_committee = []
+    ; body_md =
+        {js|
 OCaml 2018 will be held on September 27th, 2018 in St. Louis, Missouri, USA, colocated with ICFP 2018.|js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<p>OCaml 2018 will be held on September 27th, 2018 in St. Louis, Missouri, USA, colocated with ICFP 2018.</p>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<p>OCaml 2018 will be held on September 27th, 2018 in St. Louis, Missouri, USA, colocated with ICFP 2018.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Workshop 2019|js}
-  ; slug = {js|ocaml-workshop-2019|js}
-  ; location = Some {js|Berlin, Germany|js}
-  ; date = {js|2019-08-23|js}
-  ; online = false
-  ; important_dates = 
- [
-  { date = {js|2019-05-17|js};
-    info = {js|Abstract submission deadline (any timezone)|js};
-  };
-  
-  { date = {js|2019-06-30|js};
-    info = {js|Author notification|js};
-  };
-  
-  { date = {js|2019-08-23|js};
-    info = {js|OCaml Workshop|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|Codept, a whole-project dependency analyzer for OCaml|js};
-    authors = 
-  ["Florian Angeletti"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|MirageOS 4: the dawn of practical build systems for exotic targets|js};
-    authors = 
-  ["Lucas Pluvinage"; "Romain Calascibetta"; "Rudi Grinberg";
-   "Anil Madhavapeddy"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Makecloud: Simple, Fast, Robust CI/CD for the modern era|js};
-    authors = 
-  ["Adam Ringwood"; "Hezekiah Carty"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The future of OCaml PPX: towards a unified and more robust ecosystem|js};
-    authors = 
-  ["Nathan Rebours"; "Jeremie Dimino"; "Xavier Clerc"; "Carl Eastlund"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|CausalRPC: traceable distributed computation|js};
-    authors = 
-  ["Craig Ferguson"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The OCaml Platform in 2019|js};
-    authors = ["Anil Madhavapeddy";
-                                                                  "Gemma Gordon"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Lessons from building a succinct blockchain with OCaml|js};
-    authors = 
-  ["Nathan Holland"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OwlDE: making ODEs first-class Owl citizens|js};
-    authors = 
-  ["Marcello Seri"; "Ta-Chu Kao"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Benchmarking the OCaml compiler: our experience|js};
-    authors = 
-  ["Tom Kelly"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Executing Owl Computation on GPU and TPU|js};
-    authors = 
-  ["Jianxin Zhao"];
-    link = None;
-    video = None;
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|David Allsopp|js};
-    role = Some `Chair;
-    affiliation = Some {js|University of Cambridge, UK|js};
-  };
-  
-  { name = {js|Raja Boujbel|js};
-    role = None;
-    affiliation = Some {js|OCamlPro, France|js};
-  };
-  
-  { name = {js|Timothy Bourke|js};
-    role = None;
-    affiliation = Some {js|INRIA, France|js};
-  };
-  
-  { name = {js|Simon Cruanes|js};
-    role = None;
-    affiliation = Some {js|Imandra, USA|js};
-  };
-  
-  { name = {js|Emilio Jésus Gallego Arias|js};
-    role = None;
-    affiliation = Some {js|MINES ParisTech, France|js};
-  };
-  
-  { name = {js|Thomas Gazagnaire|js};
-    role = None;
-    affiliation = Some {js|Tarides, France|js};
-  };
-  
-  { name = {js|Ivan Gotovchits|js};
-    role = None;
-    affiliation = Some {js|CMU, USA|js};
-  };
-  
-  { name = {js|Hannes Mehnert|js};
-    role = None;
-    affiliation = Some {js|robur.io, Germany|js};
-  };
-  
-  { name = {js|Igor Pikovets|js};
-    role = None;
-    affiliation = Some {js|Ahrefs, Singapore|js};
-  };
-  
-  { name = {js|Thomas Refis|js};
-    role = None;
-    affiliation = Some {js|Jane Street Europe, UK|js};
-  };
-  
-  { name = {js|KC Sivaramakrishan|js};
-    role = None;
-    affiliation = Some {js|IIT Madras, India|js};
-  }]
-  ; organising_committee = 
- []
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Workshop 2019|js}
+    ; slug = {js|ocaml-workshop-2019|js}
+    ; location = Some {js|Berlin, Germany|js}
+    ; date = {js|2019-08-23|js}
+    ; online = false
+    ; important_dates =
+        [ { date = {js|2019-05-17|js}
+          ; info = {js|Abstract submission deadline (any timezone)|js}
+          }
+        ; { date = {js|2019-06-30|js}; info = {js|Author notification|js} }
+        ; { date = {js|2019-08-23|js}; info = {js|OCaml Workshop|js} }
+        ]
+    ; presentations =
+        [ { title =
+              {js|Codept, a whole-project dependency analyzer for OCaml|js}
+          ; authors = [ "Florian Angeletti" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|MirageOS 4: the dawn of practical build systems for exotic targets|js}
+          ; authors =
+              [ "Lucas Pluvinage"
+              ; "Romain Calascibetta"
+              ; "Rudi Grinberg"
+              ; "Anil Madhavapeddy"
+              ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Makecloud: Simple, Fast, Robust CI/CD for the modern era|js}
+          ; authors = [ "Adam Ringwood"; "Hezekiah Carty" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|The future of OCaml PPX: towards a unified and more robust ecosystem|js}
+          ; authors =
+              [ "Nathan Rebours"
+              ; "Jeremie Dimino"
+              ; "Xavier Clerc"
+              ; "Carl Eastlund"
+              ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|CausalRPC: traceable distributed computation|js}
+          ; authors = [ "Craig Ferguson" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The OCaml Platform in 2019|js}
+          ; authors = [ "Anil Madhavapeddy"; "Gemma Gordon" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|Lessons from building a succinct blockchain with OCaml|js}
+          ; authors = [ "Nathan Holland" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OwlDE: making ODEs first-class Owl citizens|js}
+          ; authors = [ "Marcello Seri"; "Ta-Chu Kao" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Benchmarking the OCaml compiler: our experience|js}
+          ; authors = [ "Tom Kelly" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Executing Owl Computation on GPU and TPU|js}
+          ; authors = [ "Jianxin Zhao" ]
+          ; link = None
+          ; video = None
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|David Allsopp|js}
+          ; role = Some `Chair
+          ; affiliation = Some {js|University of Cambridge, UK|js}
+          }
+        ; { name = {js|Raja Boujbel|js}
+          ; role = None
+          ; affiliation = Some {js|OCamlPro, France|js}
+          }
+        ; { name = {js|Timothy Bourke|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA, France|js}
+          }
+        ; { name = {js|Simon Cruanes|js}
+          ; role = None
+          ; affiliation = Some {js|Imandra, USA|js}
+          }
+        ; { name = {js|Emilio Jésus Gallego Arias|js}
+          ; role = None
+          ; affiliation = Some {js|MINES ParisTech, France|js}
+          }
+        ; { name = {js|Thomas Gazagnaire|js}
+          ; role = None
+          ; affiliation = Some {js|Tarides, France|js}
+          }
+        ; { name = {js|Ivan Gotovchits|js}
+          ; role = None
+          ; affiliation = Some {js|CMU, USA|js}
+          }
+        ; { name = {js|Hannes Mehnert|js}
+          ; role = None
+          ; affiliation = Some {js|robur.io, Germany|js}
+          }
+        ; { name = {js|Igor Pikovets|js}
+          ; role = None
+          ; affiliation = Some {js|Ahrefs, Singapore|js}
+          }
+        ; { name = {js|Thomas Refis|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street Europe, UK|js}
+          }
+        ; { name = {js|KC Sivaramakrishan|js}
+          ; role = None
+          ; affiliation = Some {js|IIT Madras, India|js}
+          }
+        ]
+    ; organising_committee = []
+    ; body_md =
+        {js|
 The OCaml Users and Developers Workshop brings together the OCaml community, including users of OCaml in industry, academia, hobbyists and the free software community.
 
 The meeting is an informal community gathering of users of the language, library authors, and developers, using and extending OCaml in new ways.
 |js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<p>The OCaml Users and Developers Workshop brings together the OCaml community, including users of OCaml in industry, academia, hobbyists and the free software community.</p>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<p>The OCaml Users and Developers Workshop brings together the OCaml community, including users of OCaml in industry, academia, hobbyists and the free software community.</p>
 <p>The meeting is an informal community gathering of users of the language, library authors, and developers, using and extending OCaml in new ways.</p>
 |js}
-  };
- 
-  { title = {js|OCaml Workshop 2020|js}
-  ; slug = {js|ocaml-workshop-2020|js}
-  ; location = Some {js|Jersey City, New Jersey, USA|js}
-  ; date = {js|2020-08-28|js}
-  ; online = true
-  ; important_dates = 
- [
-  { date = {js|2020-05-29|js};
-    info = {js|Abstract submission deadline (any timezone)|js};
-  };
-  
-  { date = {js|2020-07-17|js};
-    info = {js|Author notification|js};
-  };
-  
-  { date = {js|2020-08-14|js};
-    info = {js|Camera-ready Deadline|js};
-  };
-  
-  { date = {js|2020-08-28|js};
-    info = {js|OCaml Workshop|js};
-  }]
-  ; presentations = 
- [
-  { title = {js|A Declarative Syntax Definition for OCaml|js};
-    authors = 
-  ["Luis Eduardo de Souza Amorim"; "Eelco Visser"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js};
-    authors = 
-  ["Jan Midtgaard"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/08b429ea-2eb8-427d-a625-5495f4ee0fef|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js};
-    authors = 
-  ["Markus Mottl"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/c9e85690-732f-4b03-836f-2ee0fd8f0658|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|API Migration: compare transformed|js};
-    authors = 
-  ["Joseph Harrison"; "Steven Varoumas"; "Simon Thompson"; "Reuben Rowe"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/c46b925b-bd77-404f-ac5d-5dab65047529|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Irmin v2|js};
-    authors = ["Clément Pascutto";
-                                                "Ioana Cristescu";
-                                                "Craig Ferguson";
-                                                "Thomas Gazagnaire";
-                                                "Romain Liautaud"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|LexiFi Runtime Types|js};
-    authors = ["Patrik Keller";
-                                                            "Marc Lasson"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/cc7e3242-0bef-448a-aa13-8827bba933e3|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCaml Under The Hood: SmartPy|js};
-    authors = ["Sebastien Mondet"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|OCaml-CI: A Zero-Configuration CI|js};
-    authors = 
-  ["Thomas Leonard"; "Craig Ferguson"; "Kate Deplaix"; "Magnus Skjegstad";
-   "Anil Madhavapeddy"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Parallelising your OCaml Code with Multicore OCaml|js};
-    authors = 
-  ["Sadiq Jaffer"; "Sudha Parimala"; "KC Sivaramakrishnan"; "Tom Kelly";
-   "Anil Madhavapeddy"];
-    link = Some {js|https://github.com/ocaml-multicore/multicore-talks/tree/master/ocaml2020-workshop-parallel|js};
-    video = Some {js|https://watch.ocaml.org/videos/watch/ce20839e-4bfc-4d74-925b-485a6b052ddf|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The ImpFS filesystem|js};
-    authors = ["Tom Ridge"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/28545b27-4637-47a5-8edd-6b904daef19c|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|The Final Pieces of the OCaml Documentation Puzzle|js};
-    authors = 
-  ["Jonathan Ludlam"; "Gabriel Radanne"; "Leo White"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/2acebff9-25fa-4733-83cc-620a65b12251|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  };
-  
-  { title = {js|Types in amber|js};
-    authors = ["Paul Steckler";
-                                                      "Matthew Ryan"];
-    link = None;
-    video = Some {js|https://watch.ocaml.org/videos/watch/99b3dc75-9f93-4677-9f8b-076546725512|js};
-    slides = None;
-    poster = None;
-    additional_links = None;
-  }]
-  ; program_committee = 
- [
-  { name = {js|Ivan Gotovchits|js};
-    role = Some `Chair;
-    affiliation = Some {js|CMU, USA|js};
-  };
-  
-  { name = {js|Florian Angeletti|js};
-    role = None;
-    affiliation = Some {js|INRIA, France|js};
-  };
-  
-  { name = {js|Chris Casinghino|js};
-    role = None;
-    affiliation = Some {js|Draper Laboratory, USA|js};
-  };
-  
-  { name = {js|Catherine Gasnier|js};
-    role = None;
-    affiliation = Some {js|Facebook, USA|js};
-  };
-  
-  { name = {js|Rudi Grinberg|js};
-    role = None;
-    affiliation = Some {js|OCaml Labs, UK|js};
-  };
-  
-  { name = {js|Oleg Kiselyov|js};
-    role = None;
-    affiliation = Some {js|Tohoku University, Japan|js};
-  };
-  
-  { name = {js|Andreas Rossberg|js};
-    role = None;
-    affiliation = Some {js|Dfinity Stiftung, Germany|js};
-  };
-  
-  { name = {js|Marcello Seri|js};
-    role = None;
-    affiliation = Some {js|University of Groningen, Netherlands|js};
-  };
-  
-  { name = {js|Edwin Torok|js};
-    role = None;
-    affiliation = Some {js|Citrix, UK|js};
-  };
-  
-  { name = {js|Leo White|js};
-    role = None;
-    affiliation = Some {js|Jane Street, USA|js};
-  };
-  
-  { name = {js|Greta Yorsh|js};
-    role = None;
-    affiliation = Some {js|Jane Street, USA|js};
-  };
-  
-  { name = {js|Sarah Zennou|js};
-    role = None;
-    affiliation = Some {js|Airbus, France|js};
-  }]
-  ; organising_committee = 
- [
-  { name = {js|Ivan Gotovchits|js};
-    role = Some `Chair;
-    affiliation = None;
-  };
-  
-  { name = {js|Gemma Gordon|js};
-    role = Some `Co_chair;
-    affiliation = None;
-  };
-  
-  { name = {js|Anil Madhavapeddy|js};
-    role = Some `Co_chair;
-    affiliation = None;
-  };
-  
-  { name = {js|Frédéric Bour|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Enzo Crance|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Shon Feder|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Sonja Heinze|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Shakthi Kannan|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Flynn Ludlam|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Tim McGilchrist|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Sebastien Mondet|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Sudha Parimala|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Tom Ridge|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Marcello Seri|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Daniel Tornabene|js};
-    role = None;
-    affiliation = None;
-  };
-  
-  { name = {js|Shiwei Weng|js};
-    role = None;
-    affiliation = None;
-  }]
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Workshop 2020|js}
+    ; slug = {js|ocaml-workshop-2020|js}
+    ; location = Some {js|Jersey City, New Jersey, USA|js}
+    ; date = {js|2020-08-28|js}
+    ; online = true
+    ; important_dates =
+        [ { date = {js|2020-05-29|js}
+          ; info = {js|Abstract submission deadline (any timezone)|js}
+          }
+        ; { date = {js|2020-07-17|js}; info = {js|Author notification|js} }
+        ; { date = {js|2020-08-14|js}; info = {js|Camera-ready Deadline|js} }
+        ; { date = {js|2020-08-28|js}; info = {js|OCaml Workshop|js} }
+        ]
+    ; presentations =
+        [ { title = {js|A Declarative Syntax Definition for OCaml|js}
+          ; authors = [ "Luis Eduardo de Souza Amorim"; "Eelco Visser" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/a5b86864-8e43-4138-b6d6-ed48d2d4b63d|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title =
+              {js|A Simple State-Machine Framework for Property-Based Testing in OCaml|js}
+          ; authors = [ "Jan Midtgaard" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/08b429ea-2eb8-427d-a625-5495f4ee0fef|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|AD-OCaml: Algorithmic Differentiation for OCaml|js}
+          ; authors = [ "Markus Mottl" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/c9e85690-732f-4b03-836f-2ee0fd8f0658|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|API Migration: compare transformed|js}
+          ; authors =
+              [ "Joseph Harrison"
+              ; "Steven Varoumas"
+              ; "Simon Thompson"
+              ; "Reuben Rowe"
+              ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/c46b925b-bd77-404f-ac5d-5dab65047529|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Irmin v2|js}
+          ; authors =
+              [ "Clément Pascutto"
+              ; "Ioana Cristescu"
+              ; "Craig Ferguson"
+              ; "Thomas Gazagnaire"
+              ; "Romain Liautaud"
+              ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/53e497b0-898f-4c85-8da9-39f65ef0e0b1|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|LexiFi Runtime Types|js}
+          ; authors = [ "Patrik Keller"; "Marc Lasson" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/cc7e3242-0bef-448a-aa13-8827bba933e3|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml Under The Hood: SmartPy|js}
+          ; authors = [ "Sebastien Mondet" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|OCaml-CI: A Zero-Configuration CI|js}
+          ; authors =
+              [ "Thomas Leonard"
+              ; "Craig Ferguson"
+              ; "Kate Deplaix"
+              ; "Magnus Skjegstad"
+              ; "Anil Madhavapeddy"
+              ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/da88d6ac-7ba1-4261-9308-d03fe21e35b9|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Parallelising your OCaml Code with Multicore OCaml|js}
+          ; authors =
+              [ "Sadiq Jaffer"
+              ; "Sudha Parimala"
+              ; "KC Sivaramakrishnan"
+              ; "Tom Kelly"
+              ; "Anil Madhavapeddy"
+              ]
+          ; link =
+              Some
+                {js|https://github.com/ocaml-multicore/multicore-talks/tree/master/ocaml2020-workshop-parallel|js}
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/ce20839e-4bfc-4d74-925b-485a6b052ddf|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The ImpFS filesystem|js}
+          ; authors = [ "Tom Ridge" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/28545b27-4637-47a5-8edd-6b904daef19c|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|The Final Pieces of the OCaml Documentation Puzzle|js}
+          ; authors = [ "Jonathan Ludlam"; "Gabriel Radanne"; "Leo White" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/2acebff9-25fa-4733-83cc-620a65b12251|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ; { title = {js|Types in amber|js}
+          ; authors = [ "Paul Steckler"; "Matthew Ryan" ]
+          ; link = None
+          ; video =
+              Some
+                {js|https://watch.ocaml.org/videos/watch/99b3dc75-9f93-4677-9f8b-076546725512|js}
+          ; slides = None
+          ; poster = None
+          ; additional_links = None
+          }
+        ]
+    ; program_committee =
+        [ { name = {js|Ivan Gotovchits|js}
+          ; role = Some `Chair
+          ; affiliation = Some {js|CMU, USA|js}
+          }
+        ; { name = {js|Florian Angeletti|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA, France|js}
+          }
+        ; { name = {js|Chris Casinghino|js}
+          ; role = None
+          ; affiliation = Some {js|Draper Laboratory, USA|js}
+          }
+        ; { name = {js|Catherine Gasnier|js}
+          ; role = None
+          ; affiliation = Some {js|Facebook, USA|js}
+          }
+        ; { name = {js|Rudi Grinberg|js}
+          ; role = None
+          ; affiliation = Some {js|OCaml Labs, UK|js}
+          }
+        ; { name = {js|Oleg Kiselyov|js}
+          ; role = None
+          ; affiliation = Some {js|Tohoku University, Japan|js}
+          }
+        ; { name = {js|Andreas Rossberg|js}
+          ; role = None
+          ; affiliation = Some {js|Dfinity Stiftung, Germany|js}
+          }
+        ; { name = {js|Marcello Seri|js}
+          ; role = None
+          ; affiliation = Some {js|University of Groningen, Netherlands|js}
+          }
+        ; { name = {js|Edwin Torok|js}
+          ; role = None
+          ; affiliation = Some {js|Citrix, UK|js}
+          }
+        ; { name = {js|Leo White|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street, USA|js}
+          }
+        ; { name = {js|Greta Yorsh|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street, USA|js}
+          }
+        ; { name = {js|Sarah Zennou|js}
+          ; role = None
+          ; affiliation = Some {js|Airbus, France|js}
+          }
+        ]
+    ; organising_committee =
+        [ { name = {js|Ivan Gotovchits|js}
+          ; role = Some `Chair
+          ; affiliation = None
+          }
+        ; { name = {js|Gemma Gordon|js}
+          ; role = Some `Co_chair
+          ; affiliation = None
+          }
+        ; { name = {js|Anil Madhavapeddy|js}
+          ; role = Some `Co_chair
+          ; affiliation = None
+          }
+        ; { name = {js|Frédéric Bour|js}; role = None; affiliation = None }
+        ; { name = {js|Enzo Crance|js}; role = None; affiliation = None }
+        ; { name = {js|Shon Feder|js}; role = None; affiliation = None }
+        ; { name = {js|Sonja Heinze|js}; role = None; affiliation = None }
+        ; { name = {js|Shakthi Kannan|js}; role = None; affiliation = None }
+        ; { name = {js|Flynn Ludlam|js}; role = None; affiliation = None }
+        ; { name = {js|Tim McGilchrist|js}; role = None; affiliation = None }
+        ; { name = {js|Sebastien Mondet|js}; role = None; affiliation = None }
+        ; { name = {js|Sudha Parimala|js}; role = None; affiliation = None }
+        ; { name = {js|Tom Ridge|js}; role = None; affiliation = None }
+        ; { name = {js|Marcello Seri|js}; role = None; affiliation = None }
+        ; { name = {js|Daniel Tornabene|js}; role = None; affiliation = None }
+        ; { name = {js|Shiwei Weng|js}; role = None; affiliation = None }
+        ]
+    ; body_md =
+        {js|
 The OCaml Users and Developers Workshop brings together the OCaml
 community, including users of OCaml in industry, academia, hobbyists,
 and the free software community.
@@ -3313,7 +3140,7 @@ The meeting will be held online this year.
 - May 7, 2020: Deadline Extension.
 - March 30, 2020: [Workshop annoucement](https://icfp20.sigplan.org/home/ocaml-2020#Call-for-Presentations). The [submission website](https://ocaml2020.hotcrp.com/) is also open.
 |js}
-  ; toc_html = {js|<ul>
+    ; toc_html = {js|<ul>
 <li><ul>
 <li>News
 </li>
@@ -3321,7 +3148,8 @@ The meeting will be held online this year.
 </li>
 </ul>
 |js}
-  ; body_html = {js|<p>The OCaml Users and Developers Workshop brings together the OCaml
+    ; body_html =
+        {js|<p>The OCaml Users and Developers Workshop brings together the OCaml
 community, including users of OCaml in industry, academia, hobbyists,
 and the free software community.</p>
 <p>The meeting is an informal community gathering of users of the language,
@@ -3337,116 +3165,97 @@ The meeting will be held online this year.</p>
 </li>
 </ul>
 |js}
-  };
- 
-  { title = {js|OCaml Workshop 2021|js}
-  ; slug = {js|ocaml-workshop-2021|js}
-  ; location = None
-  ; date = {js|2021-08-27|js}
-  ; online = true
-  ; important_dates = 
- [
-  { date = {js|2021-05-20|js};
-    info = {js|Abstract submission deadline|js};
-  };
-  
-  { date = {js|2021-07-18|js};
-    info = {js|Author notification|js};
-  };
-  
-  { date = {js|2021-08-27|js};
-    info = {js|OCaml Workshop|js};
-  }]
-  ; presentations = 
- []
-  ; program_committee = [
-  { name = {js|Frédéric Bour|js};
-    role = Some `Chair;
-    affiliation = None;
-  };
-                             
-  { name = {js|Mehdi Bouaziz|js};
-    role = None;
-    affiliation = Some {js|Nomadic Labs, France|js};
-  };
-                             
-  { name = {js|Simon Castellan|js};
-    role = None;
-    affiliation = Some {js|INRIA, France|js};
-  };
-                             
-  { name = {js|Youyou Cong|js};
-    role = None;
-    affiliation = Some {js|Tokyo Institute of Technology, Japan|js};
-  };
-                             
-  { name = {js|Kate Deplaix|js};
-    role = None;
-    affiliation = Some {js|OCaml Labs, UK|js};
-  };
-                             
-  { name = {js|Jun Furuse|js};
-    role = None;
-    affiliation = Some {js|DaiLambda, Japan|js};
-  };
-                             
-  { name = {js|Joris Giovannangeli|js};
-    role = None;
-    affiliation = Some {js|Ahrefs Research|js};
-  };
-                             
-  { name = {js|Kihong Heo|js};
-    role = None;
-    affiliation = Some {js|KAIST, South Korea|js};
-  };
-                             
-  { name = {js|Hugo Heuzard|js};
-    role = None;
-    affiliation = Some {js|Jane Street|js};
-  };
-                             
-  { name = {js|Vaivaswatha Nagaraj|js};
-    role = None;
-    affiliation = Some {js|Zilliqa Research, India|js};
-  };
-                             
-  { name = {js|Hakjoo Oh|js};
-    role = None;
-    affiliation = Some {js|Korea University|js};
-  };
-                             
-  { name = {js|Jonathan Protzenko|js};
-    role = None;
-    affiliation = Some {js|Microsoft Research Redmond, USA|js};
-  };
-                             
-  { name = {js|Cristina Rosu|js};
-    role = None;
-    affiliation = Some {js|Jane Street|js};
-  };
-                             
-  { name = {js|Jeffrey A. Scofield|js};
-    role = None;
-    affiliation = Some {js|Psellos|js};
-  };
-                             
-  { name = {js|Ryohei Tokuda|js};
-    role = None;
-    affiliation = Some {js|Idein|js};
-  }]
-  ; organising_committee = 
- [
-  { name = {js|Frédéric Bour|js};
-    role = Some `Chair;
-    affiliation = Some {js|Tarides, France|js};
-  }]
-  ; body_md = {js|
+    }
+  ; { title = {js|OCaml Workshop 2021|js}
+    ; slug = {js|ocaml-workshop-2021|js}
+    ; location = None
+    ; date = {js|2021-08-27|js}
+    ; online = true
+    ; important_dates =
+        [ { date = {js|2021-05-20|js}
+          ; info = {js|Abstract submission deadline|js}
+          }
+        ; { date = {js|2021-07-18|js}; info = {js|Author notification|js} }
+        ; { date = {js|2021-08-27|js}; info = {js|OCaml Workshop|js} }
+        ]
+    ; presentations = []
+    ; program_committee =
+        [ { name = {js|Frédéric Bour|js}
+          ; role = Some `Chair
+          ; affiliation = None
+          }
+        ; { name = {js|Mehdi Bouaziz|js}
+          ; role = None
+          ; affiliation = Some {js|Nomadic Labs, France|js}
+          }
+        ; { name = {js|Simon Castellan|js}
+          ; role = None
+          ; affiliation = Some {js|INRIA, France|js}
+          }
+        ; { name = {js|Youyou Cong|js}
+          ; role = None
+          ; affiliation = Some {js|Tokyo Institute of Technology, Japan|js}
+          }
+        ; { name = {js|Kate Deplaix|js}
+          ; role = None
+          ; affiliation = Some {js|OCaml Labs, UK|js}
+          }
+        ; { name = {js|Jun Furuse|js}
+          ; role = None
+          ; affiliation = Some {js|DaiLambda, Japan|js}
+          }
+        ; { name = {js|Joris Giovannangeli|js}
+          ; role = None
+          ; affiliation = Some {js|Ahrefs Research|js}
+          }
+        ; { name = {js|Kihong Heo|js}
+          ; role = None
+          ; affiliation = Some {js|KAIST, South Korea|js}
+          }
+        ; { name = {js|Hugo Heuzard|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street|js}
+          }
+        ; { name = {js|Vaivaswatha Nagaraj|js}
+          ; role = None
+          ; affiliation = Some {js|Zilliqa Research, India|js}
+          }
+        ; { name = {js|Hakjoo Oh|js}
+          ; role = None
+          ; affiliation = Some {js|Korea University|js}
+          }
+        ; { name = {js|Jonathan Protzenko|js}
+          ; role = None
+          ; affiliation = Some {js|Microsoft Research Redmond, USA|js}
+          }
+        ; { name = {js|Cristina Rosu|js}
+          ; role = None
+          ; affiliation = Some {js|Jane Street|js}
+          }
+        ; { name = {js|Jeffrey A. Scofield|js}
+          ; role = None
+          ; affiliation = Some {js|Psellos|js}
+          }
+        ; { name = {js|Ryohei Tokuda|js}
+          ; role = None
+          ; affiliation = Some {js|Idein|js}
+          }
+        ]
+    ; organising_committee =
+        [ { name = {js|Frédéric Bour|js}
+          ; role = Some `Chair
+          ; affiliation = Some {js|Tarides, France|js}
+          }
+        ]
+    ; body_md =
+        {js|
 OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.
 
 Please contact the PC Chair (Frédéric Bour) for any questions.|js}
-  ; toc_html = {js||js}
-  ; body_html = {js|<p>OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.</p>
+    ; toc_html = {js||js}
+    ; body_html =
+        {js|<p>OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.</p>
 <p>Please contact the PC Chair (Frédéric Bour) for any questions.</p>
 |js}
-  }]
-
+    }
+  ]


### PR DESCRIPTION
- Format the files in `ocamlorg_data`
- Update the contributing guide and README to reflect the new directory structure and project setup
- Replace documentation url from `/current` to `/live` (Fixes #80)