### PR TITLE
split jsoo toplevel into web-worker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- Split js_of_ocaml toplevel execution into web-worker (#135, by @patricoferris)
+
+  The execution of OCaml expressions in the toplevel now takes place in a web 
+  worker which prevents the main UI thread from blocking and makes it easier to
+  terminate executions that have been running too long.
+
 - Compute and display reverse dependencies (#134, by @patricoferris and @TheLortex)
 
   Extend package information structure to add reverse dependencies. Display that

--- a/asset/toplevel.css
+++ b/asset/toplevel.css
@@ -1,5 +1,4 @@
 #toplevel-container {
-  color: #ccc;
   overflow: auto;
   overflow-x: hidden;
 }
@@ -7,9 +6,8 @@
 #toplevel-container textarea {
   width: 90%;
   line-height: 18px;
-  font-size: 12px;
+  font-size: 14px;
   background-color: transparent;
-  color: #fff;
   border: 0;
   resize: none;
   outline: none;
@@ -22,17 +20,16 @@
 
 #toplevel-container #output {
   background-color: transparent;
-  color: #ccc;
   border: none;
   line-height: 18px;
-  font-size: 12px;
+  font-size: 14px;
   margin-bottom: 0px;
 }
 
 #toplevel-container #sharp {
   float: left;
   line-height: 18px;
-  font-size: 12px;
+  font-size: 14px;
   font-family: Menlo, Monaco, Consolas, monospace;
   white-space: pre;
 }
@@ -40,7 +37,7 @@
 #toplevel-container .sharp:before {
   content: "# ";
   line-height: 18px;
-  font-size: 12px;
+  font-size: 14px;
   font-family: Menlo, Monaco, Consolas, monospace;
 }
 

--- a/dune-project
+++ b/dune-project
@@ -61,6 +61,7 @@
   timedesc
   yojson
   lwt
+  brr
   (js_of_ocaml
    (>= 3.11.0))
   (js_of_ocaml-ppx

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -37,6 +37,7 @@ depends: [
   "timedesc"
   "yojson"
   "lwt"
+  "brr"
   "js_of_ocaml" {>= "3.11.0"}
   "js_of_ocaml-ppx" {>= "3.11.0"}
   "js_of_ocaml-compiler" {>= "3.11.0"}

--- a/src/ocamlorg/lib/config.ml
+++ b/src/ocamlorg/lib/config.ml
@@ -19,7 +19,7 @@ let opam_repository_path =
   |> Option.map (fun x -> Result.get_ok (Fpath.of_string x))
   |> Option.value ~default:Fpath.(default_cache_dir / "opam-repository")
 
-let topelevels_path =
+let toplevels_path =
   Sys.getenv_opt "OCAMLORG_TOPLEVELS_PATH"
   |> Option.map (fun x -> Result.get_ok (Fpath.of_string x))
   |> Option.value ~default:Fpath.(v "src" / "ocamlorg_toplevel" / "bin" / "js")

--- a/src/ocamlorg/lib/config.mli
+++ b/src/ocamlorg/lib/config.mli
@@ -6,6 +6,7 @@ val documentation_url : string
 
 val opam_repository_path : Fpath.t
 
-val topelevels_path : Fpath.t
-
 val package_state_path : Fpath.t
+
+val toplevels_path : Fpath.t
+

--- a/src/ocamlorg/lib/config.mli
+++ b/src/ocamlorg/lib/config.mli
@@ -9,4 +9,3 @@ val opam_repository_path : Fpath.t
 val package_state_path : Fpath.t
 
 val toplevels_path : Fpath.t
-

--- a/src/ocamlorg/lib/ocamlorg.ml
+++ b/src/ocamlorg/lib/ocamlorg.ml
@@ -1,4 +1,4 @@
 module Opam_user = Opam_user
 module Package = Package
 
-let topelevels_path = Config.topelevels_path
+let toplevels_path = Config.toplevels_path

--- a/src/ocamlorg/lib/ocamlorg.mli
+++ b/src/ocamlorg/lib/ocamlorg.mli
@@ -3,6 +3,6 @@
 module Opam_user = Opam_user
 module Package = Package
 
-val topelevels_path : Fpath.t
+val toplevels_path : Fpath.t
 (** The path where the toplevel scripts are located. Delete when they are served
     from a CDN. *)

--- a/src/ocamlorg/lib/package.ml
+++ b/src/ocamlorg/lib/package.ml
@@ -425,7 +425,7 @@ let toplevel t =
   let name = Name.to_string t.name in
   let version = Version.to_string t.version in
   let path =
-    Fpath.(to_string (Config.topelevels_path / (name ^ "-" ^ version ^ ".js")))
+    Fpath.(to_string (Config.toplevels_path / (name ^ "-" ^ version ^ ".js")))
   in
   if Sys.file_exists path then
     Some (topelevel_url name version)

--- a/src/ocamlorg_toplevel/bin/dune
+++ b/src/ocamlorg_toplevel/bin/dune
@@ -1,3 +1,12 @@
+; Worker library
+
+(library
+ (name worker)
+ (modules worker)
+ (libraries brr ocamlorg_toplevel js_of_ocaml-toplevel js_of_ocaml-compiler)
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
 ; Base
 
 (executable
@@ -12,6 +21,14 @@
  (action
   (run jsoo_listunits -o %{targets} stdlib base)))
 
+(executable
+ (name worker_base)
+ (modules worker_base)
+ (libraries worker stdlib base)
+ (flags
+  (:standard -rectypes -linkall))
+ (modes byte))
+
 (rule
  (targets worker_base.js)
  (action
@@ -24,7 +41,7 @@
    +toplevel.js
    +dynlink.js
    +base/runtime.js
-   %{dep:worker.bc}
+   %{dep:worker_base.bc}
    -o
    %{targets})))
 
@@ -45,14 +62,9 @@
   (run jsoo_listunits -o %{targets} stdlib)))
 
 (executable
- (name worker)
- (libraries
-  brr
-  ocamlorg_toplevel
-  js_of_ocaml-toplevel
-  js_of_ocaml-compiler
-  stdlib)
- (modules worker)
+ (name worker_stdlib)
+ (modules worker_stdlib)
+ (libraries worker stdlib)
  (flags
   (:standard -rectypes -linkall))
  (preprocess
@@ -70,7 +82,7 @@
    --pretty
    +toplevel.js
    +dynlink.js
-   %{dep:worker.bc}
+   %{dep:worker_stdlib.bc}
    -o
    %{targets})))
 

