### PR TITLE
OCaml 4.14.0 release page

### DIFF
--- a/data/releases/4.14.0.md
+++ b/data/releases/4.14.0.md
@@ -1,0 +1,682 @@
+---
+kind: compiler
+version: 4.14.0
+date: 2022-03-28
+intro: >
+
+This page describes OCaml version **4.14.0**, released on
+2022-03-28.  Go [here](./) for a list of all releases.
+
+This release is available as an
+[opam](p/ocaml/4.14.0) package.
+
+highlights: >
+
+Some of the highlights in OCaml 4.14.0 are:
+
+- Integrated support for "go to definitions" in Merlin.
+- Standard library: new modules In_channel and Out_channel,
+  many new functions in Seq module, UTF decoding and validation support
+  for strings and bytes.
+- Runtime optimisation: GC prefetching. Benchmarks show a speedup of around 20%
+  in GC-heavy programs.
+- Improved error messages in particular for module-level error.
+- Deprecated functions and modules in preparation for OCaml 5.
+  In particular, the Stream and Genlex modules are now deprecated.
+- Type variables can be explicitly introduced in value and variant constructor
+  declarations. For instance,
+```ocaml
+    val fold: ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
+    type showable = Show: 'a * ('a -> string) -> showable
+```
+can now be written as
+```ocaml
+    val fold: 'acc 'elt. ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
+    type showable = Show: 'a. 'a * ('a -> string) -> showable
+```
+- Tail-call with up to 64 arguments are now guaranteed to be optimized
+  for all architectures.
+- Experimental tail modulo cons (TMC) transformation
+---
+
+## What's new
+
+Some of the highlights in OCaml 4.14.0 are:
+
+- Integrated support for "go to definitions" in Merlin.
+- Standard library: new modules In_channel and Out_channel,
+  many new functions in Seq module, UTF decoding and validation support
+  for strings and bytes.
+- Runtime optimisation: GC prefetching. Benchmarks show a speedup of around 20%
+  in GC-heavy programs.
+- Improved error messages in particular for module-level error.
+- Deprecated functions and modules in preparation for OCaml 5.
+  In particular, the Stream and Genlex modules are now deprecated.
+- Type variables can be explicitly introduced in value and variant constructor
+  declarations. For instance,
+```ocaml
+    val fold: ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
+    type showable = Show: 'a * ('a -> string) -> showable
+```
+can now be written as
+```ocaml
+    val fold: 'acc 'elt. ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
+    type showable = Show: 'a. 'a * ('a -> string) -> showable
+```
+- Tail-call with up to 64 arguments are now guaranteed to be optimized
+  for all architectures.
+- Experimental tail modulo cons (TMC) transformation
+
+For a comprehensive list of changes and details on all new features,
+bug fixes, optimizations, etc., please consult the
+[changelog](#Changes).
+
+Configuration options
+---------------------
+
+The configuration of the installed opam switch can be tuned with the
+following options:
+
+- ocaml-option-32bit: set OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts
+- ocaml-option-afl: set OCaml to be compiled with afl-fuzz instrumentation
+- ocaml-option-bytecode-only: compile OCaml without the native-code compiler
+- ocaml-option-default-unsafe-string: set OCaml to be compiled without safe strings by default
+- ocaml-option-flambda: set OCaml to be compiled with flambda activated
+- ocaml-option-fp: set OCaml to be compiled with frame-pointers enabled
+- ocaml-option-musl: set OCaml to be compiled with musl-gcc
+- ocaml-option-nnp : set OCaml to be compiled with --disable-naked-pointers
+- ocaml-option-nnpchecker: set OCaml to be compiled with --enable-naked-pointers-checker
+- ocaml-option-no-flat-float-array: set OCaml to be compiled with --disable-flat-float-array
+- ocaml-option-static :set OCaml to be compiled with musl-gcc -static
+
+For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with
+
+```
+opam switch create 4.14.0+flambda+nnpchecker --package=ocaml-variants.4.14.0+options,ocaml-option-flambda,ocaml-option-nnpchecker
+```
+
+or with opam 2.1:
+
+```
+opam switch create 4.14.0+flambda+nnpchecker ocaml-variants.4.14.0+options ocaml-option-flambda ocaml-option-nnpchecker
+```
+
+
+![](../img/source.gif "") Source distribution
+---------------------------------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and MacOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.14.0.zip)
+  format.
+- [OPAM](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](4.14/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions — see also the [Windows release
+notes](4.14/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+Alternative Compilers
+---------------------
+
+Additionally, the following projects allow you to compile OCaml code to
+targets traditionally associated with other languages:
+
+* [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
+  to JavaScript compiler.
+
+![](../img/doc.gif "") User's manual
+------------------------------------
+
+The user's manual for OCaml can be:
+
+- [browsed
+  online](4.14/manual/index.html),
+- downloaded as a single
+  [PDF](4.14/ocaml-4.14-refman.pdf),
+  or [plain
+  text](4.14/ocaml-4.14-refman.txt)
+  document,
+- downloaded as a single
+  [TAR](4.14/ocaml-4.14-refman-html.tar.gz)
+  or
+  [ZIP](4.14/ocaml-4.14-refman-html.zip)
+  archive of HTML files,
+- downloaded as a single
+  [tarball](4.14/ocaml-4.14-refman.info.tar.gz)
+  of Emacs info files,
+
+
+
+## Changes
+
+This is the
+[changelog](https://v2.ocaml.org/releases/4.14/notes/Changes).
+(Changes that can break existing programs are marked with a  "breaking change" warning)
+
+
+### Language features (highlights):
+
+- [#10437](https://github.com/ocaml/ocaml/issues/10437): Allow explicit binders for type variables.
+  (Stephen Dolan, review by Leo White)
+
+- [#181](https://github.com/ocaml/ocaml/issues/181), [#9760](https://github.com/ocaml/ocaml/issues/9760), [#10740](https://github.com/ocaml/ocaml/issues/10740): opt-in tail-modulo-cons (TMC) transformation
+    let[@tail_mod_cons] rec map f li = ...
+  (Frédéric Bour, Gabriel Scherer, Basile Clément,
+   review by Basile Clément and Pierre Chambart,
+   tested by Konstantin Romanov)
+
+### Runtime system (highlights):
+
+- [#10195](https://github.com/ocaml/ocaml/issues/10195), [#10680](https://github.com/ocaml/ocaml/issues/10680): Speed up GC by prefetching during marking
+  (Stephen Dolan, review by Xavier Leroy, Guillaume Munch-Maccagnoni,
+   Jacques-Henri Jourdan, Damien Doligez and Leo White)
+
+### Code generation and optimizations (highlights):
+
+- [#10595](https://github.com/ocaml/ocaml/issues/10595): Tail calls with up to 64 arguments are guaranteed to be compiled
+  as tail calls.  To this end, memory locations in the domain state
+  are used for passing arguments that do not fit in registers.
+  (Xavier Leroy, review by Vincent Laviron)
+
+### Standard library (highlights):
+
+* (*breaking change*) [#10710](https://github.com/ocaml/ocaml/issues/10710): Add UTF tools, codecs and validations to the Uchar, Bytes and
+  String modules.
+  (Daniel Bünzli, review by Florian Angeletti, Nicolás Ojeda Bär, Alain
+   Frisch and Gabriel Scherer)
+
+* (*breaking change*) [#10482](https://github.com/ocaml/ocaml/issues/10482): mark the Stream and Genlex modules as deprecated, in preparation
+  for a future removal.  These modules (without deprecation alert)
+  are now provided by the camlp-streams library.
+  (Xavier Leroy, review by Nicolás Ojeda Bär)
+
+- [#10545](https://github.com/ocaml/ocaml/issues/10545): Add In_channel and Out_channel modules.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli, Simon Cruanes, Gabriel Scherer,
+  Guillaume Munch-Maccagnoni, Alain Frisch and Xavier Leroy)
+
+### Compiler user-interface and warnings (highlights)
+
+- [#10328](https://github.com/ocaml/ocaml/issues/10328), [#10780](https://github.com/ocaml/ocaml/issues/10780): Give more precise error when disambiguation could not
+  possibly work.
+  (Leo White, review by Gabriel Scherer and Florian Angeletti)
+
+- [#10361](https://github.com/ocaml/ocaml/issues/10361): Improve error messages for mismatched record and variant
+  definitions.
+  (Florian Angeletti, review by Gabriel Radanne and Gabriel Scherer)
+
+- [#10407](https://github.com/ocaml/ocaml/issues/10407): Produce more detailed error messages that contain full error traces
+  when module inclusion fails.
+  (Antal Spector-Zabusky, review by Florian Angeletti)
+
+### Internal/compiler-libs changes (highlights):
+
+- [#10718](https://github.com/ocaml/ocaml/issues/10718), [#11012](https://github.com/ocaml/ocaml/issues/11012): Add "Shape" information to the cmt files. Shapes are an
+  abstraction of modules that can be used by external tooling to perform
+  definition-aware operations.
+  (Ulysse Gérard, Thomas Refis and Leo White, review by Florian Angeletti)
+
+
+### Language features:
+
+- [#10462](https://github.com/ocaml/ocaml/issues/10462): Add attribute to produce a compiler error for polls.
+  (Sadiq Jaffer, review by Mark Shinwell, Stephen Dolan
+   and Guillaume Munch-Maccagnoni)
+
+- [#10441](https://github.com/ocaml/ocaml/issues/10441): Remove unnecessary parentheses surrounding immediate objects.
+  Allow 'object ... end # f', 'f object ... end', etc.
+  (Yan Dong, review by Nicolás Ojeda Bär, Florian Angeletti and Gabriel Scherer)
+
+### Runtime system:
+
+* (*breaking change*) [#9391](https://github.com/ocaml/ocaml/issues/9391), [#9424](https://github.com/ocaml/ocaml/issues/9424): Fix failed assertion in runtime due to ephemerons *set_* and
+  *blit_* function during Mark phase
+  (François Bobot, reported by Stephen Dolan, reviewed by Damien Doligez)
+
+- [#10549](https://github.com/ocaml/ocaml/issues/10549): Stack overflow detection and naked pointers checking for ARM64
+  (Xavier Leroy, review by Stephen Dolan)
+
+* (*breaking change*) [#10675](https://github.com/ocaml/ocaml/issues/10675), [#10937](https://github.com/ocaml/ocaml/issues/10937): Emit deprecation warnings when old C runtime function names
+  are used.  This will break C stub code that uses these old names and
+  treats warnings as errors.  The workaround is to use the new names.
+  (Xavier Leroy and David Allsopp, review by Sébastien Hinderer and
+   Damien Doligez)
+
+- [#10698](https://github.com/ocaml/ocaml/issues/10698), [#10726](https://github.com/ocaml/ocaml/issues/10726), [#10891](https://github.com/ocaml/ocaml/issues/10891): Free the alternate signal stack when the main OCaml
+   code or an OCaml thread stops
+  (Xavier Leroy, review by David Allsopp and Damien Doligez)
+
+- [#10730](https://github.com/ocaml/ocaml/issues/10730), 10731: Fix bug in `Obj.reachable_words` causing a slowdown when called
+  multiple time (Alain Frisch, report by ygrek, review by Xavier Leroy)
+
+### Code generation and optimizations:
+
+- [#10578](https://github.com/ocaml/ocaml/issues/10578): Increase the number of integer registers used for
+  parameter passing on PowerPC (16 registers) and on s390x (8 registers).
+  (Xavier Leroy, review by Mark Shinwell)
+
+- [#10591](https://github.com/ocaml/ocaml/issues/10591), [#10615](https://github.com/ocaml/ocaml/issues/10615): Tune the heuristic for CSE of integer constants
+  so as to avoid excessive CSE on compiler-generated constants
+  and long register allocation times.
+  (Xavier Leroy, report by Edwin Török, review by Nicolás Ojeda Bär)
+
+- [#10681](https://github.com/ocaml/ocaml/issues/10681): Enforce boolean conditions for the native backend
+  (Vincent Laviron, review by Gabriel Scherer)
+
+- [#10719](https://github.com/ocaml/ocaml/issues/10719): Ensure that build_apply respects Lambda.max_arity
+  (Stephen Dolan, review by Xavier Leroy)
+
+- [#10728](https://github.com/ocaml/ocaml/issues/10728): Ensure that functions are evaluated after their arguments
+  (Stephen Dolan, review by Mark Shinwell)
+
+- [#10732](https://github.com/ocaml/ocaml/issues/10732): Ensure right-to-left evaluation of arguments in cmm_helpers
+  (Greta Yorsh, review by Xavier Leroy)
+
+### Standard library:
+
+* (*breaking change*) [#10622](https://github.com/ocaml/ocaml/issues/10622): Annotate `Uchar.t` with immediate attribute
+  (Hongbo Zhang, reivew by Gabriel Scherer and Nicolás Ojeda Bär)
+
+* (*breaking change*) [#7812](https://github.com/ocaml/ocaml/issues/7812), [#10475](https://github.com/ocaml/ocaml/issues/10475): `Filename.chop_suffix name suff` now checks that `suff`
+  is actually a suffix of `name` and raises Invalid_argument otherwise.
+  (Xavier Leroy, report by whitequark, review by David Allsopp)
+
+- [#10526](https://github.com/ocaml/ocaml/issues/10526): add Random.bits32, Random.bits64, Random.nativebits
+  (Xavier Leroy, review by Gabriel Scherer and François Bobot)
+
+* (*breaking change*) [#10568](https://github.com/ocaml/ocaml/issues/10568): remove Obj.marshal and Obj.unmarshal
+  (these functions have been deprecated for a while and are superseded
+   by the functions from module Marshal)
+  (François Pottier, review by Gabriel Scherer and Kate Deplaix)
+
+- [#10538](https://github.com/ocaml/ocaml/issues/10538): add Out_channel.set_buffered and Out_channel.is_buffered to control
+  the buffering mode of output channels.
+  (Nicolás Ojeda Bär, review by John Whitington, Daniel Bünzli, David Allsopp
+  and Xavier Leroy)
+
+* (*breaking change*) [#10583](https://github.com/ocaml/ocaml/issues/10583), [#10998](https://github.com/ocaml/ocaml/issues/10998): Add over 40 new functions in Seq.
+  (François Pottier and Simon Cruanes, review by Nicolás Ojeda Bär,
+  Daniel Bünzli, Naëla Courant, Craig Ferguson, Wiktor Kuchta,
+  Xavier Leroy, Guillaume Munch-Maccagnoni, Raphaël Proust, Gabriel Scherer
+  and Thierry Martinez)
+
+- [#10596](https://github.com/ocaml/ocaml/issues/10596), [#10978](https://github.com/ocaml/ocaml/issues/10978): Add with_open_bin, with_open_text and with_open_gen to
+  In_channel and Out_channel. Also, add In_channel.input_all.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli, Jérémie Dimino, Damien Doligez
+  and Xavier Leroy)
+
+- [#10658](https://github.com/ocaml/ocaml/issues/10658): add detailed information about the current version of OCaml
+  to the Sys module of the standard library.
+  (Sébastien Hinderer, review by Damien Doligez, Gabriel Scherer, David
+  Allsopp, Nicolás Ojeda Bär, Vincent Laviron)
+
+- [#10642](https://github.com/ocaml/ocaml/issues/10642): On Windows, Sys.remove and Unix.unlink now remove symlinks
+  to directories instead of raising EACCES. Introduce
+  caml/winsupport.h to hold more common code between the runtime,
+  lib-sys, and win32unix.
+  (Antonin Décimo, review by David Allsopp and Xavier Leroy)
+
+- [#10737](https://github.com/ocaml/ocaml/issues/10737): add new ephemeron API for forward compatibility with Multicore
+  OCaml.
+  (Damien Doligez, review by Stephen Dolan)
+
+* (*breaking change*) [#10922](https://github.com/ocaml/ocaml/issues/10922): Add deprecation warnings on {Int32,Int64,Nativeint}.format.
+  (Nicolás Ojeda Bär, review by Xavier Leroy and Florian Angeletti)
+
+### Other libraries:
+
+- [#10192](https://github.com/ocaml/ocaml/issues/10192): Add support for Unix domain sockets on Windows and use them
+  to emulate Unix.socketpair (only available on Windows 1803+)
+  (Antonin Décimo, review by David Allsopp)
+
+- [#10469](https://github.com/ocaml/ocaml/issues/10469): Add Thread.set_uncaught_exception_handler and
+  Thread.default_uncaught_exception_handler.
+  (Enguerrand Decorne, review by David Allsopp)
+
+- [#10697](https://github.com/ocaml/ocaml/issues/10697): Bindings of dup and dup2 in win32unix now correctly call
+  WSADuplicateSocket on sockets instead of DuplicateHandle.
+  (Antonin Décimo, review by Xavier Leroy and Nicolás Ojeda Bär)
+
+- [#10951](https://github.com/ocaml/ocaml/issues/10951): Introduce the Thread.Exit exception as an alternative way to
+  terminate threads prematurely.  This alternative way will become
+  the standard way in 5.00.
+  (Xavier Leroy, review by Florian Angeletti)
+
+### Tools:
+
+- [#10839](https://github.com/ocaml/ocaml/issues/10839): Fix regression of #show when printing class type
+  (Élie Brami, review by Florian Angeletti)
+
+- [#3959](https://github.com/ocaml/ocaml/issues/3959), [#7202](https://github.com/ocaml/ocaml/issues/7202), [#10476](https://github.com/ocaml/ocaml/issues/10476): ocaml, in script mode, directive errors
+  (`#use "missing_file";;`) use stderr and exit with an error.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#10438](https://github.com/ocaml/ocaml/issues/10438): add a new toplevel cli argument `-e <script>` to
+  run script passed to the toplevel.
+  (Pavlo Khrystenko, review by Gabriel Scherer)
+
+- [#10524](https://github.com/ocaml/ocaml/issues/10524): Directive argument type error now shows expected and received type.
+  (Wiktor Kuchta, review by Gabriel Scherer)
+
+- [#10560](https://github.com/ocaml/ocaml/issues/10560): Disable colors if the env variable `NO_COLOR` is set.  If
+  `OCAML_COLOR` is set, its setting takes precedence over `NO_COLOR`.
+  (Nicolás Ojeda Bär, report by Gabriel Scherer, review by Daniel Bünzli,
+  Gabriel Scherer and David Allsopp)
+
+- [#10565](https://github.com/ocaml/ocaml/issues/10565): Toplevel value printing: truncate strings only after 8 bytes.
+  (Wiktor Kuchta, review by Xavier Leroy)
+
+- [#10527](https://github.com/ocaml/ocaml/issues/10527): Show "#help;; for help" at toplevel startup
+  (Wiktor Kuchta, review by David Allsopp and Florian Angeletti)
+
+- [#10846](https://github.com/ocaml/ocaml/issues/10846): add the `-shape` command-line option to ocamlobjinfo. When reading a
+  `cmt` file, shape information will only be shown if that option is used.
+  (Ulysse Gérard, review by Florian Angeletti)
+
+### Debugging:
+
+- [#10517](https://github.com/ocaml/ocaml/issues/10517), [#10594](https://github.com/ocaml/ocaml/issues/10594): when running ocamldebug on a program linked with the
+  threads library, don't fail immediately; instead, allow debugging
+  until the program creates a thread for the first time, then fail cleanly.
+  (Xavier Leroy, report by @anentropic, review by Gabriel Scherer)
+
+- [#9621](https://github.com/ocaml/ocaml/issues/9621): Pack the ocamldebug modules to minimize clashes
+  (Raphael Sousa Santos, review by Vincent Laviron and Gabriel Scherer)
+
+### Manual and documentation:
+
+- [#7812](https://github.com/ocaml/ocaml/issues/7812), [#10475](https://github.com/ocaml/ocaml/issues/10475): reworded the description of the behaviors of
+  float->int conversions in case of overflow, and of iterators
+  in case of concurrent modifications.
+  (Xavier Leroy, report by whitequark, review by David Allsopp)
+
+- [#8697](https://github.com/ocaml/ocaml/issues/8697), [#10666](https://github.com/ocaml/ocaml/issues/10666): add M, m, n options of the OCAMLRUNPARAM to manual and man page
+  for ocamlrun command line options
+  (Dong An and Anukriti Kumar, review by David Allsopp, Gabriel Scherer
+   and Damien Doligez)
+
+- [#10281](https://github.com/ocaml/ocaml/issues/10281), [#10685](https://github.com/ocaml/ocaml/issues/10685): Add description of C compiler on macOS and Windows platforms.
+  (Dong An, review by Xavier Leroy and David Allsopp)
+
+- [#10397](https://github.com/ocaml/ocaml/issues/10397): Document exceptions raised by Unix module functions on Windows
+  (Martin Jambon, review by Daniel Bünzli, David Alsopp, Damien Doligez,
+   Xavier Leroy, and Florian Angeletti)
+
+- [#10589](https://github.com/ocaml/ocaml/issues/10589): Fix many typos (excess/inconsistent spaces) in the HTML manual.
+  (Wiktor Kuchta, review by Florian Angeletti)
+
+- [#10605](https://github.com/ocaml/ocaml/issues/10605): manual, name few css classes to ease styling and maintainability.
+  (Florian Angeletti, review by Wiktor Kuchta and Gabriel Scherer)
+
+- [#10668](https://github.com/ocaml/ocaml/issues/10668), [#10669](https://github.com/ocaml/ocaml/issues/10669): the changelog (this file), LICENSE and README files are now
+  installed as part of the distribution. The destination directory can be
+  customized using the `--docdir` argument to `./configure`.
+  (Nicolás Ojeda Bär, report by Daniel Bünzli, review by David Allsopp,
+  Sébastien Hinderer, and Daniel Bünzli)
+
+- [#10671](https://github.com/ocaml/ocaml/issues/10671), [#10672](https://github.com/ocaml/ocaml/issues/10672): webman: Fix misalignments in unordered lists by changing the
+  CSS for coloring bullets
+  (Wiktor Kuchta, review by Florian Angeletti)
+
+- [#11107](https://github.com/ocaml/ocaml/issues/11107): Lifted comments in the Parsetree module into actual documentation.
+  (Paul-Elliot Anglès d'Auriac, review by Florian Angeletti)
+
+- [#11120](https://github.com/ocaml/ocaml/issues/11120), [#11133](https://github.com/ocaml/ocaml/issues/11133): man pages, add missing warning entries and add mnemonic names
+  to the list of warnings.
+  (Florian Angeletti, report by Kate Deplaix, review by Gabriel Scherer)
+
+### Compiler user-interface and warnings:
+
+- [#10531](https://github.com/ocaml/ocaml/issues/10531): add naked_pointers to ocamlc -config exporting NAKED_POINTERS from
+  Makefile.config.
+  (Damien Doligez, review by Mark Shinwell and Gabriel Scherer)
+
+- [#9116](https://github.com/ocaml/ocaml/issues/9116), [#9118](https://github.com/ocaml/ocaml/issues/9118), [#10582](https://github.com/ocaml/ocaml/issues/10582): Fix single-line source highlighting in the
+  presence of tabs
+  (Armaël Guéneau, review by Gabriel Scherer,
+   split off from [#9118](https://github.com/ocaml/ocaml/issues/9118) by Kate Deplaix, report by Ricardo M. Correia)
+
+- [#10488](https://github.com/ocaml/ocaml/issues/10488): Improve type variable name generation and recursive type detection
+  when printing type errors; this ensures that the names given to type variables
+  are always reused in the following portion of the trace and also removes
+  spurious `as 'a`s in types.
+  (Antal Spector-Zabusky, review by Florian Angeletti)
+
+- [#10794](https://github.com/ocaml/ocaml/issues/10794): Clarify warning 57 (Ambiguous or-pattern variables under guard)
+  (Wiktor Kuchta, review by Gabriel Scherer)
+
+### Internal/compiler-libs changes:
+
+- [#1599](https://github.com/ocaml/ocaml/issues/1599): add unset directive to ocamltest to clear environment variables before
+  running tests.
+  (David Allsopp, review by Damien Doligez and Sébastien Hinderer)
+
+- [#8516](https://github.com/ocaml/ocaml/issues/8516): Change representation of class signatures
+  (Leo White, review by Thomas Refis)
+
+- [#9444](https://github.com/ocaml/ocaml/issues/9444): -dtypedtree, print more explictly extra nodes in pattern ast.
+  (Frédéric Bour, review by Gabriel Scherer)
+
+- [#10337](https://github.com/ocaml/ocaml/issues/10337): Normalize type_expr nodes on access
+  One should now use accessors such as get_desc and get_level to access fields
+  of type_expr, rather than calling manually Btype.repr (which is now hidden
+  in Types.Transient_expr).
+  (Jacques Garrigue and Takafumi Saikawa,
+   review by Florian Angeletti and Gabriel Radanne)
+
+- [#10474](https://github.com/ocaml/ocaml/issues/10474): Force normalization on access to row_desc
+  Similar to [#10337](https://github.com/ocaml/ocaml/issues/10337). Make row_desc an abstract types, with constructor
+  create_row and accessors defined in Types rather than Btype.
+  A normalized view row_desc_repr is provided for convenience.
+  (Jacques Garrigue and Takafumi Saikawa,
+   review by Leo White and Florian Angeletti)
+
+- [#10541](https://github.com/ocaml/ocaml/issues/10541): Make field_kind and commutable abstract, enforcing correct access
+  (Jacques Garrigue and Takafumi Saikawa,
+   review by Thomas Refis and Florian Angeletti)
+
+- [#10575](https://github.com/ocaml/ocaml/issues/10575): add a -dump-dir flag, which redirects all debugging printer
+   (`-dprofile`, `-dlambda`, ...) to the target directory
+  (Florian Angeletti, review by Thomas Refis and Gabriel Scherer)
+
+* (*breaking change*) [#10627](https://github.com/ocaml/ocaml/issues/10627): Make row_field abstract
+  Completes [#10474](https://github.com/ocaml/ocaml/issues/10474) by making row_field abstract too.
+  An immutable view row_field_view is provided, and one converts between it
+  and row_field via inj_row_field and row_field_repr.
+  (Jacques Garrigue and Takafumi Saikawa, review by Florian Angeletti)
+
+- [#10433](https://github.com/ocaml/ocaml/issues/10433): Remove the distinction between 32-bit aligned and 64-bit aligned
+  64-bit floats in Cmm.memory_chunk.
+  (Greta Yorsh, review by Xavier Leroy)
+
+- [#10434](https://github.com/ocaml/ocaml/issues/10434): Pun labelled arguments with type constraint in function applications.
+  (Greta Yorsh, review by Nicolas Chataing and Nicolás Ojeda Bär)
+
+- [#10470](https://github.com/ocaml/ocaml/issues/10470): Remove unused `cstr_normal` field from the `constructor_description`
+  type
+  (Nicolas Chataing, review by Gabriel Scherer)
+
+- [#10382](https://github.com/ocaml/ocaml/issues/10382): Don't repeat environment entries in Typemod.check_type_decl
+  (Leo White, review by Gabriel Scherer and Florian Angeletti)
+
+- [#10472](https://github.com/ocaml/ocaml/issues/10472): refactor caml_sys_random_seed to ease future Multicore changes
+  (Gabriel Scherer, review by Xavier Leroy)
+
+- [#10487](https://github.com/ocaml/ocaml/issues/10487): Move logic to get the type path from a constructor return type in
+  Types
+  (Nicolas Chataing, review by Jacques Garrigue)
+
+- [#10555](https://github.com/ocaml/ocaml/issues/10555): Do not use ghost locations for type constraints
+  (Nicolás Ojeda Bär, report by Anton Bachin, review by Thomas Refis)
+
+- [#10598](https://github.com/ocaml/ocaml/issues/10598), [#10616](https://github.com/ocaml/ocaml/issues/10616): fix an exponential blow-up when typechecking nested module
+  types
+  (Florian Angeletti, report and review by Stephen Dolan)
+
+- [#10559](https://github.com/ocaml/ocaml/issues/10559): Evaluate signature substitutions lazily
+  (Stephen Dolan, review by Leo White)
+
+- [#8776](https://github.com/ocaml/ocaml/issues/8776), [#10624](https://github.com/ocaml/ocaml/issues/10624): Fix compilation time regression introduced in 4.08
+  (Nicolás Ojeda Bär, fix by Leo White, report by Alain Frisch, review by Thomas
+  Refis)
+
+- [#10618](https://github.com/ocaml/ocaml/issues/10618): Expose more Pprintast functions
+  (Guillaume Petiot, review by Gabriel Scherer)
+
+- [#10637](https://github.com/ocaml/ocaml/issues/10637): Outcometree: introduce a record type for constructors
+  (Gabriel Scherer, review by Thomas Refis)
+
+- [#10516](https://github.com/ocaml/ocaml/issues/10516): refactor the compilation of the 'switch' construct
+  (Gabriel Scherer, review by Wiktor Kuchta and Luc Maranget)
+
+- [#10670](https://github.com/ocaml/ocaml/issues/10670): avoid global C state in the RE engine for the "str" library
+  (Xavier Leroy, review by Gabriel Scherer)
+
+- [#10678](https://github.com/ocaml/ocaml/issues/10678): Expose descriptions in Warnings module
+  (Leo White, review by Gabriel Scherer and Alain Frisch)
+
+- [#10690](https://github.com/ocaml/ocaml/issues/10690): Always build ocamltoplevel.cmxa
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#10692](https://github.com/ocaml/ocaml/issues/10692): Expose Parse.module_type and Parse.module_expr
+  (Guillaume Petiot, review by Gabriel Scherer)
+
+- [#10714](https://github.com/ocaml/ocaml/issues/10714): Add X86_proc.with_internal_assembler for temporarily changing the
+  assembler used by the backend.
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#10715](https://github.com/ocaml/ocaml/issues/10715): Allow the assembler and loader to be substituted in ocamlnat, for
+  example to be replaced with a binary emitter.
+  (David Allsopp and Nathan Rebours, review by Louis Gesbert,
+  Nicolás Ojeda Bär and Gabriel Scherer)
+
+- [#10742](https://github.com/ocaml/ocaml/issues/10742): strong call-by-need reduction for shapes
+  (Gabriel Scherer and Nathanaëlle Courant,
+   review by Florian Angeletti, Ulysse Gérard and Thomas Refis)
+
+### Build system:
+
+- [#10828](https://github.com/ocaml/ocaml/issues/10828) Build native-code compilers on OpenBSD/aarch64
+  (Christopher Zimmermann)
+
+- [#10835](https://github.com/ocaml/ocaml/issues/10835) Disable DT_TEXTREL warnings on x86 32 bit architecture by passing
+  -Wl,-z,notext in mksharedlib and mkmaindll. Fixes relocation issues, reported
+  in [#9800](https://github.com/ocaml/ocaml/issues/9800), making local patches in Debian, Alpine, and FreeBSD superfluous.
+  (Hannes Mehnert with Kate Deplaix and Stéphane Glondu, review by Xavier Leroy)
+
+- [#10717](https://github.com/ocaml/ocaml/issues/10717): Simplify the installation of man pages
+  (Sébastien Hinderer, review by David Allsopp)
+
+- [#10739](https://github.com/ocaml/ocaml/issues/10739): Stop installing extract_crc
+  (Sébastien Hinderer, review by David Allsopp, Daniel Bünzli, Xavier Leroy
+  and Gabriel Scherer)
+
+- [#10797](https://github.com/ocaml/ocaml/issues/10797): Compile with -d2VolatileMetadata- on supporting versions of Visual
+  Studio. This suppresses the addition of .voltbl sections and eliminates
+  linking errors in systhreads.
+  (David Allsopp, review by Jonah Beckford and Sébastien Hinderer)
+
+### Bug fixes:
+
+- [#9214](https://github.com/ocaml/ocaml/issues/9214), [#10709](https://github.com/ocaml/ocaml/issues/10709): Wrong unmarshaling of function pointers in debugger mode.
+  This was causing ocamldebug to crash when running some user-defined printers.
+  (Xavier Leroy, report by Rehan Malak, review by Gabriel Scherer and
+   Vincent Laviron)
+
+- [#10473](https://github.com/ocaml/ocaml/issues/10473): Add CFI directives to RISC-V runtime and asmcomp.
+  This allows stacktraces to work in gdb through C and OCaml calls.
+  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
+
+- [#10539](https://github.com/ocaml/ocaml/issues/10539): Field kinds should be kept when copying types
+  Losing the sharing meant that one could desynchronize them between several
+  occurrences of self, allowing a method to be both public and hidden,
+  which broke type soundness.
+  (Jacques Garrigue, review by Leo White)
+
+- [#10542](https://github.com/ocaml/ocaml/issues/10542): Fix detection of immediate64 types through unboxed types.
+  (Leo White, review by Stephen Dolan and Gabriel Scherer)
+
+- [#10590](https://github.com/ocaml/ocaml/issues/10590): Some typechecker optimisations
+  (Stephen Dolan, review by Gabriel Scherer and Leo White)
+
+- [#10633](https://github.com/ocaml/ocaml/issues/10633): Stack overflow recovery in ocamlopt for AMD64/Linux and ARM/Linux
+  was not restoring the minor heap pointer correctly
+  (Stephen Dolan, review by Xavier Leroy)
+
+- [#10659](https://github.com/ocaml/ocaml/issues/10659): Fix freshening substitutions on imported modules
+  (Leo White and Stephen Dolan, review by Matthew Ryan)
+
+- [#10677](https://github.com/ocaml/ocaml/issues/10677), [#10679](https://github.com/ocaml/ocaml/issues/10679): Fix detection of CC as gcc in configure (allow for
+  triplet-prefixed GCC) and fix all C compiler detection when CC is a path
+  rather than a basename.
+  (David Allsopp, report by Fabian @copy, review by Gabriel Scherer)
+
+- [#10690](https://github.com/ocaml/ocaml/issues/10690): Add --enable-native-toplevel to configure to enable installing
+  ocamlnat as part of the main build (default is not to install it)
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#10693](https://github.com/ocaml/ocaml/issues/10693): Fix ident collision in includemod
+  (Leo White, review by Matthew Ryan)
+
+- [#10702](https://github.com/ocaml/ocaml/issues/10702): Fix cast of more strictly aligned pointer in win32unix
+  implementation of stat
+  (Antonin Décimo, review by David Allsopp)
+
+- [#10712](https://github.com/ocaml/ocaml/issues/10712): Type-check toplevel terms in the native toplevel in the same way as
+  the bytecode toplevel. In particular, this fixes the loss of type variable
+  names in the native toplevel.
+  (Leo White, review by David Allsopp and Gabriel Scherer)
+
+- [#10735](https://github.com/ocaml/ocaml/issues/10735): Uncaught unify exception from `build_as_type`
+  (Jacques Garrigue, report and review by Leo White)
+
+- [#10763](https://github.com/ocaml/ocaml/issues/10763), [#10764](https://github.com/ocaml/ocaml/issues/10764): fix miscompilation of method delegation
+  (Alain Frisch, review by Vincent Laviron and Jacques Garrigue)
+
+- [#10822](https://github.com/ocaml/ocaml/issues/10822), [#10823](https://github.com/ocaml/ocaml/issues/10823): Bad interaction between ambivalent types and subtyping
+  coercions (Jacques Garrigue, report and review by Frédéric Bour)
+
+- [#10836](https://github.com/ocaml/ocaml/issues/10836), [#10952](https://github.com/ocaml/ocaml/issues/10952): avoid internal typechecker errors when checking signature
+  inclusion in presence of incompatible types.
+  (Florian Angeletti, report by Craig Ferguson, review by Gabriel Scherer)
+
+- [#10849](https://github.com/ocaml/ocaml/issues/10849): Display the result of `let _ : <type> = <expr>` in the native
+  toplevel, as in the bytecode toplevel.
+  (David Allsopp, report by Nathan Rebours, review by Gabriel Scherer)
+
+- [#10853](https://github.com/ocaml/ocaml/issues/10853): `Obj.reachable_words` could crash if called after a marshaling
+  operation in `NO_SHARING` mode.
+  (Xavier Leroy, report by Anil Madhavapeddy, review by Alain Frisch)
+
+- [#10907](https://github.com/ocaml/ocaml/issues/10907), [#10959](https://github.com/ocaml/ocaml/issues/10959): Wrong type inferred from existential types
+  (Jacques Garrigue and Gabriel Scherer, report by @dyzsr, review by Leo White)
+
+- [#10688](https://github.com/ocaml/ocaml/issues/10688): Move frame descriptor table from `rodata` to `data` section on
+  RISC-V.  Improves support for building DLLs and PIEs. In particular, this
+  applies to all binaries in distributions that build PIEs by default (eg
+  Gentoo and Alpine).
+  (Alex Fan, review by Gabriel Scherer)
+
+- [#11031](https://github.com/ocaml/ocaml/issues/11031): Exception handlers restore the rbp register when using frame-pointers
+  on amd64.
+  (Fabrice Buoro, with help from Stephen Dolan, Tom Kelly and Mark Shinwell,
+  review by Xavier Leroy)
+
+- [#11025](https://github.com/ocaml/ocaml/issues/11025), [#11036](https://github.com/ocaml/ocaml/issues/11036): Do not pass -no-pie to the C compiler on musl/arm64
+  (omni, Kate Deplaix and Antonio Nuno Monteiro, review by Xavier Leroy)
+
+- [#11101](https://github.com/ocaml/ocaml/issues/11101), [#11109](https://github.com/ocaml/ocaml/issues/11109): A recursive type constraint fails on 4.14
+  (Jacques Garrigue, report and review by Florian Angeletti)
+
+- [#11118](https://github.com/ocaml/ocaml/issues/11118): Fix integer overflow on 64-bit Windows when indexing bigarrays (which
+  could lead to a segmentation fault).
+  (Roven Gabriel, review by Nicolás Ojeda Bär and Xavier Leroy)

--- a/data/releases/4.14.0.md
+++ b/data/releases/4.14.0.md
@@ -2,41 +2,37 @@
 kind: compiler
 version: 4.14.0
 date: 2022-03-28
-intro: >
+intro: |
+  This page describes OCaml version **4.14.0**, released on
+  2022-03-28. Go [here](/releases) for a list of all releases.
 
-This page describes OCaml version **4.14.0**, released on
-2022-03-28.  Go [here](./) for a list of all releases.
+  This release is available as an [opam](p/ocaml/4.14.0) package.
+highlights: |
+  Some of the highlights in OCaml 4.14.0 are:
 
-This release is available as an
-[opam](p/ocaml/4.14.0) package.
-
-highlights: >
-
-Some of the highlights in OCaml 4.14.0 are:
-
-- Integrated support for "go to definitions" in Merlin.
-- Standard library: new modules In_channel and Out_channel,
-  many new functions in Seq module, UTF decoding and validation support
-  for strings and bytes.
-- Runtime optimisation: GC prefetching. Benchmarks show a speedup of around 20%
-  in GC-heavy programs.
-- Improved error messages in particular for module-level error.
-- Deprecated functions and modules in preparation for OCaml 5.
-  In particular, the Stream and Genlex modules are now deprecated.
-- Type variables can be explicitly introduced in value and variant constructor
-  declarations. For instance,
-```ocaml
-    val fold: ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
-    type showable = Show: 'a * ('a -> string) -> showable
-```
-can now be written as
-```ocaml
-    val fold: 'acc 'elt. ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
-    type showable = Show: 'a. 'a * ('a -> string) -> showable
-```
-- Tail-call with up to 64 arguments are now guaranteed to be optimized
-  for all architectures.
-- Experimental tail modulo cons (TMC) transformation
+  - Integrated support for "go to definitions" in Merlin.
+  - Standard library: new modules In_channel and Out_channel,
+    many new functions in Seq module, UTF decoding and validation support
+    for strings and bytes.
+  - Runtime optimisation: GC prefetching. Benchmarks show a speedup of around 20%
+    in GC-heavy programs.
+  - Improved error messages in particular for module-level error.
+  - Deprecated functions and modules in preparation for OCaml 5.
+    In particular, the Stream and Genlex modules are now deprecated.
+  - Type variables can be explicitly introduced in value and variant constructor
+    declarations. For instance,
+    ```ocaml
+        val fold: ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
+        type showable = Show: 'a * ('a -> string) -> showable
+    ```
+    can now be written as
+    ```ocaml
+        val fold: 'acc 'elt. ('acc -> 'elt -> 'acc) -> 'acc -> 'elt list -> 'acc
+        type showable = Show: 'a. 'a * ('a -> string) -> showable
+    ```
+  - Tail-call with up to 64 arguments are now guaranteed to be optimized
+    for all architectures.
+  - Experimental tail modulo cons (TMC) transformation
 ---
 
 ## What's new
@@ -102,8 +98,8 @@ opam switch create 4.14.0+flambda+nnpchecker ocaml-variants.4.14.0+options ocaml
 ```
 
 
-![](../img/source.gif "") Source distribution
----------------------------------------------
+Source distribution
+-------------------
 
 - [Source
   tarball](https://github.com/ocaml/ocaml/archive/4.14.0.tar.gz)
@@ -134,8 +130,8 @@ targets traditionally associated with other languages:
 * [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
   to JavaScript compiler.
 
-![](../img/doc.gif "") User's manual
-------------------------------------
+User's manual
+-------------
 
 The user's manual for OCaml can be:
 


### PR DESCRIPTION
This is the release page for OCaml 4.14.0, hopefully correctly translated to the correct format.