### PR TITLE
Fix some 404s on ocaml.org

### DIFF
--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -140,7 +140,7 @@ val hello : unit -> unit
 
 (note the double asterisk at the beginning of the comment - it is a good habit
 to document .mli files using the format supported by
-[ocamldoc](/releases/4.14.0/htmlman/ocamldoc.html))
+[ocamldoc](/releases/4.14/htmlman/ocamldoc.html))
 
 Such .mli files must be compiled just before the matching .ml files. They are
 compiled using `ocamlc`, even if .ml files are compiled to native code using

--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -126,7 +126,7 @@ let render ?(wide=false) () =
                 transform="scale(64)" fill="#1B1F23" />
             </svg>
           </a>
-          <a aria-label="The OCaml Language Twitter Account" href="ttps://twitter.com/ocamllang" class="opacity-60 hover:opacity-100">
+          <a aria-label="The OCaml Language Twitter Account" href="https://twitter.com/ocamllang" class="opacity-60 hover:opacity-100">
             <svg width="20" height="100%" viewBox="0 0 172 140" fill="none" xmlns="http://www.w3.org/2000/svg">
               <g clip-path="url(#clip0_964_8840)">
                 <path


### PR DESCRIPTION
There are more, these are just the ones that are found first by `linkchecker` and were obvious how to fix.