### PR TITLE
Accessibility improvements

### DIFF
--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -144,7 +144,7 @@ inner =
         <li>
 
           <div class="space-x-6 text-2xl flex items-center">
-            <a href="https://discord.gg/cCYQbqN" class="opacity-60 hover:opacity-100">
+            <a aria-label="OCaml's Discord" href="https://discord.gg/cCYQbqN" class="opacity-60 hover:opacity-100">
               <svg width="24" height="auto" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clip-path="url(#clip0)">
                   <path
@@ -159,14 +159,14 @@ inner =
               </svg>
 
             </a>
-            <a href="https://github.com/ocaml/ocaml" class="opacity-60 hover:opacity-100">
+            <a aria-label="The OCaml compiler on Github" href="https://github.com/ocaml/ocaml" class="opacity-60 hover:opacity-100">
               <svg width="20" height="auto" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd"
                   d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z"
                   transform="scale(64)" fill="#1B1F23" />
               </svg>
             </a>
-            <a href="ttps://twitter.com/ocamllang" class="opacity-60 hover:opacity-100">
+            <a aria-label="The OCaml language Twitter account" href="ttps://twitter.com/ocamllang" class="opacity-60 hover:opacity-100">
               <svg width="20" height="auto" viewBox="0 0 172 140" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clip-path="url(#clip0_964_8840)">
                   <path
@@ -196,7 +196,7 @@ inner =
           <img width="160" src="img/logo-footer.svg" alt="">
           <div class="py-8">Innovation. Community. Security.</div>
           <div class="space-x-6 text-2xl flex items-center">
-            <a href="https://discord.gg/cCYQbqN" class="opacity-60 hover:opacity-100">
+            <a aria-label="OCaml's Discord" href="https://discord.gg/cCYQbqN" class="opacity-60 hover:opacity-100">
               <svg width="28" height="auto" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clip-path="url(#clip0)">
                   <path
@@ -210,14 +210,14 @@ inner =
                 </defs>
               </svg>
             </a>
-            <a href="https://github.com/ocaml/ocaml" class="opacity-60 hover:opacity-100">
+            <a aria-label="The OCaml compiler on Github" href="https://github.com/ocaml/ocaml" class="opacity-60 hover:opacity-100">
               <svg width="24" height="auto" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd"
                   d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z"
                   transform="scale(64)" fill="#1B1F23" />
               </svg>
             </a>
-            <a href="https://twitter.com/ocamllang" class="opacity-60 hover:opacity-100">
+            <a aria-label="The OCaml language Twitter account" href="https://twitter.com/ocamllang" class="opacity-60 hover:opacity-100">
               <svg width="24" height="auto" viewBox="0 0 172 140" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clip-path="url(#clip0_964_8840)">
                   <path

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -59,7 +59,7 @@ Layout.render
                 <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
               </svg>
             </div>
-            <div class="ml-3 font-semibold opacity-60">99 Problems</div>
+            <div class="ml-3 font-semibold opacity-70">99 Problems</div>
           </a>
         </div>
 

--- a/src/ocamlorg_frontend/pages/academic_users.eml
+++ b/src/ocamlorg_frontend/pages/academic_users.eml
@@ -17,7 +17,7 @@ about the strong academic roots of the language." @@
 <div class="bg-white py-0 md:pt-10 lg:pt-20 lg:pb-0">
     <div class="container-fluid" x-data="{ continent: 'All' }">
         <div class="flex justify-between mb-0 md:mb-10 lg:mb-20 lg:flex-row flex-col items-center">
-            <h5 class="font-bold mt-10 lg:mt-0 mb-10 lg:mb-0">30+ Academic Entries</h5>
+            <h2 class="font-bold mt-10 lg:mt-0 mb-10 lg:mb-0">30+ Academic Entries</h2>
             <div
                 class="flex justify-between flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-full lg:w-auto">
                 <form action="<%s Url.academic_users %>" method="GET" class="form-input">
@@ -28,8 +28,8 @@ about the strong academic roots of the language." @@
                                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                         </svg>
                     </div>
-                    <label for="q" class="sr-only">Institutions</label>
-                    <input id="q" name="q" type="search" placeholder="Search institutions">
+                    <label for="q2" class="sr-only">Institutions</label>
+                    <input id="q2" name="q" type="search" placeholder="Search institutions">
                 </form>
                 <div class="relative h-14">
                     <select

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -69,19 +69,19 @@ with an emphasis on expressiveness and safety."
       </div>
     </div>
     <div class="text-center">
