### PR TITLE
factoring out shared code between 'Learn' and 'Exercises' pages and their sub-pages

### DIFF
--- a/src/ocamlorg_frontend/components/learn_sidebar.eml
+++ b/src/ocamlorg_frontend/components/learn_sidebar.eml
@@ -1,0 +1,35 @@
+let render
+~current_tutorial
+~tutorials
+=
+  let render_tutorial_link ~title ~slug = 
+    Learn_layout.sidebar_link ~title ~href:(Url.tutorial slug) ~current:(current_tutorial = Some (slug))
+  in
+  let render_tutorial (tutorial : Ood.Tutorial.t) = render_tutorial_link ~title:tutorial.title ~slug:tutorial.slug in
+  let tutorial_sidebar_links_by_category category =
+    tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = category) |> List.map render_tutorial |> String.concat "\n"
+  in
+  <%s! Learn_layout.sidebar_icon_link_block ~current:Learn %>
+
+  <%s! Learn_layout.sidebar_link_group "Getting Started"
+    (tutorial_sidebar_links_by_category "getting-started") %>
+
+  <%s! Learn_layout.sidebar_link_group "Language"
+    (tutorial_sidebar_links_by_category "language") %>
+
+  <%s! Learn_layout.sidebar_link_group "Data Structures"
+    (tutorial_sidebar_links_by_category "data-structures") %>
+
+  <%s! Learn_layout.sidebar_link_group "Runtime"
+    (tutorial_sidebar_links_by_category "runtime") %>
+
+  <%s! Learn_layout.sidebar_link_group "Tutorials"
+    (tutorial_sidebar_links_by_category "tutorials") %>
+
+  <%s! Learn_layout.sidebar_link_group "Guides"
+    (tutorial_sidebar_links_by_category "guides") %>
+
+  <%s! Learn_layout.sidebar_link_group "Resources"
+    (tutorial_sidebar_links_by_category "resources")
+    ~extra_html:((render_tutorial_link ~title:"Best Practices" ~slug:"best-practices")
+      ^ (render_tutorial_link ~title:"OCaml Platform" ~slug:"platform")) %>

