### PR TITLE
Replace qualifier for the OCaml community to Vibrant

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -217,7 +217,7 @@ with an emphasis on expressiveness and safety."
   <div class="container-fluid">
     <div class="">
       <div class="text-center px-15">
-        <h2 class="font-bold text-primary-600 mb-6">Strong Community</h2>
+        <h2 class="font-bold text-primary-600 mb-6">Vibrant Community</h2>
         <div class="text-lg text-white">
           OCaml has a passionate and diverse community behind it that enriches the experience of everyone working with
           the language. The community flags problems, develops new solutions, investigates new avenues of research, and


### PR DESCRIPTION
This seems to be a better qualifier for the community. Strong doesn't seem to align well with our diversity and inclusion values.