### PR TITLE
package documentation status title attribute and inactive link

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -12,7 +12,18 @@ let render
 ~(package : Package_intf.package)
 inner =
 let tab_class = "border-transparent border-b-2 hover:border-primary-600 p-4 font-medium relative text-body-400" in
+let unavailable_tab_class = "border-transparent border-b-2 p-4 font-medium relative text-gray-400" in
 let current_tab_class = "border-b-2 hover:border-primary-600 p-4 font-medium border-primary-600 relative text-primary-600" in
+let documentation_dot = match documentation_status with 
+  | `Failure -> "<span class=\"bg-red-500 ml-2 absolute top-2 p-1 rounded-full inline-block\"></span>"
+  | `Success -> "<span class=\"bg-green-500 ml-2 absolute top-2 p-1 rounded-full inline-block\"></span>"
+  | `Unknown -> "<span class=\"bg-orange-300 ml-2 absolute top-2 p-1 rounded-full inline-block\"></span>"
+in
+let doc_status_tooltip = match documentation_status with
+  | `Failure -> "title=\"documentation failed to build\""
+  | `Unknown -> "title=\"failed to fetch documentation\""
+  | _ -> ""
+in
 Layout.render
 ?styles
 ~wide:true
@@ -48,29 +59,25 @@ Layout.render
       </div>
       <div class="flex flex-col">
         <div class="flex mt-8 gap-x-6 border-b border-gray-200 items-stretch flex-wrap">
-          <a href="<%s Url.package_with_version package.name package.version %>">
-            <button
-              class="<%s if tab = Overview then current_tab_class else tab_class %>">
-              Overview
-            </button>
+          <a href="<%s Url.package_with_version package.name package.version %>" class="<%s if tab = Overview then current_tab_class else tab_class %>">
+            Overview
           </a>
-          <a href="<%s Url.package_doc package.name package.version "index.html" %>">
-            <button
-            class="<%s if tab = Documentation then current_tab_class else tab_class %>">
-              Documentation
-              <% (match documentation_status with 
-                 | `Failure -> %>
-                 <span class="bg-red-500 ml-2 absolute top-2 p-1 rounded-full inline-block">
-                 </span>
-              <% | `Success -> %>
-                <span class="bg-green-500 ml-2 absolute top-2 p-1 rounded-full inline-block">
-                </span>
-              <% | `Unknown -> %>
-                <span class="bg-orange-300 ml-2 absolute top-2 p-1 rounded-full inline-block">
-                </span>
-              <% ); %>
-            </button>
-          </a>
+
+          <% (match documentation_status with
+            | `Unknown -> %>
+            <span class="<%s unavailable_tab_class %>" <%s! doc_status_tooltip %>>
+            Documentation
+              <%s! documentation_dot %>
+            </span>
+          <% | _ -> %>
+            <a href="<%s Url.package_doc package.name package.version "index.html" %>"
+              class="<%s if tab = Documentation then current_tab_class else tab_class %>"
+              <%s! doc_status_tooltip %>>
+                Documentation
+                <%s! documentation_dot %>
+            </a>
+          <% ); %>
+          
           <%s! extra_nav %>
         </div>
       </div>


### PR DESCRIPTION
Resolves https://github.com/ocaml/ocaml.org/issues/494 and simplifies the markup by removing the unnecessary `button` tag inside `a`.

before              |  after 
:-------------------------:|:-------------------------:
![Screenshot from 2022-09-23 09-06-41](https://user-images.githubusercontent.com/6594573/191908350-b6ef7ded-04a8-49e3-a4c0-800e9381cb63.png) "Documentation" tab is clickable and links to a 404 page, even when we know that documentation is not available. There is no indication of what the colored dot means. | ![Screenshot from 2022-09-23 09-05-48](https://user-images.githubusercontent.com/6594573/191908361-e847429a-e52c-48d5-b582-ccd2cbb8a306.png) "Documentation" tab is inactive and not clickable when there is no documentation available. A tooltip (title attribute) tells us why.
