### PR TITLE
Fix pinned code-mirror dependency

### DIFF
--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -87,7 +87,7 @@ dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   ["esbuild.dev" "git+https://github.com/tmattio/opam-esbuild#main"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#main"]
-  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#static"]
+  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#3e47f324456aafd84dece3dec4e7be70c2696f11"]
   ["js_top_worker-rpc.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker-client.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,7 +1,7 @@
 pin-depends: [
   ["esbuild.dev" "git+https://github.com/tmattio/opam-esbuild#main"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#main"]
-  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#static"]
+  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#3e47f324456aafd84dece3dec4e7be70c2696f11"]
   ["js_top_worker-rpc.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker-client.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]


### PR DESCRIPTION
Current pinned `code-mirror` dependency for up and running is pinned to a branch which gives an environment setting error.
This PR fixes the dependency to the appropriate commit hash.
