### PR TITLE
Add tags to overview (#39)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Add tags to overview (#39, by @JiaeK)
+
 - Switch to using RPCs to talk to toplevel worker (#159, by @jonludlam)
 
 - Add completion to toplevel (#155, by @jonludlam)

--- a/src/ocamlorg_web/lib/templates/pages/package_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/package_template.eml
@@ -25,6 +25,7 @@ let render ~readme ~license:_ package =
   let package_version = Ocamlorg.Package.(Version.to_string (version package)) in
   let package_info = Ocamlorg.Package.info package in
   let package_homepages = package_info.Ocamlorg.Package.Info.homepage in
+  let package_tags = package_info.Ocamlorg.Package.Info.tags in
   let package_authors = package_info.Ocamlorg.Package.Info.authors in
   let package_maintainers = package_info.Ocamlorg.Package.Info.maintainers in
   let package_source = package_info.Ocamlorg.Package.Info.url in
@@ -74,6 +75,15 @@ let render ~readme ~license:_ package =
       </section>
       <section>
         <dl class="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
+          <div class="sm:col-span-2">
+            <dt class="text-sm font-medium text-gray-500"><%s gettext "Tags" %></dt>
+            <dd class="mt-2 text-sm text-gray-900">
+              <% package_tags |> List.iter begin fun tag -> %>
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium bg-gray-100 text-gray-800"> <%s tag %> 
+              <% end; %>
+              </span>
+            </dd>
+          </div>
           <div class="sm:col-span-2">
             <dt class="text-sm font-medium text-gray-500"><%s gettext "Authors" %></dt>
             <dd class="mt-2 text-sm text-gray-900">


### PR DESCRIPTION
Previously the new package overview page looked like this,

![add tags preview](https://user-images.githubusercontent.com/78751231/138493675-3ffd9ffb-2898-4e64-a47a-4835ef5f2192.png)




<br>
<br>


 And now Tags are added between Install and Authors where the red pointer indicated.

![add tags](https://user-images.githubusercontent.com/78751231/138494806-ff41d36d-4cb5-4214-89fb-661f75c6104d.png)

