### PR TITLE
Better formatting of odoc def tables, hiding comment-delim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- Better formatting of odoc def tables, hiding comment-delim (#130, by @panglesd)
+
+  Added css rules to hide comment delimiters and improve overall sizing
+
+  Copy pasting still include comments delimiters to output valid code.
+
 - Highlight code blocks in BKMs (#122, by @patricoferris)
 
   As with the tutorials, the code blocks in the BKMs are primarily dune files, opam 

--- a/asset/doc.css
+++ b/asset/doc.css
@@ -68,3 +68,19 @@ div.odoc code::before {
 div.odoc code::after {
   content: '';
 }
+
+div.odoc td.def-doc .comment-delim {
+    height:0;
+    display: block;
+    opacity: 0;
+}
+
+div.odoc .def-doc p {
+    margin-top: 0.75em;
+    margin-bottom: 0.75em;
+}
+
+div.odoc div.spec tbody td.def {
+    padding-top: 0.75em;
+    white-space: nowrap;
+}


### PR DESCRIPTION
This PR addresses issue #53. 

Example: 
![image](https://user-images.githubusercontent.com/34110029/135858728-a9b0a1ab-6692-4a56-a1a2-bef9de405547.png)
is turned into:
![image](https://user-images.githubusercontent.com/34110029/135858625-c39a4994-10eb-4122-b424-24c1ddf5515b.png)

Comment delimiters are hidden but still selectable (although the selection can miss them) so copy and paste yield valid code. 