### PR TITLE
add all OCaml workshops

### DIFF
--- a/data/workshops/2013.md
+++ b/data/workshops/2013.md
@@ -1,40 +1,42 @@
 ---
-title: OCaml Users and Developers Workshop 2016
-location: Boston (MA,USA)
-date: 2013-09-23
+title: OCaml Users and Developers Workshop 2013
+location: Boston, Massachusetts, USA
+date: 2013-09-24
 online: false
 important_dates: 
-  - date: 2013-10-07
-    info: The final program, with links to papers and slides is available.
-  - date: 2013-07-11
-    info: The preliminary program is available.
-  - date: 2016-05-07
-    info: The submission site is now open! Please submit a presentation before June 18
-  - date: 2016-04-16
-    info: workshop announcement. The submission site should open in the next days.
+  - date: 2013-06-18
+    info: Extended deadline for submissions
+  - date: 2013-07-07
+    info: Notification to speakers
+  - date: 2013-09-24
+    info: Workshop
 presentations: 
   - title: Accessing and using weather-related data in OCaml  
     authors: 
       - Hezekiah Carty
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/weather-related-data.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/weather-related-data.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf
   - title: The Frenetic Network Controller 
     authors: 
       - Nate Foster
       - Arjun Guha
       - Frenetic Contributors
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/frenetic.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/frenetic.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf
   - title: 'Pfff: PHP Program analysis at Facebook'
     authors: 
       - Yoann Padioleau
-    link: https://github.com/facebook/pfff/wiki/Main https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/padioleau.pdf
+    link: https://github.com/facebook/pfff/wiki/Main 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/padioleau.pdf
   - title: The design of the wxOCaml library
     authors: 
-      - jjjjj
-    link: xxxxx
+      - Fabrice Le Fessant
+    link: 
   - title: 'Goji: an Automated Tool for Building High Level OCaml-JavaScript Interfaces'
     authors: 
       - Benjamin Canou
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/wxocaml.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/lefessant.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/wxocaml.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/lefessant.pdf
   - title: 'ctypes: foreign calls in your native language'
     authors: 
       - Jeremy Yallop
@@ -42,7 +44,7 @@ presentations:
   - title: The State of OCaml  
     authors: 
       - Xavier Leroy
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/leroy.pdf
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/leroy.pdf
   - title: The OCaml Platform v0.1 
     authors: 
       - Anil Madhavapeddy
@@ -52,21 +54,24 @@ presentations:
       - Philippe Wang 
       - Leo White 
       - Jeremy Yallop
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/platform.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/madhavapeddy.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/platform.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/madhavapeddy.pdf
   - title: Extensions points for OCaml 
     authors: 
       - Leo White
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/white.pdf
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/white.pdf
   - title: High-Performance GPGPU Programming with OCaml   
     authors: 
       - Mathias Bourgoin
       - Emmmanuel Chailloux
       - Jean-Luc Lamotte
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/gpgpu.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bourgoin.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/gpgpu.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bourgoin.pdf
   - title: Improving OCaml high level optimisations 
     authors: 
       - Pierre Chambart 
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf
   - title: A new implementation of OCaml formats based on GADTs 
     authors: 
       - Benoît Vaugon
@@ -75,18 +80,21 @@ presentations:
     authors: 
       - Grégoire Henry
       - Jacques Garrigue
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/runtime-types.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/henry.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/runtime-types.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/henry.pdf
   - title: On variance, injectivity, and abstraction  
     authors: 
       - Jacques Garrigue
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/injectivity.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/garrigue.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/injectivity.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/garrigue.pdf
   - title: 'Ocamlot: OCaml Online Testing' 
     authors: 
       - David Sheets
       - Anil Madhavapeddy
       - Amir Chaudhry 
       - Thomas Gazagnaire
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf
   - title: Merlin, an assistant for editing OCaml code  
     authors: 
       - Frédéric Bour
@@ -99,15 +107,16 @@ presentations:
       - Michel Mauny
       - Fabrice Le Fessant
       - Thomas Gazagnaire
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/profiling-memory.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/profiling-memory.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf
   - title: 'Core bench: micro-benchmarking for OCaml'
     authors: 
       - Christopher Hardin 
       - James Roshan
-    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/core-bench.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/james.pdf
+    link: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/core-bench.pdf 
+    slides: https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/james.pdf
 organising_committee: []
 program_committee: 
-
   - name: Mark Shinwell
     affiliation: Jane Street Europe, UK 
   - name: Damien Doligez
@@ -124,7 +133,6 @@ program_committee:
     affiliation: University of Cambridge, UK
   - name: Sarah Zennou
     affiliation: EADS IW, France
-
 ---
 
 ### Call for Presentations

--- a/data/workshops/2020.md
+++ b/data/workshops/2020.md
@@ -3,7 +3,9 @@ title: OCaml Workshop 2020
 location: Jersey City, New Jersey, USA
 date: 2020-08-28
 online: true
-important_dates: 
+important_dates:
+  - date: 2020-03-30 
+    info: Workshop Announcement
   - date: 2020-05-29
     info: Abstract submission deadline (any timezone)
   - date: 2020-07-17
@@ -137,8 +139,3 @@ and the free software community.
 The meeting is an informal community gathering of users of the language,
 library authors, and developers, using and extending OCaml in new ways.
 The meeting will be held online this year.
