### PR TITLE
Generate msgid for tags

### DIFF
--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -1,0 +1,27 @@
+name: Gettext check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.12.1
+          dune-cache: true
+          opam-local-packages: |
+            !ocamlorg.opam !ocamlorg-data.opam
+
+      - name: Install dependencies
+        run: opam update && opam depext -yi gettext dream crunch logs fmt cmdliner
+
+      - name: Generate PO files
+        run: make gen-po

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
 # Unreleased
+
+- Fix tags in overview page by calling `make gen-po`
+
+  Rewrite `gen-po`'s Makefile rules in `dune`. Created a `@gen-po` alias.
+  Add a Github action to check if the PO files match the
+  status of the repository (#172, by @TheLortex)
+
 - Add tags to overview (#39, by @JiaeK)
 
 - Switch to using RPCs to talk to toplevel worker (#159, by @jonludlam)

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,4 @@ utop: ## Run a REPL and link with the project's libraries
 
 .PHONY: gen-po
 gen-po: ## Generate the po files
-	cd _build/default; opam exec -- dune exec ocaml-gettext -- extract src/ocamlorg_web/lib/templates/**/*.ml src/ocamlorg_web/lib/*.ml > ../../gettext/messages.pot
-	# en
-	cp gettext/en/LC_MESSAGES/messages.po gettext/en/LC_MESSAGES/messages.po.bak
-	opam exec -- dune exec ocaml-gettext -- merge gettext/messages.pot gettext/en/LC_MESSAGES/messages.po.bak > gettext/en/LC_MESSAGES/messages.po
-	rm gettext/en/LC_MESSAGES/messages.po.bak
-	# fr 
-	cp gettext/fr/LC_MESSAGES/messages.po gettext/fr/LC_MESSAGES/messages.po.bak
-	opam exec -- dune exec ocaml-gettext -- merge gettext/messages.pot gettext/fr/LC_MESSAGES/messages.po.bak > gettext/fr/LC_MESSAGES/messages.po
-	rm gettext/fr/LC_MESSAGES/messages.po.bak
+	opam exec -- dune build --root . @gen-po --auto-promote

--- a/gettext/dune
+++ b/gettext/dune
@@ -1,0 +1,33 @@
+; messages.pot
+
+(rule
+ (target messages.pot.expected)
+ (deps
+  (glob_files
+   %{workspace_root}/src/ocamlorg_web/lib/templates/components/*.ml)
+  (glob_files %{workspace_root}/src/ocamlorg_web/lib/templates/pages/*.ml)
+  (glob_files %{workspace_root}/src/ocamlorg_web/lib/templates/layouts/*.ml)
+  (glob_files %{workspace_root}/src/ocamlorg_web/lib/*.ml))
+ (action
+  (chdir
+   %{workspace_root}
+   (with-stdout-to
+    %{target}
+    (run ocaml-gettext extract %{deps})))))
+
+(rule
+ (alias gen-po)
+ (action
+  (diff messages.pot messages.pot.expected)))
+
+; en/LC_MESSAGES/messages.po
+
+(subdir
+ en
+ (include ../dune.inc))
+
+; fr/LC_MESSAGES/messages.po
+
+(subdir
+ fr
+ (include ../dune.inc))

--- a/gettext/dune.inc
+++ b/gettext/dune.inc
@@ -1,0 +1,18 @@
+; assumes it's included from one of the language folder (en, fr, ..)
+
+(subdir
+ LC_MESSAGES
+ (rule
+  (target messages.po.merged)
+  (deps ../../messages.pot.expected messages.po)
+  (action
+   (with-stdout-to
+    %{target}
+    (run ocaml-gettext merge %{deps})))))
+
+(subdir
+ LC_MESSAGES
+ (rule
+  (alias gen-po)
+  (action
+   (diff messages.po messages.po.merged))))

--- a/gettext/en/LC_MESSAGES/messages.po
+++ b/gettext/en/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Around the Web"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:62
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:85
 msgid "Authors"
 msgstr ""
 
@@ -85,7 +85,7 @@ msgstr ""
 msgid "Continuous Integration"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:130
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:144
 msgid "Dependencies"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr ""
 msgid "Discover the organisations that use OCaml to accomplish their goals."
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:123
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:137
 msgid "Download"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr[1] ""
 msgid "Go back home"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:90
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:104
 msgid "Homepage"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Innovation. Community. Security."
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:43
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:48
 msgid "Install"
 msgstr ""
 
@@ -177,11 +177,11 @@ msgstr ""
 msgid "Legal"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:85
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:99
 msgid "License"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:79
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:93
 msgid "Maintainers"
 msgstr ""
 
@@ -190,7 +190,7 @@ msgstr ""
 msgid "News"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:33
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:34
 #. src/ocamlorg_web/lib/templates/pages/package_search_template.eml:121
 msgid "No License"
 msgstr ""
@@ -281,7 +281,7 @@ msgstr ""
 msgid "Search packages"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:103
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:117
 msgid "Sources"
 msgstr ""
 
@@ -304,6 +304,10 @@ msgstr ""
 #: src/ocamlorg_web/lib/navigation.ml:44
 #. src/ocamlorg_web/lib/templates/components/footer_template.eml:37
 msgid "Success Stories"
+msgstr ""
+
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:67
+msgid "Tags"
 msgstr ""
 
 #: src/ocamlorg_web/lib/templates/components/footer_template.eml:68

--- a/gettext/fr/LC_MESSAGES/messages.po
+++ b/gettext/fr/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr "Archive"
 msgid "Around the Web"
 msgstr "Sur Internet"
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:62
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:85
 msgid "Authors"
 msgstr "Auteurs"
 
@@ -85,7 +85,7 @@ msgstr "Communauté"
 msgid "Continuous Integration"
 msgstr "Intégration continue"
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:130
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:144
 msgid "Dependencies"
 msgstr "Dépendances"
 
@@ -93,7 +93,7 @@ msgstr "Dépendances"
 msgid "Discover the organisations that use OCaml to accomplish their goals."
 msgstr "Découvrez les organisations qui utilisent OCaml pour atteindre leurs objectifs."
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:123
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:137
 msgid "Download"
 msgstr "Télécharger"
 
@@ -127,7 +127,7 @@ msgstr[1] "%i paquets trouvés."
 msgid "Go back home"
 msgstr "Retour à la page d'accueil"
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:90
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:104
 msgid "Homepage"
 msgstr "Page d'accueil"
 
@@ -144,7 +144,7 @@ msgstr "Utilisateurs industriels"
 msgid "Innovation. Community. Security."
 msgstr "Innovation. Communauté. Sécurité."
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:43
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:48
 msgid "Install"
 msgstr "Installer"
 
@@ -177,11 +177,11 @@ msgstr "Apprenez les techniques de création d'outils et d'applications en OCaml
 msgid "Legal"
 msgstr "Légale"
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:85
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:99
 msgid "License"
 msgstr "Licence"
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:79
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:93
 msgid "Maintainers"
 msgstr "Mainteneurs"
 
@@ -190,7 +190,7 @@ msgstr "Mainteneurs"
 msgid "News"
 msgstr "Nouvelles"
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:33
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:34
 #. src/ocamlorg_web/lib/templates/pages/package_search_template.eml:121
 msgid "No License"
 msgstr "Pas de licence"
@@ -281,7 +281,7 @@ msgstr "Résultats de recherche"
 msgid "Search packages"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:103
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:117
 msgid "Sources"
 msgstr "Sources"
 
@@ -305,6 +305,10 @@ msgstr "État de l'art"
 #. src/ocamlorg_web/lib/templates/components/footer_template.eml:37
 msgid "Success Stories"
 msgstr "Réussites"
+
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:67
+msgid "Tags"
+msgstr ""
 
 #: src/ocamlorg_web/lib/templates/components/footer_template.eml:68
 msgid "Terms"

--- a/gettext/messages.pot
+++ b/gettext/messages.pot
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Around the Web"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:62
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:85
 msgid "Authors"
 msgstr ""
 
@@ -85,7 +85,7 @@ msgstr ""
 msgid "Continuous Integration"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:130
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:144
 msgid "Dependencies"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr ""
 msgid "Discover the organisations that use OCaml to accomplish their goals."
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:123
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:137
 msgid "Download"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr[1] ""
 msgid "Go back home"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:90
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:104
 msgid "Homepage"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Innovation. Community. Security."
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:43
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:48
 msgid "Install"
 msgstr ""
 
@@ -177,11 +177,11 @@ msgstr ""
 msgid "Legal"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:85
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:99
 msgid "License"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:79
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:93
 msgid "Maintainers"
 msgstr ""
 
@@ -190,7 +190,7 @@ msgstr ""
 msgid "News"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:33
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:34
 #. src/ocamlorg_web/lib/templates/pages/package_search_template.eml:121
 msgid "No License"
 msgstr ""
@@ -281,7 +281,7 @@ msgstr ""
 msgid "Search packages"
 msgstr ""
 
-#: src/ocamlorg_web/lib/templates/pages/package_template.eml:103
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:117
 msgid "Sources"
 msgstr ""
 
@@ -304,6 +304,10 @@ msgstr ""
 #: src/ocamlorg_web/lib/navigation.ml:44
 #. src/ocamlorg_web/lib/templates/components/footer_template.eml:37
 msgid "Success Stories"
+msgstr ""
+
+#: src/ocamlorg_web/lib/templates/pages/package_template.eml:67
+msgid "Tags"
 msgstr ""
 
 #: src/ocamlorg_web/lib/templates/components/footer_template.eml:68


### PR DESCRIPTION
Called `make gen-po` to create a new `msgid` for the `"Tags"` text in _gettext_.
Shoud fix https://github.com/ocaml/v3.ocaml.org-server/issues/171


I'll create a Github action to check that `po` files are up to date for future PRs

EDIT: struggling with the CI but I will succeed