### PR TITLE
Complete redirections for v2.ocaml.org URLs

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -59,7 +59,7 @@ Layout.render
             <div class="ml-3 font-semibold opacity-70">Language Manual</div>
           </a>
 
-          <a href="https://ocaml.org/api/index.html" class="flex justify-start items-center">
+          <a href="<%s Url.api %>" class="flex justify-start items-center">
             <div class="bg-sky-600 text-white rounded w-8 h-8 flex items-center justify-center">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -51,7 +51,7 @@ Layout.render
             <div class="ml-3 font-semibold opacity-70">Language Manual</div>
           </a>
 
-          <a href="https://ocaml.org/api/index.html" class="flex justify-start items-center">
+          <a href="<%s Url.api %>" class="flex justify-start items-center">
             <div class="bg-sky-600 text-white rounded w-8 h-8 flex items-center justify-center">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -24,8 +24,11 @@ let success_story v = "/success-stories/" ^ v
 let industrial_users = "/industrial-users"
 let academic_users = "/academic-users"
 let about = "/about"
-let manual_with_version v = "/manual/" ^ v
-let manual = "/manual"
+
+let manual_with_version v =
+  "https://v2.ocaml.org/releases/" ^ v ^ "/htmlman/index.html"
+
+let manual = "https://v2.ocaml.org/releases/latest/manual.html"
 let books = "/books"
 let releases = "/releases"
 let release v = "/releases/" ^ v

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -26,9 +26,16 @@ let academic_users = "/academic-users"
 let about = "/about"
 
 let manual_with_version v =
-  "https://v2.ocaml.org/releases/" ^ v ^ "/htmlman/index.html"
+  let minor = String.sub v 0 4 in
+  "https://v2.ocaml.org/releases/" ^ minor ^ "/htmlman/index.html"
 
 let manual = "https://v2.ocaml.org/releases/latest/manual.html"
+
+let api_with_version v =
+  let minor = String.sub v 0 4 in
+  "https://v2.ocaml.org/releases/" ^ minor ^ "/api/index.html"
+
+let api = "https://v2.ocaml.org/api/index.html"
 let books = "/books"
 let releases = "/releases"
 let release v = "/releases/" ^ v

--- a/src/ocamlorg_web/lib/redirection.ml
+++ b/src/ocamlorg_web/lib/redirection.ml
@@ -1,339 +1,645 @@
 module Url = Ocamlorg_frontend.Url
 
