### PR TITLE
Add breadcrumbs for documentation navigation

### DIFF
--- a/src/ocamlorg_frontend/components/breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/breadcrumbs.eml
@@ -15,13 +15,13 @@ let module_name = function
 
 let render module_path =
   let n_items = List.length module_path in
-  let item_class index =
+  let _item_class index =
     if index == n_items - 1 then
       "text-orange-600 border-orange-600 border-b-2"
     else
       "hover:text-gray-900 hover:border-gray-400 hover:border-b-2 border-transparent border-b-2"
   in
-  let  item_href index =
+  let item_href index =
     let rec href_url index =
       if index == n_items - 1 then "" else
       "../" ^ href_url (index + 1)
@@ -29,17 +29,12 @@ let render module_path =
     if index == n_items - 1 then "" else
     "href='"^(href_url index)^"index.html'"
   in
-  <div class='flex-1'></div>
-  <div class="flex items-stretch text-gray-600">
-    <span class='font-light p-4'><%s module_path_kind module_path %></span>
-    <% module_path |> List.iteri (fun index item -> 
-      if index > 0 then ( %>
-      <div class='flex items-center'>
-        <span class='font-mono font-medium text-lg'>.</span>
-      </div> 
-    <% ); %>
-    <div class='flex items-center <%s item_class index %>'>
-      <a <%s! item_href index %> class='whitespace-nowrap font-mono font-medium text-lg'><%s module_name item %></a>
-    </div>
+  <div class="flex pb-4">
+    <span class="mr-4 mt-2 text-sm font-light inline-block align-bottom"><%s module_path_kind module_path %></span>
+    <% module_path |> List.iteri (fun index item -> %>
+    <% if index > 0 then ( %><span class="ml-1">.</span><% ); %>
+    <span>
+      <a <%s! item_href index %> class="ml-1 text-2xl font-medium text-gray-800 hover:text-black"><%s module_name item %></a>
+    </span>
     <% ); %>
   </div>

--- a/src/ocamlorg_frontend/components/breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/breadcrumbs.eml
@@ -1,0 +1,45 @@
+let module_kind = function
+  | `Module _ -> "Module"
+  | `ModuleType _ -> "Module type"
+  | `FunctorArgument (number, _) -> "Parameter #" ^ (Int.to_string number)
+
+let module_path_kind path =
+  match List.fold_left (fun _ v -> Some v) None path with 
+  | None -> ""
+  | Some v -> module_kind v
+
+let module_name = function
+  | `Module name
+  | `ModuleType name
+  | `FunctorArgument (_, name) -> name
+
+let render module_path =
+  let n_items = List.length module_path in
+  let item_class index =
+    if index == n_items - 1 then
+      "text-orange-600 border-orange-600 border-b-2"
+    else
+      "hover:text-gray-900 hover:border-gray-400 hover:border-b-2 border-transparent border-b-2"
+  in
+  let  item_href index =
+    let rec href_url index =
+      if index == n_items - 1 then "" else
+      "../" ^ href_url (index + 1)
+    in
+    if index == n_items - 1 then "" else
+    "href='"^(href_url index)^"index.html'"
+  in
+  <div class='flex-1'></div>
+  <div class="flex items-stretch text-gray-600">
+    <span class='font-light p-4'><%s module_path_kind module_path %></span>
+    <% module_path |> List.iteri (fun index item -> 
+      if index > 0 then ( %>
+      <div class='flex items-center'>
+        <span class='font-mono font-medium text-lg'>.</span>
+      </div> 
+    <% ); %>
+    <div class='flex items-center <%s item_class index %>'>
+      <a <%s! item_href index %> class='whitespace-nowrap font-mono font-medium text-lg'><%s module_name item %></a>
+    </div>
+    <% ); %>
+  </div>

--- a/src/ocamlorg_frontend/dune
+++ b/src/ocamlorg_frontend/dune
@@ -186,4 +186,9 @@
   (targets icons.ml)
   (deps icons.eml)
   (action
+   (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+ (rule
+  (targets breadcrumbs.ml)
+  (deps breadcrumbs.eml)
+  (action
    (run %{bin:dream_eml} %{deps} --workspace %{workspace_root}))))

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -4,6 +4,7 @@ type tab =
   
 let render
 ?styles
+?(extra_nav="")
 ~title
 ~description
 ~tab
@@ -46,7 +47,7 @@ Layout.render
         </div>
       </div>
       <div class="flex flex-col">
-        <div class="flex mt-8 space-x-6 border-b border-gray-200">
+        <div class="flex mt-8 gap-x-6 border-b border-gray-200 items-stretch flex-wrap">
           <a href="<%s Url.package_with_version package.name package.version %>">
             <button
               class="<%s if tab = Overview then current_tab_class else tab_class %>">
@@ -70,6 +71,7 @@ Layout.render
               <% ); %>
             </button>
           </a>
+          <%s! extra_nav %>
         </div>
       </div>
       <div class="py-12">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -6,7 +6,15 @@ let render
 ~maptoc
 ~content
 (package : Package_intf.package) =
+let extra_nav = Breadcrumbs.render path in
+let path =
+  List.map (function
+        | `Module s -> s
+        | `ModuleType s -> s
+        | `FunctorArgument (_, s) -> s) path
+in
 Package_layout.render
+~extra_nav
 ~documentation_status
 ~title
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -6,15 +6,13 @@ let render
 ~maptoc
 ~content
 (package : Package_intf.package) =
-let extra_nav = Breadcrumbs.render path in
-let path =
+let str_path =
   List.map (function
         | `Module s -> s
         | `ModuleType s -> s
         | `FunctorArgument (_, s) -> s) path
 in
 Package_layout.render
-~extra_nav
 ~documentation_status
 ~title
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)
@@ -39,11 +37,14 @@ Package_layout.render
       x-transition:leave-end="-translate-x-full">
       <div class="space-y-2 flex flex-col">
         <div class="text-sm font-semibold text-body-600 mb-6 py-2">IN THIS PACKAGE</div>
