### PR TITLE
Redirect to the latest documented version of a package

### DIFF
--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -2,6 +2,7 @@ let index = "/"
 let packages = "/packages"
 let packages_search = "/packages/search"
 let package v = "/p/" ^ v
+let package_docs v = "/p/" ^ v ^ "/docs"
 let package_with_univ hash v = "/u/" ^ hash ^ "/" ^ v
 let package_with_version v version = "/p/" ^ v ^ "/" ^ version
 

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -2,7 +2,7 @@ let index = "/"
 let packages = "/packages"
 let packages_search = "/packages/search"
 let package v = "/p/" ^ v
-let package_docs v = "/p/" ^ v ^ "/docs"
+let package_docs v = "/p/" ^ v ^ "/doc"
 let package_with_univ hash v = "/u/" ^ hash ^ "/" ^ v
 let package_with_version v version = "/p/" ^ v ^ "/" ^ version
 

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -147,6 +147,9 @@ val get_package_latest : state -> Name.t -> t option
 val get_package : state -> Name.t -> Version.t -> t option
 (** Get a package given its name and version. *)
 
+val latest_documented_version : state -> Name.t -> Version.t option Lwt.t
+(** Find the latest documented version of a package. **)
+
 val search_package : state -> string -> t list
 (** Search package that match the given string.
 

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -376,21 +376,54 @@ let package t req =
       Dream.redirect req target
   | None -> not_found req
 
-let package_docs t req =
+(** Find out if documentation exists for a certain package version. *)
+let exists_doc t kind name version =
+  let package = Ocamlorg_package.get_package t name version in
+  let open Lwt.Syntax in
+  match package with
+  | None -> Lwt.return None
+  | Some package -> (
+      let* doc_stat = Ocamlorg_package.documentation_status ~kind package in
+      match doc_stat with
+      | `Success -> Lwt.return (Some version)
+      | _ -> Lwt.return None)
+
+(** Find the latest documented version of a package given a list of its
+    versions in descending order (latest version first). **)
+let rec find_latest_doc t kind name vlist = 
+  let open Lwt.Syntax in
+  match vlist with
+  | [] -> Lwt.return None
+  | _ -> let version = List.hd vlist in
+    let* doc = exists_doc t kind name version in
+    match doc with
+    | Some version -> Lwt.return (Some version)
+    | None -> find_latest_doc t kind name (List.tl vlist)
+
+(** Redirect any URL with suffix /p/PACKAGE/docs to the latest documentation
+    for PACKAGE. *)
+let package_docs t kind req =
     let package = Dream.param req "name" in
-    let find_default_version name =
-      Ocamlorg_package.get_package_latest t name
-      |> Option.map (fun pkg -> Ocamlorg_package.version pkg)
-    in
     let name = Ocamlorg_package.Name.of_string package in
-    let version = find_default_version name in
-    match version with
-    | Some version ->
-        let target =
-          "/p/" ^ package ^ "/" ^ Ocamlorg_package.Version.to_string version ^ "/doc/index.html"
-        in
-        Dream.redirect req target
+    let unsorted_opt = Ocamlorg_package.get_package_versions t name in
+    match unsorted_opt with
     | None -> not_found req
+    | Some unsorted -> let versions = List.rev (List.sort compare unsorted) in
+      let open Lwt.Syntax in
+      let kind =
+        match kind with
+        | Package -> `Package
+        | Universe -> `Universe (Dream.param req "hash")
+      in
+      let* version_opt = find_latest_doc t kind name versions in
+      (* Ignoring the `Universe case here. The URLs are longer, and don't
+        seem to follow a simple formula. Maybe something to look into. *)
+      match version_opt with
+      | Some version' ->
+          let version = Ocamlorg_package.Version.to_string version' in
+          let target = "/p/" ^ package ^ "/" ^ version ^ "/doc/index.html" in
+          Dream.redirect req target
+      | None -> not_found req
 
 let package_versioned t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -406,11 +406,11 @@ let rec find_latest_doc t kind name vlist =
 let package_docs t kind req =
   let package = Dream.param req "name" in
   let name = Ocamlorg_package.Name.of_string package in
-  let unsorted_opt = Ocamlorg_package.get_package_versions t name in
-  match unsorted_opt with
+  let vlist_opt = Ocamlorg_package.get_package_versions t name in
+  match vlist_opt with
   | None -> not_found req
-  | Some unsorted -> (
-      let versions = List.rev (List.sort compare unsorted) in
+  | Some vlist_inc -> (
+      let versions = List.rev vlist_inc in
       let open Lwt.Syntax in
       let kind =
         match kind with

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -376,6 +376,22 @@ let package t req =
       Dream.redirect req target
   | None -> not_found req
 
+let package_docs t req =
+    let package = Dream.param req "name" in
+    let find_default_version name =
+      Ocamlorg_package.get_package_latest t name
+      |> Option.map (fun pkg -> Ocamlorg_package.version pkg)
+    in
+    let name = Ocamlorg_package.Name.of_string package in
+    let version = find_default_version name in
+    match version with
+    | Some version ->
+        let target =
+          "/p/" ^ package ^ "/" ^ Ocamlorg_package.Version.to_string version ^ "/doc/index.html"
+        in
+        Dream.redirect req target
+    | None -> not_found req
+
 let package_versioned t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
   let version =

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -60,7 +60,7 @@ let package_route t =
       Dream.get Url.packages (Handler.packages t);
       Dream.get Url.packages_search (Handler.packages_search t);
       Dream.get (Url.package ":name") (Handler.package t);
-      Dream.get (Url.package_docs ":name") (Handler.package_docs t);
+      Dream.get (Url.package_docs ":name") ((Handler.package_docs t) Handler.Package);
       Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
       Dream.get
         (Url.package_with_version ":name" ":version")

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -60,7 +60,8 @@ let package_route t =
       Dream.get Url.packages (Handler.packages t);
       Dream.get Url.packages_search (Handler.packages_search t);
       Dream.get (Url.package ":name") (Handler.package t);
-      Dream.get (Url.package_docs ":name") ((Handler.package_docs t) Handler.Package);
+      Dream.get (Url.package_docs ":name")
+        ((Handler.package_docs t) Handler.Package);
       Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
       Dream.get
         (Url.package_with_version ":name" ":version")

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -60,6 +60,7 @@ let package_route t =
       Dream.get Url.packages (Handler.packages t);
       Dream.get Url.packages_search (Handler.packages_search t);
       Dream.get (Url.package ":name") (Handler.package t);
+      Dream.get (Url.package_docs ":name") (Handler.package_docs t);
       Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
       Dream.get
         (Url.package_with_version ":name" ":version")

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -60,8 +60,7 @@ let package_route t =
       Dream.get Url.packages (Handler.packages t);
       Dream.get Url.packages_search (Handler.packages_search t);
       Dream.get (Url.package ":name") (Handler.package t);
-      Dream.get (Url.package_docs ":name")
-        ((Handler.package_docs t) Handler.Package);
+      Dream.get (Url.package_docs ":name") (Handler.package_docs t);
       Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
       Dream.get
         (Url.package_with_version ":name" ":version")


### PR DESCRIPTION
Resolves #174

This PR implements a redirect from /p/package/docs to the latest documented version of a package. If the latest version is undocumented, /p/package/docs redirects to the last version that was documented (i.e. currently, Irmin's latest version—3.3.2—is undocumented, so my code redirects https://v3.ocaml.org/p/irmin/docs to https://v3.ocaml.org/p/irmin/3.3.1/doc/index.html).

(p.s. I wasn't positive about referencing a previous version if the latest version is undocumented, so the first commit on this PR implements a redirect to the latest version's documentation—even if it doesn't exist.)