### PR TITLE
Tutorials: Fix containers complexity

### DIFF
--- a/data/tutorials/en/028_comparison_of_standard_containers.md
+++ b/data/tutorials/en/028_comparison_of_standard_containers.md
@@ -22,10 +22,9 @@ is also instructive to read the corresponding implementation.
 Adding an element always creates a new list l from an element x and list
 tl. tl remains unchanged, but it is not copied either.
 
-* "adding" an element: O(1), cons operator `::`
+* adding an element to the front: O(1), cons operator `::`
 * length: O(n), function `List.length`
-* accessing cell `i`: O(i)
-* finding an element: O(n)
+* random access: O(n)
 
 Well-suited for: IO, pattern-matching
 
@@ -34,70 +33,56 @@ Not very efficient for: random access, indexed elements
 ## Arrays: mutable vectors
 Arrays are mutable data structures with a fixed length and random access.
 
-* "adding" an element (by creating a new array): O(n)
-* length: O(1), function `Array.length`
-* accessing cell `i`: O(1)
-* finding an element: O(n)
+* adding an element (by creating a new array): O(n)
+* modifying an element: O(1)
+* random access: O(1)
 
 Well-suited for sets of elements of known size, access by numeric index,
 in-place modification. Basic arrays have a fixed length.
 
 ## Strings: immutable vectors
-Strings are very similar to arrays but are immutable. Strings are
+Strings are similar to arrays but are immutable. Strings are
 specialized for storing chars (bytes) and have some convenient syntax.
 Strings have a fixed length. For extensible strings, the standard Buffer
 module can be used (see below).
 
-* "adding" an element (by creating a new string): O(n)
-* length: O(1)
-* accessing character `i`: O(1)
-* finding an element: O(n)
+* adding an element (by creating a new string): O(n)
+* random access: O(1)
 
 ## Set and Map: immutable trees
 Like lists, these are immutable and they may share some subtrees. They
 are a good solution for keeping older versions of sets of items.
 
-* "adding" an element: O(log n)
+* adding an element: O(log n)
 * returning the number of elements: O(n)
 * finding an element: O(log n)
-
-Sets and maps are very useful in compilation and meta-programming, but
-in other situations hash tables are often more appropriate (see below).
+* finding the biggest or smallest: O(log n)
 
 ## Hashtbl: automatically growing hash tables
 Ocaml hash tables are mutable data structures, which are a good solution
 for storing (key, data) pairs in one single place.
 
-* adding an element: O(1) if the initial size of the table is larger
- than the number of elements it contains; O(log n) on average if n
- elements have been added in a table which is initially much smaller
- than n.
-* returning the number of elements: O(1)
+* adding an element: O(1) amortized
+* removing an element: O(1) amortized
 * finding an element: O(1)
 
 ## Buffer: extensible strings
 Buffers provide an efficient way to accumulate a sequence of bytes in a
 single place. They are mutable.
 
-* adding a char: O(1) if the buffer is big enough, or O(log n) on
- average if the initial size of the buffer was much smaller than the
- number of bytes n.
-* adding a string of k chars: O(k * "adding a char")
-* length: O(1)
-* accessing cell `i`: O(1)
+* adding bytes at the end: O(1) amortized
+* random access: O(1)
 
 ## Queue
 OCaml queues are mutable first-in-first-out (FIFO) data structures.
 
-* adding an element: O(1)
-* taking an element: O(1)
-* length: O(1)
+* adding an element on the "in" side: O(1)
+* taking an element on the "out" side: O(1)
 
 ## Stack
 OCaml stacks are mutable last-in-first-out (LIFO) data structures. They
 are just like lists, except that they are mutable, i.e. adding an
 element doesn't create a new stack but simply adds it to the stack.
 
-* adding an element: O(1)
-* taking an element: O(1)
-* length: O(1)
+* adding an element at the top: O(1)
+* taking an element at the top: O(1)


### PR DESCRIPTION
- Remove uninteresting or not well defined complexities (length, finding
  an element)
- Rename "accessing cell `i`" into "random access"
- ~~The "returning the number of elements" complexity for Set and Map was
  wrong~~
- The "adding an element" complexity for Hashtbl and Buffer was wrong