### PR TITLE
Packages: Add listing stats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+- Add listing stats on the Packages page (#213, by @Julow)
+
+  The stats are:
+  Recently added packages and recently updated packages, which are computed
+  from the Git history of opam-repository, and packages with the biggest number
+  of revdeps.
+  The stats are rendered with a data point and an icon (number of revdeps, date
+  of addition and lastest version).
+
 - Integrate blog and community pages (#196, by @tmattio)
 
 - Add legal pages (#207, by @tmattio)

--- a/src/ocamlorg_frontend/components/icons.eml
+++ b/src/ocamlorg_frontend/components/icons.eml
@@ -1,0 +1,21 @@
+(** Using icons from {:https://heroicons.com/} *)
+
+let downloads =
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+  </svg>
+
+let calendar =
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+  </svg>
+
+let refresh =
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+  </svg>
+
+let star =
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+  </svg>

--- a/src/ocamlorg_frontend/dune
+++ b/src/ocamlorg_frontend/dune
@@ -191,4 +191,9 @@
   (targets toc.ml)
   (deps toc.eml)
   (action
+   (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+ (rule
+  (targets icons.ml)
+  (deps icons.eml)
+  (action
    (run %{bin:dream_eml} %{deps} --workspace %{workspace_root}))))

--- a/src/ocamlorg_frontend/package_intf.ml
+++ b/src/ocamlorg_frontend/package_intf.ml
@@ -14,4 +14,7 @@ type packages_stats =
   { nb_packages : int
   ; nb_update_week : int
   ; nb_packages_month : int
+  ; newest_packages : package list
+  ; recently_updated : package list
+  ; most_revdeps : (package * int) list
   }

--- a/src/ocamlorg_frontend/package_intf.ml
+++ b/src/ocamlorg_frontend/package_intf.ml
@@ -14,7 +14,7 @@ type packages_stats =
   { nb_packages : int
   ; nb_update_week : int
   ; nb_packages_month : int
-  ; newest_packages : package list
+  ; newest_packages : (package * string) list
   ; recently_updated : package list
   ; most_revdeps : (package * int) list
   }

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -134,11 +134,7 @@ Layout.render
 % let render_package_most_revdeps (pkg, nb_revdeps) =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-        </svg>
+        <%s! Icons.star %>
         Used by <%d nb_revdeps %> other packages
       </div>
 %   )
@@ -153,12 +149,7 @@ Layout.render
 % let render_newest_package (pkg, date) =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-        </svg>
-        <%s date %>
+        <%s! Icons.calendar %> <%s date %>
       </div>
 %   )
 % in
@@ -171,12 +162,7 @@ Layout.render
 % let render_package_recently_updated pkg =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-        </svg>
-        Version <%s pkg.version %>
+        <%s! Icons.refresh %> Version <%s pkg.version %>
       </div>
 %   )
 % in

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -1,4 +1,5 @@
-let render (stats : Package_intf.packages_stats option) =
+open Package_intf
+let render (stats : packages_stats option) =
 Layout.render
 ~turbo_full_reload:true
 ~title:"OCaml Packages · Browse community packages"
@@ -115,170 +116,62 @@ Layout.render
     </div>
 </div>
 <div class="bg-white py-20 lg:py-32">
+% let render_package_stat pkg render_extra_stats =
+    <a href=""
+        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
+      <div class="font-semibold mb-2"><%s pkg.name %></div>
+      <div class="mb-3 text-sm text-body-400"><%s pkg.description %></div>
+% render_extra_stats ();
+    </a>
+% in
+% ( match stats with
+% | Some stats ->
     <div class="container-fluid">
         <div class="flex justify-between flex-col space-y-10 lg:space-y-0 lg:flex-row">
             <div>
-                <h3 class="font-bold text-center mb-8">Most downloaded</h3>
+                <h3 class="font-bold text-center mb-8">Most used packages</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Tincidunt et</div>
-                        <div class="mb-3 text-sm text-body-400">A eleifend pretium orci felis, adipiscing velit justo.
-                        </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Tincidunt et</div>
-                        <div class="mb-3 text-sm text-body-400">A eleifend pretium orci felis, adipiscing velit justo.
-                        </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Tincidunt et</div>
-                        <div class="mb-3 text-sm text-body-400">A eleifend pretium orci felis, adipiscing velit justo.
-                        </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover inline-block">
-                        <div class="font-semibold mb-2">Tincidunt et</div>
-                        <div class="mb-3 text-sm text-body-400">A eleifend pretium orci felis, adipiscing velit justo.
-                        </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
+% let render_package_most_revdeps (pkg, nb_revdeps) =
+%   render_package_stat pkg (fun () ->
+      <div class="text-sm text-body-400 flex space-x-2">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        Used by <%d nb_revdeps %> other packages
+      </div>
+%   )
+% in
+% List.iter render_package_most_revdeps stats.most_revdeps;
                 </div>
 
             </div>
             <div>
                 <h3 class="font-bold text-center mb-8">New Packages</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover inline-block ">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
+% let render_newest_package pkg =
+%   render_package_stat pkg (fun () -> ())
+% in
+% List.iter render_newest_package stats.newest_packages;
                 </div>
             </div>
             <div>
                 <h3 class="font-bold text-center mb-8">Recently Updated</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
-                    <a href=""
-                        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover inline-block">
-                        <div class="font-semibold mb-2">Dolor consectetur</div>
-                        <div class="mb-3 text-sm text-body-400">Consequat aliquam nunc, sit nulla eget fringilla. </div>
-                        <div class="text-sm text-body-400 flex space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg></i>15,494,808 Downloads
-                        </div>
-                    </a>
+% let render_package_recently_updated pkg =
+%   render_package_stat pkg (fun () ->
+      <div class="text-sm text-body-400 flex space-x-2">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        Version <%s pkg.version %>
+      </div>
+%   )
+% in
+% List.iter render_package_recently_updated stats.recently_updated;
                 </div>
             </div>
         </div>
@@ -339,6 +232,7 @@ Layout.render
             </div>
         </div>
     </div>
+% | None -> () );
 </div>
 <div class="bg-primary-600 ">
     <div class="container-fluid">

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -150,8 +150,17 @@ Layout.render
             <div>
                 <h3 class="font-bold text-center mb-8">New Packages</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
-% let render_newest_package pkg =
-%   render_package_stat pkg (fun () -> ())
+% let render_newest_package (pkg, date) =
+%   render_package_stat pkg (fun () ->
+      <div class="text-sm text-body-400 flex space-x-2">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 pr-1" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        <%s date %>
+      </div>
+%   )
 % in
 % List.iter render_newest_package stats.newest_packages;
                 </div>

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -118,7 +118,7 @@ Layout.render
 <div class="bg-white py-20 lg:py-32">
 % let render_package_stat pkg render_extra_stats =
     <a href=""
-        class="bg-white border border-gray-200 rounded-xl py-6 px-7 flex-col text-body-600 text-left card-hover">
+        class="block bg-white border border-gray-200 rounded-xl py-6 px-7 text-body-600 text-left card-hover">
       <div class="font-semibold mb-2"><%s pkg.name %></div>
       <div class="mb-3 text-sm text-body-400"><%s pkg.description %></div>
 % render_extra_stats ();
@@ -127,10 +127,9 @@ Layout.render
 % ( match stats with
 % | Some stats ->
     <div class="container-fluid">
-        <div class="flex justify-between flex-col space-y-10 lg:space-y-0 lg:flex-row">
-            <div>
+        <div class="flex justify-between flex-col space-y-10 lg:space-y-0 lg:space-x-6 lg:flex-row">
+            <div class="flex-1 space-y-6">
                 <h3 class="font-bold text-center mb-8">Most used packages</h3>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
 % let render_package_most_revdeps (pkg, nb_revdeps) =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
@@ -140,12 +139,10 @@ Layout.render
 %   )
 % in
 % List.iter render_package_most_revdeps stats.most_revdeps;
-                </div>
 
             </div>
-            <div>
+            <div class="flex-1 space-y-6">
                 <h3 class="font-bold text-center mb-8">New Packages</h3>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
 % let render_newest_package (pkg, date) =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
@@ -154,11 +151,9 @@ Layout.render
 %   )
 % in
 % List.iter render_newest_package stats.newest_packages;
-                </div>
             </div>
-            <div>
+            <div class="flex-1 space-y-6">
                 <h3 class="font-bold text-center mb-8">Recently Updated</h3>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 gap-6">
 % let render_package_recently_updated pkg =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
@@ -167,7 +162,6 @@ Layout.render
 %   )
 % in
 % List.iter render_package_recently_updated stats.recently_updated;
-                </div>
             </div>
         </div>
 

--- a/src/ocamlorg_package/lib/import.ml
+++ b/src/ocamlorg_package/lib/import.ml
@@ -35,3 +35,54 @@ module String = struct
     | Exit ->
       true
 end
+
+module List = struct
+  include Stdlib.List
+
+  let rec take n = function
+    | _ when n = 0 ->
+      []
+    | [] ->
+      []
+    | hd :: tl ->
+      hd :: take (n - 1) tl
+end
+
+module Acc_biggest (Elt : sig
+  type t
+
+  val compare : t -> t -> int
+end) : sig
+  (** Accumulate the [n] bigger elements given to [acc]. *)
+
+  type elt = Elt.t
+
+  type t
+
+  val make : int -> t
+
+  val acc : elt -> t -> t
+
+  val to_list : t -> elt list
+end = struct
+  type elt = Elt.t
+
+  type t = int * elt list
+
+  let make size = size, []
+
+  (* Insert sort is enough. *)
+  let rec insert_sort elt = function
+    | [] ->
+      [ elt ]
+    | hd :: _ as t when Elt.compare hd elt >= 0 ->
+      elt :: t
+    | hd :: tl ->
+      hd :: insert_sort elt tl
+
+  let acc elt (rem, elts) =
+    let elts = insert_sort elt elts in
+    if rem = 0 then 0, List.tl elts else rem - 1, elts
+
+  let to_list (_, elts) = elts
+end

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -118,7 +118,8 @@ let update ~commit t =
   let* packages = read_packages () in
   Logs.info (fun f -> f "Computing additional informations...");
   let* packages = Info.of_opamfiles packages in
-  let+ stats = Packages_stats.compute commit packages in
+  Logs.info (fun f -> f "Computing packages statistics...");
+  let+ stats = Packages_stats.compute packages in
   t.packages <- packages;
   t.stats <- Some stats;
   Logs.info (fun m ->

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -65,7 +65,8 @@ module Packages_stats : sig
     ; nb_update_week : int
           (** Number of packages updated during the last 7 days. *)
     ; nb_packages_month : int  (** Number of packages added the last 30 days. *)
-    ; newest_packages : package_stat list  (** The 5 newest packages. *)
+    ; newest_packages : (package_stat * string) list
+          (** The 5 newest packages and date, in Git's relative format. *)
     ; recently_updated : package_stat list
           (** The 5 most recently updated packages. *)
     ; most_revdeps : (package_stat * int) list

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -54,11 +54,22 @@ module Info : sig
 end
 
 module Packages_stats : sig
+  type package_stat =
+    { name : Name.t
+    ; version : Version.t
+    ; info : Info.t
+    }
+
   type t =
     { nb_packages : int  (** Total number of packages. *)
     ; nb_update_week : int
           (** Number of packages updated during the last 7 days. *)
     ; nb_packages_month : int  (** Number of packages added the last 30 days. *)
+    ; newest_packages : package_stat list  (** The 5 newest packages. *)
+    ; recently_updated : package_stat list
+          (** The 5 most recently updated packages. *)
+    ; most_revdeps : (package_stat * int) list
+          (** The 5 packages with the most number of revdeps. *)
     }
 end
 

--- a/src/ocamlorg_package/lib/opam_repository.mli
+++ b/src/ocamlorg_package/lib/opam_repository.mli
@@ -21,5 +21,7 @@ val commit_at_date : string -> string Lwt.t
 (** Find the first commit that happened before or at a date. Will be passed to
     Git's [--before] option, for example ["30.days"]. *)
 
-val new_files_since : a:string -> b:string -> Fpath.t list Lwt.t
-(** Files created during a range of commit. *)
+val new_files_since : a:string -> b:string -> (Fpath.t * string) list Lwt.t
+(** Files created during a range of commit. Associate the date at which each
+    file as been added, in Git's relative format. Returns more recent files
+    first. *)

--- a/src/ocamlorg_package/lib/packages_stats.ml
+++ b/src/ocamlorg_package/lib/packages_stats.ml
@@ -57,13 +57,71 @@ let compute_new_packages_since date =
   in
   List.length new_packages
 
+module Acc_biggest (Elt : sig
+  type t
+
+  val compare : t -> t -> int
+end) : sig
+  (** Accumulate the [n] bigger elements given to [acc]. *)
+
+  type elt = Elt.t
+
+  type t
+
+  val make : int -> t
+
+  val acc : elt -> t -> t
+
+  val to_list : t -> elt list
+end = struct
+  type elt = Elt.t
+
+  type t = int * elt list
+
+  let make size = size, []
+
+  (* Insert sort is enough. *)
+  let rec insert_sort elt = function
+    | [] ->
+      [ elt ]
+    | hd :: _ as t when Elt.compare hd elt >= 0 ->
+      elt :: t
+    | hd :: tl ->
+      hd :: insert_sort elt tl
+
+  let acc elt (rem, elts) =
+    let elts = insert_sort elt elts in
+    if rem = 0 then 0, List.tl elts else rem - 1, elts
+
+  let to_list (_, elts) = elts
+end
+
+let compute_most_revdeps n packages =
+  let module Acc =
+    Acc_biggest (struct
+      type t = package_stat * int
+
+      let compare (_, a) (_, b) = Int.compare a b
+    end)
+  in
+  OpamPackage.Name.Map.fold
+    (fun name versions acc ->
+      (* Look only at the lastest version *)
+      let version, info = OpamPackage.Version.Map.max_binding versions in
+      let rev_deps = List.length info.Info.rev_deps in
+      Acc.acc ({ name; version; info }, rev_deps) acc)
+    packages
+    (Acc.make n)
+  |> Acc.to_list
+  |> List.rev
+
 let compute packages =
   let nb_packages = OpamPackage.Name.Map.cardinal packages in
   let+ nb_update_week = compute_updates_since "7.days"
   and+ nb_packages_month = compute_new_packages_since "30.days" in
   let newest_packages = []
   and recently_updated = []
-  and most_revdeps = [] in
+  and most_revdeps = compute_most_revdeps 5 packages in
   { nb_packages
   ; nb_update_week
   ; nb_packages_month

--- a/src/ocamlorg_package/lib/packages_stats.ml
+++ b/src/ocamlorg_package/lib/packages_stats.ml
@@ -18,8 +18,8 @@ type t =
 
 let package_of_path p =
   match Fpath.segs p with
-  | "packages" :: namespace :: name_version :: _ ->
-    Some (namespace, name_version)
+  | "packages" :: _ :: name_version :: _ ->
+    Some name_version
   | _ ->
     None
 
@@ -27,35 +27,35 @@ let compute_updates_since date =
   let* commit = Opam_repository.commit_at_date date in
   let+ paths = Opam_repository.new_files_since ~a:commit ~b:"@" in
   List.filter_map package_of_path paths
-  |> List.map snd
   |> List.sort_uniq String.compare
   |> List.length
 
+(** Newly added packages. Most recent first. *)
 let compute_new_packages_since date =
+  let module NameMap = OpamPackage.Name.Map in
   let* commit = Opam_repository.commit_at_date date in
   let+ paths = Opam_repository.new_files_since ~a:commit ~b:"@" in
+  let of_path path = package_of_path path |> Option.map OpamPackage.of_string in
+  let packages = List.filter_map of_path paths in
   let new_versions =
-    List.filter_map package_of_path paths
-    |> List.fold_left
-         (fun acc (name, name_version) ->
-           (* Group versions by package name. *)
-           let pkgs = try StringMap.find name acc with Not_found -> [] in
-           StringMap.add name (name_version :: pkgs) acc)
-         StringMap.empty
+    (* Count the number of new versions for each packages. *)
+    let count_new_versions acc pkg =
+      let name = OpamPackage.name pkg in
+      let n = try NameMap.find name acc with Not_found -> 0 in
+      NameMap.add name (n + 1) acc
+    in
+    List.fold_left count_new_versions NameMap.empty packages
   in
-  let new_packages =
-    StringMap.fold
-      (fun name new_versions acc ->
-        (* Keep packages that have only new versions. *)
-        let all_versions = Opam_repository.list_package_versions name in
-        if List.length new_versions >= List.length all_versions then
-          name :: acc
-        else
-          acc)
-      new_versions
-      []
-  in
-  List.length new_packages
+  (* Keep packages that only have new versions. *)
+  packages
+  |> List.filter (fun pkg ->
+         let name = OpamPackage.name pkg in
+         let new_versions = NameMap.find name new_versions in
+         let all_versions =
+           Opam_repository.list_package_versions
+             (OpamPackage.Name.to_string name)
+         in
+         new_versions >= List.length all_versions)
 
 module Acc_biggest (Elt : sig
   type t
@@ -96,6 +96,26 @@ end = struct
   let to_list (_, elts) = elts
 end
 
+let rec list_take n = function
+  | _ when n = 0 ->
+    []
+  | [] ->
+    []
+  | hd :: tl ->
+    hd :: list_take (n - 1) tl
+
+let compute_newest_packages n new_packages packages =
+  let mk_package pkg =
+    let name = OpamPackage.name pkg
+    and version = OpamPackage.version pkg in
+    let info =
+      OpamPackage.Name.Map.find name packages
+      |> OpamPackage.Version.Map.find version
+    in
+    { name; version; info }
+  in
+  list_take n new_packages |> List.map mk_package
+
 (** Remove some packages from the revdeps stats to make it more interesting. *)
 let most_revdeps_hidden = function
   | "ocaml" | "ocamlfind" | "dune" | "ocamlbuild" | "jbuilder" ->
@@ -128,9 +148,11 @@ let compute_most_revdeps n packages =
 let compute packages =
   let nb_packages = OpamPackage.Name.Map.cardinal packages in
   let+ nb_update_week = compute_updates_since "7.days"
-  and+ nb_packages_month = compute_new_packages_since "30.days" in
-  let newest_packages = []
-  and recently_updated = []
+  and+ nb_packages_month, newest_packages =
+    let+ new_pkgs = compute_new_packages_since "30.days" in
+    List.length new_pkgs, compute_newest_packages 5 new_pkgs packages
+  in
+  let recently_updated = []
   and most_revdeps = compute_most_revdeps 5 packages in
   { nb_packages
   ; nb_update_week

--- a/src/ocamlorg_package/lib/packages_stats.ml
+++ b/src/ocamlorg_package/lib/packages_stats.ml
@@ -108,11 +108,11 @@ let compute_new_packages_since date =
   let+ packages = compute_updated_packages_since date in
   (* Keep packages that only have new versions. *)
   let filter_new_packages acc modified_versions =
-    let pkg, _ = List.hd modified_versions in
+    let ((pkg, _) as lastest) = List.hd modified_versions in
     let name = OpamPackage.(Name.to_string (name pkg)) in
     let all_versions = Opam_repository.list_package_versions name in
     if List.length modified_versions >= List.length all_versions then
-      List.rev_append modified_versions acc (* [acc] is in reverse order *)
+      lastest :: acc
     else
       acc
   in

--- a/src/ocamlorg_package/lib/packages_stats.ml
+++ b/src/ocamlorg_package/lib/packages_stats.ml
@@ -1,10 +1,19 @@
 open Lwt.Syntax
 module StringMap = Map.Make (String)
 
+type package_stat =
+  { name : OpamPackage.Name.t
+  ; version : OpamPackage.Version.t
+  ; info : Info.t
+  }
+
 type t =
   { nb_packages : int
   ; nb_update_week : int
   ; nb_packages_month : int
+  ; newest_packages : package_stat list
+  ; recently_updated : package_stat list
+  ; most_revdeps : (package_stat * int) list
   }
 
 let package_of_path p =
@@ -48,8 +57,17 @@ let compute_new_packages_since date =
   in
   List.length new_packages
 
-let compute _opam_repo_commit packages =
+let compute packages =
   let nb_packages = OpamPackage.Name.Map.cardinal packages in
   let+ nb_update_week = compute_updates_since "7.days"
   and+ nb_packages_month = compute_new_packages_since "30.days" in
-  { nb_packages; nb_update_week; nb_packages_month }
+  let newest_packages = []
+  and recently_updated = []
+  and most_revdeps = [] in
+  { nb_packages
+  ; nb_update_week
+  ; nb_packages_month
+  ; newest_packages
+  ; recently_updated
+  ; most_revdeps
+  }

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -369,6 +369,7 @@ let packages state _req =
     let versions = package_versions state name in
     package_of_info ~name ~version ~versions info
   in
+  let package_pair (pkg, snd) = package pkg, snd in
   let stats =
     match Ocamlorg_package.packages_stats state with
     | Some
@@ -381,10 +382,9 @@ let packages state _req =
         { Ocamlorg_frontend.nb_packages
         ; nb_update_week
         ; nb_packages_month
-        ; newest_packages = List.map package t.newest_packages
+        ; newest_packages = List.map package_pair t.newest_packages
         ; recently_updated = List.map package t.recently_updated
-        ; most_revdeps =
-            List.map (fun (pkg, r) -> package pkg, r) t.most_revdeps
+        ; most_revdeps = List.map package_pair t.most_revdeps
         }
     | None ->
       None

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -344,15 +344,48 @@ type package_kind =
   | Package
   | Universe
 
+let package_of_info ~name ~version ~versions info =
+  Ocamlorg_frontend.
+    { name = Ocamlorg_package.Name.to_string name
+    ; version = Ocamlorg_package.Version.to_string version
+    ; versions
+    ; description = info.Ocamlorg_package.Info.synopsis
+    ; tags = info.tags
+    ; authors = info.authors
+    ; maintainers = info.maintainers
+    ; license = info.license
+    }
+
+(** Query all the versions of a package. *)
+let package_versions state name =
+  Ocamlorg_package.get_package_versions state name
+  |> Option.value ~default:[]
+  |> List.sort Ocamlorg_package.Version.compare
+  |> List.map Ocamlorg_package.Version.to_string
+  |> List.rev
+
 let packages state _req =
+  let package { Ocamlorg_package.Packages_stats.name; version; info } =
+    let versions = package_versions state name in
+    package_of_info ~name ~version ~versions info
+  in
   let stats =
     match Ocamlorg_package.packages_stats state with
     | Some
-        { Ocamlorg_package.Packages_stats.nb_packages
+        ({ Ocamlorg_package.Packages_stats.nb_packages
+         ; nb_update_week
+         ; nb_packages_month
+         ; _
+         } as t) ->
+      Some
+        { Ocamlorg_frontend.nb_packages
         ; nb_update_week
         ; nb_packages_month
-        } ->
-      Some { Ocamlorg_frontend.nb_packages; nb_update_week; nb_packages_month }
+        ; newest_packages = List.map package t.newest_packages
+        ; recently_updated = List.map package t.recently_updated
+        ; most_revdeps =
+            List.map (fun (pkg, r) -> package pkg, r) t.most_revdeps
+        }
     | None ->
       None
   in
@@ -361,26 +394,11 @@ let packages state _req =
 let package_meta state (package : Ocamlorg_package.t)
     : Ocamlorg_frontend.package
   =
-  let name = Ocamlorg_package.(Name.to_string @@ name package) in
-  let version = Ocamlorg_package.(Version.to_string @@ version package) in
-  let info = Ocamlorg_package.info package in
-  let versions =
-    Ocamlorg_package.get_package_versions state (Ocamlorg_package.name package)
-    |> Option.value ~default:[]
-    |> List.sort Ocamlorg_package.Version.compare
-    |> List.map Ocamlorg_package.Version.to_string
-    |> List.rev
-  in
-  Ocamlorg_frontend.
-    { name
-    ; version
-    ; versions
-    ; description = info.synopsis
-    ; tags = info.tags
-    ; authors = info.authors
-    ; maintainers = info.maintainers
-    ; license = info.license
-    }
+  let name = Ocamlorg_package.name package
+  and version = Ocamlorg_package.version package
+  and info = Ocamlorg_package.info package in
+  let versions = package_versions state name in
+  package_of_info ~name ~version ~versions info
 
 let packages_search t req =
   match Dream.query "q" req with


### PR DESCRIPTION
The stats are:

- Newest packages
  Computed from the Git history.

- Most recently updated packages
  Computed from the Git history too.

- Packages with the biggest number of revdeps
  The rev-deps for each packages were already computed, so this one is easy.

There's a data point rendered next to each package with an icon (number of rev-deps, package addition date, lastest version).

Computing these statistics isn't that time-consuming, it takes 200ms on my laptop, compared to 35s for the other package computations.
