### PR TITLE
Fix syntax coloring for home page snippet

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -39,7 +39,7 @@ Layout.render
                   <span><i class="text-gray-400 ">val square : int -> int = < fun ></i></span>
                   <span>square 3</span>
                   <span><i class="text-gray-400 ">- : int = 9</i></span>
-                  <span><span class="text-blue-500 ">let</span> <span class="text-code-yellow ">rec</span> fac x =</span>
+                  <span><span class="text-blue-500 ">let rec</span> <span class="text-code-yellow ">fac</span> x =</span>
                   <span><span class="text-blue-500  ml-4">if</span> x <= 1 <span class="text-blue-500 ">then</span> 1 <span class="text-blue-500">else</span> x * fac (x - 1)</span></span>
                   <span><i class="text-gray-400">val fac : int -> int = < fun ></i></span>
                   <span>fac 5</span>


### PR DESCRIPTION
The code snippet on the home page has the syntax coloring wrong: `let rec fac x` is colored as if `rec` was the name of the function and `fac x` its arguments. I'm changing it to color `rec` as a keyword instead.