### PR TITLE
Handle HEAD requests

### DIFF
--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -13,7 +13,7 @@ let head handler request =
       let open Lwt.Syntax in
       let* response = handler request in
       let transfer_encoding = Dream.header response "Transfer-Encoding" in
-      let* _ =
+      let* () =
         if
           transfer_encoding = Some "chunked"
           || Dream.has_header response "Content-Length"

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -7,17 +7,21 @@ let no_trailing_slash next_handler request =
         Dream.redirect request (String.sub target 0 (String.length target - 1))
       else next_handler request
 
-let head handler request = match Dream.method_ request with
-| `HEAD ->
-    let open Lwt.Syntax in
-    let* response = handler request in
-    let transfer_encoding = Dream.header response "Transfer-Encoding" in
-    let* _ =
-      if transfer_encoding = Some "chunked" || Dream.has_header response "Content-Length" then
-        Lwt.return_unit
-      else
-        let+ body = Dream.body response in
-        body |> String.length |> string_of_int |> Dream.add_header response "Content-Length"
+let head handler request =
+  match Dream.method_ request with
+  | `HEAD ->
+      let open Lwt.Syntax in
+      let* response = handler request in
+      let transfer_encoding = Dream.header response "Transfer-Encoding" in
+      let* _ =
+        if
+          transfer_encoding = Some "chunked"
+          || Dream.has_header response "Content-Length"
+        then Lwt.return_unit
+        else
+          let+ body = Dream.body response in
+          body |> String.length |> string_of_int
+          |> Dream.add_header response "Content-Length"
       in
-    Dream.empty ~headers:(Dream.all_headers response) (Dream.status response)
-| _ -> handler request
+      Dream.empty ~headers:(Dream.all_headers response) (Dream.status response)
+  | _ -> handler request

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -11,6 +11,7 @@ let head handler request =
   match Dream.method_ request with
   | `HEAD ->
       let open Lwt.Syntax in
+      Dream.set_method_ request `GET;
       let* response = handler request in
       let transfer_encoding = Dream.header response "Transfer-Encoding" in
       let* () =

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -6,3 +6,18 @@ let no_trailing_slash next_handler request =
       if String.ends_with ~suffix:"/" target then
         Dream.redirect request (String.sub target 0 (String.length target - 1))
       else next_handler request