--- a/src/ocamlorg_toplevel/bin/dune
+++ b/src/ocamlorg_toplevel/bin/dune
@@ -4,9 +4,7 @@
  (name toplevel_base)
  (libraries ocamlorg_toplevel base)
  (modules toplevel_base)
- (flags
-  (:standard -rectypes -linkall))
- (modes byte))
+ (modes js))
 
 (rule
  (targets export_base.txt)
@@ -15,7 +13,7 @@
   (run jsoo_listunits -o %{targets} stdlib base)))
 
 (rule
- (targets toplevel_base.js)
+ (targets worker_base.js)
  (action
   (run
    %{bin:js_of_ocaml}
@@ -26,7 +24,7 @@
    +toplevel.js
    +dynlink.js
    +base/runtime.js
-   %{dep:toplevel_base.bc}
+   %{dep:worker.bc}
    -o
    %{targets})))
 
@@ -36,9 +34,9 @@
  (name toplevel_stdlib)
  (libraries ocamlorg_toplevel stdlib)
  (modules toplevel_stdlib)
- (flags
-  (:standard -rectypes -linkall))
- (modes byte))
+ (modes js))
+
+; Stdlib worker
 
 (rule
  (targets export_stdlib.txt)
@@ -46,8 +44,23 @@
  (action
   (run jsoo_listunits -o %{targets} stdlib)))
 
+(executable
+ (name worker)
+ (libraries
+  brr
+  ocamlorg_toplevel
+  js_of_ocaml-toplevel
+  js_of_ocaml-compiler
+  stdlib)
+ (modules worker)
+ (flags
+  (:standard -rectypes -linkall))
+ (preprocess
+  (pps js_of_ocaml-ppx))
+ (modes byte))
+
 (rule
- (targets toplevel_stdlib.js)
+ (targets worker.js)
  (action
   (run
    %{bin:js_of_ocaml}
@@ -57,7 +70,7 @@
    --pretty
    +toplevel.js
    +dynlink.js
-   %{dep:toplevel_stdlib.bc}
+   %{dep:worker.bc}
    -o
    %{targets})))
 
@@ -65,9 +78,15 @@
  js/
  (rule
   (alias toplevel)
-  (targets stdlib-4.13.0.js base-v0.14.1.js)
-  (deps ../toplevel_stdlib.js ../toplevel_base.js)
+  (targets stdlib-4.13.0.js worker.js worker_base.js base-v0.14.1.js)
+  (deps
+   ../toplevel_stdlib.bc.js
+   ../worker.js
+   ../worker_base.js
+   ../worker_base.js)
   (action
    (progn
-    (run jsoo_minify ../toplevel_stdlib.js -o stdlib-4.13.0.js)
-    (run jsoo_minify ../toplevel_base.js -o base-v0.14.1.js)))))
+    (run jsoo_minify ../toplevel_stdlib.bc.js -o stdlib-4.13.0.js)
+    (run jsoo_minify ../worker.js -o worker.js)
+    (run jsoo_minify ../toplevel_base.bc.js -o base-v0.14.1.js)
+    (run jsoo_minify ../worker_base.js -o worker_base.js)))))