--- a/src/ocamlorg_frontend/dune
+++ b/src/ocamlorg_frontend/dune
@@ -196,4 +196,9 @@
   (targets breadcrumbs.ml)
   (deps breadcrumbs.eml)
   (action
+   (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+ (rule
+  (targets learn_sidebar.ml)
+  (deps learn_sidebar.eml)
+  (action
    (run %{bin:dream_eml} %{deps} --workspace %{workspace_root}))))

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -1,3 +1,70 @@
+type active_icon_link = 
+  | Learn
+  | Exercises
+
+let sidebar_icon_link_block
+~current =
+  <div class="space-y-4">
+    <a href="<%s Url.learn %>" class="flex justify-start items-center">
+      <div class="bg-primary-600 text-white rounded w-8 h-8 flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+          stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+        </svg>
+      </div>
+      <div class="ml-3 font-semibold <%s if current != Learn then "opacity-70" else "" %>">Learn OCaml</div>
+    </a>
+
+    <a href="<%s Url.manual %>" class="flex justify-start items-center">
+      <div class="bg-green-600 text-white rounded w-8 h-8 flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      </div>
+      <div class="ml-3 font-semibold opacity-70">Language Manual</div>
+    </a>
+
+    <a href="<%s Url.api %>" class="flex justify-start items-center">
+      <div class="bg-sky-600 text-white rounded w-8 h-8 flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+      </div>
+      <div class="ml-3 font-semibold opacity-70">Standard Library API</div>
+    </a>
+
+    <a href="<%s Url.problems %>" class="flex justify-start items-center">
+      <div class="bg-indigo-600 text-white rounded w-8 h-8 flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <div class="ml-3 font-semibold <%s if current != Exercises then "opacity-70" else "" %>">Exercises</div>
+    </a>
+  </div>
+
+let sidebar_link
+~title
+~href
+~current = 
+  match current with
+  | true ->
+    <a class="flex text-primary-600 bg-primary-100 py-2 px-3 rounded-md text-sm font-semibold" href="<%s href %>">
+      <%s title %>
+    </a>
+  | false ->
+    <a class="font-semibold text-sm text-body-400 hover:bg-gray-100 block py-2 px-3" href="<%s href %>">
+      <%s title %>
+    </a>
+
+let sidebar_link_group
+title
+link_html =
+  <div class="space-y-2 flex mt-10 flex-col">
+    <div class="text-sm font-semibold flex px-3 py-2 uppercase"><%s title %></div>
+    <%s! link_html %>
+  </div>
 
 let render
 ?use_swiper
@@ -7,115 +74,64 @@ let render
 ~description
 ~tutorials
 inner =
-let render_link title slug = 
-  match current_tutorial with
-  | Some x when x = slug ->
-    <a class="flex text-primary-600 bg-primary-100 py-2 px-3 rounded-md text-sm font-semibold" href="<%s Url.tutorial slug %>">
-      <%s title %>
-    </a>
-  | _ ->
-    <a class="font-semibold text-sm text-body-400 hover:bg-gray-100 block py-2 px-3" href="<%s Url.tutorial slug %>">
-      <%s title %>
-    </a>
-in
-let render_tutorial (tutorial : Ood.Tutorial.t) = render_link tutorial.title tutorial.slug in
-Layout.render
-?use_swiper
-?styles
-~wide:true
-~title
-~description @@
-<div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
-  <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
-    :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">
-    <div class="transition-transform" :class='sidebar ? "" : "rotate-180" '>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
-      </svg>
-    </div>
-  </button>
-  <div class="lg:py-24 bg-white pt-10 md:pt-16">
-    <div class="container-fluid wide">
-      <div class="flex">
-        <div
-          class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0 md:py-4 h-screen overflow-auto"
-          x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
-          x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
-          x-transition:leave-end="-translate-x-full">
+  let render_tutorial_link ~title ~slug = 
+    sidebar_link ~title ~href:(Url.tutorial slug) ~current:(current_tutorial = Some (slug))
+  in
+  let render_tutorial (tutorial : Ood.Tutorial.t) = render_tutorial_link ~title:tutorial.title ~slug:tutorial.slug in
+  let tutorial_sidebar_links_by_category category =
+    tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = category) |> List.map render_tutorial |> String.concat "\n"
+  in
+  Layout.render
+  ?use_swiper
+  ?styles
+  ~wide:true
+  ~title
+  ~description @@
+  <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
+    <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
+      :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">
+      <div class="transition-transform" :class='sidebar ? "" : "rotate-180" '>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
+        </svg>
+      </div>
+    </button>
+    <div class="lg:py-24 bg-white pt-10 md:pt-16">
+      <div class="container-fluid wide">
+        <div class="flex">
+          <div
+            class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0 md:py-4 h-screen overflow-auto"
+            x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
+            x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
+            x-transition:leave-end="-translate-x-full">
 
-          <div class="space-y-4">
-            <a href="<%s Url.learn %>" class="flex justify-start items-center">
-              <div class="bg-primary-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
-                  stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold">Documentation</div>
-            </a>
+            <%s! sidebar_icon_link_block ~current:Learn %>
 
-            <a href="<%s Url.manual %>" class="flex justify-start items-center">
-              <div class="bg-green-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold opacity-70">Language Manual</div>
-            </a>
+            <%s! sidebar_link_group "Getting Started"
+              (tutorial_sidebar_links_by_category "getting-started") %>
 
-            <a href="<%s Url.api %>" class="flex justify-start items-center">
-              <div class="bg-sky-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold opacity-70">Standard Library API</div>
-            </a>
+            <%s! sidebar_link_group "Language"
+              (tutorial_sidebar_links_by_category "language") %>
 
