### PR TITLE
Remove useless double slashes

### DIFF
--- a/data/academic_institutions/Beira.md
+++ b/data/academic_institutions/Beira.md
@@ -3,7 +3,7 @@ name: Universidade da Beira Interior
 description: >
   The University of Beira Interior is a public university located in the city of Covilhã, Portugal.
 url: "https://www.ubi.pt/en/"
-logo: /academic_institution/beira.jpg
+logo: academic_institution/beira.jpg
 continent: Europe
 courses:
     - name: Certified Programming

--- a/data/academic_institutions/Birmingham.md
+++ b/data/academic_institutions/Birmingham.md
@@ -4,7 +4,7 @@ description: >
  The University of Birmingham is a public research university located in Edgbaston, Birmingham, United Kingdom. It received its royal charter in 1900 as a successor to Queen's College, Birmingham, and Mason Science College, making it the first English civic or 'red brick' university to receive its own royal
  charter.
 url: "https://www.birmingham.ac.uk/index.aspx"
-logo: /academic_institution/Birmingham.jpg
+logo: academic_institution/Birmingham.jpg
 continent: Europe
 courses:
     - name: Foundations of Computer Science 

--- a/data/academic_institutions/Boston.md
+++ b/data/academic_institutions/Boston.md
@@ -3,7 +3,7 @@ name: Boston College
 description: >
  Boston College is a private, Jesuit research university in Chestnut Hill, Massachusetts. Founded in 1863, the university has more than 9,300 full-time undergraduates and nearly 5,000 graduate students. 
 url: "https://www.bc.edu/"
-logo: /academic_institution/boston.png
+logo: academic_institution/boston.png
 continent: North America
 courses:
     - name: Computer Science I 

--- a/data/academic_institutions/Cambridge.md
+++ b/data/academic_institutions/Cambridge.md
@@ -3,7 +3,7 @@ name: University of Cambridge
 description: >
  The University of Cambridge is a collegiate research university in Cambridge, United Kingdom. 
 url: "https://www.cam.ac.uk/"
-logo: /academic_institution/cambridge.jpg
+logo: academic_institution/cambridge.jpg
 continent: Europe
 courses:
     - name: Advanced Functional Programming 

--- a/data/academic_institutions/ISAE.md
+++ b/data/academic_institutions/ISAE.md
@@ -3,7 +3,7 @@ name: ISAE/Supaéro
 description: >
  The Institut supérieur de l'aéronautique et de l'espace is a French engineering school, founded in 1909. It was the world's first dedicated aerospace engineering school.
 url: "https://www.isae-supaero.fr/en/"
-logo: /academic_institution/isae.png
+logo: academic_institution/isae.png
 continent: Europe
 courses:
     - name: Functional programming and introduction to type systems

--- a/data/academic_institutions/aix.md
+++ b/data/academic_institutions/aix.md
@@ -3,7 +3,7 @@ name: Aix-Marseille University
 description: >
   Aix-Marseille University is a public research university located in the region of Provence, southern France. 
 url: "https://www.univ-amu.fr/en"
-logo: /academic_institution/aix.jpg
+logo: academic_institution/aix.jpg
 continent: Europe
 courses:
     - name: Functional Programming   

--- a/data/academic_institutions/arhus.md
+++ b/data/academic_institutions/arhus.md
@@ -3,7 +3,7 @@ name: Aarhus University
 description: >
   Aarhus University (Danish: Aarhus Universitet, abbreviated AU) is the largest and second oldest research university in Denmark.The university belongs to the Coimbra Group, the Guild, and Utrecht Network of European universities and is a member of the European University Association.
 url: "https://international.au.dk/"
-logo: /academic_institution/arhus.png
+logo: academic_institution/arhus.png
 continent: Europe
 courses:
     - name: The compilation course (along with Java)

--- a/data/academic_institutions/brown.md
+++ b/data/academic_institutions/brown.md
@@ -3,7 +3,7 @@ name: Brown University
 description: >
  Brown University is a private Ivy League research university in Providence, Rhode Island. 
 url: "https://www.brown.edu/"
-logo: /academic_institution/brown.png
+logo: academic_institution/brown.png
 continent: North America
 courses:
     - name:  An Integrated introducion (along with Racket, Scala and Java)

--- a/data/academic_institutions/caltech.md
+++ b/data/academic_institutions/caltech.md
@@ -3,7 +3,7 @@ name: California Institute of Technology
 description: >
  The California Institute of Technology is a private research university in Pasadena, California. 
 url: "https://www.caltech.edu/"
-logo: /academic_institution/caltech.png
+logo: academic_institution/caltech.png
 continent: North America
 courses:
     - name: Fundamentals of Computer Programming

--- a/data/academic_institutions/columbia.md
+++ b/data/academic_institutions/columbia.md
@@ -3,7 +3,7 @@ name: Columbia University
 description: >
  Columbia University is a private Ivy League research university in New York City. 
 url: "https://www.columbia.edu/"
