### PR TITLE
Improve homepage content

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -70,7 +70,7 @@ with an emphasis on expressiveness and safety."
     <div class="text-center">
       <h2 class="font-bold text-body-600">Trusted by Industry Leaders</h2>
       <div class="text-body-400 text-base mt-3">
-        These companies and organizations rely on OCaml every day — along with thousands of other developers
+        These companies and organizations rely on OCaml every day — along with thousands of other developers. See <a href="<%s Url.success_stories %>" class="link-orange">Success Stories</a>
       </div>
       <div class="flex flex-row justify-center m-auto flex-wrap py-8 items-center">
           <div class="mx-8 my-4">
@@ -83,7 +83,7 @@ with an emphasis on expressiveness and safety."
               <img class="h-8" src="/logos/docker.svg" alt="Docker">
           </div>
           <div class="mx-8 my-4">
-              <img class="h-10" src="/logos/janestreet.svg" alt="JaneStreet">
+              <img class="h-10" src="/logos/janestreet.svg" alt="Jane Street">
           </div>
           <div class="mx-8 my-4">
               <img class="h-6" src="/logos/bloomberg.svg" alt="Bloomberg">
@@ -115,12 +115,9 @@ with an emphasis on expressiveness and safety."
             <div class="text-lg my-4 font-bold" style="color: #225b90">
               BE SAFE
             </div>
-            <h3 class="text-body-600 font-bold">Safe and Stable</h3>
+            <h3 class="text-body-600 font-bold">Unobtrusive Type Safety</h3>
             <div class="my-4 text-lg">
-              OCaml is a safe language with many features that promote stability by eliminating bugs and runtime issues.
-              This makes it a good language for running code that is critical to the rest of the application. It also
-              optimises the programmer experience, making it popular with developers as well as with commercial
-              businesses.
+              OCaml’s powerful type system means more bugs are caught at compile time, and large, complex codebases are easier to maintain. This makes it a good language for running critical code. At the same time, sophisticated inference makes the type system unobtrusive,  creating a smooth developer experience.
             </div>
           </div>
         </div>
@@ -139,15 +136,12 @@ with an emphasis on expressiveness and safety."
                   clip-rule="evenodd" />
               </svg>
             </div>
-            <div class="text-lg my-4 font-bold text-teal-800">WORK FASTER</div>
+            <div class="text-lg my-4 font-bold text-teal-800">BUILD FASTER</div>
             <h3 class="text-body-600 font-bold">
               Fast Compiler and Efficient Applications
             </h3>
             <div class="my-4 font-normal text-lg">
-              OCaml has two batch compilers. One is a bytecode compiler which generates small, portable executables and
-              is very fast. The other is a native code compiler that produces more efficient machine code; its
-              performance matches the highest standards of modern compilers. Both of these compilers support separate
-              compilation and keep OCaml running smoothly and quickly.
+              OCaml has two compilers. One is a bytecode compiler which generates small, portable executables and is very fast. The other is a native code compiler that produces more efficient machine code; its performance matches the highest standards of modern compilers. 
             </div>
           </div>
         </div>
@@ -167,16 +161,13 @@ with an emphasis on expressiveness and safety."
               </svg>
             </div>
             <div class="text-lg my-4 font-bold text-purple-600">
-              BUILD ANYTHING
+              WORK JOYFULLY
             </div>
             <h3 class="text-body-600 font-bold">
-              First Class Editor and Tooling
+              First-Class Editor and Tooling
             </h3>
             <div class="my-4 text-lg">
-              OCaml has several editor tools that make it easier to program in. Usually, VS Code is recommended for
-              beginners, but there is also good support for Vim and Emacs. Tools like the toplevel Utop and
-              document generator Odoc are also well supported and used by OCaml programmers all over the world. Highly
-              maintained tools makes OCaml well-liked with developers as it provides a smooth programming experience.
+              OCaml has great support for the most popular editors. VS Code is recommended for beginners, and for power users there is  deep integration with Vim and Emacs. OCaml has a rich and dynamic community and best-in-class tooling. Between Opam, a popular package manager; Utop, a powerful interactive REPL; and Odoc, an easy-to-use documentation generator, OCaml programmers have access to a complete, modern developer experience.
             </div>
             <div class=" w-56">
               <div class="swiper mySwiper">
@@ -222,10 +213,7 @@ with an emphasis on expressiveness and safety."
       <div class="text-center px-15">
         <h2 class="font-bold text-primary-600 mb-6">Vibrant Community</h2>
         <div class="text-lg text-white">
-          OCaml has a passionate and diverse community behind it that enriches the experience of everyone working with
-          the language. The community flags problems, develops new solutions, investigates new avenues of research, and
-          keeps OCaml moving forward. This makes OCaml an attractive option as a language with a lot of support and
-          momentum behind it.
+          OCaml has a passionate and diverse community, with more than ten thousand developers and four thousand open source packages. It is a truly general-purpose language with extensive libraries in a variety of problem areas, including data science, bioinformatics, and programming language design. OCaml has roots in academic and theoretical contexts but has also become popular among application developers looking to build command-line utilities or performant, dynamic web apps without resorting to a less safe or feature-rich language.
         </div>
       </div>
     </div>
@@ -343,8 +331,7 @@ with an emphasis on expressiveness and safety."
     <div class="text-center px-15">
       <h2 class="text-body-600 font-bold mb-6">Users of OCaml</h2>
       <div class="text-lg text-body-400 mb-16">
-        OCaml is used by thousands of developers, companies, research labs,
-        teachers, etc. Learn how it fits your use case
+        OCaml is used by thousands of developers, companies, research labs, teachers, and more. Learn how it fits your use case.
       </div>
     </div>
     <div class="flex flex-col lg:flex-row justify-between lg:space-x-20 space-y-10 lg:space-y-0">
