### PR TITLE
packages: Fix crash when package is removed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 
   This is a static list of packages that are highlighted on the Packages page.
 
-- Add listing stats on the Packages page (#213, by @Julow)
+- Add listing stats on the Packages page (#213, #256, by @Julow)
 
   The stats are:
   Recently added packages and recently updated packages, which are computed

--- a/src/ocamlorg_package/lib/opam_repository.ml
+++ b/src/ocamlorg_package/lib/opam_repository.ml
@@ -73,11 +73,19 @@ let last_commit () =
   output
 
 let ls_dir directory =
-  Sys.readdir directory
-  |> Array.to_list
-  |> List.filter (fun x -> Sys.is_directory (Filename.concat directory x))
+  match Sys.readdir directory with
+  | exception Sys_error _ ->
+    None
+  | entries ->
+    let entry_is_dir x = Sys.is_directory (Filename.concat directory x) in
+    Some (List.filter entry_is_dir (Array.to_list entries))
 
-let list_packages () = ls_dir Fpath.(to_string (clone_path / "packages"))
+let list_packages () =
+  match ls_dir Fpath.(to_string (clone_path / "packages")) with
+  | Some pkgs ->
+    pkgs
+  | None ->
+    []
 
 let list_package_versions package =
   ls_dir Fpath.(to_string (clone_path / "packages" / package))

--- a/src/ocamlorg_package/lib/opam_repository.mli
+++ b/src/ocamlorg_package/lib/opam_repository.mli
@@ -10,9 +10,10 @@ val last_commit : unit -> string Lwt.t
 val list_packages : unit -> string list
 (** List the packages in the [packages/] directory of the opam repository. *)
 
-val list_package_versions : string -> string list
+val list_package_versions : string -> string list option
 (** List the versions of the given package by reading the directories in the
-    [packages/<package>/] directory *)
+    [packages/<package>/] directory. Returns [None] if the specified package
+    doesn't exist in [packages/]. *)
 
 val opam_file : string -> string -> OpamFile.OPAM.t Lwt.t
 (** Return the opam file structure given a package name and package version. *)

--- a/src/ocamlorg_package/lib/packages_stats.ml
+++ b/src/ocamlorg_package/lib/packages_stats.ml
@@ -110,11 +110,14 @@ let compute_new_packages_since date =
   let filter_new_packages acc modified_versions =
     let ((pkg, _) as lastest) = List.hd modified_versions in
     let name = OpamPackage.(Name.to_string (name pkg)) in
-    let all_versions = Opam_repository.list_package_versions name in
-    if List.length modified_versions >= List.length all_versions then
+    match Opam_repository.list_package_versions name with
+    | Some all_versions
+      when List.length modified_versions >= List.length all_versions ->
       lastest :: acc
-    else
+    | Some _ | None ->
       acc
+    (* Might be [None] if a package has been added then removed, eg.
+       https://github.com/ocaml/opam-repository/pull/20065/commits *)
   in
   List.fold_left filter_new_packages [] packages |> List.rev
 


### PR DESCRIPTION
The query for detecting new files has been changed to using git log, which has the disadvantage of returning paths to file that have been added then removed.