### PR TITLE
Remove vertical scrollbar for the documentation navigation bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+-  Remove vertical scrollbar for the documentation navigation bar (#132, by @TheLortex)
+
+  Removed a negative margin in the documentation navigation bar that caused
+  a vertical overflow.
+
 - Smarter and sorted package search (#131, by @panglesd)
 
   Improve the search algorithm to sort packages by relevance.

--- a/src/ocamlorg_web/lib/templates/layouts/package_layout_template.eml
+++ b/src/ocamlorg_web/lib/templates/layouts/package_layout_template.eml
@@ -96,7 +96,7 @@ let render ?(extra_nav="") ~title ~description ~tab ~package ~status ~versions ?
         <div class="mx-auto lg:max-w-8xl lg:px-8">
           <div class="mt-2">
             <div class="px-4 sm:px-6 lg:px-0 flex items-center border-b border-gray-200 overflow-x-auto">
-              <nav class="flex-1 -mb-px flex space-x-6 xl:space-x-8 items-stretch" aria-label="Tabs">
+              <nav class="flex-1 flex space-x-6 xl:space-x-8 items-stretch" aria-label="Tabs">
                 <a href="/p/<%s package_name %>/<%s package_version %>" class="<%s overview_tab_class %>"> Overview </a>
                 <%s! render_documentation_tab ~package_name ~package_version ~documentation_tab_class status %>
                 <%s! render_toplevel_tab ~package_name ~package_version ~toplevel_tab_class toplevel %>


### PR DESCRIPTION
It rendered like this because of an overflow caused by a negative margin: 
![Screenshot 2021-10-05 at 10-37-16 Cmdliner · cmdliner 1 0 4 · OCaml Packages](https://user-images.githubusercontent.com/966015/135989811-8f6284c2-34f4-4929-b316-023e03367e72.png)

Now it's like this:
![Screenshot 2021-10-05 at 10-37-49 Cmdliner · cmdliner 1 0 4 · OCaml Packages](https://user-images.githubusercontent.com/966015/135989906-4bfca1c6-1f89-43d9-b085-719665dc978c.png)


Not sure why there was a negative margin though.