-      <h4 class="font-bold text-body-600">Trusted by Industry Leaders</h4>
+      <h2 class="font-bold text-body-600">Trusted by Industry Leaders</h2>
       <div class="text-body-400 text-base mt-3">
         These awesome companies and organizations trust our software—along with
         thousands of other developers
       </div>
       <div class="flex flex-row justify-center m-auto flex-wrap py-8 items-center">
-        <div class="mx-8 my-4"><img src="/img/Facebook.svg" alt="" /></div>
+        <div class="mx-8 my-4"><img src="/img/Facebook.svg" alt="Facebook logo" /></div>
         <div class="mx-8 my-4">
-          <img src="/img/janestreet-black.svg" width="104" alt="" />
+          <img src="/img/janestreet-black.svg" width="104" alt="Janestreet logo" />
         </div>
-        <div class="mx-8 my-4"><img src="/img/Bloomberg.svg" alt="" /></div>
-        <div class="mx-8 my-4"><img src="/img/tezos.svg" alt="" /></div>
-        <div class="mx-8 my-4"><img src="/img/aHrefs.svg" alt="" /></div>
+        <div class="mx-8 my-4"><img src="/img/Bloomberg.svg" alt="Bloomberg logo" /></div>
+        <div class="mx-8 my-4"><img src="/img/tezos.svg" alt="Tezos logo" /></div>
+        <div class="mx-8 my-4"><img src="/img/aHrefs.svg" alt="Ahrefs logo" /></div>
       </div>
     </div>
   </div>
@@ -100,7 +100,7 @@ with an emphasis on expressiveness and safety."
                   d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
               </svg>
             </div>
-            <div class="text-lg my-4 font-bold" style="color: #3182ce">
+            <div class="text-lg my-4 font-bold" style="color: #225b90">
               BE SAFE
             </div>
             <h3 class="text-body-600 font-bold">Safe and Stable</h3>
@@ -113,7 +113,7 @@ with an emphasis on expressiveness and safety."
           </div>
         </div>
         <div class="lg:flex-1 lg:mr-24 lg:mt-0 mt-10 flex justify-center">
-          <img src="/img/home/safe-stable.svg" alt="" />
+          <img src="/img/home/safe-stable.svg" alt="An example OCaml program defining nested lists in OCaml. A terminal output also shows the compiler catching a type error where a pattern-match was not exhaustive." />
         </div>
       </div>
 
@@ -127,7 +127,7 @@ with an emphasis on expressiveness and safety."
                   clip-rule="evenodd" />
               </svg>
             </div>
-            <div class="text-lg my-4 font-bold text-teal-600">WORK FASTER</div>
+            <div class="text-lg my-4 font-bold text-teal-800">WORK FASTER</div>
             <h3 class="text-body-600 font-bold">
               Fast compiler, Efficient applications
             </h3>
@@ -170,13 +170,13 @@ with an emphasis on expressiveness and safety."
               <div class="swiper mySwiper">
                 <div class="swiper-wrapper">
                   <div class="swiper-slide">
-                    <img src="/img/vscode.svg" width="56px" />
+                    <img src="/img/vscode.svg" width="56px" alt="" />
                   </div>
                   <div class="swiper-slide">
-                    <img src="/img/vimlogo.svg" width="56px" />
+                    <img src="/img/vimlogo.svg" width="56px" alt="" />
                   </div>
                   <div class="swiper-slide">
-                    <img src="/img/EmacsIcon.svg" width="56px" />
+                    <img src="/img/EmacsIcon.svg" width="56px" alt="" />
                   </div>
                 </div>
               </div>
@@ -188,13 +188,13 @@ with an emphasis on expressiveness and safety."
             <div style="--swiper-navigation-color: #fff;--swiper-pagination-color: #fff;" class="swiper mySwiper2">
               <div class="swiper-wrapper">
                 <div class="swiper-slide">
-                  <img width="785" src="/img/home/vscode-preview.png" />
+                  <img width="785" src="/img/home/vscode-preview.png" alt="An OCaml program being edited in VSCode" />
                 </div>
                 <div class="swiper-slide">
