### PR TITLE
Make the "read online" link consistent

### DIFF
--- a/data/books/developpement-d-applications-avec-objective-caml.md
+++ b/data/books/developpement-d-applications-avec-objective-caml.md
@@ -11,7 +11,7 @@ cover: /books/developpement-d-applications-avec-objective-caml.jpg
 language: french
 isbn: "2-84177-121-0"
 links:
-  - description: Online
+  - description: Read Online
     uri: https://www.pps.jussieu.fr/Livres/ora/DA-OCAML/index.html
   - description: Order at Amazon.fr
     uri: https://www.amazon.fr/exec/obidos/ASIN/2841771210

--- a/data/books/ocaml-from-the-very-beginning.md
+++ b/data/books/ocaml-from-the-very-beginning.md
@@ -10,7 +10,7 @@ published: 2013-06-07
 cover: /books/ocaml-from-the-very-beginning.jpg
 language: english
 links:
-  - description: Free in PDF and HTML formats
+  - description: Read Online
     uri: https://ocaml-book.com/
   - description: Buy on Amazon
     uri: https://www.amazon.com/gp/product/0957671105


### PR DESCRIPTION
The other links already use "Read Online" phrasing, so it is nice to be consistent and also the text is slightly shorter.