### PR TITLE
anchor target highlighting and clickability of anchors in package docs

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -11,7 +11,7 @@ div.odoc-include .spec {
   border-color: rgba(251, 146, 60, 1);
   border-radius: 0.25rem /* 4px */;
   background-color: rgba(243, 244, 246, 1);
-  padding-left: 1rem /* 16px */;
+  padding-left: 1.7rem /* needs to provide enough space for the hashtag anchor */;
   padding-right: 1rem /* 16px */;
   padding-top: 0.5rem /* 16px */;
   padding-bottom: 0.5rem /* 16px */;
@@ -27,14 +27,64 @@ div.odoc div.spec code {
   white-space: pre-wrap;
 }
 
-div.odoc a.anchor {
+/* clickable anchors with targets and code highlighting of targeted specs */
+
+div.odoc h1,
+div.odoc h2,
+div.odoc h3,
+div.odoc h4,
+div.odoc h5,
+div.odoc h6 {
+  position:relative;
+}
+
+div.odoc h1 a.anchor,
+div.odoc h2 a.anchor,
+div.odoc h3 a.anchor,
+div.odoc h4 a.anchor,
+div.odoc h5 a.anchor,
+div.odoc h6 a.anchor {
   position: absolute;
-  left: 0px;
+  left: 0;
+  right: 0;
+  top:0;
+  bottom:0;
   opacity: 0;
   text-decoration: none;
   color: rgb(156 163 175);
-  margin-left: -0.75em;
   box-shadow: none;
+}
+
+div.odoc h1 a.anchor::after,
+div.odoc h2 a.anchor::after,
+div.odoc h3 a.anchor::after,
+div.odoc h4 a.anchor::after,
+div.odoc h5 a.anchor::after,
+div.odoc h6 a.anchor::after {
+  content: "#";
+  margin-left: -1.2em;
+  padding: 0.4em;
+}
+
+div.odoc .spec {
+  position: relative;
+}
+
+div.odoc .spec a.anchor {
+  position: absolute;
+  left: 0;
+  top:0.3em;
+  opacity: 0;
+  text-decoration: none;
+  color: rgb(156 163 175);
+  box-shadow: none;
+}
+
+div.odoc .spec a.anchor::after {
+  content: "#";
+  font-size:120%;
+  margin-left: -4px;
+  padding: 0.6em;
 }
 
 div.odoc *:hover > a.anchor {
@@ -45,12 +95,25 @@ div.odoc *:hover > a.anchor:hover {
   color: rgb(75 85 99);
 }
 
-div.odoc a.anchor::after {
-  content: "#";
-  padding-right: 1em;
-  padding-left: 1em;
-  font-size: large;
+/* selected anchor target highlighting */
+
+div.odoc .spec:target,
+div.odoc .anchored:target,
+div.odoc h1:target,
+div.odoc h2:target,
+div.odoc h3:target,
+div.odoc h4:target,
+div.odoc h5:target,
+div.odoc h6:target {
+  background: rgb(255, 243, 173);
 }
+
+div.odoc .spec:target a,
+div.odoc .anchored:target a {
+  color: rgb(204, 48, 0);
+}
+
+/* ----- */
 
 div.odoc div.spec table {
   margin-top: 0px;

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -40,7 +40,7 @@ Package_layout.render
         <%s! Navmap.render ~path:str_path maptoc %>
       </div>
     </div>
-    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6">
+    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6 md:pl-12">
       <%s! Breadcrumbs.render path %>
       <div class="odoc prose prose-orange">
         <%s! content %>


### PR DESCRIPTION
Use case: Person A kindly answers person B's OCaml question (e.g. on the OCaml discord, on StackOverflow, Slack, or wherever) and includes a link to a particular position in the documentation of a package.

before              |  after 
:-------------------------:|:-------------------------:
![Screenshot from 2022-09-26 08-18-01](https://user-images.githubusercontent.com/6594573/192206273-bb8c4c36-8b3a-42a8-8389-41e40cc66061.png) the hashtag symbol on Anchors was in an unsuitable position on h1,h2,h3,h4,h5,h6 Elements. The only way to get a link to a particular heading on the package docs was to click the little Hashbang. See https://ocaml.org/p/streaming/0.8.0/doc/index.html#streaming   |  ![Screenshot 2022-09-22 at 17-44-15 Documentation · streaming 0 8 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/191793623-0beffdd3-567c-450f-8b71-ed14f416cc43.png) The anchor of h1,h2,h3,h4,h5,h6 "fully covers" the heading, so the user can click on the heading to get a link to that particular section. The targeted section is now highlighted (like a text marker) to make it easier for the recipient of a targeted link to see which section they are being referred to.
![Screenshot 2022-09-22 at 17-54-17 Streaming Flow · streaming 0 8 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/191794713-db89f6df-2b8c-4575-8a73-d261eacb59ee.png) It is hard to see which definition is highlighted. See https://ocaml.org/p/streaming/0.8.0/doc/Streaming/Flow/index.html#val-identity | ![Screenshot 2022-09-22 at 17-52-34 Streaming Flow · streaming 0 8 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/191794419-100f54c9-39f2-4ea3-a371-98ebe4d15382.png)

Further improvements to anchor clickability in package docs (on the type and function definitions generated by `odoc`) require upstream changes. The same applies to adding clickable anchors to section headings on the tutorials (which requires an upstream change to `omd`).