### PR TITLE
Imrprove table layout in doc

### DIFF
--- a/asset/doc.css
+++ b/asset/doc.css
@@ -70,17 +70,18 @@ div.odoc code::after {
 }
 
 div.odoc td.def-doc .comment-delim {
-    height:0;
-    display: block;
-    opacity: 0;
+  height: 0;
+  display: block;
+  opacity: 0;
 }
 
 div.odoc .def-doc p {
-    margin-top: 0.75em;
-    margin-bottom: 0.75em;
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
 }
 
 div.odoc div.spec tbody td.def {
-    padding-top: 0.75em;
-    white-space: nowrap;
+  padding-top: 0.75em;
+  overflow-wrap: anywhere;
+  min-width: 40%
 }

--- a/asset/doc.css
+++ b/asset/doc.css
@@ -1,7 +1,7 @@
 div.odoc {
   margin-left: auto;
   margin-right: auto;
-  max-width: 37.5rem /* 600px */;
+  max-width: 42.5rem /* 600px */;
   position: relative;
 }
 

--- a/asset/doc.css
+++ b/asset/doc.css
@@ -1,7 +1,7 @@
 div.odoc {
   margin-left: auto;
   margin-right: auto;
-  max-width: 42.5rem /* 600px */;
+  max-width: 56rem /* 896px */;
   position: relative;
 }
 

--- a/src/ocamlorg_web/lib/templates/pages/package_doc_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/package_doc_template.eml
@@ -49,12 +49,12 @@ let maptoc = toc_of_map ~root map in
 <div class="flex-auto flex sm:px-6 lg:px-8">
   <div class="relative flex flex-col w-full">
     <div class="relative flex w-full mx-auto">
-      <div class="w-full flex-none sm:grid sm:grid-cols-5 lg:grid-cols-3 sm:gap-6 lg:gap-8">
-        <div class="relative px-4 sm:px-0 sm:col-span-2 lg:col-span-1 ">
+      <div class="w-full flex-none sm:grid sm:grid-cols-5 lg:grid-cols-7 sm:gap-6 lg:gap-8">
+        <div class="relative px-4 sm:px-0 sm:col-span-2 lg:col-span-2 ">
           <%s! Navmap_template.render ~path maptoc %>
           <%s! Toc_template.render toc %>
         </div>
-        <div class="px-0 lg:pl-8 relative sm:col-span-3 lg:col-span-2 lg:-ml-8 bg-white sm:shadow-md sm:rounded-lg">
+        <div class="px-0 lg:pl-8 relative sm:col-span-3 lg:col-span-5 lg:-ml-8 bg-white sm:shadow-md sm:rounded-lg">
           <div class="relative py-8 px-8 lg:px-16">
             <div class="odoc prose prose-orange">
               <%s! doc.content %>

--- a/src/ocamlorg_web/lib/templates/pages/package_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/package_template.eml
@@ -42,8 +42,8 @@ let render ~readme ~license:_ package =
       (Ocamlorg.Package.Name.to_string name, x)
     )
   in
-  <div class="grid grid-cols-1 gap-8 sm:grid-flow-col-dense sm:grid-cols-5 lg:grid-cols-3 sm:px-6 lg:px-8">
-    <div class="px-4 sm:px-0 lg:px-0 sm:col-span-2 sm:col-start-4 lg:col-start-3 lg:col-span-1 space-y-6">
+  <div class="grid grid-cols-1 gap-8 sm:grid-flow-col-dense sm:grid-cols-5 lg:grid-cols-7 sm:px-6 lg:px-8">
+    <div class="px-4 sm:px-0 lg:px-0 sm:col-span-2 sm:col-start-4 lg:col-start-6 lg:col-span-2 space-y-6">
       <section>
         <script src="/assets/vendors/alpine-clipboard.js"></script>
 
@@ -168,13 +168,13 @@ let render ~readme ~license:_ package =
       </section>
     </div>
 
-    <div class="px-0 space-y-6 sm:col-span-3 sm:col-start-1 lg:col-span-2">
+    <div class="px-0 space-y-6 sm:col-span-3 sm:col-start-1 lg:col-span-5">
       <section>
         <div class="bg-white shadow sm:rounded-lg">
           <div class="px-4 py-4 sm:px-6 border-b border-gray-200">
             <h2 class="text-lg leading-6 font-medium text-gray-900"><pre>README.md</pre></h2>
           </div>
-          <div class="px-4 py-5 sm:px-6 prose prose-orange max-w-3xl mx-auto">
+          <div class="px-4 py-5 sm:px-6 prose prose-orange max-w-4xl mx-auto">
             <%s! readme %>
           </div>
         </div>


### PR DESCRIPTION
This PR solves the regressions introduced by #130 when addressing #53 .

Now, wrapping inside of words is allowed to prevent OCaml long words (such as `Tezos_crypto.Operation_list_list_hash.t;` for instance) making a cell very wide. A `min-width` is introduced to prevent the browser to make a cell very small by breaking all the words.

Additionally, a bigger part of the screen is given to `div.odoc`.