-## News
-
-- July 17, 2020: Talks are accepted!
-- May 7, 2020: Deadline Extension.
-- March 30, 2020: [Workshop annoucement](https://icfp20.sigplan.org/home/ocaml-2020#Call-for-Presentations). The [submission website](https://ocaml2020.hotcrp.com/) is also open.

--- a/data/workshops/2021.md
+++ b/data/workshops/2021.md
@@ -9,7 +9,123 @@ important_dates:
     info: Author notification
   - date: 2021-08-27
     info: OCaml Workshop
-presentations: []
+presentations:
+  - title: "25 Years of OCaml"
+    authors:
+      - Xavier Leroy
+    video: https://watch.ocaml.org/videos/watch/e1ee0fc0-50ef-4a1c-894a-17df181424cb
+  - title: "A Multiverse of Glorious Documentation"
+    authors:
+      - Lucas Pluvinage
+      - Jonathan Ludlam
+    video: https://watch.ocaml.org/videos/watch/9bb452d6-1829-4dac-a6a2-46b31050c931
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/15/A-Multiverse-of-Glorious-Documentation 
+  - title: "Adapting the OCaml Ecosystem for Multicore OCaml"
+    authors:
+      - Sudha Parimala 
+      - Enguerrand Decorne
+      - Sadiq Jaffer
+      - Tom Kelly
+      - KC Sivaramakrishnan
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/7/Adapting-the-OCaml-ecosystem-for-Multicore-OCaml
+    video: https://watch.ocaml.org/videos/watch/629b89a8-bbd5-490d-98b0-d0c740912b02
+  - title: "Binary Analysis Platform (BAP). Using Universal Algebra and Tagless-Final Style for Developing Representation-Agnostic Frameworks"
+    authors:
+      - Ivan Gotovchits
+      - David Brumley
+    video: https://watch.ocaml.org/videos/watch/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/10/Binary-Analysis-Platform-BAP-Using-Universal-Algebra-and-Tagless-Final-Style-for-D
+  - title: "Continuous Benchmarking for OCaml Projects"
+    authors:
+      - Gargi Sharma
+      - Rizo Isrof
+      - Magnus Skjegstad
+    video: https://watch.ocaml.org/videos/watch/1c994370-1aaa-4db6-b901-d762786e4904
+  - title: "Deductive Verification of Realistic OCaml Code"
+    authors:
+      - Carlos Pinto
+      - Mário Pereira
+      - Simão Melo de Sousa
+    video: https://watch.ocaml.org/videos/watch/92309d92-8cbf-4545-980c-209c96e42a79
+  - title: "Digodoc and Docs"
+    authors:
+      - Mohamed Hernouf
+      - Fabrice Le Fessant
+      - Thomas Blanc
+      - Louis Gesbert
+    video: https://watch.ocaml.org/videos/watch/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
+  - title: "Experiences with Effects"
+    authors:
+      - Thomas Leonard
+      - Craig Ferguson
+      - Patrick Ferris
+      - Sadiq Jaffer
+      - Tom Kelly
+      - KC Sivaramakrishnan
+      - Anil Madhavapeddy
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/16/Experiences-with-Effects
+    video: https://watch.ocaml.org/videos/watch/74ece0a8-380f-4e2a-bef5-c6bb9092be89
+  - title: "From 2n+1 to n"
+    authors:
+      - Nandor Licker
+      - Timothy M. Jones
+    video: https://watch.ocaml.org/videos/watch/74b32dae-11c6-4713-be1b-946260196e50
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/14/From-2n-1-to-n
+  - title: "GopCaml: A Structural Editor for OCaml"
+    authors:
+      - Kiran Gopinathan
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/11/GopCaml-A-Structural-Editor-for-OCaml
+    video: https://watch.ocaml.org/videos/watch/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
+  - title: "Leveraging Formal Specifications to Generate Fuzzing Suites"
+    authors:
+      - Nicolas Osborne
+      - Clément Pascutto
+    video: https://watch.ocaml.org/videos/watch/d9a36c9f-1611-42f9-8854-981b1e2d7d75
+  - title: "Love: a readable language interpreted by a blockchain"
+    authors:
+      - Steven de Oliveira
+      - David Declerck
+    video: https://watch.ocaml.org/videos/watch/d3b2b31e-1739-406e-8de7-d5f21bc01836
+  - title: "OCaml and Python: Getting the Best of Both Worlds"
+    authors:
+      - Laurent Mazare
+    video: https://watch.ocaml.org/videos/watch/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
+  - title: "Opam-bin: Binary Packages with Opam"
+    authors:
+      - Fabrice Le Fessant
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/5/Opam-bin-Binary-Packages-with-Opam
+    video: https://watch.ocaml.org/videos/watch/a889e4d3-0508-4734-b667-7060b0a253cd
+  - title: "Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs"
+    authors:
+      - Sumit Padhiyar
+      - Adharsh Kamath
+      - KC Sivaramakrishnan
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/9/Parafuzz-Coverage-guided-Property-Fuzzing-for-Multicore-OCaml-programs
+    slides: https://speakerdeck.com/kayceesrk/parafuzz-fuzzing-multicore-ocaml-programs
+    video: https://watch.ocaml.org/videos/watch/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
+  - title: "Probabilistic resource limits, or: Programming with interrupts in OCaml"
+    authors: 
+      - Guillaume Munch-Maccagnoni
+    video: https://watch.ocaml.org/videos/watch/bc297e85-82dd-4baf-8556-4a3a934978f9
+  - title: "Property-Based Testing for OCaml through Coq"
+    authors:
+      - Paaras Bhandari
+      - Leonidas Lampropoulos
+    video: https://watch.ocaml.org/videos/watch/9324fba4-2482-4bab-bfdd-b8881b3ed94a
+  - title: "Safe Protocol Updates via Propositional Logic"
+    authors:
+      - Michael O'Connor
+    video: https://watch.ocaml.org/videos/watch/c6176f51-0277-46f0-937b-1e2721044492
+  - title: "Semgrep, a fast, lightweight, polyglot, static analysis tool to find bugs"
+    authors:
+      - Yoann Padioleau
+    link: https://icfp21.sigplan.org/details/ocaml-2021-papers/18/Semgrep-a-fast-lightweight-polyglot-static-analysis-tool-to-find-bugs
+    video: https://watch.ocaml.org/videos/watch/c0d07213-1426-46a1-98e0-0b0c4515c841
+  - title: "Wibbily Wobbly Timey Camly"
+    authors: 
+      - Di Long Li
+      - Gabriel Radanne
+    video: https://watch.ocaml.org/videos/watch/ec641446-823b-40ec-a207-85157a18f88e
 organising_committee: 
   - name: Frédéric Bour
     affiliation: Tarides, France
@@ -48,5 +164,3 @@ program_committee:
 ---
 
 OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.
-
-Please contact the PC Chair (Frédéric Bour) for any questions.

--- a/src/ocamlorg_data/workshop.ml
+++ b/src/ocamlorg_data/workshop.ml
@@ -884,36 +884,32 @@ There is also an ASCII version of this information available, suitable for disse
 |js}
   };
  
