### PR TITLE
docs: add note on ocamlopt argument order in modules tutorial

### DIFF
--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -50,6 +50,9 @@ $ ocamlopt -c bmodule.ml
 $ ocamlopt -o hello amodule.cmx bmodule.cmx
 ```
 
+Note that the order of arguments here matter. Modules with dependencies must
+be listed after the modules they depend on.
+
 Now we have an executable that prints "Hello". As you can see, if you want to
 access anything from a given module, use the name of the module (always
 starting with a capital) followed by a dot and the thing that you want to use.


### PR DESCRIPTION
Based on an issue reported on here: https://stackoverflow.com/questions/73429850/unbound-module-personal-files