### PR TITLE
Correct small spelling mistake on https://ocaml.org/problems#3

### DIFF
--- a/data/problems/003_nth_element.md
+++ b/data/problems/003_nth_element.md
@@ -10,13 +10,13 @@ tags: [ "list" ]
 ```ocaml
 # let rec at k = function
     | [] -> None
-    | h :: t -> if k = 1 then Some h else at (k - 1) t;;
+    | h :: t -> if k = 0 then Some h else at (k - 1) t;;
 val at : int -> 'a list -> 'a option = <fun>
 ```
 
 # Statement
 
-Find the K'th element of a list.
+Find the N'th element of a list.
 
 > REMARK: OCaml has `List.nth` which numbers elements from `0` and
 > raises an exception if the index is out of bounds.

--- a/data/problems/003_nth_element.md
+++ b/data/problems/003_nth_element.md
@@ -1,5 +1,5 @@
 ---
-title: N'th lement of a list
+title: N'th element of a list
 number: "3"
 difficulty: beginner
 tags: [ "list" ]


### PR DESCRIPTION
While working through the problems on https://ocaml.org/problems to learn OCaml I noticed an ever so small spelling mistake, thought I would do my part in correcting it rather than letting it sit (I know, I know, it's extremely nit picky) 

Also, when attempting to write a solution for problem # 3, it references the implementation of `List.nth` as the problem statement, which uses zero based numbering, however, the solution uses one based numbering. To align with the problem statement, should the solution be updated to:

```ocaml
# let rec at k = function
    | [] -> None
    | h :: t -> if k = 0 then Some h else at (k - 1) t;;

(* passes using zero based numbering *)
# let%test "zero based numbering" = at 2 [ 6; 5; 4; 3; 2; 1; 0 ] = Some ( List.nth [ 6; 5; 4; 3; 2; 1; 0 ] 2 ) (* 4 *)
```


(FWIW my solution was much uglier but something I noticed when writing tests for my solution and against the proposed solution)