@@ -362,9 +349,7 @@ with an emphasis on expressiveness and safety."
         </div>
         <div>
           <div class="text-base text-body-600">
-            With its strong mathematical roots, OCaml has always had strong ties to academia. Currently, it is being
-            taught in universities around the world, and has accrued an ever growing body of research. This page will
-            provide you with an overview of the academic excellence that defines the culture of OCaml.
+            With its mathematical roots, OCaml has always had strong ties to academia. Currently, it is being taught in universities around the world, and has accrued an ever-growing body of research. This page will provide you with an overview of the academic rigor that defines the culture of OCaml.
           </div>
           <a href="<%s Url.academic_users %>"><button class="btn mt-10">Learn more</button></a>
         </div>
@@ -383,10 +368,7 @@ with an emphasis on expressiveness and safety."
         </div>
         <div>
           <div class="text-base text-body-600">
-            With its strong security features and high performance, several
-            companies rely on OCaml to keep their data operating both safely and
-            speedily. On this page, you can get an overview of the companies in
-            the community and learn more about how they use OCaml.
+            With its powerful compile-time guarantees and high performance, several companies rely on OCaml to keep their systems operating both reliably and speedily. On this page, you can get an overview of the companies in the community and learn more about how they use OCaml.
           </div>
           <a href="<%s Url.industrial_users %>"><button class="btn mt-10">Learn more</button></a>
         </div>
@@ -400,7 +382,7 @@ with an emphasis on expressiveness and safety."
       <div class="text-center">
         <h2 class="font-bold text-primary-600 mb-6">Curated Resources</h2>
         <div class="text-lg text-white mb-16">
-          Get up to speed quickly to enjoy the benefits of the OCaml programming language across your projects
+          Get up to speed quickly to enjoy the benefits of the OCaml programming language across your projects.
         </div>
       </div>
       <div class="grid lg:grid-cols-3 gap-8 lg:gap-16">
@@ -411,7 +393,7 @@ with an emphasis on expressiveness and safety."
           </svg>
       
           <p class="font-semibold text-xl mb-3">Getting Started</p>
-          <p>Install OCaml, setup your favorite text editor and start your first project.</p>
+          <p>Install OCaml, set up your favorite text editor and start your first project.</p>
         </a>
         <a href="<%s Url.manual %>" class="resources-card card-hover">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -419,7 +401,7 @@ with an emphasis on expressiveness and safety."
           </svg>
       
           <p class="font-semibold text-xl mb-3">Language Manual</p>
-          <p>Read the reference manual of the language and the documentation on the compiler tools.</p>
+          <p>Read the reference manual of the language and documentation on the compiler.</p>
         </a>
         <a href="<%s Url.books %>" class="resources-card card-hover">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -432,7 +414,7 @@ with an emphasis on expressiveness and safety."
           </svg>
       
           <p class="font-semibold text-xl mb-3">Books</p>
-          <p>What expert programmers and researchers are saying about OCaml, from the beginner level to the more advanced topics.</p>
+          <p>What expert programmers and researchers are saying about OCaml, from the beginner level to more advanced topics.</p>
         </a>
         <a href="<%s Url.package_doc "ocaml-base-compiler" "4.13.1" "index.html" %>" class="resources-card card-hover">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -440,7 +422,7 @@ with an emphasis on expressiveness and safety."
           </svg>
       
           <p class="font-semibold text-xl mb-3">Standard Library</p>
-          <p>Read the standard library documentation and search its API for functions.</p>
+          <p>Searchable API documentation.</p>
         </a>
         <a href="<%s Url.problems %>" class="resources-card card-hover">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mb-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/ocamlorg_frontend/pages/industrial_users.eml
+++ b/src/ocamlorg_frontend/pages/industrial_users.eml
@@ -123,7 +123,7 @@ the community and learn more about how they use OCaml." @@
                 <img src="/logos/janestreet.svg" class="mb-12" alt="" width="99" height="100%" />
                 <div class="mb-12">OCaml helps us to quickly adopt to changing market conditions, and go from prototypes to production systems with less effort ... Billions of dollars of transactions flow through our systems every day, so getting it right matters</div>
                 <div class="font-bold">Yaron Minsky</div>
-                <div>CTO, JaneStreet.</div>
+                <div>CTO, Jane Street.</div>
               </div>
             </a>
 

--- a/src/ocamlorg_frontend/pages/success_stories.eml
+++ b/src/ocamlorg_frontend/pages/success_stories.eml
@@ -64,7 +64,7 @@ Layout.render
                     <img class="h-8" src="/logos/docker.svg" alt="Docker">
                 </div>
                 <div class="mx-8 my-4">
-                    <img class="h-10" src="/logos/janestreet.svg" alt="JaneStreet">
+                    <img class="h-10" src="/logos/janestreet.svg" alt="Jane Street">
                 </div>
                 <div class="mx-8 my-4">
                     <img class="h-6" src="/logos/bloomberg.svg" alt="Bloomberg">
@@ -171,7 +171,7 @@ Layout.render
                                     from prototypes to production systems with less effort ... Billions of dollars of
                                     transactions flow through our systems every day, so getting it right matters</div>
                                 <div class="font-bold">Yaron Minsky</div>
-                                <div>CTO, JaneStreet.</div>
+                                <div>CTO, Jane Street.</div>
                             </div>
                         </a>
 


### PR DESCRIPTION
This improves the homepage copy as per @jsomers's suggestions.

@jsomers I didn't include the changes on the success page, as I thought it would be better done in the separate PR that will merge the success stories and industrial users pages. If this looks good to you, we can merge the changes on the homepage independently.