+
+let head handler request = match Dream.method_ request with
+| `HEAD ->
+    let open Lwt.Syntax in
+    let* response = handler request in
+    let transfer_encoding = Dream.header response "Transfer-Encoding" in
+    let* _ =
+      if transfer_encoding = Some "chunked" || Dream.has_header response "Content-Length" then
+        Lwt.return_unit
+      else
+        let+ body = Dream.body response in
+        body |> String.length |> string_of_int |> Dream.add_header response "Content-Length"
+      in
+    Dream.empty ~headers:(Dream.all_headers response) (Dream.status response)
+| _ -> handler request

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -12,4 +12,5 @@ let run () =
   Mirage_crypto_rng_lwt.initialize ();
   let state = Ocamlorg_package.init () in
   Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
-  @@ Dream.logger @@ Middleware.no_trailing_slash @@ Router.router state
+  @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.head
+  @@ Router.router state

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -23,66 +23,68 @@ let media_loader =
       let* store in
       Media.last_modified store (Mirage_kv.Key.v path))
 
+let get_and_head pattern handler = [ Dream.get pattern handler; Dream.head pattern handler ]
+
 let page_routes =
   Dream.scope ""
     [ Dream_dashboard.analytics (); Dream_encoding.compress ]
-    [
-      Dream.get Url.index Handler.index;
-      Dream.get Url.learn Handler.learn;
-      Dream.get Url.platform Handler.platform;
-      Dream.get Url.community Handler.community;
-      Dream.get (Url.success_story ":id") Handler.success_story;
-      Dream.get Url.industrial_users Handler.industrial_users;
-      Dream.get Url.academic_users Handler.academic_users;
-      Dream.get Url.about Handler.about;
-      Dream.get Url.books Handler.books;
-      Dream.get Url.releases Handler.releases;
-      Dream.get (Url.release ":id") Handler.release;
-      Dream.get (Url.workshop ":id") Handler.workshop;
-      Dream.get Url.blog Handler.blog;
-      Dream.get Url.news Handler.news;
-      Dream.get (Url.news_post ":id") Handler.news_post;
-      Dream.get Url.jobs Handler.jobs;
-      Dream.get Url.carbon_footprint Handler.carbon_footprint;
-      Dream.get Url.privacy_policy Handler.privacy_policy;
-      Dream.get Url.governance Handler.governance;
-      Dream.get Url.papers Handler.papers;
-      Dream.get Url.best_practices Handler.best_practices;
-      Dream.get Url.problems Handler.problems;
-      Dream.get (Url.tutorial ":id") Handler.tutorial;
-      Dream.get Url.playground Handler.playground;
-    ]
+    (List.flatten [
+      get_and_head Url.index Handler.index;
+      get_and_head Url.learn Handler.learn;
+      get_and_head Url.platform Handler.platform;
+      get_and_head Url.community Handler.community;
+      get_and_head (Url.success_story ":id") Handler.success_story;
+      get_and_head Url.industrial_users Handler.industrial_users;
+      get_and_head Url.academic_users Handler.academic_users;
+      get_and_head Url.about Handler.about;
+      get_and_head Url.books Handler.books;
+      get_and_head Url.releases Handler.releases;
+      get_and_head (Url.release ":id") Handler.release;
+      get_and_head (Url.workshop ":id") Handler.workshop;
+      get_and_head Url.blog Handler.blog;
+      get_and_head Url.news Handler.news;
+      get_and_head (Url.news_post ":id") Handler.news_post;
+      get_and_head Url.jobs Handler.jobs;
+      get_and_head Url.carbon_footprint Handler.carbon_footprint;
+      get_and_head Url.privacy_policy Handler.privacy_policy;
+      get_and_head Url.governance Handler.governance;
+      get_and_head Url.papers Handler.papers;
+      get_and_head Url.best_practices Handler.best_practices;
+      get_and_head Url.problems Handler.problems;
+      get_and_head (Url.tutorial ":id") Handler.tutorial;
+      get_and_head Url.playground Handler.playground;
+    ])
 
 let package_route t =
   Dream.scope ""
     [ Dream_dashboard.analytics (); Dream_encoding.compress ]
-    [
-      Dream.get Url.packages (Handler.packages t);
-      Dream.get Url.packages_search (Handler.packages_search t);
-      Dream.get (Url.package ":name") (Handler.package t);
-      Dream.get (Url.package_docs ":name") (Handler.package_docs t);
-      Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
-      Dream.get
+    (List.flatten [
+      get_and_head Url.packages (Handler.packages t);
+      get_and_head Url.packages_search (Handler.packages_search t);
+      get_and_head (Url.package ":name") (Handler.package t);
+      get_and_head (Url.package_docs ":name") (Handler.package_docs t);
+      get_and_head (Url.package_with_univ ":hash" ":name") (Handler.package t);
+      get_and_head
         (Url.package_with_version ":name" ":version")
         ((Handler.package_versioned t) Handler.Package);
-      Dream.get
+      get_and_head
         (Url.package_with_hash_with_version ":hash" ":name" ":version")
         ((Handler.package_versioned t) Handler.Universe);
-      Dream.get
+      get_and_head
         (Url.package_doc ":name" ":version" "**")
         ((Handler.package_doc t) Handler.Package);
-      Dream.get
+      get_and_head
         (Url.package_doc_with_hash ":hash" ":name" ":version" "**")
         ((Handler.package_doc t) Handler.Universe);
-    ]
+    ])
 
 let graphql_route t =
   Dream.scope ""
     [ Dream_encoding.compress ]
-    [
-      Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t));
-      Dream.get "/graphiql" (Dream.graphiql "/api");
-    ]
+    (
+      Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t)) ::
+      get_and_head "/graphiql" (Dream.graphiql "/api");
+    )
 
 let router t =
   Dream.router
@@ -94,8 +96,8 @@ let router t =
       graphql_route t;
       Dream.scope ""
         [ Dream_encoding.compress ]
-        [ Dream.get "/media/**" (Dream.static ~loader:media_loader "") ];
+        (List.flatten [ get_and_head "/media/**" (Dream.static ~loader:media_loader "") ]);
       Dream.scope ""
         [ Dream_encoding.compress ]
-        [ Dream.get "/**" (Dream.static ~loader:asset_loader "") ];
+        (List.flatten [ get_and_head "/**" (Dream.static ~loader:asset_loader "") ]);
     ]

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -32,11 +32,15 @@ let head_handler handler request =
   Dream.add_header response "Content-Length" length;
   Dream.empty ~headers:(Dream.all_headers response) (Dream.status response)
 
-let get_and_head pattern handler = [ Dream.get pattern handler; Dream.head pattern (head_handler handler) ]
+let head_middleware handler request = match Dream.method_ request with
+| `HEAD -> head_handler handler request
+| _ -> handler request
+
+let get_and_head pattern handler = [ Dream.get pattern handler; Dream.head pattern handler ]
 
 let page_routes =
   Dream.scope ""