-logo: /academic_institution/columbia.png
+logo: academic_institution/columbia.png
 continent: North America
 courses:
     - name: Programming Languages and Translators

--- a/data/academic_institutions/cornell.md
+++ b/data/academic_institutions/cornell.md
@@ -3,7 +3,7 @@ name: Cornell University
 description: >
  Cornell University is a private, statutory, Ivy League and land-grant research university in Ithaca, New York. 
 url: "https://www.cornell.edu/"
-logo: /academic_institution/cornell.png
+logo: academic_institution/cornell.png
 continent: North America
 courses:
     - name: Data Structures and Functional Programming 

--- a/data/academic_institutions/curie.md
+++ b/data/academic_institutions/curie.md
@@ -3,7 +3,7 @@ name: University Pierre & Marie Curie
 description: >
  Pierre and Marie Curie University, titled as UPMC from 2007 to 2017 and also known as Paris 6, was a public research university in Paris, France, from 1971 to 2017. The university was located on the Jussieu Campus in the Latin Quarter of the 5th arrondissement of Paris, France. 
 url: "https://www.sorbonne-universite.fr/"
-logo: /academic_institution/curie.jpg
+logo: academic_institution/curie.jpg
 continent: Europe
 courses:
     - name: Types and static analysis 

--- a/data/academic_institutions/epita.md
+++ b/data/academic_institutions/epita.md
@@ -3,7 +3,7 @@ name: Epita
 description: >
  The École Pour l'Informatique et les Techniques Avancées, more commonly known as EPITA, is a private French grande école specialized in the field of computer science and software engineering created in 1984 by Patrice Dumoucel. 
 url: "https://www.epita.fr/"
-logo: /academic_institution/epita.png
+logo: academic_institution/epita.png
 continent: Europe
 courses:
     - name:  Introduction to Algorithms (Year 1 & 2)

--- a/data/academic_institutions/harvard.md
+++ b/data/academic_institutions/harvard.md
@@ -3,7 +3,7 @@ name: Harvard University
 description: >
  Harvard University is a private Ivy League research university in Cambridge, Massachusetts. higher education academy. 
 url: "https://www.harvard.edu/"
-logo: /academic_institution/harvard.png
+logo: academic_institution/harvard.png
 continent: North America
 courses:
     - name: Principles of Programming Language Compilation 

--- a/data/academic_institutions/iitd.md
+++ b/data/academic_institutions/iitd.md
@@ -3,7 +3,7 @@ name: Indian Institute of Technology, Delhi
 description: >
  Indian Institute of Technology Delhi is a public technical and research university located in Hauz Khas in South Delhi, Delhi, India. 
 url: "https://home.iitd.ac.in/"
-logo: /academic_institution/iitd.png
+logo: academic_institution/iitd.png
 continent: Asia
 courses:
     - name: Introduction to Computers and Programming (along with Pascal and Java)

--- a/data/academic_institutions/iitm.md
+++ b/data/academic_institutions/iitm.md
@@ -3,7 +3,7 @@ name: Indian Institute of Technology, Madras
 description: >
  Indian Institute of Technology Madras is a public technical and research university located in Chennai, India.
 url: "https://www.iitm.ac.in/"
-logo: /academic_institution/iitm.png
+logo: academic_institution/iitm.png
 continent: Asia
 courses:
     - name: Paradigms of Programming

--- a/data/academic_institutions/illinois.md
+++ b/data/academic_institutions/illinois.md
@@ -3,7 +3,7 @@ name: University of Illinois at Urbana-Champaign
 description: >
  The University of Illinois Urbana-Champaign is a public land-grant research university in Illinois in the twin cities of Champaign and Urbana.
 url: "https://illinois.edu/"
-logo: /academic_institution/illinois.jpeg
+logo: academic_institution/illinois.jpeg
 continent: North America
 courses:
     - name: Programming Languages and Compilers 

--- a/data/academic_institutions/innsbruck.md
+++ b/data/academic_institutions/innsbruck.md
@@ -3,7 +3,7 @@ name: University of Innsbruck
 description: >
  The University of Innsbruck is a public university in Innsbruck, the capital of the Austrian federal state of Tyrol, founded in 1669. 
 url: "https://www.uibk.ac.at/index.html.en"
-logo: /academic_institution/university-of-innsbruck-logo.jpg
+logo: academic_institution/university-of-innsbruck-logo.jpg
 continent: Europe
 courses:
     - name: Programming in OCAML

--- a/data/academic_institutions/los.md
+++ b/data/academic_institutions/los.md
@@ -3,7 +3,7 @@ name: University of California, Los Angeles
 description: >
  The University of California, Los Angeles is a public land-grant research university in Los Angeles, California.
 url: "https://www.ucla.edu/"