-            <a href="<%s Url.problems %>" class="flex justify-start items-center">
-              <div class="bg-indigo-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold opacity-70">Exercises</div>
-            </a>
-          </div>
+            <%s! sidebar_link_group "Data Structures"
+              (tutorial_sidebar_links_by_category "data-structures") %>
 
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Getting Started</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "getting-started") |> List.map render_tutorial |> String.concat "\n" %>
+            <%s! sidebar_link_group "Runtime"
+              (tutorial_sidebar_links_by_category "runtime") %>
+
+            <%s! sidebar_link_group "Tutorials"
+              (tutorial_sidebar_links_by_category "tutorials") %>
+
+            <%s! sidebar_link_group "Guides"
+              (tutorial_sidebar_links_by_category "guides") %>
+
+            <%s! sidebar_link_group "Resources"
+              ((tutorial_sidebar_links_by_category "resources")
+              ^ (render_tutorial_link ~title:"Best Practices" ~slug:"best-practices")
+              ^ (render_tutorial_link ~title:"OCaml Platform" ~slug:"platform")) %>
           </div>
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Language</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "language") |> List.map render_tutorial |> String.concat "\n" %>
-          </div>
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Data Structures</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "data-structures") |> List.map render_tutorial |> String.concat "\n" %>
-          </div>
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Runtime</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "runtime") |> List.map render_tutorial |> String.concat "\n" %>
-          </div>
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Tutorials</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "tutorials") |> List.map render_tutorial |> String.concat "\n" %>
-          </div>
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Guides</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "guides") |> List.map render_tutorial |> String.concat "\n" %>
-          </div>
-          <div class="space-y-2 flex mt-10 flex-col">
-            <div class="text-sm font-semibold flex px-3 py-2 uppercase">Resources</div>
-            <%s! tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = "resources") |> List.map render_tutorial |> String.concat "\n" %>
-            <%s! render_link "Best Practices" "best-practices" %>
-            <%s! render_link "OCaml Platform" "platform" %>
-          </div>
+          <%s! inner %>
         </div>
-        <%s! inner %>
       </div>
     </div>
   </div>
-</div>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -59,28 +59,24 @@ let sidebar_link
     </a>
 
 let sidebar_link_group
+?(extra_html="")
 title
-link_html =
+link_html
+=
   <div class="space-y-2 flex mt-10 flex-col">
     <div class="text-sm font-semibold flex px-3 py-2 uppercase"><%s title %></div>
     <%s! link_html %>
+    <%s! extra_html %>
   </div>
 
 let render
 ?use_swiper
-?current_tutorial
 ?styles
 ~title
 ~description
-~tutorials
-inner =
-  let render_tutorial_link ~title ~slug = 
-    sidebar_link ~title ~href:(Url.tutorial slug) ~current:(current_tutorial = Some (slug))
-  in
-  let render_tutorial (tutorial : Ood.Tutorial.t) = render_tutorial_link ~title:tutorial.title ~slug:tutorial.slug in
-  let tutorial_sidebar_links_by_category category =
-    tutorials |> List.filter (fun (x : Ood.Tutorial.t) -> x.category = category) |> List.map render_tutorial |> String.concat "\n"
-  in
+sidebar_html
+inner_html
+=
   Layout.render
   ?use_swiper
   ?styles
@@ -105,32 +101,9 @@ inner =
             x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
             x-transition:leave-end="-translate-x-full">
 
-            <%s! sidebar_icon_link_block ~current:Learn %>
-
-            <%s! sidebar_link_group "Getting Started"
-              (tutorial_sidebar_links_by_category "getting-started") %>
-
-            <%s! sidebar_link_group "Language"
-              (tutorial_sidebar_links_by_category "language") %>
-
-            <%s! sidebar_link_group "Data Structures"
-              (tutorial_sidebar_links_by_category "data-structures") %>
-
-            <%s! sidebar_link_group "Runtime"
-              (tutorial_sidebar_links_by_category "runtime") %>
-
-            <%s! sidebar_link_group "Tutorials"
-              (tutorial_sidebar_links_by_category "tutorials") %>
-
-            <%s! sidebar_link_group "Guides"
-              (tutorial_sidebar_links_by_category "guides") %>
-
-            <%s! sidebar_link_group "Resources"
-              ((tutorial_sidebar_links_by_category "resources")
-              ^ (render_tutorial_link ~title:"Best Practices" ~slug:"best-practices")
-              ^ (render_tutorial_link ~title:"OCaml Platform" ~slug:"platform")) %>
+            <%s! sidebar_html %>
           </div>
-          <%s! inner %>
+          <%s! inner_html %>
         </div>
       </div>
     </div>

