### PR TITLE
Search by tag, authors (and synopsis, description...)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Adding search by authors, tag and other package fields (#194, by @panglesd)
+
 - Integrate new toplevel design with toplevel logic and basic syntax highlighting (#188, by @patricoferris)
 
 - Support HTTPS and provision certificates with Let's Encrypt (#182, by @tmattio and @patricoferris)

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,4 +1,4 @@
-let render ~total (packages : Package_intf.meta list)  (query : string) =
+let render ~total ~search (packages : Package_intf.meta list) =
 Layout.render
 ~turbo_full_reload:true
 ~title:"OCaml Packages · Search Result"
@@ -17,7 +17,7 @@ Layout.render
                         <div class="relative w-full text-gray-400 focus-within:text-gray-600">
                             <input name="q" id="q"
                                 class="w-full appearance-none outline-none focus:border-primary-600 text-body-600 border rounded-md py-3 pr-6 border-gray-200 pl-14 h-full"
-                                placeholder="Search packages" type="search" value="<%s Dream.from_percent_encoded query %>">
+                                placeholder="Search packages" type="search" value="<%s search %>">
                             <div class="absolute h-full flex items-center pl-6 opacity-60 left-0 top-0">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-body-400" fill="none"
                                     viewBox="0 0 24 24" stroke="rgba(26, 32, 44, 1)">

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,4 +1,4 @@
-let render ~total (packages : Package_intf.meta list) =
+let render ~total (packages : Package_intf.meta list)  (query : string) =
 Layout.render
 ~turbo_full_reload:true
 ~title:"OCaml Packages · Search Result"
@@ -17,7 +17,7 @@ Layout.render
                         <div class="relative w-full text-gray-400 focus-within:text-gray-600">
                             <input name="q" id="q"
                                 class="w-full appearance-none outline-none focus:border-primary-600 text-body-600 border rounded-md py-3 pr-6 border-gray-200 pl-14 h-full"
-                                placeholder="Search packages" type="search">
+                                placeholder="Search packages" type="search" value="<%s Dream.from_percent_encoded query %>">
                             <div class="absolute h-full flex items-center pl-6 opacity-60 left-0 top-0">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-body-400" fill="none"
                                     viewBox="0 0 24 24" stroke="rgba(26, 32, 44, 1)">
@@ -42,8 +42,7 @@ Layout.render
                         </div>
                         <div class="flex flex-wrap">
                             <% package.tags |> List.iter (fun (tag : string) -> %>
-                                <!-- TODO(tmattio): Support searching for tags -->
-                                <a href=""
+                                <a href="?q=tag:<%s Dream.to_percent_encoded ("\""^tag^"\"") %>"
                                     class="px-2 py-1 text-body-400 font-medium bg-gray-100 rounded hover:underline mr-3 mt-3 text-sm">
                                     <%s tag %>
                                 </a>
@@ -52,8 +51,7 @@ Layout.render
                         <div class="flex items-center space-x-4 text-body-600 text-sm">
                             <div class="flex items-center flex-wrap">
                                 <% package.authors |> List.iter (fun (author : Ood.Opam_user.t) -> %>
-                                    <!-- TODO(tmattio): Support searching for authors -->
-                                    <a href="" class="text-sm hover:underline mr-3 mt-3">
+                                    <a href="?q=author:<%s Dream.to_percent_encoded ("\""^author.name^"\"") %>" class="text-sm hover:underline mr-3 mt-3">
                                         <%s author.name %>
                                     </a>
                                     <% ); %>

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -614,46 +614,183 @@ let module_map ~kind t =
   | Error _ ->
     { Module_map.libraries = Module_map.String_map.empty }
 
-let search_package t pattern =
-  let pattern = String.lowercase_ascii pattern in
-  let name_is_s { name; _ } =
-    String.lowercase_ascii @@ Name.to_string name = pattern
-  in
-  let name_contains_s { name; _ } =
-    String.contains_s (String.lowercase_ascii @@ Name.to_string name) pattern
-  in
-  let synopsis_contains_s { info; _ } =
-    String.contains_s (String.lowercase_ascii info.synopsis) pattern
-  in
-  let description_contains_s { info; _ } =
-    String.contains_s (String.lowercase_ascii info.description) pattern
-  in
-  let has_tag_s { info; _ } =
+module Search : sig
+  type search_request
+
+  type score
+
+  val to_request : string -> search_request
+
+  val match_request : search_request -> t -> bool
+
+  val score : t -> search_request -> score
+
+  val compare_score : score -> score -> int
+end = struct
+  type search_constraint =
+    | Tag of string
+    | Name of string
+    | Synopsis of string
+    | Description of string
+    | Author of string
+    | Any of string
+
+  type search_request = search_constraint list
+
+  let re =
+    let ascii_no_quote = Re.rep1 @@ Re.diff Re.ascii @@ Re.set "\"" in
+    let unquoted = Re.group @@ Re.rep1 @@ Re.diff Re.ascii @@ Re.set " \"" in
+    let quoted = Re.seq [ Re.str "\""; Re.group ascii_no_quote; Re.str "\"" ] in
+    let option name =
+      Re.seq [ Re.group @@ Re.str name; Re.alt [ quoted; unquoted ] ]
+    in
+    let tag = option "tag:"
+    and author = option "author:"
+    and plain = option "" in
+    let atom = Re.alt [ author; tag; plain ] in
+    Re.compile atom
+
+  let to_request str =
+    let str = String.lowercase_ascii str in
+    let to_constraint = function
+      | [ _; s ] ->
+        Any s
+      | [ _; "tag:"; s ] ->
+        Tag s
+      | [ _; "author:"; s ] ->
+        Author s
+      | [ _; "synopsis:"; s ] ->
+        Synopsis s
+      | [ _; "description:"; s ] ->
+        Description s
+      | [ _; "name:"; s ] ->
+        Name s
+      | _ ->
+        Any str
+    in
+    let g = Re.all re str in
+    List.map
+      (fun g ->
+        Re.Group.all g
+        |> Array.to_list
+        |> List.filter (fun a -> not (String.equal a ""))
+        |> to_constraint)
+      g
+
+  let match_ f s pattern = f (String.lowercase_ascii @@ s) pattern
+
+  let match_tag ?(f = String.contains_s) pattern package =
+    List.exists (fun tag -> match_ f tag pattern) package.info.tags
+
+  let match_name ?(f = String.contains_s) pattern package =
+    match_ f (Name.to_string package.name) pattern
+
+  let match_synopsis ?(f = String.contains_s) pattern package =
+    match_ f package.info.synopsis pattern
+
+  let match_description ?(f = String.contains_s) pattern package =
+    match_ f package.info.description pattern
+
+  let match_author ?(f = String.contains_s) pattern package =
+    let match_opt s =
+      match s with Some s -> match_ f s pattern | None -> false
+    in
     List.exists
-      (fun tag -> String.contains_s (String.lowercase_ascii tag) pattern)
-      info.tags
-  in
-  let score package =
-    if name_is_s package then
-      -1
-    else if name_contains_s package then
-      0
-    else if has_tag_s package then
-      1
-    else if synopsis_contains_s package then
-      2
-    else if description_contains_s package then
-      3
+      (fun (author : Ood.Opam_user.t) ->
+        match_opt (Some author.name)
+        || match_opt author.email
+        || match_opt author.github_username)
+      package.info.authors
+
+  let match_constraint (package : t) (cst : search_constraint) =
+    match cst with
+    | Tag pattern ->
+      match_tag pattern package
+    | Name pattern ->
+      match_name pattern package
+    | Synopsis pattern ->
+      match_synopsis pattern package
+    | Description pattern ->
+      match_description pattern package
+    | Author pattern ->
+      match_author pattern package
+    | Any pattern ->
+      match_author pattern package
+      || match_description pattern package
+      || match_name pattern package
+      || match_synopsis pattern package
+      || match_tag pattern package
+
+  let match_request c package = List.for_all (match_constraint package) c
+
+  type score =
+    { name : int
+    ; exact_name : int
+    ; author : int
+    ; exact_author : int
+    ; tag : int
+    ; exact_tag : int
+    ; synopsis : int
+    ; description : int
+    }
+
+  let score package query =
+    let score_if f s = if f s package then 1 else 0 in
+    let update_score score = function
+      | Any s ->
+        { tag = score.tag + score_if match_tag s
+        ; exact_tag = score.exact_tag + score_if (match_tag ~f:String.equal) s
+        ; name = score.name + score_if match_name s
+        ; exact_name =
+            score.exact_name + score_if (match_name ~f:String.equal) s
+        ; author = score.author + score_if match_author s
+        ; exact_author =
+            score.exact_author + score_if (match_author ~f:String.equal) s
+        ; synopsis = score.synopsis + score_if match_synopsis s
+        ; description = score.description + score_if match_description s
+        }
+      | _ ->
+        score
+    in
+    let null =
+      { name = 0
+      ; exact_name = 0
+      ; author = 0
+      ; exact_author = 0
+      ; tag = 0
+      ; exact_tag = 0
+      ; synopsis = 0
+      ; description = 0
+      }
+    in
+    List.fold_left update_score null query
+
+  let compare_score s1 s2 =
+    if s1.exact_name != s2.exact_name then
+      Int.compare s2.exact_name s1.exact_name
+    else if s1.name != s2.name then
+      Int.compare s2.name s1.name
+    else if s1.exact_author != s2.exact_author then
+      Int.compare s2.exact_author s1.exact_author
+    else if s1.author != s2.author then
+      Int.compare s2.author s1.author
+    else if s1.exact_tag != s2.exact_tag then
+      Int.compare s2.exact_tag s1.exact_tag
+    else if s1.tag != s2.tag then
+      Int.compare s2.tag s1.tag
+    else if s1.synopsis != s2.synopsis then
+      Int.compare s2.synopsis s1.synopsis
     else
-      failwith "impossible package score"
-  in
+      Int.compare s2.description s1.description
+end
+
+let search_package t pattern =
+  let request = Search.to_request pattern in
   all_packages_latest t
-  |> List.filter (fun p ->
-         name_contains_s p
-         || synopsis_contains_s p
-         || description_contains_s p
-         || has_tag_s p)
+  |> List.filter (Search.match_request request)
   |> List.sort (fun package1 package2 ->
-         compare (score package1) (score package2))
+         Search.compare_score
+           (Search.score package1 request)
+           (Search.score package2 request))
 
 let toplevels_path = Config.toplevels_path

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -646,8 +646,11 @@ end = struct
     in
     let tag = option "tag:"
     and author = option "author:"
