### PR TITLE
Add contribution guidelines for the content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Welcome to Ocaml.org's contributing guide.
 
-Thank you for taking the time to read the contributing guide. Your help with Ocaml.org is extremely welcome. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/v3.ocaml.org-server/issues/new).
+This guide documents the best way to contribute to the project. If you're looking for a guide on how to setup the project and submit a contribution, you can refer to our [HACKING](./HACKING.md) guide.
 
-## How to get started
+Thank you for taking the time to read the contributing guide. Your help with Ocaml.org is extremely welcome. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/v3.ocaml.org-server/issues/new).
 
 We are particularly motivated to support new contributors and people who are looking to learn and develop their skills.
 
@@ -19,167 +19,92 @@ We use GitHub issues to track all bugs and feature requests; feel free to open a
 
 Please include images and browser-specific information if the bug is related to some visual aspect of the site. This tends to make it easier to reproduce and fix.
 
-## Setup and Development
+## Contributing content
 
-### Setting up the Project
+Here's a list of the content that is community driven and how you can contribute to it:
 
-The `Makefile` contains many commands that can get you up and running, a typical workflow will be to clone the repository after forking it.
+- [The blog](#content-blog)
+- [The job board](#content-job)
+- [The success stories](#content-success-story)
+- [The academic and industrial users](#content-user)
+- [The OCaml books](#content-book)
+- [The community events](#content-event)
+- [The featured packages](#content-package)
 
-```
-git clone https://github.com/<username>/v3.ocaml.org-server.git
-cd v3.ocaml.org-server
-```
+### <a name="content-blog"></a> Add an RSS feed to the blog
 
-For the smoothest setup experience make sure you have some version of `npm` and `node` installed. The best way to do this is probably to [use nvm](https://github.com/nvm-sh/nvm/blob/master/README.md#install--update-script). You might have to source your `~/.bashrc` after installation of `nvm` then you can run something like `nvm install 16`. We use `node` and `npm` to have tailwind css.
+> Contribute to the [OCaml Blog](https://v3.ocaml.org/blog).
 
-After this ensure you have `opam` installed. Opam will manage the OCaml compiler along with all of the OCaml packages needed to build and run the project. By this point we should all be using some Unix-like system (Linux, macOS, WSL2) so you should [run the opam install script](https://opam.ocaml.org/doc/Install.html#Binary-distribution). There are also manual instructions for people that don't want to run a script from the internet. We assume you are using `opam.2.1.0` or later which provides a cleaner, friendlier experience when installing system dependencies.
+The blog is composed of two type of content:
 
-With opam installed you can now initialise opam with `opam init`. Note in containers or WSL2 you will have to run `opam init --disable-sandboxing`. Opam might complain about some missing system dependencies like `unzip`, `cc` (a C compiler like `gcc`) etc. Make sure to install these before `opam init`.
+- Community blog posts fetched from RSS feeds.
+- Original blog posts.
 
-Finally from the root of your project you can setup a [local opam switch](https://opam.ocaml.org/doc/Manual.html#Switches) and install the dependencies. There is a single `make` target to do just that.
+If you write about OCaml and have an RSS or Atom feed, you can add your feed to [`data/rss-sources.yml`](data/rss-sources.yml).
 
-```
-make switch
-```
+When compiling, the entries of the feed will be downloaded and markdown files for each item of the feed will be created in [`data/rss`](data/rss/). For instance: [building-ahrefs-codebase-with-melange.md`](data/rss/ahrefs/building-ahrefs-codebase-with-melange.md).
 
-If you don't want a local opam switch and are happy to install everything globally (in the opam sense) then you can just install the dependencies directly.
+Please, make sure your feed only contains articles about OCaml.
 
-```
-make deps
-```
+To contribute an original blog post (refer to as News on the site), you can add a new markdown file in [`data/news/`](/data/news/). For instance: [`multicore-2021-12.md`](data/news/multicore/multicore-2021-12.md).
 
-Opam will likely ask questions about installing system dependencies, for the project to work you will have to answer yes to installing these.
-
-### Running the server
-
-After building the project, you can run the server with:
-
-```bash
-make start
-```
-
-To start the server in watch mode, you can run:
-
-```bash
-make watch
-```
-
-This will restart the server on filesystem changes.
-
-### Running tests
-
-You can run the unit test suite with:
-
-```bash
-make test
-```
-
-### Deploying
-
-Commits added on `main` are automatically deployed on <https://v3.ocaml.org/>.
-
-The deployment pipeline is managed in <https://github.com/ocurrent/ocurrent-deployer> which listens to the `main` branch and builds the site using the `Dockerfile` at the root of the project.
-
-To test the deployment locally, you can run the following commands:
+If you want to re-publish an blog post you previously posted on Discuss, you can fetch it using Discuss API:
 
 ```
-docker build -t v3.ocaml.org .
-docker run -p 8080:8080  v3.ocaml.org
+curl https://discuss.ocaml.org/raw/<id> > data/news/<fname>.md
 ```
 
-This will build the docker image and run a docker container with the port `8080` mapped to the HTTP server.
+Where `<id>` is the ID of the Discuss post.
 
-With the docker container running, you can visit the site at <http://localhost:8080/>.
+### <a name="content-job"></a> Add an entry to the job board
 
-## Git and GitHub workflow
+> Contribute to the [Job Board](https://v3.ocaml.org/opportunities).
 
-The preferred workflow for contributing to a repository is to fork the main repository on GitHub, clone, and develop on a new branch.
+The job board displays OCaml job opportunities.
 
-If you aren't familiar with how to work with Github or would like to learn it, here is [a great tutorial](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
+To add a new entry to the job board, you can add it to [`data/jobs.yml`](data/jobs.yml).
 
-Feel free to use any approach while creating a pull request. Here are a few suggestions from the dev team:
+Please make sure that the opportunity involves mostly writing OCaml. Contributions to add opportunities unrelated to OCaml, or where OCaml is a negligible part of the opportunity won't be accepted.
 
-- If you are not sure whether your changes will be accepted or want to discuss the method before delving into it, please create an issue and ask it.
-- Clone the repo locally (or continue editing directly in github if the change is small). Checkout
-  out the branch that you created.
-- Create a draft pull request with a small initial commit. Here's how you can [create a draft pull request.](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
-- Continue developing, feel free to ask questions in the PR, if you run into obstacles or uncertainty as you make changes
-- Review your implementation according to the checks noted in the PR template
-- Once you feel your branch is ready, change the PR status to "ready to review"
-- Consult the tasks noted in the PR template
-- When merging, consider cleaning up the commit body
-- Close any issues that were addressed by this PR.
+If you notice that a job opportunity is outdated (e.g. already fullfilled, or not opened anymore), PRs to remove it are welcome as well.
 
-## Repository structure
+### <a name="content-success-story"></a> Add a success story
 
-The following snippet describes the repository structure.
+> Contribute to the [Success Stories](https://v3.ocaml.org/success-stories).
 
-```text
-.
-├── asset/
-|   The static assets served by the site.
-│
-├── data/
-|   Data used by ocaml.org in Yaml and Markdown format.
-│
-├── gettext/
-|   `.PO` files for static content translation. Not currently being used.
-│
-├── src
-│   ├── gettext
-|   |   The source code for translations.
-|   |
-│   ├── hilite
-|   |   A small library we use to do OCaml code highlighting at build time.
-|   |
-│   ├── ocamlorg_data
-|   |   The result of compiling all of the information in `/data` into OCaml modules.
-|   |
-│   ├── ocamlorg_frontend
-|   |   All of the front-end code primarily using .eml files (OCaml + HTML).
-|   |
-│   ├── ocamlorg_package
-|   |   The library for constructing opam-repository statistics and information (e.g. rev deps).
-|   |
-│   ├── ocamlorg_toplevel
-|   |   All of the js_of_ocaml toplevel code including UI and background workers.
-|   |
-│   └── ocamlorg_web
-|       The main entry-point of the server.
-│
-├── tool/
-|   Sources for development tools such as the `ocamlorg_data` code generator.
-│
-├── dune
-├── dune-project
-|   Dune file used to mark the root of the project and define project-wide parameters.
-|   For the documentation of the syntax, see https://dune.readthedocs.io/en/stable/dune-files.html#dune-project.
-│
-├── ocamlorg-data.opam
-├── ocamlorg.opam
-├── ocamlorg.opam.template
-│   opam package definitions.
-│
-├── package-lock.json
-├── package.json
-|   Package file for NPM packages. This is used to defined the JavaScript dependencies of the project.
-│
-├── CHANGES.md
-│
-├── CONTRIBUTING.md
-│
-├── Dockerfile
-|   Dockerfile used to build and deploy the site in production.
-│
-├── LICENSE
-├── LICENSE-3RD-PARTY
-|   Licenses of the source code, data and vendored third-party projects.
-│
-├── Makefile
-|   `Makefile` containing common development commands.
-│
-├── README.md
-│
-└── tailwind.config.js
-    Configuration used by TailwindCSS to generate the CSS file for the site.
-```
+You can contribute a new success story by adding a markdown file in [data/success_stories/](data/success_stories/). For instance: [janestreet.md](data/success_stories/en/janestreet.md).
+
+The success stories should be structured in the following way:
+
+- An overview of your company.
+- The challenge you faced and solved.
+- The solution you implemented, which should describe the role OCaml played in solving the challenge.
+- A post-mortem describing the results you had after implementing the solution.
+
+You can read [Ahref's success story](https://v3.ocaml.org/success-stories/peta-byte-scale-web-crawler) for an examplary succes story.
+
+### <a name="content-user"></a> Add an academic or industrial user
+
+> Contribute to the [Academic Users](https://v3.ocaml.org/academic-users) and [Industrial Users](https://v3.ocaml.org/industrial-users).
+
+You can add a new academic user by creating a new markdown file in [data/industrial_users/](data/industrial_users/). For instance: [cryptosense.md](data/industrial_users/en/cryptosense.md).
+
+You can add a new industrial user by creating a new markdown file in [data/academic_institutions/](data/academic_institutions). For instance: [cornell.md](data/academic_institutions/en/cornell.md).
+
+### <a name="content-book"></a> Add a book
+
+> Contribute to the [OCaml Books](https://v3.ocaml.org/books).
+
+You can add a new OCaml book by creating a new markdown file in [data/books/](data/books/). For instance: [ocaml-from-the-very-beginning.md](data/industrial_users/en/ocaml-from-the-very-beginning.md).
+
+### <a name="content-event"></a> Add an event
+
+> Contribute to the [Community Events](https://v3.ocaml.org/community).
+
+You can add a new community event by creating a new markdown file in [data/meetups.yml](data/meetups.yml).
+
+### <a name="content-package"></a> Add a featured packages
+
+> Contribute to the [Featured Packages](https://v3.ocaml.org/packages).
+
+To update the list of Featured Packages in the Packages page, you can update [data/packages.yml](data/packages.yml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,3 +108,22 @@ You can add a new community event by creating a new markdown file in [data/meetu
 > Contribute to the [Featured Packages](https://v3.ocaml.org/packages).
 
 To update the list of Featured Packages in the Packages page, you can update [data/packages.yml](data/packages.yml)
+
+## Git and GitHub workflow
+
+The preferred workflow for contributing to a repository is to fork the main repository on GitHub, clone, and develop on a new branch.
+
+If you aren't familiar with how to work with Github or would like to learn it, here is [a great tutorial](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
+
+Feel free to use any approach while creating a pull request. Here are a few suggestions from the dev team:
+
+- If you are not sure whether your changes will be accepted or want to discuss the method before delving into it, please create an issue and ask it.
+- Clone the repo locally (or continue editing directly in github if the change is small). Checkout
+  out the branch that you created.
+- Create a draft pull request with a small initial commit. Here's how you can [create a draft pull request.](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+- Continue developing, feel free to ask questions in the PR, if you run into obstacles or uncertainty as you make changes
+- Review your implementation according to the checks noted in the PR template
+- Once you feel your branch is ready, change the PR status to "ready to review"
+- Consult the tasks noted in the PR template
+- When merging, consider cleaning up the commit body
+- Close any issues that were addressed by this PR.

--- a/HACKING.md
+++ b/HACKING.md
@@ -72,25 +72,6 @@ This will build the docker image and run a docker container with the port `8080`
 
 With the docker container running, you can visit the site at <http://localhost:8080/>.
 
-## Git and GitHub workflow
-
-The preferred workflow for contributing to a repository is to fork the main repository on GitHub, clone, and develop on a new branch.
-
-If you aren't familiar with how to work with Github or would like to learn it, here is [a great tutorial](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
-
-Feel free to use any approach while creating a pull request. Here are a few suggestions from the dev team:
-
-- If you are not sure whether your changes will be accepted or want to discuss the method before delving into it, please create an issue and ask it.
-- Clone the repo locally (or continue editing directly in github if the change is small). Checkout
-  out the branch that you created.
-- Create a draft pull request with a small initial commit. Here's how you can [create a draft pull request.](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
-- Continue developing, feel free to ask questions in the PR, if you run into obstacles or uncertainty as you make changes
-- Review your implementation according to the checks noted in the PR template
-- Once you feel your branch is ready, change the PR status to "ready to review"
-- Consult the tasks noted in the PR template
-- When merging, consider cleaning up the commit body
-- Close any issues that were addressed by this PR.
-
 ## Repository structure
 
 The following snippet describes the repository structure.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,166 @@
+# Hacking on OCaml.org
+
+## Setup and Development
+
+### Setting up the Project
+
+The `Makefile` contains many commands that can get you up and running, a typical workflow will be to clone the repository after forking it.
+
+```
+git clone https://github.com/<username>/v3.ocaml.org-server.git
+cd v3.ocaml.org-server
+```
+
+For the smoothest setup experience make sure you have some version of `npm` and `node` installed. The best way to do this is probably to [use nvm](https://github.com/nvm-sh/nvm/blob/master/README.md#install--update-script). You might have to source your `~/.bashrc` after installation of `nvm` then you can run something like `nvm install 16`. We use `node` and `npm` to have tailwind css.
+
+After this ensure you have `opam` installed. Opam will manage the OCaml compiler along with all of the OCaml packages needed to build and run the project. By this point we should all be using some Unix-like system (Linux, macOS, WSL2) so you should [run the opam install script](https://opam.ocaml.org/doc/Install.html#Binary-distribution). There are also manual instructions for people that don't want to run a script from the internet. We assume you are using `opam.2.1.0` or later which provides a cleaner, friendlier experience when installing system dependencies.
+
+With opam installed you can now initialise opam with `opam init`. Note in containers or WSL2 you will have to run `opam init --disable-sandboxing`. Opam might complain about some missing system dependencies like `unzip`, `cc` (a C compiler like `gcc`) etc. Make sure to install these before `opam init`.
+
+Finally from the root of your project you can setup a [local opam switch](https://opam.ocaml.org/doc/Manual.html#Switches) and install the dependencies. There is a single `make` target to do just that.
+
+```
+make switch
+```
+
+If you don't want a local opam switch and are happy to install everything globally (in the opam sense) then you can just install the dependencies directly.
+
+```
+make deps
+```
+
+Opam will likely ask questions about installing system dependencies, for the project to work you will have to answer yes to installing these.
+
+### Running the server
+
+After building the project, you can run the server with:
+
+```bash
+make start
+```
+
+To start the server in watch mode, you can run:
+
+```bash
+make watch
+```
+
+This will restart the server on filesystem changes.
+
+### Running tests
+
+You can run the unit test suite with:
+
+```bash
+make test
+```
+
+### Deploying
+
+Commits added on `main` are automatically deployed on <https://v3.ocaml.org/>.
+
+The deployment pipeline is managed in <https://github.com/ocurrent/ocurrent-deployer> which listens to the `main` branch and builds the site using the `Dockerfile` at the root of the project.
+
+To test the deployment locally, you can run the following commands:
+
+```
+docker build -t v3.ocaml.org .
+docker run -p 8080:8080  v3.ocaml.org
+```
+
+This will build the docker image and run a docker container with the port `8080` mapped to the HTTP server.
+
+With the docker container running, you can visit the site at <http://localhost:8080/>.
+
+## Git and GitHub workflow
+
+The preferred workflow for contributing to a repository is to fork the main repository on GitHub, clone, and develop on a new branch.
+
+If you aren't familiar with how to work with Github or would like to learn it, here is [a great tutorial](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
+
+Feel free to use any approach while creating a pull request. Here are a few suggestions from the dev team:
+
+- If you are not sure whether your changes will be accepted or want to discuss the method before delving into it, please create an issue and ask it.
+- Clone the repo locally (or continue editing directly in github if the change is small). Checkout
+  out the branch that you created.
+- Create a draft pull request with a small initial commit. Here's how you can [create a draft pull request.](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+- Continue developing, feel free to ask questions in the PR, if you run into obstacles or uncertainty as you make changes
+- Review your implementation according to the checks noted in the PR template
+- Once you feel your branch is ready, change the PR status to "ready to review"
+- Consult the tasks noted in the PR template
+- When merging, consider cleaning up the commit body
+- Close any issues that were addressed by this PR.
+
+## Repository structure
+
+The following snippet describes the repository structure.
+
+```text
+.
+├── asset/
+|   The static assets served by the site.
+│
+├── data/
+|   Data used by ocaml.org in Yaml and Markdown format.
+│
+├── gettext/
+|   `.PO` files for static content translation. Not currently being used.
+│
+├── src
+│   ├── gettext
+|   |   The source code for translations.
+|   |
+│   ├── hilite
+|   |   A small library we use to do OCaml code highlighting at build time.
+|   |
+│   ├── ocamlorg_data
+|   |   The result of compiling all of the information in `/data` into OCaml modules.
+|   |
+│   ├── ocamlorg_frontend
+|   |   All of the front-end code primarily using .eml files (OCaml + HTML).
+|   |
+│   ├── ocamlorg_package
+|   |   The library for constructing opam-repository statistics and information (e.g. rev deps).
+|   |
+│   ├── ocamlorg_toplevel
+|   |   All of the js_of_ocaml toplevel code including UI and background workers.
+|   |
+│   └── ocamlorg_web
+|       The main entry-point of the server.
+│
+├── tool/
+|   Sources for development tools such as the `ocamlorg_data` code generator.
+│
+├── dune
+├── dune-project
+|   Dune file used to mark the root of the project and define project-wide parameters.
+|   For the documentation of the syntax, see https://dune.readthedocs.io/en/stable/dune-files.html#dune-project.
+│
+├── ocamlorg-data.opam
+├── ocamlorg.opam
+├── ocamlorg.opam.template
+│   opam package definitions.
+│
+├── package-lock.json
+├── package.json
+|   Package file for NPM packages. This is used to defined the JavaScript dependencies of the project.
+│
+├── CHANGES.md
+│
+├── CONTRIBUTING.md
+│
+├── Dockerfile
+|   Dockerfile used to build and deploy the site in production.
+│
+├── LICENSE
+├── LICENSE-3RD-PARTY
+|   Licenses of the source code, data and vendored third-party projects.
+│
+├── Makefile
+|   `Makefile` containing common development commands.
+│
+├── README.md
+│
+└── tailwind.config.js
+    Configuration used by TailwindCSS to generate the CSS file for the site.
+```


### PR DESCRIPTION
This PR adds some guidelines on how to contribute to the community-driven content of the website.

We also separate instructions on how to set up a development environment in a `HACKING.md` file.

This is the first step to resolve #288. When we have these guidelines in the `CONTRIBUTING` guide, we will be able to link to them from the different pages of the website.