--- a/src/ocamlorg_toplevel/bin/dune
+++ b/src/ocamlorg_toplevel/bin/dune
@@ -93,8 +93,8 @@
   (targets stdlib-4.13.0.js worker.js worker_base.js base-v0.14.1.js)
   (deps
    ../toplevel_stdlib.bc.js
+   ../toplevel_base.bc.js
    ../worker.js
-   ../worker_base.js
    ../worker_base.js)
   (action
    (progn

--- a/src/ocamlorg_toplevel/bin/toplevel_base.ml
+++ b/src/ocamlorg_toplevel/bin/toplevel_base.ml
@@ -1,0 +1,1 @@
+let () = Ocamlorg_toplevel.Toplevel.run "/toplevels/worker_base.js"

--- a/src/ocamlorg_toplevel/bin/toplevel_stdlib.ml
+++ b/src/ocamlorg_toplevel/bin/toplevel_stdlib.ml
@@ -1,0 +1,10 @@
+open Brr
+
+let () =
+  let button =
+    Document.find_el_by_id G.document (Jstr.v "toplevel-load") |> Option.get
+  in
+  Ev.listen
+    Ev.click
+    (fun _ -> Ocamlorg_toplevel.Toplevel.run "/toplevels/worker_base.js")
+    (El.as_target button)

--- a/src/ocamlorg_toplevel/bin/worker.ml
+++ b/src/ocamlorg_toplevel/bin/worker.ml
@@ -149,4 +149,4 @@ let recv_from_page e =
   | phrase ->
     Worker.G.post (execute phrase)
 
-let () = Jv.(set global "onmessage" @@ Jv.repr recv_from_page)
+let run () = Jv.(set global "onmessage" @@ Jv.repr recv_from_page)

--- a/src/ocamlorg_toplevel/bin/worker.ml
+++ b/src/ocamlorg_toplevel/bin/worker.ml
@@ -1,0 +1,152 @@
+open Js_of_ocaml_toplevel
+open Brr
+open Brr_io
+open Ocamlorg_toplevel.Toplevel
+
+(* OCamlorg toplevel in a web worker
+
+   This communicates with the toplevel code via simple json schema, this allows
+   the OCaml execution to not block the "main thread" keeping the page
+   responsive. *)
+
+let jstr_of_buffer v = Jstr.v @@ Buffer.contents v
+
+module Version = struct
+  type t = int list
+
+  let split_char ~sep p =
+    let len = String.length p in
+    let rec split beg cur =
+      if cur >= len then
+        if cur - beg > 0 then [ String.sub p beg (cur - beg) ] else []
+      else if sep p.[cur] then
+        String.sub p beg (cur - beg) :: split (cur + 1) (cur + 1)
+      else
+        split beg (cur + 1)
+    in
+    split 0 0
+
+  let split v =
+    match
+      split_char ~sep:(function '+' | '-' | '~' -> true | _ -> false) v
+    with
+    | [] ->
+      assert false
+    | x :: _ ->
+      List.map
+        int_of_string
+        (split_char ~sep:(function '.' -> true | _ -> false) x)
+
+  let current = split Sys.ocaml_version
+
+  let compint (a : int) b = compare a b
+
+  let rec compare v v' =
+    match v, v' with
+    | [ x ], [ y ] ->
+      compint x y
+    | [], [] ->
+      0
+    | [], y :: _ ->
+      compint 0 y
+    | x :: _, [] ->
+      compint x 0
+    | x :: xs, y :: ys ->
+      (match compint x y with 0 -> compare xs ys | n -> n)
+end
+
+let exec' s =
+  let res : bool = JsooTop.use Format.std_formatter s in
+  if not res then Format.eprintf "error while evaluating %s@." s
+
+let setup () =
+  JsooTop.initialize ();
+  Sys.interactive := false;
+  if Version.compare Version.current [ 4; 07 ] >= 0 then exec' "open Stdlib";
+  let header1 = Printf.sprintf "        %s version %%s" "OCaml" in
+  let header2 =
+    Printf.sprintf
+      "     Compiled with Js_of_ocaml version %s"
+      Js_of_ocaml.Sys_js.js_of_ocaml_version
+  in
+  exec' (Printf.sprintf "Format.printf \"%s@.\" Sys.ocaml_version;;" header1);
+  exec' (Printf.sprintf "Format.printf \"%s@.\";;" header2);
+  exec' "#enable \"pretty\";;";
+  exec' "#disable \"shortvar\";;";
+  let[@alert "-deprecated"] new_directive n k =
+    Hashtbl.add Toploop.directive_table n k
+  in
+  new_directive
+    "load_js"
+    (Toploop.Directive_string
+       (fun name -> Js_of_ocaml.Js.Unsafe.global##load_script_ name));
+  Sys.interactive := true;
+  ()
+
+let setup_printers () =
+  exec' "let _print_unit fmt (_ : 'a) : 'a = Format.pp_print_string fmt \"()\"";
+  Topdirs.dir_install_printer
+    Format.std_formatter
+    Longident.(Lident "_print_unit")
+
+let stdout_buff = Buffer.create 100
+
+let stderr_buff = Buffer.create 100
+
+let execute =
+  let code_buff = Buffer.create 100 in
+  let res_buff = Buffer.create 100 in
+  let pp_code = Format.formatter_of_buffer code_buff in
+  let pp_result = Format.formatter_of_buffer res_buff in
+  let highlighted = ref None in
+  let highlight_location loc =
+    let _file1, line1, col1 = Location.get_pos_info loc.Location.loc_start in
+    let _file2, line2, col2 = Location.get_pos_info loc.Location.loc_end in
+    highlighted := Some ((line1, col1), (line2, col2))
+  in
+  fun phrase ->
+    Buffer.clear code_buff;
+    Buffer.clear res_buff;
+    Buffer.clear stderr_buff;
+    Buffer.clear stdout_buff;
+    JsooTop.execute true ~pp_code ~highlight_location pp_result phrase;
+    Format.pp_print_flush pp_code ();
+    Format.pp_print_flush pp_result ();
+    let highlight = !highlighted in
+    let data =
+      Worker_rpc.create
+        ?highlight
+        ~stdout:(jstr_of_buffer stdout_buff)
+        ~stderr:(jstr_of_buffer stderr_buff)
+        ~sharp_ppf:(jstr_of_buffer code_buff)
+        ~caml_ppf:(jstr_of_buffer res_buff)
+        ()
+    in
+    highlighted := None;
+    let json = Worker_rpc.to_json data in
+    json
+
+let recv_from_page e =
+  let phrase = (Message.Ev.data (Ev.as_type e) : Jstr.t) in
+  match Jstr.to_string phrase with
+  | "setup" ->
+    Js_of_ocaml.Sys_js.set_channel_flusher
+      stdout
+      (Buffer.add_string stdout_buff);
+    Js_of_ocaml.Sys_js.set_channel_flusher
+      stderr
+      (Buffer.add_string stderr_buff);
+    setup ();
+    setup_printers ();
+    let data =
+      Worker_rpc.create
+        ~stdout:(jstr_of_buffer stdout_buff)
+        ~stderr:(jstr_of_buffer stderr_buff)
+        ()
+    in
+    let json = Worker_rpc.to_json data in
+    Worker.G.post json
+  | phrase ->
+    Worker.G.post (execute phrase)
+
+let () = Jv.(set global "onmessage" @@ Jv.repr recv_from_page)

--- a/src/ocamlorg_toplevel/bin/worker_base.ml
+++ b/src/ocamlorg_toplevel/bin/worker_base.ml
@@ -1,0 +1,1 @@
+let () = Worker.run ()

--- a/src/ocamlorg_toplevel/bin/worker_stdlib.ml
+++ b/src/ocamlorg_toplevel/bin/worker_stdlib.ml
@@ -1,0 +1,1 @@
+let () = Worker.run ()

--- a/src/ocamlorg_toplevel/lib/dune
+++ b/src/ocamlorg_toplevel/lib/dune
@@ -1,9 +1,6 @@
 (library
  (name ocamlorg_toplevel)
  (public_name ocamlorg.toplevel)
- (libraries lwt js_of_ocaml-compiler js_of_ocaml-tyxml js_of_ocaml-toplevel)
- (flags
-  (:standard -rectypes -linkall))
- (modes byte)
+ (libraries lwt brr js_of_ocaml-tyxml)
  (preprocess
   (pps js_of_ocaml-ppx)))

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -132,8 +132,7 @@ let toplevels_route =
   Dream.scope
     "/toplevels"
     [ Dream_encoding.compress ]
-    [ Dream.get "/**" (Dream.static (Fpath.to_string Ocamlorg.topelevels_path))
-    ]
+    [ Dream.get "/**" (Dream.static (Fpath.to_string Ocamlorg.toplevels_path)) ]
 
 let router t =
   Dream.router

--- a/src/ocamlorg_web/lib/templates/pages/index_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/index_template.eml
@@ -16,7 +16,7 @@ let render () =
                 safety.
               </p>
               <div class="mt-10 sm:flex sm:justify-center lg:justify-start">
-                <div class=" rounded-md shadow "><a
+                <div class="rounded-md shadow"><a
                     class="text-white bg-orangedark hover:bg-orangedarker w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md md:py-4 md:text-lg md:px-10"
                     href="/tutorials/up-and-running-with-ocaml#installing-ocaml">Install OCaml</a></div>
                 <div class="mt-3 sm:mt-0 sm:ml-3 rounded-md shadow "><a
@@ -30,18 +30,27 @@ let render () =
         </div>
       </div>
     </div>
-    <div class="pt-12 sm:pt-16">
-      <div class="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div id="toplevel-container" class="my-6 px-6 py-6 rounded-xl overflow-auto bg-gray-800">
-          <pre>
-            <code id="output"></code>
-          </pre>
-          <div>
-            <div id="sharp" class="sharp"></div>
-            <textarea id="userinput">Loading ...</textarea>
-          </div>
+    <div class="relative my-6 py-12 bg-orange-600 overflow-hidden">
+      <div class="sm:grid sm:grid-cols-2 sm:gap-px">
+        <div class="max-w-2xl mx-auto text-center">
+          <h2 class="text-3xl my-6 font-extrabold text-white sm:text-4xl">Try OCaml</h2>
+          <p class="text-lg my-6 font-bold text-white">Start coding OCaml in your browser, you could try <code style="background: rgba(244,244,2444,0.3);padding: 2px 6px; border-radius: 3px;">"Hello " ^ "World"</code> or <code style="background: rgba(244,244,2444,0.3);padding: 2px 6px; border-radius: 3px;">List.map ((+) 10) [1; 2; 3]</code></p>
+          <p class="flex justify-center align-center">
+            <button class="text-orangedark bg-white hover:bg-gray-50 flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md md:py-4 md:text-lg md:px-10" id="toplevel-load">Click to load toplevel</button>
+          </p>
         </div>
-        <script type="text/javascript" src="/toplevels/stdlib-4.13.0.js" defer></script>
+        <div class="w-full h-full text-gray-900 mx-auto px-4 sm:px-6 lg:px-8">
+          <div id="toplevel-container" class="my-6 px-6 py-6 rounded-xl overflow-auto bg-white">
+            <pre>
+              <code id="output"></code>
+            </pre>
+            <div>
+              <div id="sharp" class="sharp"></div>
+              <textarea disabled id="userinput">Toplevel not loaded, click the button to load toplevel</textarea>
+            </div>
+          </div>
+          <script type="text/javascript" src="/toplevels/stdlib-4.13.0.js" defer></script>
+        </div>
       </div>
     </div>
     <div class="pt-12 sm:pt-16">

--- a/src/ocamlorg_web/lib/templates/pages/package_toplevel_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/package_toplevel_template.eml
@@ -80,7 +80,7 @@ let render toplevel_url =
 <noscript>
   You need to enable JavaScript to run this app.
 </noscript>
-<div id="toplevel-container" class="my-6 px-6 py-6 rounded-xl overflow-auto bg-gray-800">
+<div id="toplevel-container" class="my-6 px-6 py-6 rounded-xl overflow-auto bg-white">
   <pre>
     <code id="output"></code>
   </pre>


### PR DESCRIPTION
This PR aims to partially fix #133 and #127 by moving the jsoo execution to a web worker which makes the chunk of the code easier to lazy load, execution of OCaml code doesn't block the main UI thread, easy to terminate the worker if there is no response in a certain amount of time (here `10s`). It also gives the toplevel a bit of a different UI just to work in the idea of having to load the toplevel runtime code in. The initial JS loaded into the homepage is now (after `dune build --profile release`) `~80kB` gzipped (`~213kB` otherwise) which is better (we could probably go further, but perhaps in a separate PR)

**Toplevel after loading the home page**

<img width="1440" alt="Screenshot 2021-10-05 at 18 22 21" src="https://user-images.githubusercontent.com/20166594/136072226-cdcf63f8-5135-42ce-bb7b-22d50bd2b3c5.png">

**Toplevel after clicking load and entering a few expressions**

<img width="1432" alt="Screenshot 2021-10-05 at 18 23 24" src="https://user-images.githubusercontent.com/20166594/136072362-91ab8468-7487-4c9e-8d11-4174b2fc34af.png">