-    [ Dream_dashboard.analytics (); Dream_encoding.compress ]
+    [ Dream_dashboard.analytics (); Dream_encoding.compress; head_middleware ]
     (List.flatten [
       get_and_head Url.index Handler.index;
       get_and_head Url.learn Handler.learn;

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -23,71 +23,71 @@ let media_loader =
       let* store in
       Media.last_modified store (Mirage_kv.Key.v path))
 
-let get_and_head pattern handler = [
-  Dream.get pattern handler;
-  Dream.head pattern handler
-]
+let get_and_head pattern handler =
+  [ Dream.get pattern handler; Dream.head pattern handler ]
 
 let page_routes =
   Dream.scope ""
     [ Dream_dashboard.analytics (); Dream_encoding.compress; Middleware.head ]
-    (List.flatten [
-      get_and_head Url.index Handler.index;
-      get_and_head Url.learn Handler.learn;
-      get_and_head Url.platform Handler.platform;
-      get_and_head Url.community Handler.community;
-      get_and_head (Url.success_story ":id") Handler.success_story;
-      get_and_head Url.industrial_users Handler.industrial_users;
-      get_and_head Url.academic_users Handler.academic_users;
-      get_and_head Url.about Handler.about;
-      get_and_head Url.books Handler.books;
-      get_and_head Url.releases Handler.releases;
-      get_and_head (Url.release ":id") Handler.release;
-      get_and_head (Url.workshop ":id") Handler.workshop;
-      get_and_head Url.blog Handler.blog;
-      get_and_head Url.news Handler.news;
-      get_and_head (Url.news_post ":id") Handler.news_post;
-      get_and_head Url.jobs Handler.jobs;
-      get_and_head Url.carbon_footprint Handler.carbon_footprint;
-      get_and_head Url.privacy_policy Handler.privacy_policy;
-      get_and_head Url.governance Handler.governance;
-      get_and_head Url.papers Handler.papers;
-      get_and_head Url.best_practices Handler.best_practices;
-      get_and_head Url.problems Handler.problems;
-      get_and_head (Url.tutorial ":id") Handler.tutorial;
-      get_and_head Url.playground Handler.playground;
-    ])
+    (List.flatten
+       [
+         get_and_head Url.index Handler.index;
+         get_and_head Url.learn Handler.learn;
+         get_and_head Url.platform Handler.platform;
+         get_and_head Url.community Handler.community;
+         get_and_head (Url.success_story ":id") Handler.success_story;
+         get_and_head Url.industrial_users Handler.industrial_users;
+         get_and_head Url.academic_users Handler.academic_users;
+         get_and_head Url.about Handler.about;
+         get_and_head Url.books Handler.books;
+         get_and_head Url.releases Handler.releases;
+         get_and_head (Url.release ":id") Handler.release;
+         get_and_head (Url.workshop ":id") Handler.workshop;
+         get_and_head Url.blog Handler.blog;
+         get_and_head Url.news Handler.news;
+         get_and_head (Url.news_post ":id") Handler.news_post;
+         get_and_head Url.jobs Handler.jobs;
+         get_and_head Url.carbon_footprint Handler.carbon_footprint;
+         get_and_head Url.privacy_policy Handler.privacy_policy;
+         get_and_head Url.governance Handler.governance;
+         get_and_head Url.papers Handler.papers;
+         get_and_head Url.best_practices Handler.best_practices;
+         get_and_head Url.problems Handler.problems;
+         get_and_head (Url.tutorial ":id") Handler.tutorial;
+         get_and_head Url.playground Handler.playground;
+       ])
 
 let package_route t =
   Dream.scope ""
     [ Dream_dashboard.analytics (); Dream_encoding.compress; Middleware.head ]
-    (List.flatten [
-      get_and_head Url.packages (Handler.packages t);
-      get_and_head Url.packages_search (Handler.packages_search t);
-      get_and_head (Url.package ":name") (Handler.package t);
-      get_and_head (Url.package_docs ":name") (Handler.package_docs t);
-      get_and_head (Url.package_with_univ ":hash" ":name") (Handler.package t);
-      get_and_head
-        (Url.package_with_version ":name" ":version")
-        ((Handler.package_versioned t) Handler.Package);
-      get_and_head
-        (Url.package_with_hash_with_version ":hash" ":name" ":version")
-        ((Handler.package_versioned t) Handler.Universe);
-      get_and_head
-        (Url.package_doc ":name" ":version" "**")
-        ((Handler.package_doc t) Handler.Package);
-      get_and_head
-        (Url.package_doc_with_hash ":hash" ":name" ":version" "**")
-        ((Handler.package_doc t) Handler.Universe);
-    ])
+    (List.flatten
+       [
+         get_and_head Url.packages (Handler.packages t);
+         get_and_head Url.packages_search (Handler.packages_search t);
+         get_and_head (Url.package ":name") (Handler.package t);
+         get_and_head (Url.package_docs ":name") (Handler.package_docs t);
+         get_and_head
+           (Url.package_with_univ ":hash" ":name")
+           (Handler.package t);
+         get_and_head
+           (Url.package_with_version ":name" ":version")
+           ((Handler.package_versioned t) Handler.Package);
+         get_and_head
+           (Url.package_with_hash_with_version ":hash" ":name" ":version")
+           ((Handler.package_versioned t) Handler.Universe);
+         get_and_head
+           (Url.package_doc ":name" ":version" "**")
+           ((Handler.package_doc t) Handler.Package);
+         get_and_head
+           (Url.package_doc_with_hash ":hash" ":name" ":version" "**")
+           ((Handler.package_doc t) Handler.Universe);
+       ])
 
 let graphql_route t =
   Dream.scope ""
     [ Dream_encoding.compress; Middleware.head ]
-    (
-      Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t)) ::
-      get_and_head "/graphiql" (Dream.graphiql "/api");
-    )
+    (Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t))
+    :: get_and_head "/graphiql" (Dream.graphiql "/api"))
 
 let router t =
   Dream.router
