### PR TITLE
Update Getting Started instructions with modern shell invocation and OPAM 1.2.2 note

### DIFF
--- a/data/tutorials/gs_00_up_and_running.md
+++ b/data/tutorials/gs_00_up_and_running.md
@@ -65,8 +65,7 @@ $ port install opam
 
 It's easy to install opam is with your system's package manager on
 Linux (e.g., `apt-get install opam` or similar). [Details of all installation
-methods.](https://opam.ocaml.org/doc/Install.html)
-
+methods](https://opam.ocaml.org/doc/Install.html). All supported Linux distributions package at least version 2.0.0 (you can check by running `opam --version`). If you are using an unsupported Linux distribution, please either download a precompiled binary or build opam from sources.
 
 ```shell
 # Ubuntu


### PR DESCRIPTION
cf. https://github.com/ocaml/ocaml/issues/11532.

- Switch to using `eval $(opam env)` - the website's styling for code (which adds backticks) made the text _extremely_ confusing!
- Add a pre-checking note for any users of an out-of-date distro who pick up OPAM 1.2.2 (AFAIK Debian 9 was the last distro still shipping OPAM 1.2.2 has been EOL since July this year). I think it's better to put the note there than pollute the instructions later on to handle an error which virtually no user should see.