-logo: /academic_institution/ucla.jpg
+logo: academic_institution/ucla.jpg
 continent: North America
 courses:
     - name: Programming Languages (along with Python and Java)

--- a/data/academic_institutions/maryland.md
+++ b/data/academic_institutions/maryland.md
@@ -3,7 +3,7 @@ name: University of Maryland
 description: >
  The University of Maryland, College Park is a public land-grant research university in College Park, Maryland.
 url: "https://www.umd.edu/"
-logo: /academic_institution/maryland.gif
+logo: academic_institution/maryland.gif
 continent: North America
 courses:
     - name: Organization of Programming Languages-(along with Ruby, Prolog, Java) 

--- a/data/academic_institutions/massachussetts.md
+++ b/data/academic_institutions/massachussetts.md
@@ -3,7 +3,7 @@ name:  University of Massachusetts
 description: >
  The University of Massachusetts is the five-campus public university system and the only public research system in the Commonwealth of Massachusetts. 
 url: "https://www.massachusetts.edu/"
-logo: /academic_institution/massachusetts.png
+logo: academic_institution/massachusetts.png
 continent: North America
 courses:
     - name: Programming Languages 

--- a/data/academic_institutions/mcgill.md
+++ b/data/academic_institutions/mcgill.md
@@ -3,7 +3,7 @@ name: McGill University
 description: >
  McGill University is a public research university located in Montreal, Quebec, Canada.
 url: "https://www.mcgill.ca/"
-logo: /academic_institution/mcgill_logo.png
+logo: academic_institution/mcgill_logo.png
 continent: North America
 courses:
     - name: Programming Languages and Paradigms 

--- a/data/academic_institutions/paris.md
+++ b/data/academic_institutions/paris.md
@@ -3,7 +3,7 @@ name: Université Paris-Diderot
 description: >
  Paris Diderot University, also known as Paris 7, was a French university located in Paris, France. It was one of the seven universities of the Paris public higher education academy. 
 url: "https://u-paris.fr/en/"
-logo: /academic_institution/paris.jpg
+logo: academic_institution/paris.jpg
 continent: Europe
 courses:
     - name: Advanced Functional Programming 

--- a/data/academic_institutions/pennsylvania.md
+++ b/data/academic_institutions/pennsylvania.md
@@ -3,7 +3,7 @@ name: University of Pennsylvania
 description: >
  The University of Pennsylvania is a private Ivy League research university in Philadelphia, Pennsylvania.
 url: "https://www.upenn.edu/"
-logo: /academic_institution/penn.png
+logo: academic_institution/penn.png
 continent: North America
 courses:
     - name: Compilers 

--- a/data/academic_institutions/princeton.md
+++ b/data/academic_institutions/princeton.md
@@ -3,7 +3,7 @@ name:  Princeton University
 description: >
  Princeton University is a private Ivy League research university in Princeton, New Jersey. 
 url: "https://www.princeton.edu/"
-logo: /academic_institution/princeton.png
+logo: academic_institution/princeton.png
 continent: North America
 courses:
     - name: Functional Programming 

--- a/data/academic_institutions/rennes.md
+++ b/data/academic_institutions/rennes.md
@@ -3,7 +3,7 @@ name: University of Rennes 1
 description: >
  The University of Rennes 1 is a public university located in the city of Rennes, France. It is under the Academy of Rennes. 
 url: "https://international.univ-rennes1.fr/en/welcome-universite-de-rennes-1"
-logo: /academic_institution/reness.png
+logo: academic_institution/reness.png
 continent: Europe
 courses:
     - name: Compilation 

--- a/data/academic_institutions/rice.md
+++ b/data/academic_institutions/rice.md
@@ -3,7 +3,7 @@ name: Rice University
 description: >
  William Marsh Rice University, commonly known as Rice University, is a private research university in Houston, Texas. 
 url: "https://www.rice.edu/"
-logo: /academic_institution/rice.jpg
+logo: academic_institution/rice.jpg
 continent: North America
 courses:
     - name: Principles of Programming Languages

--- a/data/academic_institutions/san.md
+++ b/data/academic_institutions/san.md
@@ -3,7 +3,7 @@ name: University of California, San Diego
 description: >
  The University of California, San Diego(UC San Diego or, colloquially, UCSD) is a public land-grant research university in San Diego, California.
 url: "https://ucsd.edu/"
-logo: /academic_institution/ucsd_logo.png
+logo: academic_institution/ucsd_logo.png
 continent: North America
 courses:
     - name:  Programming Languages Principles and Paradigms (along with Python and Prolog)

--- a/data/academic_institutions/twin.md
+++ b/data/academic_institutions/twin.md
@@ -3,7 +3,7 @@ name:  University of Minnesota Twin Cities
 description: >
  The University of Minnesota, Twin Cities is a public land-grant research university in the Twin Cities of Minneapolis and Saint Paul, Minnesota. 
 url: "https://twin-cities.umn.edu/"
