### PR TITLE
Add merlin-js in playground

### DIFF
--- a/dune
+++ b/dune
@@ -34,10 +34,10 @@
   (deps
    (:js %{workspace_root}/src/ocamlorg_playground/worker.js))
   (action
-   (run jsoo_minify %{js} -o worker.js)))
+   (run jsoo_minify %{js} -o %{targets})))
  (rule
-  (targets merlin_worker.bc.js)
+  (targets merlin.js)
   (deps
    (:js %{workspace_root}/src/ocamlorg_playground/merlin_worker.bc.js))
   (action
-   (run jsoo_minify %{js} -o merlin_worker.bc.js))))
+   (run jsoo_minify %{js} -o %{targets}))))

--- a/dune
+++ b/dune
@@ -34,4 +34,10 @@
   (deps
    (:js %{workspace_root}/src/ocamlorg_playground/worker.js))
   (action
-   (run jsoo_minify %{js} -o worker.js))))
+   (run jsoo_minify %{js} -o worker.js)))
+ (rule
+  (targets merlin_worker.bc.js)
+  (deps
+   (:js %{workspace_root}/src/ocamlorg_playground/merlin_worker.bc.js))
+  (action
+   (run jsoo_minify %{js} -o merlin_worker.bc.js))))

--- a/dune-project
+++ b/dune-project
@@ -60,6 +60,7 @@
   js_top_worker
   js_top_worker-client
   code-mirror