--- a/src/ocamlorg_frontend/pages/best_practices.eml
+++ b/src/ocamlorg_frontend/pages/best_practices.eml
@@ -1,8 +1,11 @@
-let render (best_practices : Ood.Workflow.t list) =
+let render
+(best_practices : Ood.Workflow.t list)
+~tutorials
+=
 Learn_layout.render
 ~title:"OCaml Best Practices"
-~current_tutorial:"best-practices"
-~description:"Some guides to commonly used tools in OCaml development workflows." @@
+~description:"Some guides to commonly used tools in OCaml development workflows." 
+(Learn_sidebar.render ~current_tutorial:(Some "best-practices") ~tutorials) @@
 <div class="flex-1 flex overflow-hidden flex-col md:pl-10">
     <div class="prose prose-orange">
       <p>

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -1,7 +1,12 @@
-let render ~(papers : Ood.Paper.t list) ~(release : Ood.Release.t) ~(books : Ood.Book.t list) =
+let render
+~(papers : Ood.Paper.t list)
+~(release : Ood.Release.t) ~(books : Ood.Book.t list) 
+~tutorials
+=
 Learn_layout.render
 ~title:"Learn OCaml"
-~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual." @@
+~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual."
+(Learn_sidebar.render ~tutorials ~current_tutorial:None) @@
 <div class="flex-1 flex flex-col md:pl-10 min-w-0">
   <h1 class="font-bold mb-8">Learn OCaml</h1>
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10">

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -3,8 +3,8 @@ Learn_layout.render
 ~title:"Learn OCaml"
 ~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual." @@
 <div class="flex-1 flex flex-col md:pl-10 min-w-0">
-  <h1 class="font-bold mb-10 md:mb-16">Learn</h1>
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10 lg:pb-20">
+  <h1 class="font-bold mb-8">Learn OCaml</h1>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10">
     <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white">
       <div class="p-8">
         <h2 class="font-bold mb-2">Get Started</h2>
@@ -38,7 +38,7 @@ Learn_layout.render
         </a>
       </div>
       <div class="flex justify-end pl-8">
-        <img src="/img/learn/learn-exercise.svg" class="w-full" alt="Exercices Background" />
+        <img src="/img/learn/learn-exercise.svg" class="w-full" alt="Exercises Background" />
       </div>
     </div>
 
@@ -59,7 +59,7 @@ Learn_layout.render
       </div>
     </div>
   </div>
-  <div class="mt-10 lg:mt-20 border-b border-gray-200 pb-10 lg:pb-20">
+  <div class="mt-10 lg:mt-20 border-b border-gray-200 pb-10">
     <h3 class="font-bold">Papers</h3>
     <div class="mt-6 text-body-400 text-lg">
       Aspiring towards greater understanding of the language? Want to push the limits and discover brand new things?
@@ -95,7 +95,7 @@ Learn_layout.render
       </button>
     </a>
   </div>
-  <div class="mt-10 lg:mt-20 border-b border-gray-200 pb-10 lg:pb-20">
+  <div class="mt-10 lg:mt-20 border-b border-gray-200 pb-10">
     <h3 class="font-bold">Releases</h3>
     <div class="mt-6 text-body-400 text-lg">
         The history of OCaml releases with a summary and a complete changelog, as well as the manual at that time.

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -1,8 +1,11 @@
-let render (tools : Ood.Tool.t list) =
+let render
+(tools : Ood.Tool.t list)
+~tutorials
+=
 Learn_layout.render
 ~title:"OCaml Platform"
-~current_tutorial:"platform"
-~description:"The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml." @@
+~description:"The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml."
+(Learn_sidebar.render ~current_tutorial:(Some "platform") ~tutorials) @@
 <div class="flex-1 flex flex-col md:pl-10 min-w-0">
   <h1 class="font-bold">The OCaml Platform</h1>
   <div class="text-body-400 mt-6">

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -1,4 +1,6 @@
-let render (problems : Ood.Problem.t list) =
+let problems_sidebar
+~problems
+= 
 let open Ood.Problem in
 let render_problem_link (problem : Ood.Problem.t) =
   let href = "#" ^ (problem.number) in
@@ -7,115 +9,93 @@ in
 let problem_sidebar_links_by_tag tag =
   List.map render_problem_link (filter_by_tag ~tag problems) |> String.concat ""
 in