-logo: /academic_institution/twin.svg
+logo: academic_institution/twin.svg
 continent: North America
 courses:
     - name: Advanced Programming Principles 

--- a/data/academic_institutions/umas.md
+++ b/data/academic_institutions/umas.md
@@ -3,7 +3,7 @@ name: University of Massachusetts Amherst
 description: >
  The University of Massachusetts Amherst is a public land-grant research university in Amherst, Massachusetts. 
 url: "https://www.umass.edu/"
-logo: /academic_institution/umas.jpeg
+logo: academic_institution/umas.jpeg
 continent: North America
 courses:
     - name: University of Massachusetts Amherst

--- a/data/academic_institutions/virginia.md
+++ b/data/academic_institutions/virginia.md
@@ -3,7 +3,7 @@ name: University of Virginia
 description: >
  The University of Virginia is a public research university in Charlottesville, Virginia. 
 url: "https://www.virginia.edu/"
-logo: /academic_institution/virginia.png
+logo: academic_institution/virginia.png
 continent: North America
 courses:
     - name: Programming Languages

--- a/data/academic_institutions/wroclaw.md
+++ b/data/academic_institutions/wroclaw.md
@@ -3,7 +3,7 @@ name: University of Wrocław
 description: >
  The University of Wrocław is a public research university located in Wrocław, Poland. 
 url: "https://uni.wroc.pl/en/"
-logo: /academic_institution/wroclaw.jpg
+logo: academic_institution/wroclaw.jpg
 continent: Europe
 courses:
     - name: Functional Programming 

--- a/data/industrial_users/4sigma.md
+++ b/data/industrial_users/4sigma.md
@@ -3,7 +3,7 @@ name: 4Sigma
 description: >
   4Sigma is an italian firm making web applications and solutions for the industrial automation sector.
 url: "https://4sigma.it"
-logo: /users/4sigma.png
+logo: users/4sigma.png
 locations:
   - Italy
 consortium: false

--- a/data/industrial_users/ahrefs.md
+++ b/data/industrial_users/ahrefs.md
@@ -3,7 +3,7 @@ name: Ahrefs
 description: >
   Ahrefs crawls the entire internet constantly to collect, process, and store data to build an all-in-one SEO toolkit.
 url: "https://www.ahrefs.com"
-logo: /users/ahrefs.png
+logo: users/ahrefs.png
 locations:
   - Singapore
   - United States

--- a/data/industrial_users/american-museum-of-natural-history.md
+++ b/data/industrial_users/american-museum-of-natural-history.md
@@ -3,7 +3,7 @@ name: American Museum of Natural History
 description: > 
   The Computational Sciences Department at the AMNH has been using OCaml for almost a decade in their software package POY for phylogenetic inference
 url: "https://www.amnh.org/our-research/computational-sciences"
-logo: /users/amnh.png
+logo: users/amnh.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/anssi.md
+++ b/data/industrial_users/anssi.md
@@ -3,7 +3,7 @@ name: ANSSI
 description: > 
   The ANSSI core missions are: to detect and react to cyber attacks, to prevent threats, to provide advice and support to governmental entities and operators of critical infrastructure, and to keep companies and the general public informed about information security threats
 url: "https://www.ssi.gouv.fr/"
-logo: /users/anssi.png
+logo: users/anssi.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/arena.md
+++ b/data/industrial_users/arena.md
@@ -3,7 +3,7 @@ name: Arena
 description: > 
   Arena helps organizations hire the right people.
 url: "https://www.arena.io"
-logo: /users/arena.jpg
+logo: users/arena.jpg
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/be-sport.md
+++ b/data/industrial_users/be-sport.md
@@ -3,7 +3,7 @@ name: Be Sport
 description: > 
   Be Sport's mission is to enhance the value that sport brings to our lives with appropriate use of digital and social media innovations
 url: "https://besport.com/"
-logo: /users/besport.png
+logo: users/besport.png
 locations: 
   - France
 consortium: true

--- a/data/industrial_users/bloomberg.md
+++ b/data/industrial_users/bloomberg.md
@@ -2,7 +2,7 @@
 name: Bloomberg L.P.
 description: > 
   Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas
-logo: /users/bloomberg.jpg
+logo: users/bloomberg.jpg
 url: "https://www.bloomberg.com"
 locations: 
   - United States

--- a/data/industrial_users/cacaoweb.md
+++ b/data/industrial_users/cacaoweb.md
@@ -3,7 +3,7 @@ name: CACAOWEB
 description: > 
   Cacaoweb is developing an application platform of a new kind. It runs on top of our peer-to-peer network, which happens to be one of the largest in the world
 url: "https://cacaoweb.org/"