+  merlin-js
   (js_of_ocaml
    (>= 4.0))
   tailwindcss

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -89,7 +89,8 @@ dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   ["esbuild.dev" "git+https://github.com/tmattio/opam-esbuild#7738af5912cc9f554d31da81d2334e88052102fb"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
-  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#3e47f324456aafd84dece3dec4e7be70c2696f11"]
+  ["code-mirror.dev" "git+https://github.com/voodoos/jsoo-code-mirror#a92bc7d8591dd139f3faa38ad398c7744e465ebe"]
+  ["merlin-js.dev" "git+https://github.com/voodoos/merlin-js#b6c3b3124430bf8db186c5f73e8b1df6e4c80565"]
   ["js_top_worker-rpc.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker-client.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -43,6 +43,7 @@ depends: [
   "js_top_worker"
   "js_top_worker-client"
   "code-mirror"
+  "merlin-js"
   "js_of_ocaml" {>= "4.0"}
   "tailwindcss"
   "esbuild"

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -90,7 +90,7 @@ dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   ["esbuild.dev" "git+https://github.com/tmattio/opam-esbuild#7738af5912cc9f554d31da81d2334e88052102fb"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
-  ["code-mirror.dev" "git+https://github.com/voodoos/jsoo-code-mirror#a92bc7d8591dd139f3faa38ad398c7744e465ebe"]
+  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#8fe48910e265ff87f9fc94ceb7b3d19fac102a96"]
   ["merlin-js.dev" "git+https://github.com/voodoos/merlin-js#b6c3b3124430bf8db186c5f73e8b1df6e4c80565"]
   ["js_top_worker-rpc.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,7 +1,7 @@
 pin-depends: [
   ["esbuild.dev" "git+https://github.com/tmattio/opam-esbuild#7738af5912cc9f554d31da81d2334e88052102fb"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
-  ["code-mirror.dev" "git+https://github.com/voodoos/jsoo-code-mirror#a92bc7d8591dd139f3faa38ad398c7744e465ebe"]
+  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#8fe48910e265ff87f9fc94ceb7b3d19fac102a96"]
   ["merlin-js.dev" "git+https://github.com/voodoos/merlin-js#b6c3b3124430bf8db186c5f73e8b1df6e4c80565"]
   ["js_top_worker-rpc.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,7 +1,8 @@
 pin-depends: [
   ["esbuild.dev" "git+https://github.com/tmattio/opam-esbuild#7738af5912cc9f554d31da81d2334e88052102fb"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
-  ["code-mirror.dev" "git+https://github.com/patricoferris/jsoo-code-mirror#3e47f324456aafd84dece3dec4e7be70c2696f11"]
+  ["code-mirror.dev" "git+https://github.com/voodoos/jsoo-code-mirror#a92bc7d8591dd139f3faa38ad398c7744e465ebe"]
+  ["merlin-js.dev" "git+https://github.com/voodoos/merlin-js#b6c3b3124430bf8db186c5f73e8b1df6e4c80565"]
   ["js_top_worker-rpc.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]
   ["js_top_worker-client.dev" "git+https://github.com/tmattio/js_top_worker#614c4b45b9a6924496f5569650ebb0676dba1526"]

--- a/src/ocamlorg_playground/dune
+++ b/src/ocamlorg_playground/dune
@@ -6,6 +6,12 @@
  (modules worker)
  (libraries js_top_worker))
 
+(executable
+ (name merlin_worker)
+ (modes js)
+ (modules merlin_worker)
+ (libraries merlin-js.worker))
+
 (rule
  (targets worker.js)
  (action
@@ -25,10 +31,11 @@
  (name main)
  (modes js)
  (modules
-  (:standard \ worker))
+  (:standard \ worker merlin_worker))
  (libraries
   brr
   js_of_ocaml
+  merlin-js.code-mirror
   code-mirror
   code-mirror.lint
   code-mirror.autocomplete

--- a/src/ocamlorg_playground/main.ml
+++ b/src/ocamlorg_playground/main.ml
@@ -45,13 +45,6 @@ let dark_theme_ext =
   let dark = Jv.get Jv.global "__CM__dark" in
   Extension.of_jv @@ Jv.get dark "oneDark"
 
-let _set_classes el cl =
-  List.iter (fun v -> El.set_class v true el) (List.map Jstr.v cl)
-
-let _set_inner_html el html =
-  let jv = El.to_jv el in
-  Jv.set jv "innerHTML" (Jv.of_string html)
-
 let get_el_by_id s =
   match Document.find_el_by_id G.document (Jstr.v s) with
   | Some v -> v
@@ -59,7 +52,6 @@ let get_el_by_id s =
       Console.warn [ Jstr.v "Failed to get elemented by id" ];
       invalid_arg s
 
-let _red el = El.set_inline_style (Jstr.v "color") (Jstr.v "red") el
 let cyan el = El.set_inline_style (Jstr.v "color") (Jstr.v "cyan") el
 
 let handle_output (o : Toplevel_api.exec_result) =

--- a/src/ocamlorg_playground/main.ml
+++ b/src/ocamlorg_playground/main.ml
@@ -39,7 +39,7 @@ let with_rpc f v = Lwt.bind rpc (fun r -> Lwt.map or_raise @@ f r v)
 let async_raise f = Lwt.async (fun () -> Lwt.map or_raise @@ f ())
 
 module Merlin = Merlin_codemirror.Make (struct
-  let worker_url = "/js/merlin_worker.bc.js"
+  let worker_url = "/js/merlin.js"
 end)
 
 (* Need to port lesser-dark and custom theme to CM6, until then just using the

--- a/src/ocamlorg_playground/main.ml
+++ b/src/ocamlorg_playground/main.ml
@@ -8,7 +8,6 @@ module Worker = Brr_webworkers.Worker
 module Toplevel_api = Js_top_worker_rpc.Toplevel_api_gen
 module Toprpc = Js_top_worker_client.W
 
-
 let timeout_container () =
   let open Brr in
   match Document.find_el_by_id G.document @@ Jstr.v "toplevel-container" with

--- a/src/ocamlorg_playground/merlin_worker.ml
+++ b/src/ocamlorg_playground/merlin_worker.ml
@@ -1,0 +1,1 @@
+let () = Worker.run ()

--- a/src/ocamlorg_web/lib/dune
+++ b/src/ocamlorg_web/lib/dune
@@ -18,7 +18,7 @@
   %{workspace_root}/asset/css/main.css
   %{workspace_root}/asset/js/playground.js
   %{workspace_root}/asset/js/worker.js
-  %{workspace_root}/asset/js/merlin_worker.bc.js
+  %{workspace_root}/asset/js/merlin.js
   (source_tree %{workspace_root}/asset))
  (action
   (with-stdout-to

--- a/src/ocamlorg_web/lib/dune
+++ b/src/ocamlorg_web/lib/dune
@@ -18,6 +18,7 @@
   %{workspace_root}/asset/css/main.css
   %{workspace_root}/asset/js/playground.js
   %{workspace_root}/asset/js/worker.js
+  %{workspace_root}/asset/js/merlin_worker.bc.js
   (source_tree %{workspace_root}/asset))
  (action
   (with-stdout-to


### PR DESCRIPTION
This enable the use of `merlin-js` in the playground.

This requires a secondary worker: `merlin_worker`. This worker weights 1mb when gzipped.

Currently supported features of Merlin:
- Type on hover
- Errors highlighting
- Completion, including Stdlib modules.

https://user-images.githubusercontent.com/5031221/181747484-f9b1513c-6e5c-499d-a58a-084e51c83807.mov

@patricoferris: since Codemirror released the first stable V6 I thought it was a good idea to upgrade. I switched the pinned repository to my fork but this can be switched back when the upgrade will be upstreamed :-)

