### PR TITLE
Demarcate include blocks (#54)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Demarcate include blocks (#54, by @JiaeK)
+
 - Add semicolons `;;` to 99 Problems toplevel sentences. (#176, by @Lontchi12)
 
 - Fix tags in overview page by calling `make gen-po`

--- a/asset/doc.css
+++ b/asset/doc.css
@@ -5,7 +5,7 @@ div.odoc {
   position: relative;
 }
 
-div.odoc div.spec {
+div.odoc div.spec, div.odoc-include .spec {
   border-left-width: 4px;
   border-color: rgba(251, 146, 60, 1);
   border-radius: 0.25rem /* 4px */;
@@ -86,12 +86,13 @@ div.odoc div.spec tbody td.def {
   min-width: 40%
 }
 
-.odoc-include details {
+div.odoc-include details {
   position: relative;
 }
 
-.odoc-include details:after {
+div.odoc-include details:after {
   display: block;
+  content: " ";
   position: absolute;
   border-radius: 0 1ex 1ex 0;
   right: -20px;

--- a/asset/doc.css
+++ b/asset/doc.css
@@ -5,7 +5,7 @@ div.odoc {
   position: relative;
 }
 
-div.odoc div.spec .spec.include {
+div.odoc div.spec {
   border-left-width: 4px;
   border-color: rgba(251, 146, 60, 1);
   border-radius: 0.25rem /* 4px */;
@@ -92,7 +92,6 @@ div.odoc div.spec tbody td.def {
 
 .odoc-include details:after {
   display: block;
-  content: " ";
   position: absolute;
   border-radius: 0 1ex 1ex 0;
   right: -20px;

--- a/asset/doc.css
+++ b/asset/doc.css
@@ -5,7 +5,7 @@ div.odoc {
   position: relative;
 }
 
-div.odoc div.spec {
+div.odoc div.spec .spec.include {
   border-left-width: 4px;
   border-color: rgba(251, 146, 60, 1);
   border-radius: 0.25rem /* 4px */;
@@ -84,4 +84,25 @@ div.odoc div.spec tbody td.def {
   padding-top: 0.75em;
   overflow-wrap: anywhere;
   min-width: 40%
+}
+
+.odoc-include details {
+  position: relative;
+}
+
+.odoc-include details:after {
+  display: block;
+  content: " ";
+  position: absolute;
+  border-radius: 0 1ex 1ex 0;
+  right: -20px;
+  top: 1px;
+  bottom: 1px;
+  width: 15px;
+  background: rgba(0, 4, 15, 0.05); 
+  box-shadow: 0 0px 0 1px rgba(204, 204, 204, 0.53); 
+}
+
+.spec.include summary:hover {
+  background-color: rgba(228, 231, 235, 1);
 }


### PR DESCRIPTION
Previously include blocks are not visually demarcated.

![tyxml v3 page](https://user-images.githubusercontent.com/78751231/139462507-3212404c-fdc8-416b-8e48-e279f89b5fbf.png)






And after this change, 

- Include blocks are demarcated 
- The border on the right-hand side shows which sections come from included signatures
![include open](https://user-images.githubusercontent.com/78751231/139463167-21652ed1-3124-4f64-b429-99f03a15b902.png)




(also the bottom)
![include open bottom](https://user-images.githubusercontent.com/78751231/139463196-c5919bdc-7757-49de-8380-c56f34fbf56d.png)





- When hovering, the shade of include blocks changes
![include hover](https://user-images.githubusercontent.com/78751231/139462110-08e1f8cc-41f2-4ab7-93eb-f9b5e60d15e6.png)