+let fwd_v2 target = (target, "https://v2.ocaml.org" ^ target)
+
+(* For assets previously hosted on V2, we redirect the requests to
+   v2.ocaml.org. *)
+let v2_assets =
+  [
+    fwd_v2 "/meetings/ocaml/2013/proposals/core-bench.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/ctypes.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/formats-as-gadts.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/frenetic.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/goji.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/gpgpu.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/injectivity.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/merlin.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/ocamlot.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/optimizations.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/platform.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/profiling-memory.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/runtime-types.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/weather-related-data.pdf";
+    fwd_v2 "/meetings/ocaml/2013/proposals/wxocaml.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/bourgoin.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/bozman.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/canou.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/carty.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/chambart.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/garrigue.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/guha.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/henry.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/james.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/lefessant.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/leroy.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/madhavapeddy.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/padioleau.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/sheets.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/vaugon.pdf";
+    fwd_v2 "/meetings/ocaml/2013/slides/white.pdf";
+    fwd_v2 "/releases/3.12/notes/Changes";
+    fwd_v2 "/releases/3.12/notes/INSTALL";
+    fwd_v2 "/releases/3.12/notes/LICENSE";
+    fwd_v2 "/releases/3.12/notes/README";
+    fwd_v2 "/releases/3.12/notes/README.win32";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman-html.tar.gz";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman-html.zip";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.dvi.gz";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.html";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.html.tar.gz";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.html.zip";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.info.tar.gz";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.pdf";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.ps.gz";
+    fwd_v2 "/releases/3.12/ocaml-3.12-refman.txt";
+    fwd_v2 "/releases/4.00/notes/Changes";
+    fwd_v2 "/releases/4.00/notes/INSTALL";
+    fwd_v2 "/releases/4.00/notes/LICENSE";
+    fwd_v2 "/releases/4.00/notes/README";
+    fwd_v2 "/releases/4.00/notes/README.win32";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman-html.tar.gz";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman-html.zip";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman.dvi.gz";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman.html";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman.info.tar.gz";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman.pdf";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman.ps.gz";
+    fwd_v2 "/releases/4.00/ocaml-4.00-refman.txt";
+    fwd_v2 "/releases/4.01/notes/Changes";
+    fwd_v2 "/releases/4.01/notes/INSTALL";
+    fwd_v2 "/releases/4.01/notes/LICENSE";
+    fwd_v2 "/releases/4.01/notes/README";
+    fwd_v2 "/releases/4.01/notes/README.win32";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman-html.tar.gz";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman-html.zip";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman.dvi.gz";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman.html";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman.info.tar.gz";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman.pdf";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman.ps.gz";
+    fwd_v2 "/releases/4.01/ocaml-4.01-refman.txt";
+    fwd_v2 "/releases/4.02/notes/Changes";
+    fwd_v2 "/releases/4.02/notes/INSTALL";
+    fwd_v2 "/releases/4.02/notes/LICENSE";
+    fwd_v2 "/releases/4.02/notes/README";
+    fwd_v2 "/releases/4.02/notes/README.win32";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman-html-0.tar.gz";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman-html-0.zip";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman-html-1.tar.gz";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman-html-1.zip";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman-html.tar.gz";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman-html.zip";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman.dvi.gz";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman.html";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman.info.tar.gz";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman.pdf";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman.ps.gz";
+    fwd_v2 "/releases/4.02/ocaml-4.02-refman.txt";
+    fwd_v2 "/releases/4.03/notes/Changes";
+    fwd_v2 "/releases/4.03/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.03/notes/LICENSE";
+    fwd_v2 "/releases/4.03/notes/README.adoc";
+    fwd_v2 "/releases/4.03/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman-html.tar.gz";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman-html.zip";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman.dvi.gz";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman.html";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman.info.tar.gz";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman.pdf";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman.ps.gz";
+    fwd_v2 "/releases/4.03/ocaml-4.03-refman.txt";
+    fwd_v2 "/releases/4.04/notes/Changes";
+    fwd_v2 "/releases/4.04/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.04/notes/LICENSE";
+    fwd_v2 "/releases/4.04/notes/README.adoc";
+    fwd_v2 "/releases/4.04/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman-html.tar.gz";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman-html.zip";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman.dvi.gz";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman.html";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman.info.tar.gz";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman.pdf";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman.ps.gz";
+    fwd_v2 "/releases/4.04/ocaml-4.04-refman.txt";
+    fwd_v2 "/releases/4.05/notes/Changes";
+    fwd_v2 "/releases/4.05/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.05/notes/LICENSE";
+    fwd_v2 "/releases/4.05/notes/README.adoc";
+    fwd_v2 "/releases/4.05/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman-html.tar.gz";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman-html.zip";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman.dvi.gz";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman.html";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman.info.tar.gz";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman.pdf";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman.ps.gz";
+    fwd_v2 "/releases/4.05/ocaml-4.05-refman.txt";
+    fwd_v2 "/releases/4.06/notes/Changes";
+    fwd_v2 "/releases/4.06/notes/Changes.4.06.0+beta1.txt";
+    fwd_v2 "/releases/4.06/notes/Changes.4.06.0+beta2.txt";
+    fwd_v2 "/releases/4.06/notes/Changes.4.06.0+rc1.txt";
+    fwd_v2 "/releases/4.06/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.06/notes/LICENSE";
+    fwd_v2 "/releases/4.06/notes/README.adoc";
+    fwd_v2 "/releases/4.06/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman-html.tar.gz";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman-html.zip";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman.dvi.gz";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman.html";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman.info.tar.gz";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman.pdf";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman.ps.gz";
+    fwd_v2 "/releases/4.06/ocaml-4.06-refman.txt";
+    fwd_v2 "/releases/4.07/notes/Changes";
+    fwd_v2 "/releases/4.07/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.07/notes/LICENSE";
+    fwd_v2 "/releases/4.07/notes/README.adoc";
+    fwd_v2 "/releases/4.07/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman-html.tar.gz";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman-html.zip";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman.dvi.gz";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman.html";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman.info.tar.gz";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman.pdf";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman.ps.gz";
+    fwd_v2 "/releases/4.07/ocaml-4.07-refman.txt";
+    fwd_v2 "/releases/4.08/notes/Changes";
+    fwd_v2 "/releases/4.08/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.08/notes/LICENSE";
+    fwd_v2 "/releases/4.08/notes/README.adoc";
+    fwd_v2 "/releases/4.08/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.08/ocaml-4.08-refman-html.tar.gz";
+    fwd_v2 "/releases/4.08/ocaml-4.08-refman-html.zip";
+    fwd_v2 "/releases/4.08/ocaml-4.08-refman.html";
+    fwd_v2 "/releases/4.08/ocaml-4.08-refman.info.tar.gz";
+    fwd_v2 "/releases/4.08/ocaml-4.08-refman.pdf";
+    fwd_v2 "/releases/4.08/ocaml-4.08-refman.txt";
+    fwd_v2 "/releases/4.09/notes/Changes";
+    fwd_v2 "/releases/4.09/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.09/notes/LICENSE";
+    fwd_v2 "/releases/4.09/notes/README.adoc";
+    fwd_v2 "/releases/4.09/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.09/ocaml-4.09-refman-html.tar.gz";
+    fwd_v2 "/releases/4.09/ocaml-4.09-refman-html.zip";
+    fwd_v2 "/releases/4.09/ocaml-4.09-refman.html";
+    fwd_v2 "/releases/4.09/ocaml-4.09-refman.info.tar.gz";
+    fwd_v2 "/releases/4.09/ocaml-4.09-refman.pdf";
+    fwd_v2 "/releases/4.09/ocaml-4.09-refman.txt";
+    fwd_v2 "/releases/4.10/notes/Changes";
+    fwd_v2 "/releases/4.10/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.10/notes/LICENSE";
+    fwd_v2 "/releases/4.10/notes/README.adoc";
+    fwd_v2 "/releases/4.10/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.10/ocaml-4.10-refman-html.tar.gz";
+    fwd_v2 "/releases/4.10/ocaml-4.10-refman-html.zip";
+    fwd_v2 "/releases/4.10/ocaml-4.10-refman.html";
+    fwd_v2 "/releases/4.10/ocaml-4.10-refman.info.tar.gz";
+    fwd_v2 "/releases/4.10/ocaml-4.10-refman.pdf";
+    fwd_v2 "/releases/4.10/ocaml-4.10-refman.txt";
+    fwd_v2 "/releases/4.11/notes/Changes";
+    fwd_v2 "/releases/4.11/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.11/notes/LICENSE";
+    fwd_v2 "/releases/4.11/notes/README.adoc";
+    fwd_v2 "/releases/4.11/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.11/ocaml-4.11-refman-html.tar.gz";
+    fwd_v2 "/releases/4.11/ocaml-4.11-refman-html.zip";
+    fwd_v2 "/releases/4.11/ocaml-4.11-refman.html";
+    fwd_v2 "/releases/4.11/ocaml-4.11-refman.info.tar.gz";
+    fwd_v2 "/releases/4.11/ocaml-4.11-refman.pdf";
+    fwd_v2 "/releases/4.11/ocaml-4.11-refman.txt";
+    fwd_v2 "/releases/4.12/notes/Changes";
+    fwd_v2 "/releases/4.12/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.12/notes/LICENSE";
+    fwd_v2 "/releases/4.12/notes/README.adoc";
+    fwd_v2 "/releases/4.12/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.12/ocaml-4.12-refman-html.tar.gz";
+    fwd_v2 "/releases/4.12/ocaml-4.12-refman-html.zip";
+    fwd_v2 "/releases/4.12/ocaml-4.12-refman.html";
+    fwd_v2 "/releases/4.12/ocaml-4.12-refman.info.tar.gz";
+    fwd_v2 "/releases/4.12/ocaml-4.12-refman.pdf";
+    fwd_v2 "/releases/4.12/ocaml-4.12-refman.txt";
+    fwd_v2 "/releases/4.13/notes/Changes";
+    fwd_v2 "/releases/4.13/notes/INSTALL.adoc";
+    fwd_v2 "/releases/4.13/notes/LICENSE";
+    fwd_v2 "/releases/4.13/notes/README.adoc";
+    fwd_v2 "/releases/4.13/notes/README.win32.adoc";
+    fwd_v2 "/releases/4.13/ocaml-4.13-refman-html.tar.gz";
+    fwd_v2 "/releases/4.13/ocaml-4.13-refman-html.zip";
+    fwd_v2 "/releases/4.13/ocaml-4.13-refman.html";
+    fwd_v2 "/releases/4.13/ocaml-4.13-refman.info.tar.gz";
+    fwd_v2 "/releases/4.13/ocaml-4.13-refman.pdf";
+    fwd_v2 "/releases/4.13/ocaml-4.13-refman.txt";
+  ]
+
 let from_v2 =
   [
-    ("/releases/4.05.html", Url.release "4.05");
-    ("/releases/4.13.0.html", Url.release "4.13.0");
-    ("/releases/4.12.1.html", Url.release "4.12.1");
-    ("/releases/4.12.0.html", Url.release "4.12.0");
-    ("/releases/4.09.1.html", Url.release "4.09.1");
-    ("/releases/4.10.2.html", Url.release "4.10.2");
-    ("/releases/4.08.0.html", Url.release "4.08.0");
-    ("/releases/4.09.0.html", Url.release "4.09.0");
-    ("/releases/4.11.2.html", Url.release "4.11.2");
-    ("/releases/4.08.1.html", Url.release "4.08.1");
-    ("/releases/4.04.html", Url.release "4.04");
-    ("/releases/4.01.0.fr.html", Url.release "4.01.0");
-    ("/releases/", Url.releases);
-    ("/releases/index.html", Url.releases);
-    ("/releases/4.00.1.html", Url.release "4.00.1");
-    ("/releases/3.12.1.html", Url.release "3.12.1");
-    ("/releases/index.fr.html", Url.releases);
-    ("/releases/4.01.0.html", Url.release "4.01.0");
-    ("/releases/4.10.0.html", Url.release "4.10.0");
-    ("/releases/4.03.html", Url.release "4.03");
-    ("/releases/4.11.1.html", Url.release "4.11.1");
-    ("/releases/4.07.1.html", Url.release "4.07.1");
-    ("/releases/4.06.html", Url.release "4.06");
-    ("/releases/4.06.1.html", Url.release "4.06.1");
-    ("/releases/4.10.1.html", Url.release "4.10.1");
-    ("/releases/4.02.html", Url.release "4.02");
-    ("/releases/4.11.0.html", Url.release "4.11.0");
-    ("/releases/caml-light/license.html", "/");
-    ("/releases/caml-light/releases/0.75.html", "/");
-    ("/releases/caml-light/releases/", "/");
-    ("/releases/caml-light/releases/index.html", "/");
-    ("/releases/caml-light/faq.html", "/");
-    ("/releases/caml-light/", "/");
-    ("/releases/caml-light/index.html", "/");
-    ("/releases/4.07.0.html", Url.release "4.07.0");
-    ("/learn/taste.html", "/");
-    ("/learn/taste.fr.html", "/");
-    ("/learn/success.html", Url.success_stories);
-    ("/learn/history.fr.html", Url.about);
-    ("/learn/history.html", Url.about);
-    ("/learn/faq.html", Url.about);
+    ("/about.fr.html", Url.about);
+    ("/about.html", Url.about);
+    ("/caml-light/faq.html", Url.index);
+    ("/caml-light/index.html", Url.index);
+    ("/caml-light/", Url.index);
+    ("/caml-light/license.html", Url.index);
+    ("/caml-light/releases/0.75.html", Url.index);
+    ("/community/announcements/CompCert_award.html", Url.community);
+    ("/community/cwn/index.html", Url.community);
+    ("/community/cwn/", Url.community);
+    ("/community/history/forge.html", Url.community);
+    ("/community/index.fr.html", Url.community);
+    ("/community/index.html", Url.community);
+    ("/community/", Url.community);
+    ("/community/mailing_lists.fr.html", Url.community);
+    ("/community/mailing_lists.html", Url.community);
+    ("/community/media.html", Url.community);
+    ("/community/planet.html", Url.blog);
+    ("/community/planet/index.html", Url.blog);
+    ("/community/planet/", Url.blog);
+    ("/community/planet/older.html", Url.blog);
+    ("/community/planet/syndication.html", Url.blog);
+    ("/community/support.fr.html", Url.community);
+    ("/community/support.html", Url.community);
+    ("/consortium/index.fr.html", Url.index);
+    ("/consortium/index.html", Url.index);
+    ("/consortium/", Url.index);
+    ("/contributors.fr.html", Url.index);
+    ("/contributors.html", Url.index);
+    ("/docs/cheat_sheets.html", Url.learn);
+    ("/docs/consortium-license.html", Url.index);
+    ("/docs/index.fr.html", Url.learn);
+    ("/docs/index.html", Url.learn);
+    ("/docs/", Url.learn);
+    ("/docs/install.fr.html", Url.getting_started);
+    ("/docs/install.html", Url.getting_started);
+    ("/docs/license.fr.html", Url.index);
+    ("/docs/license.html", Url.index);
+    ("/docs/logos.html", Url.index);
+    ("/docs/papers.html", Url.papers);
+    ("/governance.html", Url.governance);
+    ("/index.fr.html", Url.index);
+    ("/index.html", Url.index);
+    ("/learn/books.html", Url.books);
     ("/learn/companies.html", Url.industrial_users);
     ("/learn/description.html", Url.about);
-    ("/learn/", Url.learn);
-    ("/learn/index.html", Url.learn);
+    ("/learn/faq.html", Url.learn);
+    ("/learn/history.fr.html", Url.about);
+    ("/learn/history.html", Url.about);
     ("/learn/index.fr.html", Url.learn);
+    ("/learn/index.html", Url.learn);
+    ("/learn/", Url.learn);
+    ("/learn/libraries.html", Url.packages);
+    ("/learn/portability.html", Url.learn);
+    ("/learn/success.fr.html", Url.success_stories);
+    ("/learn/success.html", Url.success_stories);
+    ("/learn/taste.fr.html", Url.learn);
+    ("/learn/taste.html", Url.learn);
     ("/learn/teaching-ocaml.html", Url.academic_users);
-    ("/learn/tutorials/", Url.learn);
-    ("/learn/tutorials/index.ja.html", Url.learn);
-    ("/learn/tutorials/index.ko.html", Url.learn);
-    ("/learn/tutorials/index.it.html", Url.learn);
-    ("/learn/tutorials/index.html", Url.learn);
-    ("/learn/tutorials/index.zh.html", Url.learn);
-    ("/learn/tutorials/index.fr.html", Url.learn);
-    ("/learn/tutorials/index.de.html", Url.learn);
-    ( "/learn/tutorials/up_and_running.html",
-      Url.tutorial "up-and-running-with-ocaml" );
+    ("/learn/tutorials/99problems.html", Url.problems);
     ( "/learn/tutorials/a_first_hour_with_ocaml.html",
       Url.tutorial "a-first-hour-with-ocaml" );
-    ( "/learn/tutorials/guidelines.html",
-      Url.tutorial "ocaml-programming-guidelines" );
-    ( "/learn/tutorials/compiling_ocaml_projects.ja.html",
-      Url.tutorial "compiling-ocaml-projects" );
-    ( "/learn/tutorials/compiling_ocaml_projects.html",
-      Url.tutorial "compiling-ocaml-projects" );
-    ( "/learn/tutorials/data_types_and_matching.it.html",
-      Url.tutorial "data-types-and-matching" );
-    ( "/learn/tutorials/data_types_and_matching.fr.html",
-      Url.tutorial "data-types-and-matching" );
-    ( "/learn/tutorials/data_types_and_matching.zh.html",
-      Url.tutorial "data-types-and-matching" );
-    ( "/learn/tutorials/data_types_and_matching.ja.html",
-      Url.tutorial "data-types-and-matching" );
-    ( "/learn/tutorials/data_types_and_matching.html",
-      Url.tutorial "data-types-and-matching" );
-    ( "/learn/tutorials/functional_programming.fr.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.zh.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.it.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.ja.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/if_statements_loops_and_recursion.ko.html",
-      Url.tutorial "if-statements-loops-and-recursions" );
-    ( "/learn/tutorials/if_statements_loops_and_recursion.ja.html",
-      Url.tutorial "if-statements-loops-and-recursions" );
-    ( "/learn/tutorials/if_statements_loops_and_recursion.html",
-      Url.tutorial "if-statements-loops-and-recursions" );
-    ( "/learn/tutorials/if_statements_loops_and_recursion.fr.html",
-      Url.tutorial "if-statements-loops-and-recursions" );
-    ( "/learn/tutorials/if_statements_loops_and_recursion.zh.html",
-      Url.tutorial "if-statements-loops-and-recursions" );
-    ( "/learn/tutorials/if_statements_loops_and_recursion.it.html",
-      Url.tutorial "if-statements-loops-and-recursions" );
-    ("/learn/tutorials/modules.fr.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.zh.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.ja.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.ko.html", Url.tutorial "modules");
-    ("/learn/tutorials/labels.zh.html", Url.tutorial "labels");
-    ("/learn/tutorials/labels.ja.html", Url.tutorial "labels");
-    ("/learn/tutorials/labels.html", Url.tutorial "labels");
-    ("/learn/tutorials/pointers.zh.html", Url.tutorial "pointers-in-ocaml");
-    ("/learn/tutorials/pointers.html", Url.tutorial "pointers-in-ocaml");
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.ja.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.zh.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.fr.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.it.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ("/learn/tutorials/functors.html", Url.tutorial "functors");
-    ("/learn/tutorials/objects.ja.html", Url.tutorial "objects");
-    ("/learn/tutorials/objects.html", Url.tutorial "objects");
-    ("/learn/tutorials/objects.zh.html", Url.tutorial "objects");
-    ("/learn/tutorials/error_handling.html", Url.tutorial "error-handling");
-    ( "/learn/tutorials/common_error_messages.html",
-      Url.tutorial "common-error-messages" );
-    ( "/learn/tutorials/common_error_messages.ja.html",
-      Url.tutorial "common-error-messages" );
-    ( "/learn/tutorials/common_error_messages.zh.html",
-      Url.tutorial "common-error-messages" );
-    ( "/learn/tutorials/common_error_messages.fr.html",
-      Url.tutorial "common-error-messages" );
-    ("/learn/tutorials/debug.html", Url.tutorial "debug");
-    ("/learn/tutorials/map.html", Url.tutorial "map");
-    ("/learn/tutorials/map.ja.html", Url.tutorial "map");
-    ("/learn/tutorials/map.zh.html", Url.tutorial "map");
-    ("/learn/tutorials/map.fr.html", Url.tutorial "map");
-    ("/learn/tutorials/set.fr.html", Url.tutorial "sets");
-    ("/learn/tutorials/set.ja.html", Url.tutorial "sets");
-    ("/learn/tutorials/set.html", Url.tutorial "sets");
-    ("/learn/tutorials/set.zh.html", Url.tutorial "sets");
-    ("/learn/tutorials/hashtbl.ja.html", Url.tutorial "hashtables");
-    ("/learn/tutorials/hashtbl.html", Url.tutorial "hashtables");
-    ("/learn/tutorials/hashtbl.zh.html", Url.tutorial "hashtables");
-    ("/learn/tutorials/streams.html", Url.tutorial "streams");
-    ("/learn/tutorials/format.fr.html", Url.tutorial "format");
-    ("/learn/tutorials/format.html", Url.tutorial "format");
+    ( "/learn/tutorials/calling_c_libraries.html",
+      Url.tutorial "calling-c-libraries" );
+    ( "/learn/tutorials/calling_fortran_libraries.html",
+      Url.tutorial "calling-fortran-libraries" );
+    ("/learn/tutorials/camlp5.html", Url.learn);
     ( "/learn/tutorials/command-line_arguments.ja.html",
       Url.tutorial "command-line-arguments" );
     ( "/learn/tutorials/command-line_arguments.html",
       Url.tutorial "command-line-arguments" );
     ( "/learn/tutorials/command-line_arguments.zh.html",
       Url.tutorial "command-line-arguments" );
-    ( "/learn/tutorials/file_manipulation.zh.html",
-      Url.tutorial "file-manipulation" );
-    ("/learn/tutorials/file_manipulation.html", Url.tutorial "file-manipulation");
+    ( "/learn/tutorials/common_error_messages.fr.html",
+      Url.tutorial "common-error-messages" );
+    ( "/learn/tutorials/common_error_messages.ja.html",
+      Url.tutorial "common-error-messages" );
+    ( "/learn/tutorials/common_error_messages.html",
+      Url.tutorial "common-error-messages" );
+    ( "/learn/tutorials/common_error_messages.zh.html",
+      Url.tutorial "common-error-messages" );
+    ( "/learn/tutorials/comparison_of_standard_containers.ja.html",
+      Url.tutorial "comparison-of-standard-containers" );
+    ( "/learn/tutorials/comparison_of_standard_containers.ko.html",
+      Url.tutorial "comparison-of-standard-containers" );
+    ( "/learn/tutorials/comparison_of_standard_containers.html",
+      Url.tutorial "comparison-of-standard-containers" );
+    ( "/learn/tutorials/comparison_of_standard_containers.zh.html",
+      Url.tutorial "comparison-of-standard-containers" );
+    ( "/learn/tutorials/compiling_ocaml_projects.ja.html",
+      Url.tutorial "compiling-ocaml-projects" );
+    ( "/learn/tutorials/compiling_ocaml_projects.html",
+      Url.tutorial "compiling-ocaml-projects" );
+    ( "/learn/tutorials/data_types_and_matching.fr.html",
+      Url.tutorial "data-types-and-matching" );
+    ( "/learn/tutorials/data_types_and_matching.it.html",
+      Url.tutorial "data-types-and-matching" );
+    ( "/learn/tutorials/data_types_and_matching.ja.html",
+      Url.tutorial "data-types-and-matching" );
+    ( "/learn/tutorials/data_types_and_matching.html",
+      Url.tutorial "data-types-and-matching" );
+    ( "/learn/tutorials/data_types_and_matching.zh.html",
+      Url.tutorial "data-types-and-matching" );
+    ("/learn/tutorials/debug.html", Url.tutorial "debug");
+    ("/learn/tutorials/error_handling.html", Url.tutorial "error-handling");
     ( "/learn/tutorials/file_manipulation.ja.html",
       Url.tutorial "file-manipulation" );
-    ( "/learn/tutorials/calling_c_libraries.html",
-      Url.tutorial "calling-c-libraries" );
-    ( "/learn/tutorials/calling_fortran_libraries.html",
-      Url.tutorial "calling-fortran-libraries" );
-    ( "/learn/tutorials/garbage_collection.zh.html",
-      Url.tutorial "garbage-collection" );
+    ("/learn/tutorials/file_manipulation.html", Url.tutorial "file-manipulation");
+    ( "/learn/tutorials/file_manipulation.zh.html",
+      Url.tutorial "file-manipulation" );
+    ("/learn/tutorials/format.fr.html", Url.tutorial "format");
+    ("/learn/tutorials/format.html", Url.tutorial "format");
+    ( "/learn/tutorials/functional_programming.fr.html",
+      Url.tutorial "functional-programming" );
+    ( "/learn/tutorials/functional_programming.it.html",
+      Url.tutorial "functional-programming" );
+    ( "/learn/tutorials/functional_programming.ja.html",
+      Url.tutorial "functional-programming" );
+    ( "/learn/tutorials/functional_programming.html",
+      Url.tutorial "functional-programming" );
+    ( "/learn/tutorials/functional_programming.zh.html",
+      Url.tutorial "functional-programming" );
+    ("/learn/tutorials/functors.html", Url.tutorial "functors");
     ( "/learn/tutorials/garbage_collection.ja.html",
       Url.tutorial "garbage-collection" );
     ( "/learn/tutorials/garbage_collection.html",
       Url.tutorial "garbage-collection" );
-    ( "/learn/tutorials/performance_and_profiling_discussion.html",
-      Url.tutorial "performance-and-profiling" );
+    ( "/learn/tutorials/garbage_collection.zh.html",
+      Url.tutorial "garbage-collection" );
+    ( "/learn/tutorials/guidelines.html",
+      Url.tutorial "ocaml-programming-guidelines" );
+    ("/learn/tutorials/hashtbl.ja.html", Url.tutorial "hashtables");
+    ("/learn/tutorials/hashtbl.html", Url.tutorial "hashtables");
+    ("/learn/tutorials/hashtbl.zh.html", Url.tutorial "hashtables");
+    ("/learn/tutorials/humor_proof.html", Url.learn);
+    ( "/learn/tutorials/if_statements_loops_and_recursion.fr.html",
+      Url.tutorial "if-statements-loops-and-recursions" );
+    ( "/learn/tutorials/if_statements_loops_and_recursion.it.html",
+      Url.tutorial "if-statements-loops-and-recursions" );
+    ( "/learn/tutorials/if_statements_loops_and_recursion.ja.html",
+      Url.tutorial "if-statements-loops-and-recursions" );
+    ( "/learn/tutorials/if_statements_loops_and_recursion.ko.html",
+      Url.tutorial "if-statements-loops-and-recursions" );
+    ( "/learn/tutorials/if_statements_loops_and_recursion.html",
+      Url.tutorial "if-statements-loops-and-recursions" );
+    ( "/learn/tutorials/if_statements_loops_and_recursion.zh.html",
+      Url.tutorial "if-statements-loops-and-recursions" );
+    ("/learn/tutorials/index.de.html", Url.learn);
+    ("/learn/tutorials/index.fr.html", Url.learn);
+    ("/learn/tutorials/index.it.html", Url.learn);
+    ("/learn/tutorials/index.ja.html", Url.learn);
+    ("/learn/tutorials/index.ko.html", Url.learn);
+    ("/learn/tutorials/index.html", Url.learn);
+    ("/learn/tutorials/", Url.learn);
+    ("/learn/tutorials/index.zh.html", Url.learn);
+    ("/learn/tutorials/introduction_to_gtk.html", Url.learn);
+    ("/learn/tutorials/labels.ja.html", Url.tutorial "labels");
+    ("/learn/tutorials/labels.html", Url.tutorial "labels");
+    ("/learn/tutorials/labels.zh.html", Url.tutorial "labels");
+    ("/learn/tutorials/lists.html", Url.tutorial "lists");
+    ("/learn/tutorials/map.fr.html", Url.tutorial "map");
+    ("/learn/tutorials/map.ja.html", Url.tutorial "map");
+    ("/learn/tutorials/map.html", Url.tutorial "map");
+    ("/learn/tutorials/map.zh.html", Url.tutorial "map");
+    ("/learn/tutorials/modules.fr.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.ja.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.ko.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.zh.html", Url.tutorial "modules");
+    ( "/learn/tutorials/null_pointers_asserts_and_warnings.fr.html",
+      Url.tutorial "null-pointers-asserts-and-warnings" );
+    ( "/learn/tutorials/null_pointers_asserts_and_warnings.it.html",
+      Url.tutorial "null-pointers-asserts-and-warnings" );
+    ( "/learn/tutorials/null_pointers_asserts_and_warnings.ja.html",
+      Url.tutorial "null-pointers-asserts-and-warnings" );
+    ( "/learn/tutorials/null_pointers_asserts_and_warnings.html",
+      Url.tutorial "null-pointers-asserts-and-warnings" );
+    ( "/learn/tutorials/null_pointers_asserts_and_warnings.zh.html",
+      Url.tutorial "null-pointers-asserts-and-warnings" );
+    ("/learn/tutorials/objects.ja.html", Url.tutorial "objects");
+    ("/learn/tutorials/objects.html", Url.tutorial "objects");
+    ("/learn/tutorials/objects.zh.html", Url.tutorial "objects");
     ( "/learn/tutorials/performance_and_profiling.ja.html",
-      Url.tutorial "performance-and-profiling" );
-    ( "/learn/tutorials/comparison_of_standard_containers.html",
-      Url.tutorial "performance-and-profiling" );
-    ( "/learn/tutorials/comparison_of_standard_containers.zh.html",
       Url.tutorial "performance-and-profiling" );
     ( "/learn/tutorials/performance_and_profiling.html",
       Url.tutorial "performance-and-profiling" );
-    ( "/learn/tutorials/comparison_of_standard_containers.ko.html",
-      Url.tutorial "comparison-of-standard-containers" );
-    ( "/learn/tutorials/comparison_of_standard_containers.ja.html",
-      Url.tutorial "comparison-of-standard-containers" );
-    ("/learn/tutorials/camlp5.html", Url.learn);
-    ("/learn/tutorials/lists.html", Url.tutorial "lists");
-    ("/learn/tutorials/humor_proof.html", Url.learn);
-    ("/learn/tutorials/introduction_to_gtk.html", Url.learn);
-    ("/learn/tutorials/99problems.html", Url.problems);
-    ("/learn/libraries.html", Url.books);
-    ("/learn/books.html", Url.books);
-    ("/learn/portability.html", "/");
-    ("/learn/success.fr.html", Url.success_stories);
-    ("/consortium/", "/");
-    ("/consortium/index.html", "/");
-    ("/consortium/index.fr.html", "/");
-    ("/contributors.fr.html", "/");
-    ("/platform/", "/learn/platform");
-    ("/platform/index.html", "/learn/platform");
-    ("/platform/ocaml_on_windows.html", "/learn/ocaml-on-windows");
-    ("/governance.html", "/governance");
-    ("/docs/license.fr.html", "/");
-    ("/docs/license.html", "/");
-    ("/docs/logos.html", "/");
-    ("/docs/install.html", "/");
-    ("/docs/consortium-license.html", "/");
-    ("/docs/consortium-license.fr.html", "/");
-    ("/docs/", "/");
-    ("/docs/index.html", "/");
-    ("/docs/index.fr.html", "/");
-    ("/docs/install.fr.html", "/");
-    ("/docs/cheat_sheets.html", "/");
-    ("/docs/papers.html", Url.papers);
-    ("/index.html", Url.index);
-    ("/index.fr.html", Url.index);
-    ("/contributors.html", Url.index);
-    ("/ocamllabs/index.html", "/");
-    ("/about.fr.html", Url.about);
-    ( "/meetings/ocaml/2013/program.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2013" );
-    ( "/meetings/ocaml/2013/talks/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2013" );
-    ( "/meetings/ocaml/2013/call.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2013" );
-    ( "/meetings/ocaml/2013/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2013" );
-    ( "/meetings/ocaml/2014/program.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2014" );
-    ( "/meetings/ocaml/2014/ocaml2014_10.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2014" );
-    ( "/meetings/ocaml/2014/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2014" );
-    ( "/meetings/ocaml/2014/cfp.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2014" );
-    ( "/meetings/ocaml/2015/program.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2015" );
-    ( "/meetings/ocaml/2015/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2015" );
-    ( "/meetings/ocaml/2015/cfp.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2015" );
-    ( "/meetings/ocaml/2012/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2012" );
+    ( "/learn/tutorials/performance_and_profiling_discussion.html",
+      Url.tutorial "performance-and-profiling" );
+    ("/learn/tutorials/pointers.html", Url.tutorial "pointers-in-ocaml");
+    ("/learn/tutorials/pointers.zh.html", Url.tutorial "pointers-in-ocaml");
+    ("/learn/tutorials/set.fr.html", Url.tutorial "sets");
+    ("/learn/tutorials/set.ja.html", Url.tutorial "sets");
+    ("/learn/tutorials/set.html", Url.tutorial "sets");
+    ("/learn/tutorials/set.zh.html", Url.tutorial "sets");
+    ("/learn/tutorials/streams.html", Url.tutorial "streams");
+    ( "/learn/tutorials/up_and_running.html",
+      Url.tutorial "up-and-running-with-ocaml" );
+    ("/meetings/index.fr.html", Url.community);
+    ("/meetings/index.html", Url.community);
+    ("/meetings/", Url.community);
     ( "/meetings/ocaml/2008/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2008" );
+    ( "/meetings/ocaml/2008/",
+      Url.workshop "ocaml-users-and-developers-workshop-2008" );
+    ( "/meetings/ocaml/2008/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2008" );
+    ( "/meetings/ocaml/2008/",
       Url.workshop "ocaml-users-and-developers-workshop-2008" );
     ( "/meetings/ocaml/2009/index.html",
       Url.workshop "ocaml-users-and-developers-workshop-2009" );
-    ( "/meetings/ocaml/2017/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2017" );
+    ( "/meetings/ocaml/2009/",
+      Url.workshop "ocaml-users-and-developers-workshop-2009" );
     ( "/meetings/ocaml/2010/index.html",
       Url.workshop "ocaml-users-and-developers-workshop-2010" );
+    ( "/meetings/ocaml/2010/",
+      Url.workshop "ocaml-users-and-developers-workshop-2010" );
+    ( "/meetings/ocaml/2011/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2011" );
+    ( "/meetings/ocaml/2011/",
+      Url.workshop "ocaml-users-and-developers-workshop-2011" );
+    ( "/meetings/ocaml/2012/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2012" );
+    ( "/meetings/ocaml/2013/call.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2013" );
+    ( "/meetings/ocaml/2013/",
+      Url.workshop "ocaml-users-and-developers-workshop-2013" );
+    ( "/meetings/ocaml/2013/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2013" );
+    ( "/meetings/ocaml/2013/program.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2013" );
+    ( "/meetings/ocaml/2013/",
+      Url.workshop "ocaml-users-and-developers-workshop-2013" );
+    ( "/meetings/ocaml/2013/talks/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2013" );
+    ( "/meetings/ocaml/2014/cfp.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2014" );
+    ( "/meetings/ocaml/2014/",
+      Url.workshop "ocaml-users-and-developers-workshop-2014" );
+    ( "/meetings/ocaml/2014/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2014" );
+    ( "/meetings/ocaml/2014/ocaml2014_10.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2014" );
+    ( "/meetings/ocaml/2014/program.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2014" );
+    ( "/meetings/ocaml/2015/cfp.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/program.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/program.txt",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2015/",
+      Url.workshop "ocaml-users-and-developers-workshop-2015" );
+    ( "/meetings/ocaml/2016/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2016" );
+    ( "/meetings/ocaml/2016/",
+      Url.workshop "ocaml-users-and-developers-workshop-2016" );
+    ( "/meetings/ocaml/2017/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2017" );
+    ( "/meetings/ocaml/2017/",
+      Url.workshop "ocaml-users-and-developers-workshop-2017" );
+    ( "/meetings/ocaml/2018/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2018" );
+    ( "/meetings/ocaml/2018/",
+      Url.workshop "ocaml-users-and-developers-workshop-2018" );
     ( "/meetings/ocaml/2019/index.html",
+      Url.workshop "ocaml-users-and-developers-workshop-2019" );
+    ( "/meetings/ocaml/2019/",
       Url.workshop "ocaml-users-and-developers-workshop-2019" );
     ( "/meetings/ocaml/2020/index.html",
       Url.workshop "ocaml-users-and-developers-workshop-2020" );
-    ( "/meetings/ocaml/2018/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2018" );
-    ( "/meetings/ocaml/2011/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2011" );
-    ( "/meetings/ocaml/2016/index.html",
-      Url.workshop "ocaml-users-and-developers-workshop-2016" );
-    ("/meetings/index.html", Url.community);
-    ("/meetings/index.fr.html", Url.community);
-    ("/community/planet/index.html", Url.community);
-    ("/community/planet/older.html", Url.community);
-    ("/community/planet/syndication.html", Url.community);
-    ("/community/mailing_lists.fr.html", Url.community);
-    ("/community/planet.html", Url.community);
-    ("/community/support.fr.html", Url.community);
-    ("/community/cwn/index.html", Url.community);
-    ("/community/announcements/CompCert_award.html", Url.community);
-    ("/community/support.html", Url.community);
-    ("/community/index.html", Url.community);
-    ("/community/index.fr.html", Url.community);
-    ("/community/history/forge.html", Url.community);
-    ("/community/media.html", Url.community);
-    ("/community/mailing_lists.html", Url.community);
-    ("/about.html", Url.about);
-    ("/caml-light/license.html", "/");
-    ("/caml-light/releases/0.75.html", "/");
-    ("/caml-light/releases/index.html", "/");
-    ("/caml-light/faq.html", "/");
-    ("/caml-light/index.html", "/");
+    ( "/meetings/ocaml/2020/",
+      Url.workshop "ocaml-users-and-developers-workshop-2020" );
+    ("/meetings/ocaml/index.html", Url.community);
+    ("/meetings/ocaml/", Url.community);
+    ("/ocamllabs/index.html", Url.index);
+    ("/ocamllabs/", Url.index);
+    ("/platform/index.html", Url.platform);
+    ("/platform/", Url.platform);
+    ("/platform/ocaml_on_windows.html", Url.ocaml_on_windows);
+    ("/releases/3.12.1.html", Url.release "3.12.1");
+    ("/releases/4.00.1.html", Url.release "4.00.1");
+    ("/releases/4.01.0.fr.html", Url.release "4.01.0");
+    ("/releases/4.01.0.html", Url.release "4.01.0");
+    ("/releases/4.02.0.html", Url.release "4.02.0");
+    ("/releases/4.02.1.html", Url.release "4.02.1");
+    ("/releases/4.02.2.html", Url.release "4.02.2");
+    ("/releases/4.02.3.html", Url.release "4.02.3");
+    ("/releases/4.02.html", Url.release "4.02.0");
+    ("/releases/4.03.0.html", Url.release "4.03.0");
+    ("/releases/4.03.html", Url.release "4.03.0");
+    ("/releases/4.04.0.html", Url.release "4.04.0");
+    ("/releases/4.04.1.html", Url.release "4.04.1");
+    ("/releases/4.04.2.html", Url.release "4.04.2");
+    ("/releases/4.04.html", Url.release "4.04.0");
+    ("/releases/4.05.0.html", Url.release "4.05.0");
+    ("/releases/4.05.html", Url.release "4.05.0");
+    ("/releases/4.06.0.html", Url.release "4.06.0");
+    ("/releases/4.06.1.html", Url.release "4.06.1");
+    ("/releases/4.06.html", Url.release "4.06.0");
+    ("/releases/4.07.0.html", Url.release "4.07.0");
+    ("/releases/4.07.1.html", Url.release "4.07.1");
+    ("/releases/4.08.0.html", Url.release "4.08.0");
+    ("/releases/4.08.1.html", Url.release "4.08.1");
+    ("/releases/4.09.0.html", Url.release "4.09.0");
+    ("/releases/4.09.1.html", Url.release "4.09.1");
+    ("/releases/4.10.0.html", Url.release "4.10.0");
+    ("/releases/4.10.1.html", Url.release "4.10.1");
+    ("/releases/4.10.2.html", Url.release "4.10.2");
+    ("/releases/4.11.0.html", Url.release "4.11.0");
+    ("/releases/4.11.1.html", Url.release "4.11.1");
+    ("/releases/4.11.2.html", Url.release "4.11.2");
+    ("/releases/4.12.0.html", Url.release "4.12.0");
+    ("/releases/4.12.1.html", Url.release "4.12.1");
+    ("/releases/4.13.0.html", Url.release "4.13.0");
+    ("/releases/4.13.1.html", Url.release "4.13.1");
+    ("/releases/caml-light/faq.html", Url.index);
+    ("/releases/caml-light/index.html", Url.index);
+    ("/releases/caml-light/", Url.index);
+    ("/releases/caml-light/license.html", Url.index);
+    ("/releases/caml-light/releases/0.75.html", Url.index);
+    ("/releases/index.fr.html", Url.releases);
+    ("/releases/index.html", Url.releases);
+    ("/releases/", Url.releases);
+    ("/releases/latest/index.html", Url.release "4.13.1");
+    ("/releases/latest/manual.html", Url.manual_with_version "4.13.1");
   ]
 