-Layout.render
-~wide:true
+  <%s! Learn_layout.sidebar_icon_link_block ~current:Exercises %>
+
+  <%s! Learn_layout.sidebar_link_group "Working with lists"
+    (problem_sidebar_links_by_tag "list") %>
+
+  <%s! Learn_layout.sidebar_link_group "Arithmetic"
+    (problem_sidebar_links_by_tag "arithmetic") %>
+
+  <%s! Learn_layout.sidebar_link_group "Logic and Codes"
+    (problem_sidebar_links_by_tag "logic") %>
+
+  <%s! Learn_layout.sidebar_link_group "Binary Trees"
+    (problem_sidebar_links_by_tag "binary-tree") %>
+
+  <%s! Learn_layout.sidebar_link_group "Multiway Trees"
+    (problem_sidebar_links_by_tag "multiway-tree") %>
+
+  <%s! Learn_layout.sidebar_link_group "Graphs"
+    (problem_sidebar_links_by_tag "graph") %>
+
+  <%s! Learn_layout.sidebar_link_group "Miscellaneous Problems"
+    (List.map render_problem_link (filter_no_tag problems) |> String.concat "") %>
+
+let render
+(problems : Ood.Problem.t list)
+=
+Learn_layout.render
 ~title:"Exercises"
-~description:"A list of exercises to work on your OCaml skills." @@
-<div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
-  <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
-    :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">
-    <div class="transition-transform" :class='sidebar ? "" : "rotate-180" '>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
-      </svg>
-    </div>
-  </button>
-  <div class="lg:py-24 bg-white pt-10 md:pt-16">
-    <div class="container-fluid wide">
-      <div class="flex">
-        <div
-          class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0 md:py-4 h-screen overflow-auto"
-          x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
-          x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
-          x-transition:leave-end="-translate-x-full">
-
-          <%s! Learn_layout.sidebar_icon_link_block ~current:Exercises %>
-
-          <%s! Learn_layout.sidebar_link_group "Working with lists"
-            (problem_sidebar_links_by_tag "list") %>
-
-          <%s! Learn_layout.sidebar_link_group "Arithmetic"
-            (problem_sidebar_links_by_tag "arithmetic") %>
-
-          <%s! Learn_layout.sidebar_link_group "Logic and Codes"
-            (problem_sidebar_links_by_tag "logic") %>
-
-          <%s! Learn_layout.sidebar_link_group "Binary Trees"
-            (problem_sidebar_links_by_tag "binary-tree") %>
-
-          <%s! Learn_layout.sidebar_link_group "Multiway Trees"
-            (problem_sidebar_links_by_tag "multiway-tree") %>
-
-          <%s! Learn_layout.sidebar_link_group "Graphs"
-            (problem_sidebar_links_by_tag "graph") %>
-
-          <%s! Learn_layout.sidebar_link_group "Miscellaneous Problems"
-            (List.map render_problem_link (filter_no_tag problems) |> String.concat "") %>
-        </div>
-        <div class="flex-1 flex overflow-hidden problems-container">
-          <div
-            class="prose prose-orange overflow-hidden z-0 lg:max-w-full lg:w-full mx-auto relative py-8 px-6 lg:pt-0 lg:pl-20"
+~description:"A list of exercises to work on your OCaml skills."
+(problems_sidebar ~problems) @@
+  <div class="prose prose-orange overflow-hidden z-0 lg:max-w-full lg:w-full mx-auto relative py-8 px-6 lg:pt-0 lg:pl-10">
+    <h1 class="font-bold mb-8">Exercises</h1>
+    <% problems |> List.iter (fun (problem : Ood.Problem.t) -> %>
+    <div x-data="{statement: true}" id="<%s" problem.number %>
+      >
+      <div class="flex space-y-4 lg:space-y-0 lg:items-center flex-col lg:flex-row lg:justify-between">
+        <h4 class="font-bold text-body-600"><%s problem.title %></h4>
+        <div class="flex bg-body-600 bg-opacity-5 rounded-md p-1 items-center">
+          <button
+            class="px-3.5 h-9 font-medium flex space-x-2 items-center rounded-lg"
+            x-on:click="statement = true"
+            :class="statement ? 'bg-white text-primary-600': 'text-body-400' "
           >
-            <% problems |> List.iter (fun (problem : Ood.Problem.t) -> %>
-            <div x-data="{statement: true}" id="<%s" problem.number %>
-              >
-              <div class="flex space-y-4 lg:space-y-0 lg:items-center flex-col lg:flex-row lg:justify-between">
-                <h4 class="font-bold text-body-600"><%s problem.title %></h4>
-                <div class="flex bg-body-600 bg-opacity-5 rounded-md p-1 items-center">
-                  <button
-                    class="px-3.5 h-9 font-medium flex space-x-2 items-center rounded-lg"
-                    x-on:click="statement = true"
-                    :class="statement ? 'bg-white text-primary-600': 'text-body-400' "
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    <span :class="statement ? 'text-body-600' : 'text-body-400'">Statement</span>
-                  </button>
-                  <button
-                    class="px-3.5 h-9 font-medium flex space-x-2 items-center rounded-lg"
-                    x-on:click="statement = false"
-                    :class="statement ? 'text-body-400': 'bg-white text-primary-600' "
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    <span :class="statement ? 'text-body-400' : 'text-body-600'">Solution</span>
-                  </button>
-                </div>
-              </div>
-
-              <div x-show="statement"><%s! problem.statement %></div>
-
-              <div x-show="!statement"><%s! problem.solution %></div>
-            </div>
-            <div class="border-t border-gray-200 my-12"></div>
-            <% ); %>
-          </div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span :class="statement ? 'text-body-600' : 'text-body-400'">Statement</span>
+          </button>
+          <button
+            class="px-3.5 h-9 font-medium flex space-x-2 items-center rounded-lg"
+            x-on:click="statement = false"
+            :class="statement ? 'text-body-400': 'bg-white text-primary-600' "
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span :class="statement ? 'text-body-400' : 'text-body-600'">Solution</span>
+          </button>
         </div>
       </div>
+
+      <div x-show="statement"><%s! problem.statement %></div>
+
+      <div x-show="!statement"><%s! problem.solution %></div>
     </div>
+    <div class="border-t border-gray-200 my-12"></div>
+    <% ); %>
   </div>