@@ -99,8 +99,10 @@ let router t =
       graphql_route t;
       Dream.scope ""
         [ Dream_encoding.compress; Middleware.head ]
-        (List.flatten [ get_and_head "/media/**" (Dream.static ~loader:media_loader "") ]);
+        (List.flatten
+           [ get_and_head "/media/**" (Dream.static ~loader:media_loader "") ]);
       Dream.scope ""
         [ Dream_encoding.compress; Middleware.head ]
-        (List.flatten [ get_and_head "/**" (Dream.static ~loader:asset_loader "") ]);
+        (List.flatten
+           [ get_and_head "/**" (Dream.static ~loader:asset_loader "") ]);
     ]

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -23,71 +23,66 @@ let media_loader =
       let* store in
       Media.last_modified store (Mirage_kv.Key.v path))
 
-let get_and_head pattern handler =
-  [ Dream.get pattern handler; Dream.head pattern handler ]
-
 let page_routes =
   Dream.scope ""
-    [ Dream_dashboard.analytics (); Dream_encoding.compress; Middleware.head ]
-    (List.flatten
-       [
-         get_and_head Url.index Handler.index;
-         get_and_head Url.learn Handler.learn;
-         get_and_head Url.platform Handler.platform;
-         get_and_head Url.community Handler.community;
-         get_and_head (Url.success_story ":id") Handler.success_story;
-         get_and_head Url.industrial_users Handler.industrial_users;
-         get_and_head Url.academic_users Handler.academic_users;
-         get_and_head Url.about Handler.about;
-         get_and_head Url.books Handler.books;
-         get_and_head Url.releases Handler.releases;
-         get_and_head (Url.release ":id") Handler.release;
-         get_and_head (Url.workshop ":id") Handler.workshop;
-         get_and_head Url.blog Handler.blog;
-         get_and_head Url.news Handler.news;
-         get_and_head (Url.news_post ":id") Handler.news_post;
-         get_and_head Url.jobs Handler.jobs;
-         get_and_head Url.carbon_footprint Handler.carbon_footprint;
-         get_and_head Url.privacy_policy Handler.privacy_policy;
-         get_and_head Url.governance Handler.governance;
-         get_and_head Url.papers Handler.papers;
-         get_and_head Url.best_practices Handler.best_practices;
-         get_and_head Url.problems Handler.problems;
-         get_and_head (Url.tutorial ":id") Handler.tutorial;
-         get_and_head Url.playground Handler.playground;
-       ])
+    [ Dream_dashboard.analytics (); Dream_encoding.compress ]
+    [
+      Dream.get Url.index Handler.index;
+      Dream.get Url.learn Handler.learn;
+      Dream.get Url.platform Handler.platform;
+      Dream.get Url.community Handler.community;
+      Dream.get (Url.success_story ":id") Handler.success_story;
+      Dream.get Url.industrial_users Handler.industrial_users;
+      Dream.get Url.academic_users Handler.academic_users;
+      Dream.get Url.about Handler.about;
+      Dream.get Url.books Handler.books;
+      Dream.get Url.releases Handler.releases;
+      Dream.get (Url.release ":id") Handler.release;
+      Dream.get (Url.workshop ":id") Handler.workshop;
+      Dream.get Url.blog Handler.blog;
+      Dream.get Url.news Handler.news;
+      Dream.get (Url.news_post ":id") Handler.news_post;
+      Dream.get Url.jobs Handler.jobs;
+      Dream.get Url.carbon_footprint Handler.carbon_footprint;
+      Dream.get Url.privacy_policy Handler.privacy_policy;
+      Dream.get Url.governance Handler.governance;
+      Dream.get Url.papers Handler.papers;
+      Dream.get Url.best_practices Handler.best_practices;
+      Dream.get Url.problems Handler.problems;
+      Dream.get (Url.tutorial ":id") Handler.tutorial;
+      Dream.get Url.playground Handler.playground;
+    ]
 
 let package_route t =
   Dream.scope ""