-logo: /users/cacaoweb.png
+logo: users/cacaoweb.png
 locations: 
   - United Kingdom
   - Hong Kong

--- a/data/industrial_users/cea.md
+++ b/data/industrial_users/cea.md
@@ -3,7 +3,7 @@ name: CEA
 description: > 
   CEA is a French state company, member of the OCaml Consortium.
 url: "https://cea.fr/"
-logo: /users/cea.png
+logo: users/cea.png
 locations: 
   - France
 consortium: true

--- a/data/industrial_users/citrix.md
+++ b/data/industrial_users/citrix.md
@@ -2,7 +2,7 @@
 name: Citrix
 description: > 
   Citrix uses OCaml in XenServer, a world-class server virtualization system.
-logo: /users/citrix.png
+logo: users/citrix.png
 url: "https://www.citrix.com"
 locations: 
   - United Kingdom

--- a/data/industrial_users/coherent-graphics.md
+++ b/data/industrial_users/coherent-graphics.md
@@ -3,7 +3,7 @@ name: Coherent Graphics Ltd
 description: > 
   Coherent Graphics is a developer of both server tools and desktop software for the processing of PDF documents
 url: "https://www.coherentpdf.com/"
-logo: /users/coherent.png
+logo: users/coherent.png
 locations: 
   - United Kingdom
 consortium: false

--- a/data/industrial_users/cryptosense.md
+++ b/data/industrial_users/cryptosense.md
@@ -3,7 +3,7 @@ name: Cryptosense
 description: > 
   Cryptosense creates security analysis software with a particular focus on cryptographic systems
 url: "https://www.cryptosense.com/"
-logo: /users/cryptosense.png
+logo: users/cryptosense.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/dassault.md
+++ b/data/industrial_users/dassault.md
@@ -3,7 +3,7 @@ name: Dassault Systèmes
 description: > 
   Dassault Systèmes, the 3DEXPERIENCE Company, provides businesses and people with virtual universes to imagine sustainable innovations.
 url: "https://www.3ds.com/fr/"
-logo: /users/dassault.png
+logo: users/dassault.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/dernier-cri.md
+++ b/data/industrial_users/dernier-cri.md
@@ -3,7 +3,7 @@ name: Dernier Cri
 description: > 
   Dernier Cri is a French company based in Lille and Paris using functional programming to develop web and mobile applications.
 url: "https://derniercri.io"
-logo: /users/derniercri.png
+logo: users/derniercri.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/digirati-dba-hostnet.md
+++ b/data/industrial_users/digirati-dba-hostnet.md
@@ -3,7 +3,7 @@ name: Digirati dba Hostnet
 description: > 
   Digirati dba Hostnet is a web hosting company.
 url: "https://www.hostnet.com.br/"
-logo: /users/hostnet.gif
+logo: users/hostnet.gif
 locations: 
   - Brazil
 consortium: false

--- a/data/industrial_users/docker.md
+++ b/data/industrial_users/docker.md
@@ -2,7 +2,7 @@
 name: Docker, Inc.
 description: > 
   Docker provides an integrated technology suite that enables development and IT operations teams to build, ship, and run distributed applications anywhere
-logo: /users/docker.png
+logo: users/docker.png
 url: "https://www.docker.com"
 locations: 
   - United States

--- a/data/industrial_users/esterel-technologies.md
+++ b/data/industrial_users/esterel-technologies.md
@@ -3,7 +3,7 @@ name: Esterel Technologies
 description: > 
   Esterel Technologies is a leading provider of critical systems and software development solutions for the aerospace, defense, rail transportation, nuclear, and industrial and automotive domains
 url: "https://www.esterel-technologies.com/"
-logo: /users/esterel.jpg
+logo: users/esterel.jpg
 locations: 
   - France
 consortium: true

--- a/data/industrial_users/facebook.md
+++ b/data/industrial_users/facebook.md
@@ -1,7 +1,7 @@
 ---
 name: Facebook
 description: Facebook has built a number of major development tools using OCaml
-logo: /users/facebook.png
+logo: users/facebook.png
 url: "https://www.facebook.com/"
 locations: 
   - United States

--- a/data/industrial_users/fasoo.md
+++ b/data/industrial_users/fasoo.md
@@ -3,7 +3,7 @@ name: Fasoo
 description: > 
   Fasoo uses OCaml to develop a static analysis tool.
 url: "https://www.fasoo.com"
-logo: /users/fasoo.png
+logo: users/fasoo.png
 locations: 
   - Korea
 consortium: false

--- a/data/industrial_users/flying-frog-consultancy.md
+++ b/data/industrial_users/flying-frog-consultancy.md
@@ -3,7 +3,7 @@ name: Flying Frog Consultancy
 description: > 
   Flying Frog Consultancy Ltd. consult and write books and software on the use of OCaml in the context of scientific computing.
 url: "https://www.ffconsultancy.com"
