### PR TITLE
Fix typo in release date

### DIFF
--- a/data/releases/en/4.06.1.md
+++ b/data/releases/en/4.06.1.md
@@ -1,7 +1,7 @@
 ---
 kind: compiler
 version: 4.06.1
-date: 2016-02-16
+date: 2018-02-16
 intro: >
   This page describe OCaml **4.06.1**, released on Feb 16, 2018.  It is
   a bug-fix release of [OCaml 4.06.0](/releases/4.06.0).


### PR DESCRIPTION
Just noticed typo in date because on the new website (https://v3.ocaml.org/releases), the timeline put 4.06.1 earlier than 4.06.0