### PR TITLE
Link to license and changelog in overview

### DIFF
--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -24,10 +24,12 @@ let news ~page ~pages_number news = News.render ~page ~pages_number news
 let news_post news = News_post.render news
 let jobs ?location ~locations jobs = Jobs.render ?location ~locations jobs
 
-let package_overview ~readme ~readme_title ~dependencies ~rev_dependencies
-    ~homepages ~source package =
-  Package_overview.render ~readme ~readme_title ~dependencies ~rev_dependencies
-    ~homepages ~source package
+let package_overview ~documentation_status ~readme ~readme_title ~dependencies
+    ~rev_dependencies ~homepages ~source ~changes_filename ~license_filename
+    package =
+  Package_overview.render ~documentation_status ~readme ~readme_title
+    ~dependencies ~rev_dependencies ~homepages ~source ~changes_filename
+    ~license_filename package
 
 let package_documentation ~documentation_status ~title ~path ~toc ~maptoc
     ~content package =

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -80,9 +80,8 @@ Package_layout.render
               <%s Utils.human_date_of_timestamp package.publication %>
             </dd>
         </div>
-        <!-- TODO(tmattio): Uncomment to handle license and changelog -->
-        <!-- <div class="flex flex-col mt-9 space-y-4 text-body-400">
-            <a href="" class="flex items-center hover:text-primary-600">
+        <div class="flex flex-col mt-9 space-y-4 text-body-400">
+            <a href="<%s Url.package_readme package.name package.version %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -90,7 +89,7 @@ Package_layout.render
                 </svg>
                 Readme
             </a>
-            <a href="" class="flex items-center hover:text-primary-600">
+            <a href="<%s Url.package_changes package.name package.version %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -98,15 +97,15 @@ Package_layout.render
                 </svg>
                 Changelog
             </a>
-            <a href="" class="flex items-center hover:text-primary-600">
+            <a href="<%s Url.package_license package.name package.version %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
                 </svg>
-                MIT License
+                <%s package.license %> License
             </a>
-        </div> -->
+        </div>
         <div class="mt-8">
             <dt class="font-semibold text-base text-body-400">Authors</dt>
             <dd class="mt-3 text-sm text-gray-900">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -6,7 +6,7 @@ let render
 ~rev_dependencies
 ~homepages
 ~source
-~has_changelog (package : Package_intf.package) =
+~changes_file (package : Package_intf.package) =
 Package_layout.render
 ~documentation_status
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name package.version)
@@ -82,8 +82,8 @@ Package_layout.render
             </dd>
         </div>
         <div class="flex flex-col mt-9 space-y-4 text-body-400">
-            <% (if not has_changelog then () else %>
-            <a href="<%s Url.package_changes package.name package.version %>" class="flex items-center hover:text-primary-600">
+            <% (match changes_file with Some (is_md, _) -> %>
+            <a href="<%s Url.package_changes package.name package.version is_md %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -91,7 +91,7 @@ Package_layout.render
                 </svg>
                 Changelog
             </a>
-            <% ); %>
+            <% | _ -> ()); %>
             <a href="<%s Url.package_license package.name package.version %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -6,7 +6,8 @@ let render
 ~rev_dependencies
 ~homepages
 ~source
-~changes_file (package : Package_intf.package) =
+~changes_file
+~license_file (package : Package_intf.package) =
 Package_layout.render
 ~documentation_status
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name package.version)
@@ -82,8 +83,8 @@ Package_layout.render
             </dd>
         </div>
         <div class="flex flex-col mt-9 space-y-4 text-body-400">
