### PR TITLE
omit breadcrumbs on package docs when there are no libraries

### DIFF
--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -41,7 +41,7 @@ Package_layout.render
       </div>
     </div>
     <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6 md:pl-12">
-      <%s! Breadcrumbs.render path %>
+      <%s! if maptoc != [] then Breadcrumbs.render path else "" %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -41,7 +41,7 @@ Package_layout.render
       </div>
     </div>
     <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6 md:pl-12">
-      <%s! if maptoc != [] then Breadcrumbs.render path else "" %>
+      <%s! if (maptoc != []) && (List.length path != 0) then Breadcrumbs.render path else "" %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>


### PR DESCRIPTION
Fixes (ETA: the problem of showing breadcrumbs for packages without a hierarchy seen in) https://github.com/ocaml/ocaml.org/issues/583 by not rendering breadcrumbs for packages without libraries.

When there are no libraries/modules in a package, we should omit the breadcrumbs because they don't make sense from a UI/UX perspective.