### PR TITLE
Enable odoc 2.1's new formatting

### DIFF
--- a/src/ocamlorg_frontend/css/other/doc.css
+++ b/src/ocamlorg_frontend/css/other/doc.css
@@ -22,6 +22,10 @@ div.odoc div.spec code::after {
   content: "";
 }
 
+div.odoc div.spec code {
+  white-space: pre-wrap;
+}
+
 div.odoc a.anchor {
   position: absolute;
   left: 0px;


### PR DESCRIPTION
Odoc 2.1 is more careful in its formatting of long signatures and
types. To enable this we need to use the following css rule:

```css
code {
  white-space: pre-wrap;
}
```

This assumes a width of 80 characters, which is close to the maximum
width of the doc pane (on my laptop). The switch to mobile-style layout
happens well after the width goes below 80 and we get unintentional
wrapping.

One possibility to address this is to remove this rule below a
particular width and fall back to the original formatting. Other
possibilities exist!