-logo: /users/flying-frog.png
+logo: users/flying-frog.png
 locations: 
   - United Kingdom
 consortium: false

--- a/data/industrial_users/forallsecure.md
+++ b/data/industrial_users/forallsecure.md
@@ -3,7 +3,7 @@ name: ForAllSecure
 description: > 
   ForAllSecure's mission is to test the world's software and provide actionable information to our customers.
 url: "https://forallsecure.com"
-logo: /users/forallsecure.png
+logo: users/forallsecure.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/functori.md
+++ b/data/industrial_users/functori.md
@@ -3,7 +3,7 @@ name: Functori
 description: >
   Functori is a R&D company created by experienced engineers in programming languages (particularly OCaml), formal verification (automated reasoning, model checking, ...), and blockchain technology (core, smart contracts and applications development).
 url: "https://www.functori.com"
-logo: /users/functori.png
+logo: users/functori.png
 locations:
   - "Paris, France"
 consortium: false

--- a/data/industrial_users/galois.md
+++ b/data/industrial_users/galois.md
@@ -3,7 +3,7 @@ name: Galois
 description: > 
   Galois has developed a domain specific declarative language for cryptographic algorithms.
 url: "https://www.galois.com"
-logo: /users/galois.png
+logo: users/galois.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/imandra.md
+++ b/data/industrial_users/imandra.md
@@ -2,7 +2,7 @@
 name: Imandra Inc.
 description: >
   Imandra is the world leader in cloud-scale automated reasoning.
-logo: /users/imandra.png
+logo: users/imandra.png
 url: "https://www.imandra.ai"
 locations:
   - United States

--- a/data/industrial_users/incubaid.md
+++ b/data/industrial_users/incubaid.md
@@ -3,7 +3,7 @@ name: Incubaid
 description: > 
   Incubaid has developed Arakoon, a distributed key-value store that guarantees consistency above anything else.
 url: "https://incubaid.com"
-logo: /users/Incubaid.png
+logo: users/Incubaid.png
 locations: 
   - Belgium
 consortium: false

--- a/data/industrial_users/issuu.md
+++ b/data/industrial_users/issuu.md
@@ -3,7 +3,7 @@ name: Issuu
 description: > 
   Issuu is a digital publishing platform delivering exceptional reading experiences of magazines, catalogues, and newspapers
 url: "https://issuu.com"
-logo: /users/issuu.gif
+logo: users/issuu.gif
 locations: 
   - Denmark
 consortium: false

--- a/data/industrial_users/jane-street.md
+++ b/data/industrial_users/jane-street.md
@@ -3,7 +3,7 @@ name: Jane Street
 description: > 
   Jane Street is a quantitative trading firm that operates around the clock and around the globe
 url: "https://janestreet.com"
-logo: /users/jane-street.jpg
+logo: users/jane-street.jpg
 locations: 
   - United States
   - United Kingdom

--- a/data/industrial_users/kernelize.md
+++ b/data/industrial_users/kernelize.md
@@ -5,7 +5,7 @@ description: >
   that achieves the smallest possible worst-case error among all rank-n
   approximations.
 url: "https://kernelyze.com/"
-logo: /users/kernelyze-llc-logo.png
+logo: users/kernelyze-llc-logo.png
 locations: 
   - United States
 consortium: true

--- a/data/industrial_users/kong.md
+++ b/data/industrial_users/kong.md
@@ -3,7 +3,7 @@ name: Kong
 description: > 
   Kong makes it easy to distribute, monetize, manage and consume cloud APIs.
 url: "https://www.konghq.com"
-logo: /users/mashape.png
+logo: users/mashape.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/lexifi.md
+++ b/data/industrial_users/lexifi.md
@@ -3,7 +3,7 @@ name: LexiFi
 description: > 
   LexiFi is an innovative provider of software applications and infrastructure technology for the capital markets industry.
 url: "https://www.lexifi.com"
-logo: /users/lexifi.png
+logo: users/lexifi.png
 locations: 
   - France
 consortium: true

--- a/data/industrial_users/matrix-lead.md
+++ b/data/industrial_users/matrix-lead.md
@@ -3,7 +3,7 @@ name: Matrix Lead
 description: > 
   Matrix Lead provides professionals and companies with leading technologies and solutions for spreadsheets. 
 url: "https://www.matrixlead.com"
-logo: /users/matrixlead.png
+logo: users/matrixlead.png
 locations: 
   - France
   - China

--- a/data/industrial_users/medit.md
+++ b/data/industrial_users/medit.md
@@ -3,7 +3,7 @@ name: MEDIT
 description: > 
   MEDIT develops SuMo, an advanced bioinformatic system, for the analysis of protein 3D structures and the identification of drug-design targets. 
 url: "https://www.medit-pharma.com/"