-            <% (match changes_file with Some (is_md, _) -> %>
-            <a href="<%s Url.package_changes package.name package.version is_md %>" class="flex items-center hover:text-primary-600">
+            <% (match changes_file with Some changes_filename -> %>
+            <a href="<%s Url.package_doc package.name package.version changes_filename %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -92,7 +93,8 @@ Package_layout.render
                 Changelog
             </a>
             <% | _ -> ()); %>
-            <a href="<%s Url.package_license package.name package.version %>" class="flex items-center hover:text-primary-600">
+            <% (match license_file with Some license_filename -> %>
+            <a href="<%s Url.package_doc package.name package.version license_filename %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -100,6 +102,7 @@ Package_layout.render
                 </svg>
                 <%s package.license %> License
             </a>
+            <% | _ -> ()); %>
         </div>
         <div class="mt-8">
             <dt class="font-semibold text-base text-body-400">Authors</dt>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -5,7 +5,8 @@ let render
 ~dependencies
 ~rev_dependencies
 ~homepages
-~source (package : Package_intf.package) =
+~source
+~has_changelog (package : Package_intf.package) =
 Package_layout.render
 ~documentation_status
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name package.version)
@@ -81,14 +82,7 @@ Package_layout.render
             </dd>
         </div>
         <div class="flex flex-col mt-9 space-y-4 text-body-400">
-            <a href="<%s Url.package_readme package.name package.version %>" class="flex items-center hover:text-primary-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
-                    stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
-                Readme
-            </a>
+            <% (if not has_changelog then () else %>
             <a href="<%s Url.package_changes package.name package.version %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
@@ -97,6 +91,7 @@ Package_layout.render
                 </svg>
                 Changelog
             </a>
+            <% ); %>
             <a href="<%s Url.package_license package.name package.version %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -6,8 +6,9 @@ let render
 ~rev_dependencies
 ~homepages
 ~source
-~changes_file
-~license_file (package : Package_intf.package) =
+~changes_filename
+~license_filename
+(package : Package_intf.package) =
 Package_layout.render
 ~documentation_status
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name package.version)
@@ -83,8 +84,8 @@ Package_layout.render
             </dd>
         </div>
         <div class="flex flex-col mt-9 space-y-4 text-body-400">