-        <%s! Navmap.render ~path maptoc %>
+        <%s! Navmap.render ~path:str_path maptoc %>
       </div>
     </div>
-    <div class="flex-1 odoc prose prose-orange overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6">
-      <%s! content %>
+    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6">
+      <%s! Breadcrumbs.render path %>
+      <div class="odoc prose prose-orange">
+        <%s! content %>
+      </div>
     </div>
     <div class="hidden lg:flex top-0 sticky h-screen">
       <div class="flex-col w-60">

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -203,9 +203,9 @@ module Documentation = struct
   type toc = { title : string; href : string; children : toc list }
 
   type item =
-    | Module of string
-    | ModuleType of string
-    | FunctorArgument of int * string
+    [ `Module of string
+    | `ModuleType of string
+    | `FunctorArgument of int * string ]
 
   type t = { toc : toc list; module_path : item list; content : string }
 
@@ -228,10 +228,10 @@ module Documentation = struct
     let parse_item i =
       match String.split_on_char '-' i with
       | [ "index.html" ] | [ "" ] -> None
-      | [ module_name ] -> Some (Module module_name)
-      | [ "module"; "type"; module_name ] -> Some (ModuleType module_name)
+      | [ module_name ] -> Some (`Module module_name)
+      | [ "module"; "type"; module_name ] -> Some (`ModuleType module_name)
       | [ "argument"; arg_number; arg_name ] -> (
-          try Some (FunctorArgument (int_of_string arg_number, arg_name))
+          try Some (`FunctorArgument (int_of_string arg_number, arg_name))
           with Failure _ -> None)
       | _ -> None
     in

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -68,9 +68,9 @@ module Documentation : sig
   type toc = { title : string; href : string; children : toc list }
 
   type item =
-    | Module of string
-    | ModuleType of string
-    | FunctorArgument of int * string
+    [ `Module of string
+    | `ModuleType of string
+    | `FunctorArgument of int * string ]
 
   type t = { toc : toc list; module_path : item list; content : string }
 end

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -469,9 +469,9 @@ let package_doc t kind req =
           let canonical_module =
             doc.module_path
             |> List.map (function
-                 | Ocamlorg_package.Documentation.Module s -> s
-                 | Ocamlorg_package.Documentation.ModuleType s -> s
-                 | Ocamlorg_package.Documentation.FunctorArgument (_, s) -> s)
+                 | `Module s -> s
+                 | `ModuleType s -> s
+                 | `FunctorArgument (_, s) -> s)
             |> String.concat "."
           in
           let title =
@@ -539,13 +539,6 @@ let package_doc t kind req =
                    Ocamlorg_frontend.Navmap.
                      { title; href; kind = Page; children })
           in
-          let path =
-            doc.module_path
-            |> List.map (function
-                 | Ocamlorg_package.Documentation.Module s -> s
-                 | Ocamlorg_package.Documentation.ModuleType s -> s
-                 | Ocamlorg_package.Documentation.FunctorArgument (_, s) -> s)
-          in
           let toc = toc_of_toc doc.toc in
           let* map = Ocamlorg_package.module_map ~kind package in
           let maptoc = toc_of_map ~root map in
@@ -555,4 +548,5 @@ let package_doc t kind req =
           let package_meta = package_meta t package in
           Dream.html
             (Ocamlorg_frontend.package_documentation ~documentation_status
-               ~title ~path ~toc ~maptoc ~content:doc.content package_meta))
+               ~path:doc.module_path ~title ~toc ~maptoc ~content:doc.content
+               package_meta))


### PR DESCRIPTION
This is a revival of this PR: https://github.com/ocaml/ocaml.org/pull/28 as a fix for https://github.com/ocaml/ocaml.org/issues/402

## Changes
- ocamlorg_package.Documentation.item is now a polymorphic variant, to ease
  rendering the items in eml
- add breadcrumbs.eml as a component rendering navigation breadcrumbs
- update handler.ml, package_documentation.eml and package_layout.eml to
  render the breadcrumbs
- support wrapping the navigation bar when navigating from mobile (`space-x-6` is replaced by `gap-x-6`, and `flex-wrap` is added)

## Screenshots

- Web:
![Screenshot 2022-05-30 at 15-34-30 Base Container S1 · base v0 15 0 · OCaml Packages](https://user-images.githubusercontent.com/966015/171003374-c88b6639-4451-4e24-939a-43617c3277e3.png)

- Mobile:
![Screenshot 2022-05-30 at 15-47-03 Base Applicative S · base v0 15 0 · OCaml Packages](https://user-images.githubusercontent.com/966015/171005582-0bc7308c-420d-4cfe-8717-0efbd865f7af.png)