-logo: /users/medit.jpg
+logo: users/medit.jpg
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/microsoft.md
+++ b/data/industrial_users/microsoft.md
@@ -3,7 +3,7 @@ name: Microsoft
 description: > 
   Microsoft Corporation is an American multinational technology corporation which produces computer software, consumer electronics, personal computers, and related services.
 url: "https://www.microsoft.com"
-logo: /users/microsoft.png
+logo: users/microsoft.png
 locations: 
   - United States
 consortium: true

--- a/data/industrial_users/mount-sinai.md
+++ b/data/industrial_users/mount-sinai.md
@@ -3,7 +3,7 @@ name: Mount Sinai
 description: > 
   The Hammer Lab at Mount Sinai develops and uses Ketrew for managing complex bioinformatics workflows.
 url: "https://www.mountsinai.org"
-logo: /users/mount-sinai.png
+logo: users/mount-sinai.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/mr-number.md
+++ b/data/industrial_users/mr-number.md
@@ -3,7 +3,7 @@ name: Mr. Number
 description: > 
   Mr. Number started as a Silicon Valley startup and developed the Mr. Number app for call blocking, later acquired by WhitePages.
 url: "https://mrnumber.com/"
-logo: /users/mrnumber.jpg
+logo: users/mrnumber.jpg
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/mylife.md
+++ b/data/industrial_users/mylife.md
@@ -3,7 +3,7 @@ name: MyLife
 description: > 
   MyLife has developed a powerful people search tool that will empower those in need to find anyone, regardless of years past and the life that was built in between.
 url: "https://www.mylife.com/"
-logo: /users/mylife.jpg
+logo: users/mylife.jpg
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/narrow-gate-logic.md
+++ b/data/industrial_users/narrow-gate-logic.md
@@ -3,7 +3,7 @@ name: Narrow Gate Logic
 description: > 
   Narrow Gate Logic is a company using the OCaml language in business and non-business applications.
 url: "https://nglogic.com"
-logo: /users/nglogic.png
+logo: users/nglogic.png
 locations: 
   - Poland
 consortium: false

--- a/data/industrial_users/nomadic-labs.md
+++ b/data/industrial_users/nomadic-labs.md
@@ -5,7 +5,7 @@ description: >
   core competencies are in programming language theory and practice,
   distributed systems, and formal verification.
 url: "https://www.nomadic-labs.com"
-logo: /users/nomadic-labs.png
+logo: users/nomadic-labs.png
 locations: 
   - "Paris, France"
 consortium: false

--- a/data/industrial_users/ocamlpro.md
+++ b/data/industrial_users/ocamlpro.md
@@ -3,7 +3,7 @@ name: OCamlPro
 description: > 
   OCamlPro develops and maintains a development environment for the OCaml language.
 url: "https://www.ocamlpro.com"
-logo: /users/ocamlpro.png
+logo: users/ocamlpro.png
 locations: 
   - France
 consortium: true

--- a/data/industrial_users/prudent.md
+++ b/data/industrial_users/prudent.md
@@ -3,7 +3,7 @@ name: PRUDENT Technologies and Consulting, Inc.
 description: > 
   Prudent Consulting offers IT solutions to large and mid-sized organizations by combining industry experience and technology expertise to help our customers achieve business goals with speed, agility, and great impact.
 url: "https://www.prudentconsulting.com"
-logo: /users/prudent.jpg
+logo: users/prudent.jpg
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/psellos.md
+++ b/data/industrial_users/psellos.md
@@ -3,7 +3,7 @@ name: Psellos
 description: > 
   Psellos is a small group of computer scientists who became intrigued by the idea of coding iOS apps in OCaml.
 url: "https://www.psellos.com"
-logo: /users/psellos.png
+logo: users/psellos.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/r2c.md
+++ b/data/industrial_users/r2c.md
@@ -3,7 +3,7 @@ name: r2c
 description: > 
   r2c is a VC-funded security company headquartered in San Francisco and distributed worldwide
 url: "https://r2c.dev"
-logo: /users/r2c.png
+logo: users/r2c.png
 locations: 
   - California, United States
 consortium: false

--- a/data/industrial_users/sakhalin.md
+++ b/data/industrial_users/sakhalin.md
@@ -3,7 +3,7 @@ name: Sakhalin
 description: > 
   Sakhalin develops marine charting apps for Apple iPads and iPhones.
 url: "https://www.seaiq.com"
-logo: /users/seaiq.png
+logo: users/seaiq.png
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/shiro-games.md
+++ b/data/industrial_users/shiro-games.md
@@ -3,7 +3,7 @@ name: Shiro Games
 description: > 
   Shiro Games is developing games using Haxe, a language built with a compiler written in OCaml.
 url: "https://www.shirogames.com"
-logo: /users/shirogames.png
+logo: users/shirogames.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/simcorp.md
+++ b/data/industrial_users/simcorp.md
@@ -3,7 +3,7 @@ name: SimCorp
 description: > 
   Multi-asset platform to support investment decision-making and innovation.
 url: "https://www.simcorp.com/"
