### PR TITLE
Update lg_08_error_handling.md

### DIFF
--- a/data/tutorials/lg_08_error_handling.md
+++ b/data/tutorials/lg_08_error_handling.md
@@ -151,7 +151,7 @@ are:
 
 - `exn`, in which case the result type just makes exceptions explicit.
 - `string`, where the error case is a message that indicates what failed.
-- `string lazy_t`, a more elaborate form of error message that is only evaluated
+- `string Lazy.t`, a more elaborate form of error message that is only evaluated
   if printing is required.
 - some polymorphic variant, with one case per
   possible error. This is very accurate (each error can be dealt with


### PR DESCRIPTION
Switch from `lazy_t` to `Lazy.t`

Guidance at https://v2.ocaml.org/api/Lazy.html says:

> Note: lazy_t is the built-in type constructor used by the compiler for the lazy keyword. You should not use it directly. Always use Lazy.t instead.