### PR TITLE
Fix a broken link in a tutorial's overview page

### DIFF
--- a/data/tutorials/en/001_a_first_hour_with_ocaml.md
+++ b/data/tutorials/en/001_a_first_hour_with_ocaml.md
@@ -10,7 +10,7 @@ date: 2021-08-06T17:11:00-00:00
 ---
 
 You may follow along with this tutorial with just a basic OCaml installation,
-as described in [Up and Running](https://v3.ocaml.org/tutorials/up-and-running-with-ocaml).
+as described in [Up and Running](/tutorials/up-and-running-with-ocaml).
 
 Alternatively, you may follow almost all of it by running OCaml in your browser
 using [TryOCaml](http://try.ocamlpro.com), with no installation required.

--- a/data/tutorials/en/001_a_first_hour_with_ocaml.md
+++ b/data/tutorials/en/001_a_first_hour_with_ocaml.md
@@ -10,7 +10,7 @@ date: 2021-08-06T17:11:00-00:00
 ---
 
 You may follow along with this tutorial with just a basic OCaml installation,
-as described in [Up and Running](up_and_running.html).
+as described in [Up and Running](https://v3.ocaml.org/tutorials/up-and-running-with-ocaml).
 
 Alternatively, you may follow almost all of it by running OCaml in your browser
 using [TryOCaml](http://try.ocamlpro.com), with no installation required.


### PR DESCRIPTION
This PR fixes the broken link of 'Up and Running' inside of [A First Hour with OCaml](https://v3.ocaml.org/tutorials/a-first-hour-with-ocaml) overview page.



![broken link](https://user-images.githubusercontent.com/78751231/145483342-4a28a8ae-c6eb-4754-96d2-413ee6606a41.png)
