### PR TITLE
add Why OCaml? link on the Learn_layout's icon sidebar

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -42,6 +42,13 @@ let sidebar_icon_link_block
       </div>
       <div class="ml-3 font-semibold <%s if current != Exercises then "opacity-70" else "" %>">Exercises</div>
     </a>
+
+    <a href="<%s Url.about %>" class="flex justify-start items-center">
+      <div class="bg-primary-600 font-bold text-white rounded w-8 h-8 flex items-center justify-center">
+        ?
+      </div>
+      <div class="ml-3 font-semibold opacity-70">Why OCaml?</div>
+    </a>
   </div>
 
 let sidebar_link


### PR DESCRIPTION
This PR adds a simple "Why OCaml?" link to the sidebar. Eventually, we may get a designer to make it pretty, but at the time being, I think the question mark will do.

I deliberated a bit on where to put it, and I think at the bottom is the correct position, as it's a "catch-all" for people who still need some motivation to learn.

@christinerose is this what you had in mind in https://github.com/ocaml/ocaml.org/pull/553?

before              |  after 
:-------------------------:|:-------------------------:
![Screenshot 2022-09-26 at 12-17-23 Learn OCaml](https://user-images.githubusercontent.com/6594573/192252794-669370fa-cdb5-4e95-8be4-4eae5c95bc64.png) | ![Screenshot 2022-09-26 at 12-17-10 Learn OCaml](https://user-images.githubusercontent.com/6594573/192252804-8478e37c-3c3e-4566-ab59-b2e549ac9f29.png) there is a link "Why OCaml?" in the icon sidebar that leads to the corresponding page.
