### PR TITLE
Fix 404 on absent docs

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -53,7 +53,7 @@ Layout.render
               Overview
             </button>
           </a>
-          <a href="<%s Url.package_doc package.name package.version "index.html" %>">
+          <a href="<%s match documentation_status with | `Success -> Url.package_doc package.name package.version "index.html" | _ -> "#" %>">
             <button
             class="<%s if tab = Documentation then current_tab_class else tab_class %>">
               Documentation


### PR DESCRIPTION
If the status of the docs is anything other than 'success', then don't have the documentation tab link anywhere.

Fixes #262 (sort of)