### PR TITLE
Add a byte mode compilation target for toplevel files

### DIFF
--- a/src/ocamlorg_toplevel/bin/dune
+++ b/src/ocamlorg_toplevel/bin/dune
@@ -27,7 +27,7 @@
  (name toplevel_base)
  (libraries ocamlorg_toplevel base)
  (modules toplevel_base)
- (modes js))
+ (modes byte js))
 
 (rule
  (targets export_base.txt)
@@ -65,7 +65,7 @@
  (name toplevel_stdlib)
  (libraries ocamlorg_toplevel stdlib)
  (modules toplevel_stdlib)
- (modes js))
+ (modes byte js))
 
 ; Stdlib worker
 


### PR DESCRIPTION
Dune 3 doesn't generate bc targets for the js mode anymore. This fixes the compilation with Dune 3.
Closes https://github.com/ocaml/ocaml.org/issues/326.