### PR TITLE
Add working example of mutual recursion

### DIFF
--- a/data/tutorials/lg_02_if_statements_loops_and_recursion.md
+++ b/data/tutorials/lg_02_if_statements_loops_and_recursion.md
@@ -1252,9 +1252,14 @@ for defining a set of two or more mutually recursive functions, like
 # let rec even n =
   match n with
   | 0 -> true
-  | x -> odd (x - 1);;
-Line 4, characters 10-13:
-Error: Unbound value odd
+  | x -> odd (x - 1)
+
+and odd n =
+  match n with
+  | 0 -> false
+  | x -> even (x - 1);;
+val even : int -> bool = <fun>
+val odd : int -> bool = <fun>
 ```
 You can also
 use similar syntax for writing mutually recursive class definitions and


### PR DESCRIPTION
At the very bottom of [this doc](https://ocaml.org/docs/if-statements-and-loops), it's explained to the reader that it's possible to write mutually recursive functions in OCaml. 

The doc seems to want to show the reader a working example of mutual recursion, but instead it shows a repeat of a failed example from earlier in the doc. This PR will update that example to one that actually does work, so the reader understands how to do it themselves.