-(* TODO: Change to v2ocaml.org when deploy on ocaml.org *)
+let redirect_p pattern =
+  let handler req =
+    let target = Dream.target req in
+    Dream.redirect req ("https://v2.ocaml.org" ^ target)
+  in
+  Dream.get pattern handler
+
+let fwd_v2 origin =
+  Dream.get origin (fun req ->
+      Dream.redirect req ("https://v2.ocaml.org" ^ origin))
+
 let manual =
   [
-    (Url.manual, "https://ocaml.org/manual/");
-    ( Url.manual_with_version "3.12.1",
-      "https://ocaml.org/releases/3.12/manual/index.html" );
-    ( Url.manual_with_version "4.00.1",
-      "https://ocaml.org/releases/4.00/manual/index.html" );
-    ( Url.manual_with_version "4.01.0",
-      "https://ocaml.org/releases/4.01/manual/index.html" );
-    ( Url.manual_with_version "4.02.3",
-      "https://ocaml.org/releases/4.02/manual/index.html" );
-    ( Url.manual_with_version "4.03.0",
-      "https://ocaml.org/releases/4.03/manual/index.html" );
-    ( Url.manual_with_version "4.04.0",
-      "https://ocaml.org/releases/4.04/manual/index.html" );
-    ( Url.manual_with_version "4.05.0",
-      "https://ocaml.org/releases/4.05/manual/index.html" );
-    ( Url.manual_with_version "4.06.0",
-      "https://ocaml.org/releases/4.06/manual/index.html" );
-    ( Url.manual_with_version "4.06.1",
-      "https://ocaml.org/releases/4.06/manual/index.html" );
-    ( Url.manual_with_version "4.07.0",
-      "https://ocaml.org/releases/4.07/manual/index.html" );
-    ( Url.manual_with_version "4.07.1",
-      "https://ocaml.org/releases/4.07/manual/index.html" );
-    ( Url.manual_with_version "4.08.0",
-      "https://ocaml.org/releases/4.08/manual/index.html" );
-    ( Url.manual_with_version "4.08.1",
-      "https://ocaml.org/releases/4.08/manual/index.html" );
-    ( Url.manual_with_version "4.09.0",
-      "https://ocaml.org/releases/4.09/manual/index.html" );
-    ( Url.manual_with_version "4.09.1",
-      "https://ocaml.org/releases/4.09/manual/index.html" );
-    ( Url.manual_with_version "4.10.0",
-      "https://ocaml.org/releases/4.10/manual/index.html" );
-    ( Url.manual_with_version "4.10.1",
-      "https://ocaml.org/releases/4.10/manual/index.html" );
-    ( Url.manual_with_version "4.10.2",
-      "https://ocaml.org/releases/4.10/manual/index.html" );
-    ( Url.manual_with_version "4.11.0",
-      "https://ocaml.org/releases/4.11/manual/index.html" );
-    ( Url.manual_with_version "4.11.1",
-      "https://ocaml.org/releases/4.11/manual/index.html" );
-    ( Url.manual_with_version "4.11.2",
-      "https://ocaml.org/releases/4.11/manual/index.html" );
-    ( Url.manual_with_version "4.12.0",
-      "https://ocaml.org/releases/4.12/manual/index.html" );
-    ( Url.manual_with_version "4.12.1",
-      "https://ocaml.org/releases/4.12/manual/index.html" );
-    ( Url.manual_with_version "4.13.0",
-      "https://ocaml.org/releases/4.13/manual/index.html" );
-    ( Url.manual_with_version "4.13.1",
-      "https://ocaml.org/releases/4.13/manual/index.html" );
+    redirect_p "/api/**";
+    fwd_v2 "/api/";
+    redirect_p "/manual/**";
+    fwd_v2 "/manual/";
+    redirect_p "/releases/3.12/htmlman/**";
+    fwd_v2 "/releases/3.12/htmlman/";
+    redirect_p "/releases/4.00/htmlman/**";
+    fwd_v2 "/releases/4.00/htmlman/";
+    redirect_p "/releases/4.01/htmlman/**";
+    fwd_v2 "/releases/4.01/htmlman/";
+    redirect_p "/releases/4.02/htmlman/**";
+    fwd_v2 "/releases/4.02/htmlman/";
+    redirect_p "/releases/4.03/htmlman/**";
+    fwd_v2 "/releases/4.03/htmlman/";
+    redirect_p "/releases/4.04/htmlman/**";
+    fwd_v2 "/releases/4.04/htmlman/";
+    redirect_p "/releases/4.05/htmlman/**";
+    fwd_v2 "/releases/4.05/htmlman/";
+    redirect_p "/releases/4.06/htmlman/**";
+    fwd_v2 "/releases/4.06/htmlman/";
+    redirect_p "/releases/4.07/htmlman/**";
+    fwd_v2 "/releases/4.07/htmlman/";
+    redirect_p "/releases/4.08/htmlman/**";
+    fwd_v2 "/releases/4.08/htmlman/";
+    redirect_p "/releases/4.09/htmlman/**";
+    fwd_v2 "/releases/4.09/htmlman/";
+    redirect_p "/releases/4.10/htmlman/**";
+    fwd_v2 "/releases/4.10/htmlman/";
+    redirect_p "/releases/4.11/htmlman/**";
+    fwd_v2 "/releases/4.11/htmlman/";
+    redirect_p "/releases/4.12/api/**";
+    fwd_v2 "/releases/4.12/api/";
+    redirect_p "/releases/4.12/htmlman/**";
+    fwd_v2 "/releases/4.12/htmlman/";
+    redirect_p "/releases/4.12/manual/**";
+    fwd_v2 "/releases/4.12/manual/";
+    redirect_p "/releases/4.13/api/**";
+    fwd_v2 "/releases/4.13/api/";
+    redirect_p "/releases/4.13/htmlman/**";
+    fwd_v2 "/releases/4.13/htmlman/";
+    redirect_p "/releases/4.13/manual/**";
+    fwd_v2 "/releases/4.13/manual/";
   ]
