### PR TITLE
distinguish a package description from README

### DIFF
--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -26,10 +26,10 @@ let news_post news = News_post.render news
 let opportunities ?search ?location ~locations opportunities =
   Opportunities.render ?search ?location ~locations opportunities
 
-let package_overview ~readme ~dependencies ~rev_dependencies ~homepages ~source
-    package =
-  Package_overview.render ~readme ~dependencies ~rev_dependencies ~homepages
-    ~source package
+let package_overview ~readme ~readme_title ~dependencies ~rev_dependencies
+    ~homepages ~source package =
+  Package_overview.render ~readme ~readme_title ~dependencies ~rev_dependencies
+    ~homepages ~source package
 
 let package_documentation ~documentation_status ~title ~path ~toc ~maptoc
     ~content package =

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -1,6 +1,7 @@
 let render
 ~documentation_status
 ~readme
+~readme_title
 ~dependencies
 ~rev_dependencies
 ~homepages
@@ -13,7 +14,7 @@ Package_layout.render
 ~package @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row">
     <div class="flex-1 prose max-w-none">
-        <div class="p-3 bg-body-600 bg-opacity-5 rounded font-semibold mb-8">README.md</div>
+        <div class="p-3 bg-body-600 bg-opacity-5 rounded font-semibold mb-8"><%s! readme_title %></div>
         <%s! readme %>
     </div>
     <div class="p-3 py-6 lg:p-8 border border-gray-200 text-sm rounded-xl lg:max-w-md w-full">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -415,10 +415,11 @@ let package_versioned t kind req =
       let description =
         (Ocamlorg_package.info package).Ocamlorg_package.Info.description
       in
-      let* readme =
+      let* readme, readme_title =
         let+ readme_opt = Ocamlorg_package.readme_file ~kind package in
-        Option.value readme_opt
-          ~default:(description |> Omd.of_string |> Omd.to_html)
+        match readme_opt with
+        | Some doc -> (doc, "README")
+        | None -> (description |> Omd.of_string |> Omd.to_html, "Description")
       in
       let _license = Ocamlorg_package.license_file ~kind package in
       let package_meta = package_meta t package in
@@ -446,7 +447,8 @@ let package_versioned t kind req =
       in
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme
-           ~dependencies ~rev_dependencies ~homepages ~source package_meta)
+           ~readme_title ~dependencies ~rev_dependencies ~homepages ~source
+           package_meta)
 
 let package_doc t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in


### PR DESCRIPTION
This PR applies https://github.com/ocaml/ocaml.org/issues/286#issuecomment-1034184814 as suggested by @hyphenrf

Example with the `base` package:

<img width="971" alt="image" src="https://user-images.githubusercontent.com/5595092/163709029-68c52f96-290b-4bb9-aafd-fbe212bd4349.png">