-logo: /users/simcorp.png
+logo: users/simcorp.png
 locations: 
   - United States
 consortium: true

--- a/data/industrial_users/sleekersoft.md
+++ b/data/industrial_users/sleekersoft.md
@@ -3,7 +3,7 @@ name: Sleekersoft
 description: > 
   Specialises in functional programming software development, consultation, and training.
 url: "https://www.sleekersoft.com"
-logo: /users/sleekersoft.png
+logo: users/sleekersoft.png
 locations: 
   - Australia
 consortium: false

--- a/data/industrial_users/solvuu.md
+++ b/data/industrial_users/solvuu.md
@@ -3,7 +3,7 @@ name: Solvuu
 description: > 
   Solvuu's software allows users to store big and small data sets, share the data with collaborators, execute computationally intensive algorithms and workflows, and visualize results.
 url: "https://www.solvuu.com"
-logo: /users/solvuu.jpg
+logo: users/solvuu.jpg
 locations: 
   - United States
 consortium: false

--- a/data/industrial_users/tarides.md
+++ b/data/industrial_users/tarides.md
@@ -3,7 +3,7 @@ name: Tarides
 description: > 
   Tarides builds and maintains open-source infrastructure tools in OCaml like MirageOS, Irmin and OCaml developer tools.
 url: "https://www.tarides.com"
-logo: /users/tarides.png
+logo: users/tarides.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/trustinsoft.md
+++ b/data/industrial_users/trustinsoft.md
@@ -3,7 +3,7 @@ name: TrustInSoft
 description: > 
   TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis Frama-C platform. 
 url: "https://trust-in-soft.com"
-logo: /users/trustinsoft.png
+logo: users/trustinsoft.png
 locations: 
   - France
 consortium: false

--- a/data/industrial_users/wolfram-mathcore.md
+++ b/data/industrial_users/wolfram-mathcore.md
@@ -3,7 +3,7 @@ name: Wolfram MathCore
 description: > 
   Wolfram MathCore uses OCaml to implement its SystemModeler kernel.
 url: "https://www.wolframmathcore.com"
-logo: /users/wolfram-mathcore.gif
+logo: users/wolfram-mathcore.gif
 locations: 
   - Sweden
 consortium: false

--- a/data/industrial_users/zeo-agency.md
+++ b/data/industrial_users/zeo-agency.md
@@ -3,7 +3,7 @@ name: Zeo Agency
 description: > 
   Zeo is a digital marketing company focused on helping companies to do better in SEO.
 url: "https://www.zeo.org"
-logo: /users/zeo.svg
+logo: users/zeo.svg
 locations: 
   - "London, United Kingdom"
 consortium: false

--- a/data/success_stories/ahrefs.md
+++ b/data/success_stories/ahrefs.md
@@ -1,6 +1,6 @@
 ---
 title: Peta-Byte Scale Web Crawler
-logo: /success-stories/ahrefs.svg
+logo: success-stories/ahrefs.svg
 background: /success-stories/ahrefs-bg.jpg
 theme: blue
 synopsis: "Ahrefs crawls the entire internet constantly to collect, process, and store data to build an all-in-one SEO toolkit."

--- a/data/success_stories/hyper.md
+++ b/data/success_stories/hyper.md
@@ -1,6 +1,6 @@
 ---
 title: Sensor Analytics and Automation Platform for Sustainable Agriculture
-logo: /success-stories/hyper.png
+logo: success-stories/hyper.png
 background: /success-stories/hyper-bg.jpg
 theme: green
 synopsis: "Hyper Uses OCaml to Build an IoT System for High-Performing Farms."

--- a/data/success_stories/janestreet.md
+++ b/data/success_stories/janestreet.md
@@ -1,6 +1,6 @@
 ---
 title: Large Scale Trading System
-logo: /success-stories/janestreet.png
+logo: success-stories/janestreet.png
 background: /success-stories/janestreet-bg.png
 theme: cyan
 synopsis: "Jane Street is a quantitative trading firm and liquidity provider with a unique focus on technology and collaborative problem solving."

--- a/data/success_stories/lexifi.md
+++ b/data/success_stories/lexifi.md
@@ -1,6 +1,6 @@
 ---
 title: Modeling Language for Finance
-logo: /success-stories/lexifi.png
+logo: success-stories/lexifi.png
 background: /success-stories/lexifi-bg.jpg
 theme: orange
 synopsis: "Integrated end-user software solution to efficiently manage all types of structured investment products and provide superior client services."


### PR DESCRIPTION
Command line used:

find . -name "*.md" -exec sed -i "s/\(logo: \)\//\1/g" "{}" ";"

Those slashes introduced double slashes in urls, creating ahrefs
issues and lowering site health score.