-  { title = {js|OCaml Users and Developers Workshop 2016|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2016|js}
-  ; location = Some {js|Boston (MA,USA)|js}
-  ; date = {js|2013-09-23|js}
+  { title = {js|OCaml Users and Developers Workshop 2013|js}
+  ; slug = {js|ocaml-users-and-developers-workshop-2013|js}
+  ; location = Some {js|Boston, Massachusetts, USA|js}
+  ; date = {js|2013-09-24|js}
   ; online = false
   ; important_dates = 
  [
-  { date = {js|2013-10-07|js};
-    info = {js|The final program, with links to papers and slides is available.|js};
+  { date = {js|2013-06-18|js};
+    info = {js|Extended deadline for submissions|js};
   };
   
-  { date = {js|2013-07-11|js};
-    info = {js|The preliminary program is available.|js};
+  { date = {js|2013-07-07|js};
+    info = {js|Notification to speakers|js};
   };
   
-  { date = {js|2016-05-07|js};
-    info = {js|The submission site is now open! Please submit a presentation before June 18|js};
-  };
-  
-  { date = {js|2016-04-16|js};
-    info = {js|workshop announcement. The submission site should open in the next days.|js};
+  { date = {js|2013-09-24|js};
+    info = {js|Workshop|js};
   }]
   ; presentations = 
  [
   { title = {js|Accessing and using weather-related data in OCaml|js};
     authors = 
   ["Hezekiah Carty"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/weather-related-data.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/weather-related-data.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -921,9 +917,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|The Frenetic Network Controller|js};
     authors = 
   ["Nate Foster"; "Arjun Guha"; "Frenetic Contributors"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/frenetic.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/frenetic.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/guha.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -931,17 +927,17 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|Pfff: PHP Program analysis at Facebook|js};
     authors = 
   ["Yoann Padioleau"];
-    link = Some {js|https://github.com/facebook/pfff/wiki/Main https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/padioleau.pdf|js};
+    link = Some {js|https://github.com/facebook/pfff/wiki/Main|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/padioleau.pdf|js};
     poster = None;
     additional_links = None;
   };
   
   { title = {js|The design of the wxOCaml library|js};
     authors = 
-  ["jjjjj"];
-    link = Some {js|xxxxx|js};
+  ["Fabrice Le Fessant"];
+    link = None;
     video = None;
     slides = None;
     poster = None;
@@ -951,9 +947,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|Goji: an Automated Tool for Building High Level OCaml-JavaScript Interfaces|js};
     authors = 
   ["Benjamin Canou"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/wxocaml.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/lefessant.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/wxocaml.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/lefessant.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -970,9 +966,9 @@ There is also an ASCII version of this information available, suitable for disse
   
   { title = {js|The State of OCaml|js};
     authors = ["Xavier Leroy"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/leroy.pdf|js};
+    link = None;
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/leroy.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -985,18 +981,18 @@ There is also an ASCII version of this information available, suitable for disse
                                                                "Philippe Wang";
                                                                "Leo White";
                                                                "Jeremy Yallop"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/platform.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/madhavapeddy.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/platform.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/madhavapeddy.pdf|js};
     poster = None;
     additional_links = None;
   };
   
   { title = {js|Extensions points for OCaml|js};
     authors = ["Leo White"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/white.pdf|js};
+    link = None;
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/white.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1004,9 +1000,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|High-Performance GPGPU Programming with OCaml|js};
     authors = 
   ["Mathias Bourgoin"; "Emmmanuel Chailloux"; "Jean-Luc Lamotte"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/gpgpu.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bourgoin.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/gpgpu.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bourgoin.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1014,9 +1010,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|Improving OCaml high level optimisations|js};
     authors = 
   ["Pierre Chambart"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1034,9 +1030,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|Runtime types in OCaml|js};
     authors = ["Grégoire Henry";
                                                               "Jacques Garrigue"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/runtime-types.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/henry.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/runtime-types.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/henry.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1044,9 +1040,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|On variance, injectivity, and abstraction|js};
     authors = 
   ["Jacques Garrigue"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/injectivity.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/garrigue.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/injectivity.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/garrigue.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1056,9 +1052,9 @@ There is also an ASCII version of this information available, suitable for disse
                                                                     "Anil Madhavapeddy";
                                                                     "Amir Chaudhry";
                                                                     "Thomas Gazagnaire"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1077,9 +1073,9 @@ There is also an ASCII version of this information available, suitable for disse
     authors = 
   ["Çagdas Bozman"; "Michel Mauny"; "Fabrice Le Fessant";
    "Thomas Gazagnaire"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/profiling-memory.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/profiling-memory.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf|js};
     poster = None;
     additional_links = None;
   };
@@ -1087,9 +1083,9 @@ There is also an ASCII version of this information available, suitable for disse
   { title = {js|Core bench: micro-benchmarking for OCaml|js};
     authors = 
   ["Christopher Hardin"; "James Roshan"];
-    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/core-bench.pdf https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/james.pdf|js};
+    link = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/core-bench.pdf|js};
     video = None;
-    slides = None;
+    slides = Some {js|https://github.com/ocaml/ocaml.org/blob/master/site/meetings/ocaml/2013/slides/james.pdf|js};
     poster = None;
     additional_links = None;
   }]

--- a/src/ocamlorg_data/workshop.ml
+++ b/src/ocamlorg_data/workshop.ml
@@ -3018,6 +3018,10 @@ The meeting is an informal community gathering of users of the language, library
   ; online = true
   ; important_dates = 
  [
+  { date = {js|2020-03-30|js};
+    info = {js|Workshop Announcement|js};
+  };
+  
   { date = {js|2020-05-29|js};
     info = {js|Abstract submission deadline (any timezone)|js};
   };
@@ -3307,35 +3311,14 @@ and the free software community.
 The meeting is an informal community gathering of users of the language,
 library authors, and developers, using and extending OCaml in new ways.
 The meeting will be held online this year.
-## News
-
-- July 17, 2020: Talks are accepted!
-- May 7, 2020: Deadline Extension.
-- March 30, 2020: [Workshop annoucement](https://icfp20.sigplan.org/home/ocaml-2020#Call-for-Presentations). The [submission website](https://ocaml2020.hotcrp.com/) is also open.
 |js}
-  ; toc_html = {js|<ul>
-<li><ul>
-<li>News
-</li>
-</ul>
-</li>
-</ul>
-|js}
+  ; toc_html = {js||js}
   ; body_html = {js|<p>The OCaml Users and Developers Workshop brings together the OCaml
 community, including users of OCaml in industry, academia, hobbyists,
 and the free software community.</p>
 <p>The meeting is an informal community gathering of users of the language,
 library authors, and developers, using and extending OCaml in new ways.
 The meeting will be held online this year.</p>
-<h2>News</h2>
-<ul>
-<li>July 17, 2020: Talks are accepted!
-</li>
-<li>May 7, 2020: Deadline Extension.
-</li>
-<li>March 30, 2020: <a href="https://icfp20.sigplan.org/home/ocaml-2020#Call-for-Presentations">Workshop annoucement</a>. The <a href="https://ocaml2020.hotcrp.com/">submission website</a> is also open.
-</li>
-</ul>
 |js}
   };
  
@@ -3358,78 +3341,285 @@ The meeting will be held online this year.</p>
     info = {js|OCaml Workshop|js};
   }]
   ; presentations = 
- []
-  ; program_committee = [
+ [
+  { title = {js|25 Years of OCaml|js};
+    authors = ["Xavier Leroy"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/e1ee0fc0-50ef-4a1c-894a-17df181424cb|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|A Multiverse of Glorious Documentation|js};
+    authors = 
+  ["Lucas Pluvinage"; "Jonathan Ludlam"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/15/A-Multiverse-of-Glorious-Documentation|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/9bb452d6-1829-4dac-a6a2-46b31050c931|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Adapting the OCaml Ecosystem for Multicore OCaml|js};
+    authors = 
+  ["Sudha Parimala"; "Enguerrand Decorne"; "Sadiq Jaffer"; "Tom Kelly";
+   "KC Sivaramakrishnan"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/7/Adapting-the-OCaml-ecosystem-for-Multicore-OCaml|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/629b89a8-bbd5-490d-98b0-d0c740912b02|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Binary Analysis Platform (BAP). Using Universal Algebra and Tagless-Final Style for Developing Representation-Agnostic Frameworks|js};
+    authors = 
+  ["Ivan Gotovchits"; "David Brumley"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/10/Binary-Analysis-Platform-BAP-Using-Universal-Algebra-and-Tagless-Final-Style-for-D|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Continuous Benchmarking for OCaml Projects|js};
+    authors = 
+  ["Gargi Sharma"; "Rizo Isrof"; "Magnus Skjegstad"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/1c994370-1aaa-4db6-b901-d762786e4904|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Deductive Verification of Realistic OCaml Code|js};
+    authors = 
+  ["Carlos Pinto"; "Mário Pereira"; "Simão Melo de Sousa"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/92309d92-8cbf-4545-980c-209c96e42a79|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Digodoc and Docs|js};
+    authors = ["Mohamed Hernouf";
+                                                        "Fabrice Le Fessant";
+                                                        "Thomas Blanc";
+                                                        "Louis Gesbert"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Experiences with Effects|js};
+    authors = ["Thomas Leonard";
+                                                                "Craig Ferguson";
+                                                                "Patrick Ferris";
+                                                                "Sadiq Jaffer";
+                                                                "Tom Kelly";
+                                                                "KC Sivaramakrishnan";
+                                                                "Anil Madhavapeddy"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/16/Experiences-with-Effects|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/74ece0a8-380f-4e2a-bef5-c6bb9092be89|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|From 2n+1 to n|js};
+    authors = ["Nandor Licker";
+                                                      "Timothy M. Jones"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/14/From-2n-1-to-n|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/74b32dae-11c6-4713-be1b-946260196e50|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|GopCaml: A Structural Editor for OCaml|js};
+    authors = 
+  ["Kiran Gopinathan"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/11/GopCaml-A-Structural-Editor-for-OCaml|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Leveraging Formal Specifications to Generate Fuzzing Suites|js};
+    authors = 
+  ["Nicolas Osborne"; "Clément Pascutto"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/d9a36c9f-1611-42f9-8854-981b1e2d7d75|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Love: a readable language interpreted by a blockchain|js};
+    authors = 
+  ["Steven de Oliveira"; "David Declerck"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/d3b2b31e-1739-406e-8de7-d5f21bc01836|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|OCaml and Python: Getting the Best of Both Worlds|js};
+    authors = 
+  ["Laurent Mazare"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/9eafdb1e-9be9-4a52-98b4-f4696eda4c18|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Opam-bin: Binary Packages with Opam|js};
+    authors = 
+  ["Fabrice Le Fessant"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/5/Opam-bin-Binary-Packages-with-Opam|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/a889e4d3-0508-4734-b667-7060b0a253cd|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs|js};
+    authors = 
+  ["Sumit Padhiyar"; "Adharsh Kamath"; "KC Sivaramakrishnan"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/9/Parafuzz-Coverage-guided-Property-Fuzzing-for-Multicore-OCaml-programs|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57|js};
+    slides = Some {js|https://speakerdeck.com/kayceesrk/parafuzz-fuzzing-multicore-ocaml-programs|js};
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Probabilistic resource limits, or: Programming with interrupts in OCaml|js};
+    authors = 
+  ["Guillaume Munch-Maccagnoni"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/bc297e85-82dd-4baf-8556-4a3a934978f9|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Property-Based Testing for OCaml through Coq|js};
+    authors = 
+  ["Paaras Bhandari"; "Leonidas Lampropoulos"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/9324fba4-2482-4bab-bfdd-b8881b3ed94a|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Safe Protocol Updates via Propositional Logic|js};
+    authors = 
+  ["Michael O'Connor"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/c6176f51-0277-46f0-937b-1e2721044492|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Semgrep, a fast, lightweight, polyglot, static analysis tool to find bugs|js};
+    authors = 
+  ["Yoann Padioleau"];
+    link = Some {js|https://icfp21.sigplan.org/details/ocaml-2021-papers/18/Semgrep-a-fast-lightweight-polyglot-static-analysis-tool-to-find-bugs|js};
+    video = Some {js|https://watch.ocaml.org/videos/watch/c0d07213-1426-46a1-98e0-0b0c4515c841|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  };
+  
+  { title = {js|Wibbily Wobbly Timey Camly|js};
+    authors = ["Di Long Li";
+                                                                  "Gabriel Radanne"];
+    link = None;
+    video = Some {js|https://watch.ocaml.org/videos/watch/ec641446-823b-40ec-a207-85157a18f88e|js};
+    slides = None;
+    poster = None;
+    additional_links = None;
+  }]
+  ; program_committee = 
+ [
   { name = {js|Frédéric Bour|js};
     role = Some `Chair;
     affiliation = None;
   };
-                             
+  
   { name = {js|Mehdi Bouaziz|js};
     role = None;
     affiliation = Some {js|Nomadic Labs, France|js};
   };
-                             
+  
   { name = {js|Simon Castellan|js};
     role = None;
     affiliation = Some {js|INRIA, France|js};
   };
-                             
+  
   { name = {js|Youyou Cong|js};
     role = None;
     affiliation = Some {js|Tokyo Institute of Technology, Japan|js};
   };
-                             
+  
   { name = {js|Kate Deplaix|js};
     role = None;
     affiliation = Some {js|OCaml Labs, UK|js};
   };
-                             
+  
   { name = {js|Jun Furuse|js};
     role = None;
     affiliation = Some {js|DaiLambda, Japan|js};
   };
-                             
+  
   { name = {js|Joris Giovannangeli|js};
     role = None;
     affiliation = Some {js|Ahrefs Research|js};
   };
-                             
+  
   { name = {js|Kihong Heo|js};
     role = None;
     affiliation = Some {js|KAIST, South Korea|js};
   };
-                             
+  
   { name = {js|Hugo Heuzard|js};
     role = None;
     affiliation = Some {js|Jane Street|js};
   };
-                             
+  
   { name = {js|Vaivaswatha Nagaraj|js};
     role = None;
     affiliation = Some {js|Zilliqa Research, India|js};
   };
-                             
+  
   { name = {js|Hakjoo Oh|js};
     role = None;
     affiliation = Some {js|Korea University|js};
   };
-                             
+  
   { name = {js|Jonathan Protzenko|js};
     role = None;
     affiliation = Some {js|Microsoft Research Redmond, USA|js};
   };
-                             
+  
   { name = {js|Cristina Rosu|js};
     role = None;
     affiliation = Some {js|Jane Street|js};
   };
-                             
+  
   { name = {js|Jeffrey A. Scofield|js};
     role = None;
     affiliation = Some {js|Psellos|js};
   };
-                             
+  
   { name = {js|Ryohei Tokuda|js};
     role = None;
     affiliation = Some {js|Idein|js};
@@ -3441,12 +3631,9 @@ The meeting will be held online this year.</p>
     affiliation = Some {js|Tarides, France|js};
   }]
   ; body_md = {js|
-OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.
-
-Please contact the PC Chair (Frédéric Bour) for any questions.|js}
+OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.|js}
   ; toc_html = {js||js}
   ; body_html = {js|<p>OCaml 2021 will be a virtual workshop, co-located with ICFP 2021.</p>
-<p>Please contact the PC Chair (Frédéric Bour) for any questions.</p>
 |js}
   }]
 

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -51,6 +51,9 @@ let page_routes =
     ; Dream.get Url.history Page_handler.history
     ; Dream.get Url.community_around_web Page_handler.community_around_web
     ; Dream.get Url.community_events Page_handler.community_events
+    ; Dream.get
+        (Url.community_events ^ "/:id")
+        Page_handler.community_events_workshop
     ; Dream.get Url.community_media_archive Page_handler.community_media_archive
     ; Dream.get Url.community_news Page_handler.community_news
     ; Dream.get Url.community_news_archive Page_handler.community_news_archive

--- a/src/ocamlorg_web/lib/templates/components/common.eml
+++ b/src/ocamlorg_web/lib/templates/components/common.eml
@@ -1,0 +1,49 @@
+let human_date s =
+  let date_time = Timedesc.of_iso8601_exn s in
+  Format.asprintf
+    "%a."
+    (Timedesc.pp ~format:"{wday:Xxx} {mon:Xxx} {mon:0X} {year}" ())
+    date_time
+
+let orange_link ~href text =
+ <a class="font-semibold text-orangedark" href="<%s href %>">
+    <%s text %>
+ </a>
+
+let orange_link_button ~href text =
+  <div class="inline-flex rounded-md shadow">
+    <a class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-orangedark hover:bg-orangedarker" href="<%s href %>">
+      <%s text %>
+    </a>
+  </div>
+
+
+let timeline ?(iso8601=true) ~last events =
+  <ul role="list" class="-mb-8">
+    <% events |> List.iteri (fun i (date, title) -> 
+      let is_last = i = last in
+    %>
+    <li>
+      <div class="relative pb-8">
+        <% if not is_last then ( %><span class="absolute top-4 left-4 -ml-px h-full w-0.5 bg-gray-200" aria-hidden="true"></span><% ); %>
+        <div class="relative flex space-x-3">
+          <div>
+            <span class="h-8 w-8 rounded-full bg-orange-500 flex items-center justify-center ring-8 ring-white">
+              <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"></svg>
+            </span>
+          </div>
+          <div class="min-w-0 flex-1 pt-1.5 flex justify-between space-x-4">
+            <div>
+              <p class="text-sm text-gray-500"><%s title %></p>
+            </div>
+            <div class="text-right text-sm whitespace-nowrap text-gray-500">
+              <time datetime="<%s date %>">
+                <%s if iso8601 then human_date date else date %>
+              </time>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <% ); %>
+  </ul>

--- a/src/ocamlorg_web/lib/templates/components/dune
+++ b/src/ocamlorg_web/lib/templates/components/dune
@@ -51,3 +51,15 @@
  (deps navmap_template.eml)
  (action
   (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+
+(rule
+ (targets common.ml)
+ (deps common.eml)
+ (action
+  (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+
+(rule
+ (targets table.ml)
+ (deps table.eml)
+ (action
+  (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))

--- a/src/ocamlorg_web/lib/templates/components/table.eml
+++ b/src/ocamlorg_web/lib/templates/components/table.eml
@@ -1,0 +1,39 @@
+module Basic = struct
+  type t = {
+    headers : string list;
+    data : string list list;
+  }
+
+  let render { headers; data } =
+    <div class="flex flex-col">
+      <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+        <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+          <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-orangedark">
+                <tr>
+                  <% headers |> List.iter (fun header -> %>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider" scope="col">
+                      <%s header %>
+                    </th>
+                  <% ); %>
+                </tr>
+              </thead>
+              <tbody>
+                <% data |> List.iter (fun items -> %>
+                  <tr class="odd:bg-white even:bg-gray-50">
+                     <% items |> List.iter (fun item -> %>
+                        <td class="px-6 py-4 text-sm font-medium text-gray-900">
+                          <p><%s! item %></p>
+                        </td>
+                      <% ); %>
+                  </tr>
+                <% ); %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+end

--- a/src/ocamlorg_web/lib/templates/pages/community_around_web_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/community_around_web_template.eml
@@ -4,14 +4,6 @@ let rec take k xs = match k with
   | [] -> failwith "take"
   | y::ys -> y :: (take (k - 1) ys)
 
-let human_date s =
-  let date_time = Timedesc.of_iso8601_exn s in
-  Format.asprintf
-    "%a."
-    (Timedesc.pp ~format:"{wday:Xxx} {mon:Xxx} {mon:0X} {year}" ())
-    date_time
-
-
 let render_news (news : Ood.News.t) =
   <li class="px-6 py-4"><a
       href="https://tech.ahrefs.com/building-ahrefs-codebase-with-melange-9f881f6d022b?source=rss----303662d88bae--ocaml"
@@ -84,49 +76,20 @@ let events = Ood.Event.all in
           <div>
             <div class="flex h-full flex-col items-center justify-center">
               <div class="py-8 sm:pl-12">
-                <p class="mt-2 text-orangedark text-center text-3xl font-extrabold tracking-tight sm:text-4xl">Events
-                </p>
-                <p class="mt-4 text-lg leading-6 text-gray-900 text-center">Several events take place in the OCaml
+                <p class="mt-2 text-orangedark text-center text-3xl font-extrabold tracking-tight sm:text-4xl">Events</p>
+                <p class="mt-4 text-lg leading-6 text-gray-900 text-center">
+                  Several events take place in the OCaml
                   community over the course of each year, in countries all over the world. This calendar will help you
-                  stay up to date on what is coming up in the OCaml sphere. </p>
+                  stay up to date on what is coming up in the OCaml sphere.
+                </p>
                 <div class="mt-8 text-center">
-                  <div class="inline-flex rounded-md shadow"><a
-                      class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-orangedark hover:bg-orangedarker"
-                      href="/events">Show me Events</a></div>
+                  <%s! Common.orange_link_button ~href:"/events" "Show me Events" %>
                 </div>
               </div>
             </div>
           </div>
-
           <div class="flow-root px-8 py-16">
-            <ul role="list" class="-mb-8">
-              <% (take 3 events) |> List.iteri (fun i (event : Ood.Event.t) -> 
-              let is_last = i = 2 in
-              %>
-              <li>
-                <div class="relative pb-8">
-                  <% if not is_last then ( %><span class="absolute top-4 left-4 -ml-px h-full w-0.5 bg-gray-200" aria-hidden="true"></span><% ); %>
-                  <div class="relative flex space-x-3">
-                    <div>
-                      <span class="h-8 w-8 rounded-full bg-orange-500 flex items-center justify-center ring-8 ring-white">
-                        <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"></svg>
-                      </span>
-                    </div>
-                    <div class="min-w-0 flex-1 pt-1.5 flex justify-between space-x-4">
-                      <div>
-                        <p class="text-sm text-gray-500"><%s event.title %></p>
-                      </div>
-                      <div class="text-right text-sm whitespace-nowrap text-gray-500">
-                        <time datetime="<%s event.date %>">
-                          <%s human_date event.date %>
-                        </time>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </li>
-              <% ); %>
-            </ul>
+              <%s! Common.timeline ~last:2 (take 3 events |> List.map (fun e -> (e.Ood.Event.date, e.Ood.Event.title))) %>
           </div>
         </div>
       </div>

--- a/src/ocamlorg_web/lib/templates/pages/community_events_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/community_events_template.eml
@@ -1,63 +1,31 @@
-let human_date s =
-  let date_time = Timedesc.of_iso8601_exn s in
-  Format.asprintf
-    "%a."
-    (Timedesc.pp ~format:"{wday:Xxx} {mon:Xxx} {mon:0X} {year}" ())
-    date_time
+open Ood
+
+let render_workshops (workshops : Workshop.t list) = 
+  let headers = [ "Date"; "Workshop Title"; "Location" ] in
+  let render_workshop (workshop : Workshop.t) =
+    [
+      workshop.date;
+      Common.orange_link ~href:("/events/" ^ workshop.slug) workshop.title;
+      match workshop.location with | Some x -> x | None -> "Virtual"
+    ]
+  in
+  let data = List.map render_workshop workshops in
+    Table.Basic.(render { headers; data })
 
 let render () =
-let events = Ood.Event.all in
-<main class="relative bg-graylight">
-  <div class="max-w-8xl mx-auto">
-    <div class=" mx-auto py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
-      <div class="text-center">
-        <h1 class=" text-4xl font-extrabold text-gray-900 sm:text-5xl sm:tracking-tight lg:text-6xl">Events</h1>
-        <p class="max-w-xl mt-5 mx-auto text-xl text-gray-500">Several events take place in the OCaml community over the
-          course of each year, in countries all over the world. This calendar will help you stay up to date on what is
-          coming up in the OCaml sphere.</p>
-      </div>
-    </div>
-    <div class="mb-16 max-w-5xl mx-auto   ">
-      <div class="flex flex-col">
-        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-          <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-            <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-orangedark">
-                  <tr>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider" scope="col">
-                      Date</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider" scope="col">
-                      Event Name</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider" scope="col">
-                      Location</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider" scope="col">
-                      Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <% events |> List.iter (fun (event : Ood.Event.t) -> %>
-                  <tr class="odd:bg-white even:bg-gray-50">
-                    <td class="px-6 py-4 text-sm font-medium text-gray-900">
-                      <p><%s human_date event.date %></p>
-                    </td>
-                    <td class="px-6 py-4 text-sm font-medium text-gray-900">
-                      <p><%s event.title %></p>
-                    </td>
-                    <td class="px-6 py-4 text-sm font-medium text-gray-900">
-                      <p><%s match event.textual_location with | Some x -> x | None -> "Virtual" %></p>
-                    </td>
-                    <td class="px-6 py-4 text-sm font-medium text-gray-900">
-                      <p><%s event.description %></p>
-                    </td>
-                  </tr>
-                  <% ); %>
-                </tbody>
-              </table>
-            </div>
-          </div>
+  let workshops = Workshop.all |> List.sort (fun w1 w2 -> -(String.compare w1.Workshop.date w2.Workshop.date)) in
+  <main class="relative bg-graylight pb-4">
+    <div class="max-w-8xl mx-auto">
+      <div class=" mx-auto py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
+        <div class="text-center">
+          <h1 class=" text-4xl font-extrabold text-gray-900 sm:text-5xl sm:tracking-tight lg:text-6xl">Events</h1>
+          <p class="max-w-xl mt-5 mx-auto text-xl text-gray-500">Several events take place in the OCaml community over the
+            course of each year, in countries all over the world. This calendar will help you stay up to date on what is
+            coming up in the OCaml sphere.</p>
         </div>
       </div>
+      <div class="mb-16 max-w-5xl mx-auto">
+        <%s! render_workshops workshops %>
+      </div>
     </div>
-  </div>
-</main>
+  </main>

--- a/src/ocamlorg_web/lib/templates/pages/community_events_workshop_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/community_events_workshop_template.eml
@@ -8,6 +8,7 @@ let render_some_videos tbl (ps : Workshop.presentation list) =
   in
   if List.length videos = 0 then "" else
   <div>
+    <h2 class="text-4xl font-bold mb-8">Some Videos</h2>
     <ul role="list" class="space-y-12 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-12 sm:space-y-0">
       <% videos |> List.iter begin fun w -> %>
         <li>
@@ -53,6 +54,22 @@ let render_presentations (ps : Workshop.presentation list) =
 let pp_member ppf (v : Workshop.committee_member) =
   Fmt.(pf ppf "%s%a" v.name (option (fun ppf s -> pf ppf " (%s)" s))) v.affiliation
 
+let render_committee ~title committee = 
+  <div class="mx-auto max-w-4xl mb-16">
+    <h2 class="text-xl font-bold mb-8"><%s title %></h2>
+    <p>
+      <%s Fmt.(str "%a" (list ~sep:comma pp_member)) committee %>
+    <p>
+  </div>
+
+let render_dates (workshop : Workshop.t) =
+  let len = List.length workshop.important_dates in
+  if len = 0 then "" else
+  <h2 class="text-4xl font-bold mb-8">Important Dates</h2>
+  <div class="flow-root rounded bg-white p-6">
+    <%s! Common.timeline ~iso8601:false ~last:(len - 1) (List.map (fun ({ date; info } : Workshop.important_date) -> (date, info)) workshop.important_dates) %>
+  </div>
+
 let render (tbl : (string, Watch.t) Hashtbl.t) (workshop : Workshop.t) =
   let open Ood.Workshop in
   <%s! Header_section_template.render ?subtitle:workshop.location workshop.title %>
@@ -64,30 +81,16 @@ let render (tbl : (string, Watch.t) Hashtbl.t) (workshop : Workshop.t) =
         </div>
       </div>
       <div class="mx-auto max-w-4xl px-6 mb-16">
-        <h2 class="text-4xl font-bold mb-8">Important Dates</h2>
-        <div class="flow-root rounded bg-white p-6">
-          <%s! Common.timeline ~iso8601:false ~last:(List.length workshop.important_dates - 1) (List.map (fun ({ date; info } : important_date) -> (date, info)) workshop.important_dates) %>
-        </div>
+        <%s! render_dates workshop %>
       </div>
       <div class="mx-auto max-w-4xl mb-16">
-        <h2 class="text-4xl font-bold mb-8">Some Videos</h2>
         <%s! render_some_videos tbl workshop.presentations %>
       </div>
       <div class="mx-auto max-w-4xl mb-16">
         <h2 class="text-4xl font-bold mb-8">All Presentations</h2>
         <%s! render_presentations workshop.presentations %>
       </div>
-      <div class="mx-auto max-w-4xl mb-16">
-        <h2 class="text-xl font-bold mb-8">Organising Committee</h2>
-        <p>
-          <%s Fmt.(str "%a" (list ~sep:comma pp_member)) workshop.organising_committee %>
-        <p>
-      </div>
-      <div class="mx-auto max-w-4xl mb-16">
-        <h2 class="text-xl font-bold mb-8">Program Committee</h2>
-        <p>
-          <%s Fmt.(str "%a" (list ~sep:comma pp_member)) workshop.program_committee %>
-        <p>
-      </div>
+      <%s! if List.length workshop.organising_committee = 0 then "" else render_committee ~title:"Organising Committee" workshop.organising_committee %>
+      <%s! if List.length workshop.program_committee = 0 then "" else render_committee ~title:"Program Committee" workshop.program_committee %>
     </div>
   </main>

--- a/src/ocamlorg_web/lib/templates/pages/community_events_workshop_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/community_events_workshop_template.eml
@@ -1,0 +1,93 @@
+open Ood
+
+let render_some_videos tbl (ps : Workshop.presentation list) = 
+  let videos = List.filter_map (fun (p : Workshop.presentation) -> Hashtbl.find_opt tbl p.title) ps in
+  let videos = List.filteri (fun i _ -> i < 4) videos in
+  let iframe (w : Watch.t) = 
+    <iframe loading="lazy" width="560" height="315" sandbox="allow-same-origin allow-scripts allow-popups" src="<%s "https://watch.ocaml.org" ^ w.embed_path %>" frameborder="0" allowfullscreen></iframe>
+  in
+  if List.length videos = 0 then "" else
+  <div>
+    <ul role="list" class="space-y-12 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-12 sm:space-y-0">
+      <% videos |> List.iter begin fun w -> %>
+        <li>
+          <div class="space-y-4">
+            <div class="aspect-w-3 aspect-h-2">
+              <%s! iframe w %>
+            </div>
+            <div class="space-y-2">
+              <div class="text-lg leading-6 font-medium space-y-1">
+                <h3><%s w.name %></h3>
+              </div>
+              <p class="text-md"><%s Option.value ~default:"" w.description %></p>
+            </div>
+          </div>
+        </li>
+      <% end; %>
+    </ul>
+    <div class="text-right py-4">
+      <%s! Common.orange_link_button ~href:"https://watch.ocaml.org" "More videos at watch.ocaml.org" %>
+    </div>
+  </div>
+
+
+let render_presentations (ps : Workshop.presentation list) =
+  let headers = [ "Title"; "Authors"; "Link" ] in
+  let render_presentation (p : Workshop.presentation) =
+    let mk_link txt href = Common.orange_link ~href txt in
+    let links = [
+      Option.map (mk_link "link") p.link;
+      Option.map (mk_link "video") p.video;
+      Option.map (mk_link "slides") p.slides;
+    ] |> List.filter_map Fun.id
+    in
+    [
+      p.title;
+      Fmt.(str "%a" (list ~sep:comma string) p.authors);
+      if List.length links = 0 then "-" else  Fmt.(str "%a" (list ~sep:comma string) links)
+    ]
+  in
+  let data = List.map render_presentation ps in
+    Table.Basic.(render { headers; data })
+
+let pp_member ppf (v : Workshop.committee_member) =
+  Fmt.(pf ppf "%s%a" v.name (option (fun ppf s -> pf ppf " (%s)" s))) v.affiliation
+
+let render (tbl : (string, Watch.t) Hashtbl.t) (workshop : Workshop.t) =
+  let open Ood.Workshop in
+  <%s! Header_section_template.render ?subtitle:workshop.location workshop.title %>
+  <main class="relative bg-graylight pb-1">
+    <div class="max-w-7xl mx-auto">
+      <div class="mx-auto max-w-4xl px-6 mb-16">
+        <div class="max-w-4xl prose prose-lg">
+          <%s! workshop.body_html %>
+        </div>
+      </div>
+      <div class="mx-auto max-w-4xl px-6 mb-16">
+        <h2 class="text-4xl font-bold mb-8">Important Dates</h2>
+        <div class="flow-root rounded bg-white p-6">
+          <%s! Common.timeline ~iso8601:false ~last:(List.length workshop.important_dates - 1) (List.map (fun ({ date; info } : important_date) -> (date, info)) workshop.important_dates) %>
+        </div>
+      </div>
+      <div class="mx-auto max-w-4xl mb-16">
+        <h2 class="text-4xl font-bold mb-8">Some Videos</h2>
+        <%s! render_some_videos tbl workshop.presentations %>
+      </div>
+      <div class="mx-auto max-w-4xl mb-16">
+        <h2 class="text-4xl font-bold mb-8">All Presentations</h2>
+        <%s! render_presentations workshop.presentations %>
+      </div>
+      <div class="mx-auto max-w-4xl mb-16">
+        <h2 class="text-xl font-bold mb-8">Organising Committee</h2>
+        <p>
+          <%s Fmt.(str "%a" (list ~sep:comma pp_member)) workshop.organising_committee %>
+        <p>
+      </div>
+      <div class="mx-auto max-w-4xl mb-16">
+        <h2 class="text-xl font-bold mb-8">Program Committee</h2>
+        <p>
+          <%s Fmt.(str "%a" (list ~sep:comma pp_member)) workshop.program_committee %>
+        <p>
+      </div>
+    </div>
+  </main>

--- a/src/ocamlorg_web/lib/templates/pages/dune
+++ b/src/ocamlorg_web/lib/templates/pages/dune
@@ -17,6 +17,12 @@
   (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
 
 (rule
+ (targets community_events_workshop_template.ml)
+ (deps community_events_workshop_template.eml)
+ (action
+  (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+
+(rule
  (targets community_media_archive_template.ml)
  (deps community_media_archive_template.eml)
  (action


### PR DESCRIPTION
This PR does quite a few things including: 

 - Adds the 2021 Workshop information, in particular the presentations
 - Starts extracting some more of the components back out of HTML (`Table.Basic` and `Common.timeline` are the main two here)
 - Adds an *initial* implementation of the workshop page some points still to do (but maybe in a separate PR) are the header images, decide on how to show the committee, decide on the best way to show some watch.ocaml.org videos etc. 
 - Matches workshop presentations with watch videos to show them on the page much simpler thanks to the watch.ocaml.org scraper (thanks @guptadiksha307!)

### OCaml Workshop 2020

URL: `/events/ocaml-workshop-2020`

Here's the basic idea of the page 

<img width="1439" alt="Screenshot 2021-09-23 at 20 32 09" src="https://user-images.githubusercontent.com/20166594/134571902-793e542e-4447-43fc-b04c-584a78f5c6af.png">
<img width="1439" alt="Screenshot 2021-09-23 at 20 32 30" src="https://user-images.githubusercontent.com/20166594/134571944-8b18aacf-e9cb-4e8c-b313-60f3043199c1.png">
<img width="1436" alt="Screenshot 2021-09-23 at 20 32 46" src="https://user-images.githubusercontent.com/20166594/134571983-d2361a1c-b6ee-4ffb-993b-fd48212f67b1.png">
<img width="1423" alt="Screenshot 2021-09-23 at 20 33 15" src="https://user-images.githubusercontent.com/20166594/134572038-25f7f435-a22f-451d-9d5c-a89d0a93e43b.png">