+    and synopsis = option "synopsis:"
+    and description = option "description:"
+    and name = option "name:"
     and plain = option "" in
-    let atom = Re.alt [ author; tag; plain ] in
+    let atom = Re.alt [ name; author; tag; synopsis; description; plain ] in
     Re.compile atom
 
   let to_request str =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -337,7 +337,8 @@ let packages_search t req =
     let packages = Ocamlorg_package.search_package t search in
     let total = List.length packages in
     let results = List.map (package_meta t) packages in
-    Dream.html (Ocamlorg_frontend.packages_search ~total results search)
+    let search = Dream.from_percent_encoded search in
+    Dream.html (Ocamlorg_frontend.packages_search ~total ~search results)
   | None ->
     Dream.redirect req "/packages"
 

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -337,7 +337,7 @@ let packages_search t req =
     let packages = Ocamlorg_package.search_package t search in
     let total = List.length packages in
     let results = List.map (package_meta t) packages in
-    Dream.html (Ocamlorg_frontend.packages_search ~total results)
+    Dream.html (Ocamlorg_frontend.packages_search ~total results search)
   | None ->
     Dream.redirect req "/packages"
 


### PR DESCRIPTION
This PR implements a more expressive search for packages.

It adds support for `tag:`, `author:`, `name:`, `synopsis:`, `description:`. By defaults, it now does not take into account for the words order, except inside quoted strings.

For instance 
```
author:"alpha beta" tag:int tag:float "quoted string" html encoding
```

Clicking on an author name or on a tag redirects to the corresponding search.

Finally, the search query is put inside the input box to allow for editing the query.