### PR TITLE
Fix homepage example spacing

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -38,8 +38,8 @@ with an emphasis on expressiveness and safety."
           <div id="toplevel-container" style="flex: 1 1 50%" class="py-2 px-6 text-white text-opacity-50 overflow-auto">
             <div class="text-left overflow-auto">
               <pre id="output" class="flex flex-col w-full code-preview text-white text-sm space-y-1 font-medium">
-                  <span><span class="text-blue-500 ">let </span><span class="text-code-yellow ">square</span>  x = x * x</span>
-                  <span><i class="text-gray-400 ">val square : int -> int = < fun > </i></span>
+                  <span><span class="text-blue-500 ">let</span> <span class="text-code-yellow ">square</span> x = x * x</span>
+                  <span><i class="text-gray-400 ">val square : int -> int = < fun ></i></span>
                   <span>square 3</span>
                   <span><i class="text-gray-400 ">- : int = 9</i></span>
                   <span><span class="text-blue-500 ">let</span> <span class="text-code-yellow ">rec</span> fac x =</span>


### PR DESCRIPTION
Hey 👋, thanks for this great version of the website.

I just noticed a small spacing issue on the homepage as I opened the homepage.

<details>
<summary>Screenshots</summary>

_Before_

<img width="516" alt="spacing_before" src="https://user-images.githubusercontent.com/303170/153454914-2dfeea26-4957-40b4-b924-7ab967250dfa.png">


_After_

<img width="540" alt="spacing_after" src="https://user-images.githubusercontent.com/303170/153454965-8cade10d-675f-4f78-b6ad-e30ac9d2b3c2.png">

</details>