-</div>

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -2,12 +2,10 @@ let render (problems : Ood.Problem.t list) =
 let open Ood.Problem in
 let render_problem_link (problem : Ood.Problem.t) =
   let href = "#" ^ (problem.number) in
-  <a href=<%s href %>
-    class="group flex items-center px-3 py-2 text-sm font-medium text-gray-600 rounded-md hover:text-gray-900 hover:bg-gray-50">
-    <span class="truncate">
-      <%s problem.title %>
-    </span>
-  </a>
+  Learn_layout.sidebar_link ~title:problem.title ~href ~current:false
+in
+let problem_sidebar_links_by_tag tag =
+  List.map render_problem_link (filter_by_tag ~tag problems) |> String.concat ""
 in
 Layout.render
 ~wide:true
@@ -31,76 +29,28 @@ Layout.render
           x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
           x-transition:leave-end="-translate-x-full">
 
-          <div class="space-y-4">
-            <a href="<%s Url.learn %>" class="flex justify-start items-center">
-              <div class="bg-primary-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
-                  stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold">Documentation</div>
-            </a>
+          <%s! Learn_layout.sidebar_icon_link_block ~current:Exercises %>
 
-            <a href="<%s Url.manual %>" class="flex justify-start items-center">
-              <div class="bg-green-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold opacity-70">Language Manual</div>
-            </a>
+          <%s! Learn_layout.sidebar_link_group "Working with lists"
+            (problem_sidebar_links_by_tag "list") %>
 
-            <a href="<%s Url.api %>" class="flex justify-start items-center">
-              <div class="bg-sky-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold opacity-70">Standard Library API</div>
-            </a>
+          <%s! Learn_layout.sidebar_link_group "Arithmetic"
+            (problem_sidebar_links_by_tag "arithmetic") %>
 
-            <a href="<%s Url.problems %>" class="flex justify-start items-center">
-              <div class="bg-indigo-600 text-white rounded w-8 h-8 flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                </svg>
-              </div>
-              <div class="ml-3 font-semibold opacity-70">Exercises</div>
-            </a>
-          </div>
+          <%s! Learn_layout.sidebar_link_group "Logic and Codes"
+            (problem_sidebar_links_by_tag "logic") %>
 
