### PR TITLE
Fix versioned links from dependencies

### DIFF
--- a/src/ocamlorg/lib/package.ml
+++ b/src/ocamlorg/lib/package.ml
@@ -22,7 +22,8 @@ module Info = struct
     ; license : string
     ; homepage : string list
     ; tags : string list
-    ; dependencies : (OpamPackage.Name.t * string option) list
+    ; dependencies :
+        (OpamPackage.Name.t * string option * OpamPackage.Version.t) list
     ; rev_deps :
         (OpamPackage.Name.t * string option * OpamPackage.Version.t) list
     ; depopts : (OpamPackage.Name.t * string option) list
@@ -49,7 +50,8 @@ module Info = struct
 
   let parse_formula =
     OpamFormula.fold_left
-      (fun lst (name, cstr) -> (name, string_of_formula cstr) :: lst)
+      (fun lst (name, cstr, latest) ->
+        (name, string_of_formula cstr, latest) :: lst)
       []
 
   let depends packages opams f =
@@ -68,6 +70,7 @@ module Info = struct
                 | _ ->
                   None
               in
+              let latest = OpamPackage.Version.Set.max_elt version_set in
               let deps =
                 OpamFormula.packages packages
                 @@ OpamFilter.filter_formula ~default:true env (f opam)

--- a/src/ocamlorg/lib/package.ml
+++ b/src/ocamlorg/lib/package.ml
@@ -69,7 +69,7 @@ module Info = struct
                 | _ ->
                   None
               in
-              
+              let latest = OpamPackage.Version.Set.max_elt versions in
               let deps =
                 OpamFormula.packages packages
                 @@ OpamFilter.filter_formula ~default:true env (f opam)

--- a/src/ocamlorg/lib/package.ml
+++ b/src/ocamlorg/lib/package.ml
@@ -69,7 +69,7 @@ module Info = struct
                 | _ ->
                   None
               in
-              let latest = OpamPackage.Version.Set.max_elt versions in
+              
               let deps =
                 OpamFormula.packages packages
                 @@ OpamFilter.filter_formula ~default:true env (f opam)
@@ -217,8 +217,8 @@ module Info = struct
     Logs.info (fun f -> f "Dependencies...");
     let dependencies = get_dependency_set packages opams in
     let+ t = make ~dependencies ~rev_deps ~packages ~package opam in
-    let+ rev_deps = mk_revdeps package packages rev_deps in
-    let+ dependencies = mk_revdeps package packages dependencies in
+    let+ rev_deps = mk_revdeps package packages rev_deps
+    and+ dependencies = mk_revdeps package packages dependencies in
     Logs.info (fun f -> f "Reverse dependencies...");
     let* rev_deps = rev_depends dependencies in
     Logs.info (fun f -> f "Generate package info");

--- a/src/ocamlorg/lib/package.mli
+++ b/src/ocamlorg/lib/package.mli
@@ -45,7 +45,7 @@ module Info : sig
     ; license : string
     ; homepage : string list
     ; tags : string list
-    ; dependencies : (Name.t * string option) list
+    ; dependencies : (Name.t * string option * Version.t) list
     ; rev_deps : (Name.t * string option * Version.t) list
     ; depopts : (Name.t * string option) list
     ; conflicts : (Name.t * string option) list

--- a/src/ocamlorg_web/lib/graphql.ml
+++ b/src/ocamlorg_web/lib/graphql.ml
@@ -260,6 +260,7 @@ let package =
             ~typ:(non_null (list (non_null info)))
             ~resolve:(fun _ p ->
               let info = Package.info p in
+              let latest = OpamPackage.Version.Set.max_elt version_set in 
               get_info info.Package.Info.dependencies)
         ; field
             "depopts"

--- a/src/ocamlorg_web/lib/graphql.ml
+++ b/src/ocamlorg_web/lib/graphql.ml
@@ -4,6 +4,7 @@ module Package = Ocamlorg.Package
 type package_info =
   { name : string
   ; constraints : string option
+  ; latest : string option
   }
 
 type packages_success =
@@ -24,8 +25,8 @@ type params_validity =
 
 let get_info info =
   List.map
-    (fun (name, constraints) ->
-      { name = Package.Name.to_string name; constraints })
+    (fun (name, constraints, latest) ->
+      { name = Package.Name.to_string name; constraints; latest })
     info
 
 let is_in_range current_version from_version upto_version =
@@ -260,7 +261,7 @@ let package =
             ~typ:(non_null (list (non_null info)))
             ~resolve:(fun _ p ->
               let info = Package.info p in
-              let latest = OpamPackage.Version.Set.max_elt version_set in 
+              let latest = OpamPackage.Version.Set.max_elt versions in
               get_info info.Package.Info.dependencies)
         ; field
             "depopts"

--- a/src/ocamlorg_web/lib/templates/pages/package_template.eml
+++ b/src/ocamlorg_web/lib/templates/pages/package_template.eml
@@ -39,8 +39,8 @@ let render ~readme ~license:_ package =
     )
   in
   let package_deps = 
-    package_info.Ocamlorg.Package.Info.dependencies |> List.map (fun (name, x) ->
-      (Ocamlorg.Package.Name.to_string name, x)
+    package_info.Ocamlorg.Package.Info.dependencies |> List.map (fun (name, x, version) ->
+      (Ocamlorg.Package.Name.to_string name, x, Ocamlorg.Package.Version.to_string version)
     )
   in
   <div class="grid grid-cols-1 gap-8 sm:grid-flow-col-dense sm:grid-cols-5 lg:grid-cols-7 sm:px-6 lg:px-8">
@@ -144,9 +144,9 @@ let render ~readme ~license:_ package =
             <dt class="text-sm font-medium text-gray-500"><%s gettext "Dependencies" %></dt>
             <dd class="mt-2 text-sm text-gray-900 max-h-80 overflow-y-auto">
               <ul class="divide-y divide-gray-100">
-                <% package_deps |> List.iter begin fun (name, cstr) -> %>
+                <% package_deps |> List.iter begin fun (name, cstr, version) -> %>
                 <li class="py-2">
-                  <a href="/p/<%s name %>" class="mt-1 text-sm text-orange-600 hover:text-orange-500"><%s name %></a>
+                  <a href="/p/<%s name ^ "/" ^ version %>" class="mt-1 text-sm text-orange-600 hover:text-orange-500"><%s name %></a>
                   <% match cstr with None -> () | Some cstr -> %>
                   <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-white text-gray-800">
                     <pre><%s cstr %></pre>


### PR DESCRIPTION
This PR fixes the dependencies part of #164.

There are still a few of uncleared spots, especially inside of `graphql.ml`, but I believe opening this PR draft would accelerate to fix this issue. 