### PR TITLE
load baseless toplevel on homepage

### DIFF
--- a/src/ocamlorg_toplevel/bin/toplevel_stdlib.ml
+++ b/src/ocamlorg_toplevel/bin/toplevel_stdlib.ml
@@ -6,5 +6,5 @@ let () =
   in
   Ev.listen
     Ev.click
-    (fun _ -> Ocamlorg_toplevel.Toplevel.run "/toplevels/worker_base.js")
+    (fun _ -> Ocamlorg_toplevel.Toplevel.run "/toplevels/worker.js")
     (El.as_target button)

--- a/src/ocamlorg_toplevel/lib/toplevel.ml
+++ b/src/ocamlorg_toplevel/lib/toplevel.ml
@@ -72,7 +72,6 @@ let highlight_location ((line1, col1), (line2, col2)) =
         Colorize.highlight from_ to_ e)
 
 let append colorize output cl s =
-  Brr.Console.log [ "APPPEND"; cl; s ];
   Dom.appendChild output (Tyxml_js.To_dom.of_element (colorize ~a_class:cl s))
 
 module History = struct


### PR DESCRIPTION
Accidentally loaded the wrong toplevel that included `Base` in #135 and also left some debugging statements in the console. 