-                  <img width="785" src="/img/home/emac-preview.png" />
+                  <img width="785" src="/img/home/emac-preview.png" alt="Writing an OCaml program using emacs"/>
                 </div>
                 <div class="swiper-slide">
-                  <img width="785" src="/img/home/vim-preview.png" />
+                  <img width="785" src="/img/home/vim-preview.png" alt="Writing an OCaml program using vim" />
                 </div>
               </div>
             </div>
@@ -335,7 +335,7 @@ with an emphasis on expressiveness and safety."
     <div class="flex flex-col lg:flex-row justify-between lg:space-x-20 space-y-10 lg:space-y-0">
       <div class="shadow-lg p-10 bg-white rounded-xl lg:mb-0">
         <div class="flex flex-row items-center justify-between relative pb-8">
-          <h5 class="font-semibold">For Educators</h5>
+          <h3 class="font-semibold">For Educators</h3>
           <div>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-14 w-14" fill="none" viewBox="0 0 24 24"
               stroke="currentColor">
@@ -356,7 +356,7 @@ with an emphasis on expressiveness and safety."
       </div>
       <div class="shadow-lg p-10 bg-white rounded-xl">
         <div class="flex flex-row items-center justify-between relative pb-8">
-          <h5 class="font-semibold">For Industrial Users</h5>
+          <h3 class="font-semibold">For Industrial Users</h3>
           <div>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-14 w-14" fill="none" viewBox="0 0 24 24"
               stroke="currentColor">

--- a/src/ocamlorg_frontend/pages/industrial_users.eml
+++ b/src/ocamlorg_frontend/pages/industrial_users.eml
@@ -37,7 +37,7 @@ the community and learn more about how they use OCaml." @@
     <div class="bg-primary-600 ">
         <div class="container-fluid">
             <div class="text-center text-white lg:p-16 py-10">
-                <h3 class="font-bold mb-6">Interested in learning more?</h3>
+                <h2 class="font-bold mb-6">Interested in learning more?</h2>
                 <div class="text-lg mb-8 lg:px-28">Go to our success stores for a more indepth understanding of how our
                     users use OCaml. </div>
                 <div class="space-x-0 md:space-x-5 space-y-5 md:space-y-0">
@@ -108,12 +108,12 @@ the community and learn more about how they use OCaml." @@
                         vitae platea lectus augue vitae, egestas.</div>
                 </div>
                 <div class="flex justify-between items-center space-x-4 m-auto mt-10 mb-5 md:mb-0">
-                    <button class="text-primary-600 rounded-full py-4 px-4 hover:bg-primary-100 transition duration-300"
+                    <button aria-label="Previous" class="text-primary-600 rounded-full py-4 px-4 hover:bg-primary-100 transition duration-300"
                         @click="swiper.slidePrev()"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
                             viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
                         </svg></button>
-                    <button class="text-primary-600 rounded-full py-4 px-4 hover:bg-primary-100 transition duration-300"
+                    <button aria-label="Next" class="text-primary-600 rounded-full py-4 px-4 hover:bg-primary-100 transition duration-300"
                         @click="swiper.slideNext()"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
                             viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -8,7 +8,7 @@ Learn_layout.render
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10 lg:pb-20">
         <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white">
             <div class="p-8">
-                <h6 class="font-bold mb-2">Get Started</h6>
+                <h2 class="font-bold mb-2">Get Started</h2>
                 <div class="font-medium mb-4 opacity-80">Learn how to get OCaml set up in your project.
                 </div>
                 <a href="<%s Url.getting_started %>">
@@ -24,7 +24,7 @@ Learn_layout.render
 
         <div class="relative flex-1 bg-gradient-to-br from-purple-400 to-purple-700 rounded-xl text-white">
             <div class="p-8">
-                <h6 class="font-bold mb-2">Learn with Exercises</h6>
+                <h2 class="font-bold mb-2">Learn with Exercises</h2>
                 <div class="font-medium mb-4 opacity-80">Learning by doing, or do by <br> learning!</div>
                 <a href="<%s Url.problems %>">
                     <button
@@ -39,7 +39,7 @@ Learn_layout.render
 
         <div class="relative flex-1 bg-gradient-to-br from-emerald-400 to-emerald-700 rounded-xl text-white">
             <div class="p-8">