-            <% (match changes_file with Some changes_filename -> %>
-            <a href="<%s Url.package_doc package.name package.version changes_filename %>" class="flex items-center hover:text-primary-600">
+            <% (match changes_filename with Some changes_filename -> %>
+            <a href="<%s Url.package_doc package.name package.version (changes_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -93,8 +94,8 @@ Package_layout.render
                 Changelog
             </a>
             <% | _ -> ()); %>
-            <% (match license_file with Some license_filename -> %>
-            <a href="<%s Url.package_doc package.name package.version license_filename %>" class="flex items-center hover:text-primary-600">
+            <% (match license_filename with Some license_filename -> %>
+            <a href="<%s Url.package_doc package.name package.version (license_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -10,7 +10,6 @@ let package_with_hash_with_version hash v version =
   "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version
 
 let package_doc v version page = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
-
 let package_license v version = package_doc v version "LICENSE.md.html"
 
 let package_doc_with_hash hash v version page =

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -11,6 +11,10 @@ let package_with_hash_with_version hash v version =
 
 let package_doc v version page = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
+let package_readme v version = package_doc v version "README.md.html"
+let package_changes v version = package_doc v version "CHANGES.md.html"
+let package_license v version = package_doc v version "LICENSE.md.html"
+
 let package_doc_with_hash hash v version page =
   "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -11,7 +11,6 @@ let package_with_hash_with_version hash v version =
 
 let package_doc v version page = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
-let package_readme v version = package_doc v version "README.md.html"
 let package_changes v version = package_doc v version "CHANGES.md.html"
 let package_license v version = package_doc v version "LICENSE.md.html"
 

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -11,7 +11,9 @@ let package_with_hash_with_version hash v version =
 
 let package_doc v version page = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
-let package_changes v version = package_doc v version "CHANGES.md.html"
+let package_changes v version is_md =
+  package_doc v version (if is_md then "CHANGES.md.html" else "CHANGES.html")
+
 let package_license v version = package_doc v version "LICENSE.md.html"
 
 let package_doc_with_hash hash v version page =

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -11,9 +11,6 @@ let package_with_hash_with_version hash v version =
 
 let package_doc v version page = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
-let package_changes v version is_md =
-  package_doc v version (if is_md then "CHANGES.md.html" else "CHANGES.html")
-
 let package_license v version = package_doc v version "LICENSE.md.html"
 
 let package_doc_with_hash hash v version page =

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -310,7 +310,17 @@ let readme_file ~kind = maybe_file "README.md.html" ~kind
 
 let license_file ~kind = maybe_file "LICENSE.md.html" ~kind
 
-let changes_file ~kind = maybe_file "CHANGES.md.html" ~kind
+let changes_file ~kind t =
+  let open Lwt.Syntax in
+  let* md = maybe_file "CHANGES.md.html" ~kind t in
+  match md with
+  | Some doc -> Lwt.return_some (true, doc)
+  | None ->
+    let+ txt = maybe_file "CHANGES.html" ~kind t in
+    match txt with
+    | Some doc -> Some (false, doc)
+    | None -> None
+
 
 let documentation_status ~kind t =
   let open Lwt.Syntax in

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -301,15 +301,16 @@ let documentation_page ~kind t path =
       Some Documentation.{ content; toc; module_path }
   | Error _ -> Lwt.return None
 
-let readme_file ~kind t =
-  let open Lwt.Syntax in
-  let+ doc = documentation_page ~kind t "README.md.html" in
-  match doc with None -> None | Some { content; _ } -> Some content
+  let maybe_file filename ~kind t =
+    let open Lwt.Syntax in
+    let+ doc = documentation_page ~kind t filename in
+    match doc with None -> None | Some { content; _ } -> Some content
 
-let license_file ~kind t =
-  let open Lwt.Syntax in
-  let+ doc = documentation_page ~kind t "LICENSE.md.html" in
-  match doc with None -> None | Some { content; _ } -> Some content
+let readme_file ~kind = maybe_file "README.md.html" ~kind
+
+let license_file ~kind = maybe_file "LICENSE.md.html" ~kind
+
+let changes_file ~kind = maybe_file "CHANGES.md.html" ~kind
 
 let documentation_status ~kind t =
   let open Lwt.Syntax in

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -308,19 +308,17 @@ let documentation_page ~kind t path =
 
 let readme_file ~kind = maybe_file "README.md.html" ~kind
 
-let license_file ~kind = maybe_file "LICENSE.md.html" ~kind
+let maybe_files names ~kind t =
+  let filenames = List.map (fun s -> s ^ ".html") (List.map (fun s -> s ^ ".md") names @ names) in
+  let f filename =
+    let open Lwt.Syntax in
+    let+ doc = maybe_file filename ~kind t in
+    Option.map (fun _ -> filename) doc in
+  Lwt_stream.find_map_s f (Lwt_stream.of_list filenames)
 
-let changes_file ~kind t =
-  let open Lwt.Syntax in
-  let* md = maybe_file "CHANGES.md.html" ~kind t in
-  match md with
-  | Some doc -> Lwt.return_some (true, doc)
-  | None ->
-    let+ txt = maybe_file "CHANGES.html" ~kind t in
-    match txt with
-    | Some doc -> Some (false, doc)
-    | None -> None
+let license_file ~kind t = maybe_files [ "LICENSE" ] ~kind t
 
+let changes_file ~kind t = maybe_files [ "CHANGES"; "CHANGELOG" ] ~kind t
 
 let documentation_status ~kind t =
   let open Lwt.Syntax in

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -105,7 +105,7 @@ val license_file :
 (** Get the license of a package *)
 
 val changes_file :
-  kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
+  kind:[< `Package | `Universe of string ] -> t -> (bool * string) option Lwt.t
 (** Get the changelog of a package *)
 
 val documentation_status :

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -102,11 +102,11 @@ val readme_file :
 
 val license_file :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
-(** Get the license of a package *)
+(** Get the license file name of a package *)
 
 val changes_file :
-  kind:[< `Package | `Universe of string ] -> t -> (bool * string) option Lwt.t
-(** Get the changelog of a package *)
+  kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
+(** Get the changelog file name of a package *)
 
 val documentation_status :
   kind:[< `Package | `Universe of string ] ->

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -104,6 +104,10 @@ val license_file :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Get the license of a package *)
 
+val changes_file :
+  kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
+(** Get the changelog of a package *)
+
 val documentation_status :
   kind:[< `Package | `Universe of string ] ->
   t ->

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -100,11 +100,11 @@ val readme_file :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Get the readme of a package *)
 
-val license_file :
+val license_filename :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Get the license file name of a package *)
 
