### PR TITLE
Fix tests

### DIFF
--- a/data/tutorials/lg_02_if_statements_loops_and_recursion.md
+++ b/data/tutorials/lg_02_if_statements_loops_and_recursion.md
@@ -1230,6 +1230,7 @@ complete we need that function too:
   | x -> odd (x - 1);;
 Line 4, characters 10-13:
 Error: Unbound value odd
+
 # let rec odd n =
   match n with
   | 0 -> false
@@ -1250,17 +1251,17 @@ for defining a set of two or more mutually recursive functions, like
 
 ```ocaml
 # let rec even n =
-  match n with
-  | 0 -> true
-  | x -> odd (x - 1)
-
-and odd n =
-  match n with
-  | 0 -> false
-  | x -> even (x - 1);;
+    match n with
+    | 0 -> true
+    | x -> odd (x - 1)
+  and odd n =
+    match n with
+    | 0 -> false
+    | x -> even (x - 1);;
 val even : int -> bool = <fun>
 val odd : int -> bool = <fun>
 ```
+
 You can also
 use similar syntax for writing mutually recursive class definitions and
 modules.


### PR DESCRIPTION
The OCaml phrase starting with `and` needed to be indented for mdx to run at the same time as the let binding above.