### PR TITLE
Compilation: order of source files matter.

### DIFF
--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -41,7 +41,7 @@ We can compile the files in one command:
 $ ocamlopt -o hello amodule.ml bmodule.ml
 ```
 
-Note: The source files need to be ordered with the dependencies coming before
+Note: It's necessary to place the source files in the correct order. The dependencies must come before
 the dependent. In the example above, putting `bmodule.ml` before `amodule.ml`
 will result in an `Unbound module` error.
 

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -41,6 +41,10 @@ We can compile the files in one command:
 $ ocamlopt -o hello amodule.ml bmodule.ml
 ```
 
+Note: The source files need to be ordered with the dependencies coming before
+the dependent. In the example above, putting `bmodule.ml` before `amodule.ml`
+will result in an `Unbound module` error.
+
 Or, as a build system might do, one by one:
 
 <!-- $MDX dir=examples -->


### PR DESCRIPTION
Made a small change to help fix the `Unbound module` error. 

It should be mentioned that the order of files given to the compiler is important.

```ocamlopt -o hello bmodule.ml amodule.ml```

instead of

```ocamlopt -o hello amodule.ml bmodule.ml```

will result in an `Unbound module` error.