### PR TITLE
Fix broken links on 'Functional language' page

### DIFF
--- a/data/tutorials/lg_01_functional_programming.md
+++ b/data/tutorials/lg_01_functional_programming.md
@@ -431,7 +431,7 @@ It's possible to use this as a neat trick to save typing: aliasing function
 names, and function arguments.
 
 Although we haven't looked at object-oriented programming (that's the
-subject for the ["Objects" section](objects)),
+subject for the ["Objects" section](/docs/objects)),
 here's an example from OCamlNet of an
 aliased function call. All you need to know is that
 `cgi # output # output_string "string"` is a method call, similar to

--- a/data/tutorials/lg_01_functional_programming.md
+++ b/data/tutorials/lg_01_functional_programming.md
@@ -168,7 +168,7 @@ val f : int -> int = <fun>
 # f 99;;
 - : int = 101
 ```
-In engineering this is sufficient [proof by example](humor_proof.html)
+In engineering this is sufficient [proof by example](/docs/humor_proof)
 for us to state that `plus 2` is the function which adds 2 to things.
 
 Going back to the original definition, let's "fill in" the first
@@ -431,7 +431,7 @@ It's possible to use this as a neat trick to save typing: aliasing function
 names, and function arguments.
 
 Although we haven't looked at object-oriented programming (that's the
-subject for the ["Objects" section](objects.html)),
+subject for the ["Objects" section](/docs/objects)),
 here's an example from OCamlNet of an
 aliased function call. All you need to know is that
 `cgi # output # output_string "string"` is a method call, similar to

--- a/data/tutorials/lg_01_functional_programming.md
+++ b/data/tutorials/lg_01_functional_programming.md
@@ -168,7 +168,7 @@ val f : int -> int = <fun>
 # f 99;;
 - : int = 101
 ```
-In engineering this is sufficient [proof by example](humor_proof)
+In engineering, this is sufficient proof by example
 for us to state that `plus 2` is the function which adds 2 to things.
 
 Going back to the original definition, let's "fill in" the first

--- a/data/tutorials/lg_01_functional_programming.md
+++ b/data/tutorials/lg_01_functional_programming.md
@@ -168,7 +168,7 @@ val f : int -> int = <fun>
 # f 99;;
 - : int = 101
 ```
-In engineering this is sufficient [proof by example](/docs/humor_proof)
+In engineering this is sufficient [proof by example](humor_proof)
 for us to state that `plus 2` is the function which adds 2 to things.
 
 Going back to the original definition, let's "fill in" the first
@@ -431,7 +431,7 @@ It's possible to use this as a neat trick to save typing: aliasing function
 names, and function arguments.
 
 Although we haven't looked at object-oriented programming (that's the
-subject for the ["Objects" section](/docs/objects)),
+subject for the ["Objects" section](objects)),
 here's an example from OCamlNet of an
 aliased function call. All you need to know is that
 `cgi # output # output_string "string"` is a method call, similar to


### PR DESCRIPTION
This PR fixes 2 broken links on [Functional language page](https://v3.ocaml.org/docs/functional-programming). 

However, it looks like the link for [humor proof](https://v3.ocaml.org/docs/humor_proof) is still missing, even after the alteration.