### PR TITLE
smarter and sorted package search

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- Smarter and sorted package search (#131, by @panglesd)
+
+  Improve the search algorithm to sort packages by relevance.
+
+  The algorithm now uses the synopsis, descriptions and tags of the package.
+
 - Better formatting of odoc def tables, hiding comment-delim (#130, by @panglesd)
 
   Added css rules to hide comment delimiters and improve overall sizing

--- a/src/ocamlorg/lib/package.ml
+++ b/src/ocamlorg/lib/package.ml
@@ -428,11 +428,11 @@ let search_package t pattern =
     else if contains (String.lowercase_ascii @@ Name.to_string name) pattern then
       0
     else if List.exists (fun tag -> contains (String.lowercase_ascii tag) pattern) info.tags then
-      0
+      1
     else if contains (String.lowercase_ascii info.synopsis) pattern then
-      0
+      2
     else if contains (String.lowercase_ascii info.description) pattern then
-      0
+      3
     else
       failwith "impossible package score" in
   all_packages_latest t

--- a/src/ocamlorg/lib/package.mli
+++ b/src/ocamlorg/lib/package.mli
@@ -147,13 +147,13 @@ val get_package : state -> Name.t -> Version.t -> t option
 val search_package : state -> string -> t list
 (** Search package that match the given string.
 
-Packages returned contain the string either in the name, tags, synopsis
-or description. They are ordered in the following way:
-- Packages whose name is exactly the given string
-- packages whose name contain the given string
-- packages having the given string as a tag
-- packages whose synopsis contain the given string
-- packages whose description contain the given string.
+    Packages returned contain the string either in the name, tags, synopsis or
+    description. They are ordered in the following way:
 
-A call to this function call Lazy.force on every package info.
- *)
+    - Packages whose name is exactly the given string
+    - packages whose name contain the given string
+    - packages having the given string as a tag
+    - packages whose synopsis contain the given string
+    - packages whose description contain the given string.
+
+    A call to this function call Lazy.force on every package info. *)

--- a/src/ocamlorg/lib/package.mli
+++ b/src/ocamlorg/lib/package.mli
@@ -145,4 +145,15 @@ val get_package : state -> Name.t -> Version.t -> t option
 (** Get a package given its name and version. *)
 
 val search_package : state -> string -> t list
-(** Search package names that match the given string. *)
+(** Search package that match the given string.
+
+Packages returned contain the string either in the name, tags, synopsis
+or description. They are ordered in the following way:
+- Packages whose name is exactly the given string
+- packages whose name contain the given string
+- packages having the given string as a tag
+- packages whose synopsis contain the given string
+- packages whose description contain the given string.
+
+A call to this function call Lazy.force on every package info.
+ *)

--- a/src/ocamlorg/lib/std.ml
+++ b/src/ocamlorg/lib/std.ml
@@ -20,3 +20,18 @@ module Result = struct
     let ( and+ ) = both
   end
 end
+
+module String = struct
+  include Stdlib.String
+
+  let contains_s s1 s2 =
+    try
+      let len = String.length s2 in
+      for i = 0 to String.length s1 - len do
+        if String.sub s1 i len = s2 then raise Exit
+      done;
+      false
+    with
+    | Exit ->
+      true
+end


### PR DESCRIPTION
This PR broaden packages search to tags, description and synopsis as proposed in #87.

Additionally, the result of a search is now sorted as follow:
1) Packages whose name is exactly the given string
2) packages whose name contain the given string
3) packages having the given string as a tag
4) packages whose synopsis contain the given string
5) packages whose description contain the given string.

However, the implementation require to call `Lazy.force` on *all* package info, which might introduce performance issues. In the few tests I made, a search request (after a server restart) never took more than 1s to be answered.