### PR TITLE
reorganise and complete the OCaml events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Import all of the events data from v2 (#116, by @patricoferris)
+
 - Add a job board in opportunities (#115, by @tmattio)
 
 - Split js_of_ocaml toplevel execution into web-worker (#135, by @patricoferris)

--- a/data/events.yml
+++ b/data/events.yml
@@ -1,26 +1,47 @@
 events:
-  - date: 2021-08-27T09:00:40.154Z
-    title: OCaml Users and Developers Workshop 2021
-    description: The OCaml Workshop 2021 as part of ICFP
-    url: https://icfp21.sigplan.org/home/ocaml-2021
+  - date: 2014-07-08T19:00:00Z
+    title: "Rencontre d'été" 
+    organiser: OCaml Users in PariS
+    location: Mozilla Paris, 16 boulevard Montmartre 75009 Paris
+    url: https://www.meetup.com/ocaml-paris/events/188634632/
     tags:
-      - ocaml-workshop
-    online: true
-  - date: 2020-08-20T09:00:42.358Z
-    title: OCaml Users and Developers Workshop 2020
-    description: The OCaml Workshop 2020 as part of ICFP
-    url: https://icfp20.sigplan.org/home/ocaml-2020
-    tags:
-      - ocaml-workshop
-    online: true
-    textual_location: Jersey City
-    location: '{"type":"Point","coordinates":[-74.0739787,40.7262413]}'
-  - date: 2019-08-23T00:00:00.000Z
-    title: OCaml User and Developer Workshop 2019
-    description: The OCaml Workshop 2019 as part of ICFP
-    url: https://icfp19.sigplan.org/home/ocaml-2019#Call-for-Presentations
-    tags:
-      - ocaml-workshop
+      - oups
     online: false
-    textual_location: Berlin
-    location: '{"type":"Point","coordinates":[13.4163451,52.4861467]}'
+  - date: 2014-05-22T19:00:00Z
+    title: "Rencontre de Printemps"
+    organiser: OCaml Users in PariS
+    location: IRILL 23, avenue d'Italie 75013 Paris
+    url: https://www.meetup.com/ocaml-paris/events/181647232/
+    tags:
+      - oups
+    online: false
+  - date: 2013-05-21T19:30:00Z
+    title: "Rencontre de Mai"
+    organiser: OCaml Users in PariS
+    location: IRILL 23, avenue d'Italie 75013 Paris
+    url: https://www.meetup.com/ocaml-paris/events/116100692/
+    tags:
+      - oups
+    online: false
+  - date: 2013-01-29T20:00:00Z
+    title: "First OPAM party"
+    organiser: OCaml Users in PariS
+    location: IRILL 23, avenue d'Italie 75013 Paris
+    url: https://www.meetup.com/ocaml-paris/events/99222322/
+    tags:
+      - oups
+    online: false
+  - date: 2013-8-24T00:00:00Z
+    title: "OCaml Meeting 2013 in Nagoya"
+    location: Nagoya University, Japan
+    url: http://ocaml.jp/um2013
+    tags: 
+      - nagoya
+    online: false
+  - date: 2013-8-24T00:00:00Z
+    title: "OCaml Meeting 2010 in Nagoya"
+    location: Nagoya University, Japan
+    url: http://ocaml.jp/um2010
+    tags: 
+      - nagoya
+    online: false

--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -1,0 +1,25 @@
+meetups:
+  - title: "OCaml users in PariS (OUPS)"
+    textual_location: Paris, France
+    location:
+      lat: 48.8566
+      long: 2.3522
+    url: https://www.meetup.com/ocaml-paris/
+  - title: "NYC OCaml Meetups"
+    textual_location: New York City, New York, USA
+    location:
+      lat: 40.7128
+      long: 74.0060
+    url: https://www.meetup.com/NYC-OCaml
+  - title: "Silicon Valley OCaml meetups"
+    textual_location: San Francisco, California, USA
+    location:
+      lat: 37.7749
+      long: 122.4194
+    url: https://www.meetup.com/NYC-OCaml
+  - title: "Cambridge NonDysFunctional Programmers"
+    textual_location: Cambridge, United Kingdom
+    location:
+      lat: 52.2053
+      long: 0.1218 
+    url: https://www.meetup.com/Cambridge-NonDysFunctional-Programmers/

--- a/src/ocamlorg_data/dune
+++ b/src/ocamlorg_data/dune
@@ -44,6 +44,16 @@
 
 (rule
  (deps ../../tool/ood-gen/bin/gen.exe)
+ (targets meetup.ml)
+ (mode
+  (promote (until-clean)))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps} meetup))))
+
+(rule
+ (deps ../../tool/ood-gen/bin/gen.exe)
  (targets industrial_user.ml)
  (mode
   (promote (until-clean)))

--- a/src/ocamlorg_data/event.ml
+++ b/src/ocamlorg_data/event.ml
@@ -2,50 +2,86 @@
 type t =
   { title : string
   ; slug : string
-  ; description : string
+  ; description : string option
+  ; organiser : string option
   ; url : string
   ; date : string
   ; tags : string list
   ; online : bool
-  ; textual_location : string option
   ; location : string option
   }
 
 let all = 
 [
-  { title = {js|OCaml Users and Developers Workshop 2021|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2021|js}
-  ; description = {js|The OCaml Workshop 2021 as part of ICFP|js}
-  ; url = {js|https://icfp21.sigplan.org/home/ocaml-2021|js}
-  ; date = {js|2021-08-27T09:00:40.154Z|js}
+  { title = {js|Rencontre d'été|js}
+  ; slug = {js|rencontre-dt|js}
+  ; description = None
+  ; organiser = Some {js|OCaml Users in PariS|js}
+  ; url = {js|https://www.meetup.com/ocaml-paris/events/188634632/|js}
+  ; date = {js|2014-07-08T19:00:00Z|js}
   ; tags = 
- [{js|ocaml-workshop|js}]
-  ; online = true
-  ; textual_location = None
-  ; location = None
-  };
- 
-  { title = {js|OCaml Users and Developers Workshop 2020|js}
-  ; slug = {js|ocaml-users-and-developers-workshop-2020|js}
-  ; description = {js|The OCaml Workshop 2020 as part of ICFP|js}
-  ; url = {js|https://icfp20.sigplan.org/home/ocaml-2020|js}
-  ; date = {js|2020-08-20T09:00:42.358Z|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
-  ; online = true
-  ; textual_location = Some {js|Jersey City|js}
-  ; location = Some {js|{"type":"Point","coordinates":[-74.0739787,40.7262413]}|js}
-  };
- 
-  { title = {js|OCaml User and Developer Workshop 2019|js}
-  ; slug = {js|ocaml-user-and-developer-workshop-2019|js}
-  ; description = {js|The OCaml Workshop 2019 as part of ICFP|js}
-  ; url = {js|https://icfp19.sigplan.org/home/ocaml-2019#Call-for-Presentations|js}
-  ; date = {js|2019-08-23T00:00:00.000Z|js}
-  ; tags = 
- [{js|ocaml-workshop|js}]
+ [{js|oups|js}]
   ; online = false
-  ; textual_location = Some {js|Berlin|js}
-  ; location = Some {js|{"type":"Point","coordinates":[13.4163451,52.4861467]}|js}
+  ; location = Some {js|Mozilla Paris, 16 boulevard Montmartre 75009 Paris|js}
+  };
+ 
+  { title = {js|Rencontre de Printemps|js}
+  ; slug = {js|rencontre-de-printemps|js}
+  ; description = None
+  ; organiser = Some {js|OCaml Users in PariS|js}
+  ; url = {js|https://www.meetup.com/ocaml-paris/events/181647232/|js}
+  ; date = {js|2014-05-22T19:00:00Z|js}
+  ; tags = 
+ [{js|oups|js}]
+  ; online = false
+  ; location = Some {js|IRILL 23, avenue d'Italie 75013 Paris|js}
+  };
+ 
+  { title = {js|Rencontre de Mai|js}
+  ; slug = {js|rencontre-de-mai|js}
+  ; description = None
+  ; organiser = Some {js|OCaml Users in PariS|js}
+  ; url = {js|https://www.meetup.com/ocaml-paris/events/116100692/|js}
+  ; date = {js|2013-05-21T19:30:00Z|js}
+  ; tags = 
+ [{js|oups|js}]
+  ; online = false
+  ; location = Some {js|IRILL 23, avenue d'Italie 75013 Paris|js}
+  };
+ 
+  { title = {js|First OPAM party|js}
+  ; slug = {js|first-opam-party|js}
+  ; description = None
+  ; organiser = Some {js|OCaml Users in PariS|js}
+  ; url = {js|https://www.meetup.com/ocaml-paris/events/99222322/|js}
+  ; date = {js|2013-01-29T20:00:00Z|js}
+  ; tags = 
+ [{js|oups|js}]
+  ; online = false
+  ; location = Some {js|IRILL 23, avenue d'Italie 75013 Paris|js}
+  };
+ 
+  { title = {js|OCaml Meeting 2013 in Nagoya|js}
+  ; slug = {js|ocaml-meeting-2013-in-nagoya|js}
+  ; description = None
+  ; organiser = None
+  ; url = {js|http://ocaml.jp/um2013|js}
+  ; date = {js|2013-8-24T00:00:00Z|js}
+  ; tags = 
+ [{js|nagoya|js}]
+  ; online = false
+  ; location = Some {js|Nagoya University, Japan|js}
+  };
+ 
+  { title = {js|OCaml Meeting 2010 in Nagoya|js}
+  ; slug = {js|ocaml-meeting-2010-in-nagoya|js}
+  ; description = None
+  ; organiser = None
+  ; url = {js|http://ocaml.jp/um2010|js}
+  ; date = {js|2013-8-24T00:00:00Z|js}
+  ; tags = 
+ [{js|nagoya|js}]
+  ; online = false
+  ; location = Some {js|Nagoya University, Japan|js}
   }]
 

--- a/src/ocamlorg_data/meetup.ml
+++ b/src/ocamlorg_data/meetup.ml
@@ -1,0 +1,41 @@
+
+type location = { lat : float; long : float }
+
+type t =
+  { title : string
+  ; slug : string
+  ; url : string
+  ; textual_location : string
+  ; location : location
+  }
+
+let all = 
+[
+  { title = {js|OCaml users in PariS (OUPS)|js}
+  ; slug = {js|ocaml-users-in-paris-oups|js}
+  ; url = {js|https://www.meetup.com/ocaml-paris/|js}
+  ; textual_location = {js|Paris, France|js}
+  ; location = { lat = 48.8566; long = 2.3522 }
+  };
+ 
+  { title = {js|NYC OCaml Meetups|js}
+  ; slug = {js|nyc-ocaml-meetups|js}
+  ; url = {js|https://www.meetup.com/NYC-OCaml|js}
+  ; textual_location = {js|New York City, New York, USA|js}
+  ; location = { lat = 40.7128; long = 74.006 }
+  };
+ 
+  { title = {js|Silicon Valley OCaml meetups|js}
+  ; slug = {js|silicon-valley-ocaml-meetups|js}
+  ; url = {js|https://www.meetup.com/NYC-OCaml|js}
+  ; textual_location = {js|San Francisco, California, USA|js}
+  ; location = { lat = 37.7749; long = 122.419 }
+  };
+ 
+  { title = {js|Cambridge NonDysFunctional Programmers|js}
+  ; slug = {js|cambridge-nondysfunctional-programmers|js}
+  ; url = {js|https://www.meetup.com/Cambridge-NonDysFunctional-Programmers/|js}
+  ; textual_location = {js|Cambridge, United Kingdom|js}
+  ; location = { lat = 52.2053; long = 0.1218 }
+  }]
+

--- a/src/ocamlorg_data/ood.ml
+++ b/src/ocamlorg_data/ood.ml
@@ -90,7 +90,14 @@ module Job = struct
 
   let all_not_fullfilled = List.filter (fun x -> x.fullfilled = false) all
 
+  
   let get_by_id id = List.find_opt (fun x -> Int.equal id x.id) all
+end
+
+module Meetup = struct
+  include Meetup
+
+  let get_by_slug slug = List.find_opt (fun x -> String.equal slug x.slug) all
 end
 
 module Industrial_user = struct

--- a/src/ocamlorg_data/ood.mli
+++ b/src/ocamlorg_data/ood.mli
@@ -86,12 +86,12 @@ module Event : sig
   type t =
     { title : string
     ; slug : string
-    ; description : string
+    ; description : string option
+    ; organiser : string option
     ; url : string
     ; date : string
     ; tags : string list
     ; online : bool
-    ; textual_location : string option
     ; location : string option
     }
 
@@ -117,6 +117,25 @@ module Job : sig
   val all_not_fullfilled : t list
 
   val get_by_id : int -> t option
+end
+
+module Meetup : sig
+  type location =
+    { lat : float
+    ; long : float
+    }
+
+  type t =
+    { title : string
+    ; slug : string
+    ; url : string
+    ; textual_location : string
+    ; location : location
+    }
+
+  val all : t list
+
+  val get_by_slug : string -> t option
 end
 
 module Industrial_user : sig

--- a/src/ocamlorg_web/lib/templates/pages/community_events_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/community_events_template.eml
@@ -12,6 +12,47 @@ let render_workshops (workshops : Workshop.t list) =
   let data = List.map render_workshop workshops in
     Table.Basic.(render { headers; data })
 
+let render_events () =
+  let open Event in
+  <ul role="list" class="space-y-12 sm:grid sm:grid-cols-3 sm:gap-x-6 sm:gap-y-12 sm:space-y-0">
+    <% Event.all |> List.filteri (fun i _ -> i < 4) |> List.iter begin fun m -> %>
+      <li>
+        <a class="flex overflow-visible justify-between items-center p-4 h-32 border border-gray-300 border-solid cursor-pointer box-border hover:border-orange-600 hover:border-2" href="<%s m.url %>" style="border-radius: 12px; background-image: linear-gradient(45deg, rgb(255, 255, 255), rgb(255, 255, 255));">
+          <div class="space-y-4">
+            <div class="space-y-2">
+              <div class="text-lg leading-6 font-medium space-y-1">
+                <h3><%s m.title %></h3>
+              </div>
+              <p class="text-md"><%s Option.value ~default:"" m.organiser %></p>
+              <time datetime="<%s m.date %>">
+                <%s Common.human_date m.date %>
+              </time>
+            </div>
+          </div>
+        </a>
+      </li>
+    <% end; %>
+  </ul>
+
+let render_meetups () =
+  let open Meetup in
+  <ul role="list" class="space-y-12 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-12 sm:space-y-0">
+    <% Meetup.all |> List.iter begin fun m -> %>
+      <li>
+        <a class="flex overflow-visible justify-between items-center p-4 h-32 border border-gray-300 border-solid cursor-pointer box-border hover:border-orange-600 hover:border-2" href="<%s m.url %>" style="border-radius: 12px; background-image: linear-gradient(45deg, rgb(255, 255, 255), rgb(255, 255, 255));">
+          <div class="space-y-4">
+            <div class="space-y-2">
+              <div class="text-lg leading-6 font-medium space-y-1">
+                <h3><%s m.title %></h3>
+              </div>
+              <p class="text-md"><%s m.textual_location %></p>
+            </div>
+          </div>
+        </a>
+      </li>
+    <% end; %>
+  </ul>
+
 let render () =
   let workshops = Workshop.all |> List.sort (fun w1 w2 -> -(String.compare w1.Workshop.date w2.Workshop.date)) in
   <main class="relative bg-graylight pb-4">
@@ -25,7 +66,16 @@ let render () =
         </div>
       </div>
       <div class="mb-16 max-w-5xl mx-auto">
+        <h2 class="text-4xl font-bold mb-8">Meetups</h2>
+        <%s! render_meetups () %>
+      </div>
+      <div class="mb-16 max-w-5xl mx-auto">
+        <h2 class="text-4xl font-bold mb-8">Workshops</h2>
         <%s! render_workshops workshops %>
+      </div>
+      <div class="mb-16 max-w-5xl mx-auto">
+        <h2 class="text-4xl font-bold mb-8">Events</h2>
+        <%s! render_events () %>
       </div>
     </div>
   </main>

--- a/src/ocamlorg_web/lib/templates/previews/preview_events_template.eml
+++ b/src/ocamlorg_web/lib/templates/previews/preview_events_template.eml
@@ -10,7 +10,7 @@ let render_event (event : Ood.Event.t) =
       </h1>
     </div>
     <div class="mt-6 prose prose-indigo prose-lg text-gray-500 mx-auto">
-      <%s! event.description %>
+      <%s! Option.value ~default:"" event.description %>
     </div>
   </div>
 

--- a/tool/ood-gen/bin/gen.ml
+++ b/tool/ood-gen/bin/gen.ml
@@ -5,6 +5,7 @@ let term_templates =
   ; "book", Ood_gen.Book.template
   ; "event", Ood_gen.Event.template
   ; "job", Ood_gen.Job.template
+  ; "meetup", Ood_gen.Meetup.template
   ; "industrial_user", Ood_gen.Industrial_user.template
   ; "paper", Ood_gen.Paper.template
   ; "release", Ood_gen.Release.template

--- a/tool/ood-gen/lib/event.ml
+++ b/tool/ood-gen/lib/event.ml
@@ -1,11 +1,11 @@
 type t =
   { title : string
-  ; description : string
+  ; description : string option
+  ; organiser : string option
   ; url : string
   ; date : string
   ; tags : string list
   ; online : bool
-  ; textual_location : string option
   ; location : string option
   }
 [@@deriving yaml]
@@ -35,19 +35,21 @@ let pp ppf v =
   { title = %a
   ; slug = %a
   ; description = %a
+  ; organiser = %a
   ; url = %a
   ; date = %a
   ; tags = %a
   ; online = %b
-  ; textual_location = %a
   ; location = %a
   }|}
     Pp.string
     v.title
     Pp.string
     (Utils.slugify v.title)
-    Pp.string
+    Pp.(option string)
     v.description
+    Pp.(option string)
+    v.organiser
     Pp.string
     v.url
     Pp.string
@@ -55,8 +57,6 @@ let pp ppf v =
     (Pp.list Pp.string)
     v.tags
     v.online
-    (Pp.option Pp.string)
-    v.textual_location
     (Pp.option Pp.string)
     v.location
 
@@ -68,12 +68,12 @@ let template () =
 type t =
   { title : string
   ; slug : string
-  ; description : string
+  ; description : string option
+  ; organiser : string option
   ; url : string
   ; date : string
   ; tags : string list
   ; online : bool
-  ; textual_location : string option
   ; location : string option
   }
 

--- a/tool/ood-gen/lib/meetup.ml
+++ b/tool/ood-gen/lib/meetup.ml
@@ -1,0 +1,74 @@
+type location =
+  { lat : float
+  ; long : float
+  }
+[@@deriving yaml]
+
+type t =
+  { title : string
+  ; url : string
+  ; textual_location : string
+  ; location : location
+  }
+[@@deriving yaml]
+
+type metadata = t
+
+let path = Fpath.v "data/meetup.yml"
+
+let decode s =
+  let yaml = Utils.decode_or_raise Yaml.of_string s in
+  match yaml with
+  | `O [ ("meetups", `A xs) ] ->
+    Ok (List.map (Utils.decode_or_raise of_yaml) xs)
+  | _ ->
+    Error (`Msg "expected a list of meetups")
+
+let parse = decode
+
+let all () =
+  let content = Data.read "meetups.yml" |> Option.get in
+  Utils.decode_or_raise decode content
+
+let pp ppf v =
+  Fmt.pf
+    ppf
+    {|
+  { title = %a
+  ; slug = %a
+  ; url = %a
+  ; textual_location = %a
+  ; location = { lat = %a; long = %a }
+  }|}
+    Pp.string
+    v.title
+    Pp.string
+    (Utils.slugify v.title)
+    Pp.string
+    v.url
+    Pp.string
+    v.textual_location
+    Fmt.float
+    v.location.lat
+    Fmt.float
+    v.location.long
+
+let pp_list = Pp.list pp
+
+let template () =
+  Format.asprintf
+    {|
+type location = { lat : float; long : float }
+
+type t =
+  { title : string
+  ; slug : string
+  ; url : string
+  ; textual_location : string
+  ; location : location
+  }
+
+let all = %a
+|}
+    pp_list
+    (all ())


### PR DESCRIPTION
I think I've got all the "events" from v2 now including workshops, some individual events and generic "meetups" (i.e. recurring events). There's a bit of duplication between the OUPS meetup and some events but I think that's okay. I may have _borrowed_ some styling from #115 😁  (the event page needs restyled but just getting the data and page in). 

**The meetups**

<img width="1440" alt="Screenshot 2021-09-24 at 17 46 46" src="https://user-images.githubusercontent.com/20166594/134711924-d1365596-3eab-4abb-ade3-5a5b50df0d02.png">

**The events (the workshop table is unchanged)**

<img width="1439" alt="Screenshot 2021-09-24 at 17 46 59" src="https://user-images.githubusercontent.com/20166594/134711936-fd788c26-fbf2-4534-85d5-fe5425da646e.png">