+
+let make ?(permanant = false) t =
+  let status = if permanant then `Moved_Permanently else `See_Other in
+  Dream.scope ""
+    [ Dream_encoding.compress ]
+    (List.filter_map
+       (fun (origin, new_) ->
+         if origin = new_ then None
+         else
+           Some (Dream.get origin (fun req -> Dream.redirect ~status req new_)))
+       t)
+
+let t =
+  Dream.scope "" []
+    [
+      make from_v2;
+      make v2_assets;
+      Dream.scope "" [ Dream_encoding.compress ] manual;
+    ]

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -43,17 +43,6 @@ let toplevel_loader =
       in
       Ok (days, ps))
 
-let redirect s req = Dream.redirect req s
-
-let redirection_routes ?(permanant = false) t =
-  let status = if permanant then `Moved_Permanently else `See_Other in
-  Dream.scope ""
-    [ Dream_encoding.compress ]
-    (List.map
-       (fun (origin, new_) ->
-         Dream.get origin (fun req -> Dream.redirect ~status req new_))
-       t)
-
 let page_routes =
   Dream.scope ""
     [
@@ -131,11 +120,10 @@ let graphql_route t =
 let router t =
   Dream.router
     [
+      Redirection.t;
       page_routes;
       package_route t;
       graphql_route t;
-      redirection_routes Redirection.from_v2;
-      redirection_routes Redirection.manual;
       Dream.scope ""
         [ Dream_encoding.compress ]
         [


### PR DESCRIPTION
This PR implements a complete redirection router for v2.ocaml.org URLs.

The router behaves as follow:

- The `{img/,css/,js/}` URLs are not handled
- All the other asset routes (e.g. `/meetings/ocaml/2013/proposals/core-bench.pdf`) are redirected to `v2.ocaml.org`.
- All the `manual`, `htmlman` and `api` routes are redirected to `v2.ocaml.org`
- All the other routes, if they are not the same, are redirected to the equivalent page on v3.

I have been testing this by navigating to random pages on different parts of the website (standard pages, manual, releases, api, etc) and copying the v2 URL in V3. This seems to work correctly.

I've also made sure that the site is functioning properly on v2.ocaml.org and that the hardcoded links containing the domain name (`https://ocaml.org/**`) point to the right page on V3.