-                <h6 class="font-bold mb-2">Language Manual</h6>
+                <h2 class="font-bold mb-2">Language Manual</h2>
                 <div class="font-medium mb-4 opacity-80">Read the language manual to get a deeper
                     understanding!</div>
                 <a href="<%s Url.manual %>">
@@ -90,7 +90,7 @@ Learn_layout.render
                 <div class="font-bold text-sm mt-3"><%s String.concat ", " paper.authors %></div>
                 <div class="flex mt-5 flex-wrap">
                     <% paper.tags |> List.iter (fun (tag : string) -> %>
-                    <div class="text-blue-500 h-8 inline-flex items-center text-sm px-3 border border-blue-500 rounded-3xl whitespace-nowrap mr-2 mb-2">
+                    <div class="text-blue-700 h-8 inline-flex items-center text-sm px-3 border border-blue-700 rounded-3xl whitespace-nowrap mr-2 mb-2">
                         <%s tag %>
                     </div>
                     <% ); %>

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -126,7 +126,7 @@ Layout.render
     <div class="container-fluid">
         <div class="flex justify-between flex-col space-y-10 lg:space-y-0 lg:flex-row">
             <div>
-                <h5 class="font-bold text-center mb-8">Most downloaded</h5>
+                <h3 class="font-bold text-center mb-8">Most downloaded</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
                     <a href=""
                         class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
@@ -184,7 +184,7 @@ Layout.render
 
             </div>
             <div>
-                <h5 class="font-bold text-center mb-8">New Packages</h5>
+                <h3 class="font-bold text-center mb-8">New Packages</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
                     <a href=""
                         class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
@@ -237,7 +237,7 @@ Layout.render
                 </div>
             </div>
             <div>
-                <h5 class="font-bold text-center mb-8">Recently Updated</h5>
+                <h3 class="font-bold text-center mb-8">Recently Updated</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
                     <a href=""
                         class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -13,9 +13,9 @@ Layout.render
                 <div
                     class="flex items-center justify-between space-y-5 md:space-y-0 md:space-x-5 flex-col md:flex-row w-full md:w-auto">
                     <form class="relative h-14 w-full md:w-64" action="/packages/search" method="GET">
-                        <label for="q" class="sr-only">Search packages</label>
+                        <label for="q2" class="sr-only">Search packages</label>
                         <div class="relative w-full text-gray-400 focus-within:text-gray-600">
-                            <input name="q" id="q"
+                            <input name="q" id="q2"
                                 class="w-full appearance-none outline-none focus:border-primary-600 text-body-600 border rounded-md py-3 pr-6 border-gray-200 pl-14 h-full"
                                 placeholder="Search packages" type="search" value="<%s search %>">
                             <div class="absolute h-full flex items-center pl-6 opacity-60 left-0 top-0">

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -41,7 +41,7 @@ Layout.render
                         d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                     </svg>
                   </div>
-                  <div class="ml-3 font-semibold opacity-60">Learn</div>
+                  <div class="ml-3 font-semibold opacity-70">Learn</div>
                 </a>
 
                 <a href="/problems" class="flex justify-start items-center">
@@ -107,7 +107,7 @@ Layout.render
                     <div x-data="{statement: true}" id=<%s problem.number %>>
                         <div
                             class="flex space-y-4 lg:space-y-0 lg:items-center flex-col lg:flex-row lg:justify-between">
-                            <h5 class="font-bold text-body-600"><%s problem.title %></h5>
+                            <h4 class="font-bold text-body-600"><%s problem.title %></h4>
                             <div class="flex bg-body-600 bg-opacity-5 rounded-md p-1 items-center">
                                 <button class="px-3.5 h-9 font-medium flex space-x-2 items-center rounded-lg"
                                     x-on:click="statement = true"


### PR DESCRIPTION
This PR fixes a few accessibility issues on a couple of the main pages, primarily it:

 - Fixes some `<hX>` orderings (see: https://dequeuniversity.com/rules/axe/3.3/heading-order)
 - Increases the contrast on some text (see: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
 - Fixes duplicated input ids (see: https://www.w3.org/WAI/WCAG21/Understanding/parsing.html)
 - Discernible names for links (see: https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)

One problem is the low contrast of the orange and white used throughout the site, see #201 for thoughts. 