-val changes_file :
+val changes_filename :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Get the changelog file name of a package *)
 

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -414,9 +414,7 @@ let package_versioned t kind req =
         | Some doc -> (doc, "README")
         | None -> (description |> Omd.of_string |> Omd.to_html, "Description")
       in
-      let* has_changelog =
-        let+ changes_opt = Ocamlorg_package.changes_file ~kind package in
-        Option.is_some changes_opt in
+      let* changes_file = Ocamlorg_package.changes_file ~kind package in
       let _license = Ocamlorg_package.license_file ~kind package in
       let package_meta = package_meta t package in
       let package_info = Ocamlorg_package.info package in
@@ -444,7 +442,7 @@ let package_versioned t kind req =
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme
            ~readme_title ~dependencies ~rev_dependencies ~homepages ~source
-           ~has_changelog package_meta)
+           ~changes_file package_meta)
 
 let package_doc t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -414,8 +414,8 @@ let package_versioned t kind req =
         | Some doc -> (doc, "README")
         | None -> (description |> Omd.of_string |> Omd.to_html, "Description")
       in
-      let* changes_file = Ocamlorg_package.changes_file ~kind package in
-      let* license_file = Ocamlorg_package.license_file ~kind package in
+      let* changes_filename = Ocamlorg_package.changes_filename ~kind package in
+      let* license_filename = Ocamlorg_package.license_filename ~kind package in
       let package_meta = package_meta t package in
       let package_info = Ocamlorg_package.info package in
       let rev_dependencies =
@@ -442,7 +442,7 @@ let package_versioned t kind req =
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme
            ~readme_title ~dependencies ~rev_dependencies ~homepages ~source
-           ~changes_file ~license_file package_meta)
+           ~changes_filename ~license_filename package_meta)
 
 let package_doc t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -414,6 +414,9 @@ let package_versioned t kind req =
         | Some doc -> (doc, "README")
         | None -> (description |> Omd.of_string |> Omd.to_html, "Description")
       in
+      let* has_changelog =
+        let+ changes_opt = Ocamlorg_package.changes_file ~kind package in
+        Option.is_some changes_opt in
       let _license = Ocamlorg_package.license_file ~kind package in
       let package_meta = package_meta t package in
       let package_info = Ocamlorg_package.info package in
@@ -441,7 +444,7 @@ let package_versioned t kind req =
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme
            ~readme_title ~dependencies ~rev_dependencies ~homepages ~source
-           package_meta)
+           ~has_changelog package_meta)
 
 let package_doc t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -415,7 +415,7 @@ let package_versioned t kind req =
         | None -> (description |> Omd.of_string |> Omd.to_html, "Description")
       in
       let* changes_file = Ocamlorg_package.changes_file ~kind package in
-      let _license = Ocamlorg_package.license_file ~kind package in
+      let* license_file = Ocamlorg_package.license_file ~kind package in
       let package_meta = package_meta t package in
       let package_info = Ocamlorg_package.info package in
       let rev_dependencies =
@@ -442,7 +442,7 @@ let package_versioned t kind req =
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme
            ~readme_title ~dependencies ~rev_dependencies ~homepages ~source
-           ~changes_file package_meta)
+           ~changes_file ~license_file package_meta)
 
 let package_doc t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in


### PR DESCRIPTION
Fix https://github.com/ocaml/ocaml.org/issues/36

Display links to changelog and license in overview, if available.
