### PR TITLE
reload index page to keep toplevel functioning

### DIFF
--- a/src/ocamlorg_web/lib/handlers/page_handler.ml
+++ b/src/ocamlorg_web/lib/handlers/page_handler.ml
@@ -20,6 +20,9 @@ let not_found _req =
 
 let index _req =
   Page_layout_template.render
+  (* In order for the toplevel to work when revisiting a page, for now we force
+     a full reload when navigating back to the index page *)
+    ~turbo_full_reload:true
     ~title:"Welcome to a World of OCaml"
     ~description:
       "OCaml is a general purpose industrial-strength programming language \

--- a/src/ocamlorg_web/lib/templates/layouts/page_layout_template.eml
+++ b/src/ocamlorg_web/lib/templates/layouts/page_layout_template.eml
@@ -1,4 +1,9 @@
-let render ~title ~description inner =
+let full_reload = function 
+  | true -> 
+    <meta name="turbo-visit-control" content="reload">
+  | false -> ""
+
+let render ?(turbo_full_reload=false) ~title ~description inner =
   <!DOCTYPE html>
   <html lang="en">
     <head>
@@ -14,6 +19,7 @@ let render ~title ~description inner =
       <meta name="theme-color" content="#fff">
       <meta name="color-scheme" content="white">
       <meta name=”robots” content="noindex, nofollow">
+      <%s! full_reload turbo_full_reload  %>
       <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
       <link rel="manifest" href="/assets/manifest.json">
       <link rel="stylesheet" href="/assets/main.css" />


### PR DESCRIPTION
A simple workaround for #119, the reasoning behind the issues is explained more in this issue. If at all possible I would quite like to keep Turbo around because it is quite noticeable when it is not! But if there are too many little issues caused by it we can revisit it. 