### PR TITLE
only show the learn layout TOC sidebar on screens large enough to accommodate it

### DIFF
--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -43,9 +43,9 @@ Learn_layout.render ~current_tutorial:tutorial.slug ~title:(Printf.sprintf "%s Â
     </div>
   </div>
 </div>
-<div class="hidden lg:flex top-0 sticky h-screen">
-  <div class="flex-col w-60">
-    <div class="h-screen overflow-auto p-6 right-sidebar">
+<div class="hidden xl:flex top-0 sticky h-screen">
+  <div class="flex-col w-60 py-6 pl-6">
+    <div class="h-screen overflow-auto right-sidebar">
       <div class="font-semibold text-black text-sm mb-4">ON THIS PAGE</div>
       <div class="page-toc"><%s! tutorial.toc_html %></div>
     </div>


### PR DESCRIPTION
The TOC sidebar now only appears on xl screens (instead of already on lg screens) and I allowed the TOC to take up a bit more space on the right hand side. (so that the whitespace to the right side is equal to the whitespace to the left side of the screen).

I tried to make the sidebars narrower on lg screens to cram it all onto the same page, but the experience was not great. Code is being cut off, which means that people need to scroll sideways. For comparison: Tailwind's documentation page also shows the TOC sidebar only on xl screens.

before lg             |  after lg
:-------------------------:|:-------------------------:
![Screenshot 2022-09-20 at 10-40-20 Modules · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/191211900-b71d318c-d351-4ed9-9261-a961c291c681.png)  |  ![Screenshot 2022-09-20 at 10-40-25 Modules · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/191211912-0227fcf1-c7d3-4c64-9f79-8222b8d1c5d8.png)

before xl             |  after xl
:-------------------------:|:-------------------------:
![Screenshot 2022-09-20 at 10-40-59 Modules · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/191212482-3c151f76-4904-4046-8ee8-d5029c360533.png) | ![Screenshot 2022-09-20 at 10-40-53 Modules · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/191212489-b2d3d602-6dfa-4730-bb1c-ac1880e0cfa6.png)