-    [ Dream_dashboard.analytics (); Dream_encoding.compress; Middleware.head ]
-    (List.flatten
-       [
-         get_and_head Url.packages (Handler.packages t);
-         get_and_head Url.packages_search (Handler.packages_search t);
-         get_and_head (Url.package ":name") (Handler.package t);
-         get_and_head (Url.package_docs ":name") (Handler.package_docs t);
-         get_and_head
-           (Url.package_with_univ ":hash" ":name")
-           (Handler.package t);
-         get_and_head
-           (Url.package_with_version ":name" ":version")
-           ((Handler.package_versioned t) Handler.Package);
-         get_and_head
-           (Url.package_with_hash_with_version ":hash" ":name" ":version")
-           ((Handler.package_versioned t) Handler.Universe);
-         get_and_head
-           (Url.package_doc ":name" ":version" "**")
-           ((Handler.package_doc t) Handler.Package);
-         get_and_head
-           (Url.package_doc_with_hash ":hash" ":name" ":version" "**")
-           ((Handler.package_doc t) Handler.Universe);
-       ])
+    [ Dream_dashboard.analytics (); Dream_encoding.compress ]
+    [
+      Dream.get Url.packages (Handler.packages t);
+      Dream.get Url.packages_search (Handler.packages_search t);
+      Dream.get (Url.package ":name") (Handler.package t);
+      Dream.get (Url.package_docs ":name") (Handler.package_docs t);
+      Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
+      Dream.get
+        (Url.package_with_version ":name" ":version")
+        ((Handler.package_versioned t) Handler.Package);
+      Dream.get
+        (Url.package_with_hash_with_version ":hash" ":name" ":version")
+        ((Handler.package_versioned t) Handler.Universe);
+      Dream.get
+        (Url.package_doc ":name" ":version" "**")
+        ((Handler.package_doc t) Handler.Package);
+      Dream.get
+        (Url.package_doc_with_hash ":hash" ":name" ":version" "**")
+        ((Handler.package_doc t) Handler.Universe);
+    ]
 
 let graphql_route t =
   Dream.scope ""
-    [ Dream_encoding.compress; Middleware.head ]
-    (Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t))
-    :: get_and_head "/graphiql" (Dream.graphiql "/api"))
+    [ Dream_encoding.compress ]
+    [
+      Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t));
+      Dream.get "/graphiql" (Dream.graphiql "/api");
+    ]
 
 let router t =
   Dream.router
@@ -98,11 +93,9 @@ let router t =
       package_route t;
       graphql_route t;
       Dream.scope ""
-        [ Dream_encoding.compress; Middleware.head ]
-        (List.flatten
-           [ get_and_head "/media/**" (Dream.static ~loader:media_loader "") ]);
+        [ Dream_encoding.compress ]
+        [ Dream.get "/media/**" (Dream.static ~loader:media_loader "") ];
       Dream.scope ""
-        [ Dream_encoding.compress; Middleware.head ]
-        (List.flatten
-           [ get_and_head "/**" (Dream.static ~loader:asset_loader "") ]);
+        [ Dream_encoding.compress ]
+        [ Dream.get "/**" (Dream.static ~loader:asset_loader "") ];
     ]


### PR DESCRIPTION
Fix for https://github.com/ocaml/ocaml.org/issues/148

For each GET route added, add a twin HEAD route. By default dream
does not respond to HEAD request, unless if a ad-hoc route exists.
We probably don't want to maintain a separate set of routes for
GET and HEAD. Therefore, instead of calling Dream.get we call local
function get_and_head, which creates two routes, one for GET requests
and one for HEAD requests.

Dream documentation (dream.mli) says: "Middlewares are run only if
a route matches." Therefore, a turning HEAD requets into GET requests
using a middleware will not work as HEAD requests are discarded before
being sent through any middleware.