-          <nav aria-label="Sidebar" class="mt-10">
-            <h3 class="px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Working with lists</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_by_tag ~tag:"list" problems) |> String.concat "" %>
-            </div>
-            <h3 class="mt-8 px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Arithmetic</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_by_tag ~tag:"arithmetic" problems) |> String.concat "" %>
-            </div>
-            <h3 class="mt-8 px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Logic and Codes</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_by_tag ~tag:"logic" problems) |> String.concat "" %>
-            </div>
-            <h3 class="mt-8 px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Binary Trees</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_by_tag ~tag:"binary-tree" problems) |> String.concat "" %>
-            </div>
-            <h3 class="mt-8 px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Multiway Trees</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_by_tag ~tag:"multiway-tree" problems) |> String.concat "" %>
-            </div>
-            <h3 class="mt-8 px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Graphs</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_by_tag ~tag:"graph" problems) |> String.concat "" %>
-            </div>
-            <h3 class="mt-8 px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">Miscellaneous Problems</h3>
-            <div class="space-y-2 flex mt-4 flex-col">
-              <%s! List.map render_problem_link (filter_no_tag problems) |> String.concat "" %>
-            </div>
-          </nav>
+          <%s! Learn_layout.sidebar_link_group "Binary Trees"
+            (problem_sidebar_links_by_tag "binary-tree") %>
+
+          <%s! Learn_layout.sidebar_link_group "Multiway Trees"
+            (problem_sidebar_links_by_tag "multiway-tree") %>
+
+          <%s! Learn_layout.sidebar_link_group "Graphs"
+            (problem_sidebar_links_by_tag "graph") %>
+
+          <%s! Learn_layout.sidebar_link_group "Miscellaneous Problems"
+            (List.map render_problem_link (filter_no_tag problems) |> String.concat "") %>
         </div>
         <div class="flex-1 flex overflow-hidden problems-container">
           <div

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -1,5 +1,10 @@
-let render (tutorial : Ood.Tutorial.t) =
-Learn_layout.render ~current_tutorial:tutorial.slug ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title) ~description:tutorial.description @@
+let render
+(tutorial : Ood.Tutorial.t)
+~tutorials
+=
+Learn_layout.render ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title) ~description:tutorial.description
+(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
+@@
 <div class="flex-1 flex overflow-hidden">
   <div class="prose prose-orange overflow-hidden z-0 z- lg:max-w-4xl mx-auto relative py-8 px-6">
     <%s! tutorial.body_html %>


### PR DESCRIPTION
There were styling inconsistencies between the "Exercises" page and the "Learn" page, despite them looking similar (`h3` tags had different styles).

I refactored the code of the side menus to reduce repetition. `Learn_layout` now exports functions that render the links and link groups, as well as the icon link group of the sidebar.

As a consequence, the sidebar styles on the "Exercises" page are now consistent with those on the "Learn" page.

I changed the link "Documentation" in the sidebar icon link group to "Learn OCaml", and the `h1` title to "Learn OCaml".

On the Exercises page, the "Exercises" sidebar icon link is highlighted, whereas on the "Learn" page, the "Learn OCaml" sidebar icon link is highlighted.


before              |  after 
:-------------------------:|:-------------------------:
![Screenshot 2022-09-23 at 12-01-07 Learn OCaml](https://user-images.githubusercontent.com/6594573/191937548-9e85c0bf-09f8-4d7d-ac18-d33cbf3c2836.png) | ![Screenshot 2022-09-23 at 12-00-58 Learn OCaml](https://user-images.githubusercontent.com/6594573/191937592-8d462490-e901-45e9-aae9-7991d399bfa1.png)
![Screenshot 2022-09-23 at 12-01-22 Exercises](https://user-images.githubusercontent.com/6594573/191937647-9b63ca52-add7-4726-8ee2-18d406f1327b.png) | ![Screenshot 2022-09-23 at 12-01-18 Exercises](https://user-images.githubusercontent.com/6594573/191937661-ca03efe3-0624-48be-af8f-819a6f7dcccb.png)



