### PR TITLE
Fix hover effect for include blocks

### DIFF
--- a/asset/doc.css
+++ b/asset/doc.css
@@ -103,6 +103,6 @@ div.odoc-include details:after {
   box-shadow: 0 0px 0 1px rgba(204, 204, 204, 0.53); 
 }
 
-.spec.include summary:hover {
+div.odoc-include summary:hover {
   background-color: rgba(228, 231, 235, 1);
 }


### PR DESCRIPTION
From the PR for Demarcate include blocks ([https://github.com/ocaml/v3.ocaml.org-server/pull/175](url)), the hovering effect did not work properly. Now it has fixed.