### PR TITLE
Generate canonical links

### DIFF
--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -1,4 +1,4 @@
-let render ?(use_swiper=false) ?(wide=false) ?description ?styles ~title inner =
+let render ?(use_swiper=false) ?(wide=false) ?description ?styles ~title ?canonical inner =
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -19,6 +19,9 @@ let render ?(use_swiper=false) ?(wide=false) ?description ?styles ~title inner =
     <% | None -> ()); %>
     <meta name="theme-color" content="#fff" />
     <meta name="color-scheme" content="white" />
+    <% (match canonical with | Some canonical -> %>
+    <link rel="canonical" href="https://ocaml.org<%s canonical %>" />
+    <% | None -> ()); %>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <% (match styles with | Some styles -> styles |> List.iter (fun style -> %>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -81,6 +81,7 @@ let render
 ?styles
 ~title
 ~description
+~canonical
 sidebar_html
 inner_html
 =
@@ -89,7 +90,8 @@ inner_html
   ?styles
   ~wide:true
   ~title
-  ~description @@
+  ~description
+  ~canonical @@
   <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
     <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
       :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -28,7 +28,8 @@ Layout.render
 ?styles
 ~wide:true
 ~title
-~description @@
+~description
+~canonical:(Url.package package.name) @@
 <div class="bg-white">
   <div class="py-5 lg:py-12">
     <div class="container-fluid wide">

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -9,6 +9,7 @@ let render
 ~description
 ~tab
 ~documentation_status
+~canonical
 ~(package : Package_intf.package)
 inner =
 let tab_class = "border-transparent border-b-2 hover:border-primary-600 p-4 font-medium relative text-body-400" in
@@ -29,7 +30,7 @@ Layout.render
 ~wide:true
 ~title
 ~description
-~canonical:(Url.package package.name) @@
+~canonical @@
 <div class="bg-white">
   <div class="py-5 lg:py-12">
     <div class="container-fluid wide">

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -72,7 +72,7 @@ Layout.render
               <%s! documentation_dot %>
             </span>
           <% | _ -> %>
-            <a href="<%s Url.package_doc package.name package.version "index.html" %>"
+            <a href="<%s Url.package_doc package.name package.version %>"
               class="<%s if tab = Documentation then current_tab_class else tab_class %>"
               <%s! doc_status_tooltip %>>
                 Documentation

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -46,10 +46,10 @@ let problems problems = Problems.render problems
 let release release = Release.render release
 let releases ?search releases = Releases.render ?search releases
 let success_story success_story = Success_story.render success_story
-let tutorial tutorial = Tutorial.render tutorial
+let tutorial tutorial ~canonical = Tutorial.render tutorial ~canonical
 
-let page ~title ~description ~meta_title ~meta_description ~content =
-  Page.render ~title ~description ~meta_title ~meta_description ~content
+let page ~title ~description ~meta_title ~meta_description ~content ~canonical =
+  Page.render ~title ~description ~meta_title ~meta_description ~content ~canonical
 
 let playground () = Playground.render ()
 let not_found () = Not_found.render ()

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -49,7 +49,8 @@ let success_story success_story = Success_story.render success_story
 let tutorial tutorial ~canonical = Tutorial.render tutorial ~canonical
 
 let page ~title ~description ~meta_title ~meta_description ~content ~canonical =
-  Page.render ~title ~description ~meta_title ~meta_description ~content ~canonical
+  Page.render ~title ~description ~meta_title ~meta_description ~content
+    ~canonical
 
 let playground () = Playground.render ()
 let not_found () = Not_found.render ()

--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -1,7 +1,8 @@
 let render () =
 Layout.render 
 ~title:"Why OCaml?"
-~description:"OCaml is a mature, statically-typed, functional programming language. Learn more about its rich history and what makes it unique." @@
+~description:"OCaml is a mature, statically-typed, functional programming language. Learn more about its rich history and what makes it unique."
+~canonical:Url.about @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/academic_users.eml
+++ b/src/ocamlorg_frontend/pages/academic_users.eml
@@ -1,7 +1,8 @@
 let render (users : Ood.Academic_institution.t list) =
 Layout.render
 ~title:"Academic Users of OCaml"
-~description:"OCaml is taught all around the world and used every day by programming language researchers. Learn more about the strong academic roots of the language." @@
+~description:"OCaml is taught all around the world and used every day by programming language researchers. Learn more about the strong academic roots of the language."
+~canonical:Url.academic_users @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/best_practices.eml
+++ b/src/ocamlorg_frontend/pages/best_practices.eml
@@ -4,7 +4,8 @@ let render
 =
 Learn_layout.render
 ~title:"OCaml Best Practices"
-~description:"Some guides to commonly used tools in OCaml development workflows." 
+~description:"Some guides to commonly used tools in OCaml development workflows."
+~canonical:Url.best_practices
 (Learn_sidebar.render ~current_tutorial:(Some "best-practices") ~tutorials) @@
 <div class="flex-1 flex overflow-hidden flex-col md:pl-10">
     <div class="prose prose-orange">

--- a/src/ocamlorg_frontend/pages/blog.eml
+++ b/src/ocamlorg_frontend/pages/blog.eml
@@ -3,7 +3,7 @@ Layout.render
 ~wide:true
 ~title:"OCaml Blog"
 ~description:"Recent news and blog posts from the OCaml community."
-~canonical:Url.blog @@
+~canonical:(Url.blog ^ if rss_page = 1 then "" else "?p=" ^ string_of_int rss_page) @@
 <div class="bg-white py-24">
     <div class="container-fluid wide">
         <div>

--- a/src/ocamlorg_frontend/pages/blog.eml
+++ b/src/ocamlorg_frontend/pages/blog.eml
@@ -2,7 +2,8 @@ let render ~(featured : Ood.Rss.t list) ~(rss : Ood.Rss.t list) ~rss_pages_numbe
 Layout.render
 ~wide:true
 ~title:"OCaml Blog"
-~description:"Recent news and blog posts from the OCaml community." @@
+~description:"Recent news and blog posts from the OCaml community."
+~canonical:Url.blog @@
 <div class="bg-white py-24">
     <div class="container-fluid wide">
         <div>

--- a/src/ocamlorg_frontend/pages/books.eml
+++ b/src/ocamlorg_frontend/pages/books.eml
@@ -44,7 +44,8 @@ let render_books books =
 let render books =
 Layout.render
 ~title:"OCaml Books"
-~description:"A selection of books to learn the OCaml programming language." @@
+~description:"A selection of books to learn the OCaml programming language."
+~canonical:Url.books @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -12,7 +12,8 @@ let old_workshops = List.filter (fun (w : Ood.Workshop.t) -> w.date < current_da
 let upcoming_workshops = List.filter (fun (w : Ood.Workshop.t) -> w.date >= current_date) workshops in
 Layout.render
 ~title:"The OCaml Community"
-~description:"Looking to interact with people who are also interested in OCaml? Find out about upcoming events, read up on blogs from the community, sign up for OCaml mailing lists, and discover even more places to engage with people from the community!" @@
+~description:"Looking to interact with people who are also interested in OCaml? Find out about upcoming events, read up on blogs from the community, sign up for OCaml mailing lists, and discover even more places to engage with people from the community!"
+~canonical:Url.community @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -2,7 +2,8 @@ let render () =
 Layout.render
 ~use_swiper:true
 ~title:"Welcome to a World of OCaml"
-~description:"OCaml is a general-purpose, industrial-strength programming language with an emphasis on expressiveness and safety." @@
+~description:"OCaml is a general-purpose, industrial-strength programming language with an emphasis on expressiveness and safety."
+~canonical:"" @@
 <div class="lg:py-24 py-2">
   <div class="container-fluid space-y-24 lg:space-y-32">
     <div class="flex flex-col lg:flex-row">

--- a/src/ocamlorg_frontend/pages/industrial_users.eml
+++ b/src/ocamlorg_frontend/pages/industrial_users.eml
@@ -5,7 +5,8 @@ Layout.render
 ~description:"With its strong security features and high performance, several \
 companies rely on OCaml to keep their data operating both safely and \
 efficiently. On this page, you can get an overview of the companies in \
-the community and learn more about how they use OCaml." @@
+the community and learn more about how they use OCaml."
+~canonical:Url.industrial_users @@
 <div class="lg:py-24 py-2">
   <div class="container-fluid space-y-24 lg:space-y-32">
       <div class="flex flex-col lg:flex-row  justify-between space-x-0 lg:space-x-10">

--- a/src/ocamlorg_frontend/pages/jobs.eml
+++ b/src/ocamlorg_frontend/pages/jobs.eml
@@ -2,7 +2,8 @@ let render ?(location = "All") ~locations (jobs : Ood.Job.t list) =
 Layout.render
 ~title:"OCaml Jobs"
 ~description:"This is a space where groups, companies, and organisations can advertise their projects directly to the
-OCaml community." @@
+OCaml community."
+~canonical:Url.jobs @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -6,6 +6,7 @@ let render
 Learn_layout.render
 ~title:"Learn OCaml"
 ~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual."
+~canonical:Url.learn
 (Learn_sidebar.render ~tutorials ~current_tutorial:None) @@
 <div class="flex-1 flex flex-col md:pl-10 min-w-0">
   <h1 class="font-bold mb-8">Learn OCaml</h1>

--- a/src/ocamlorg_frontend/pages/news.eml
+++ b/src/ocamlorg_frontend/pages/news.eml
@@ -1,7 +1,8 @@
 let render ~pages_number ~page (news : Ood.News.t list) =
 Layout.render
 ~title:"OCaml News"
-~description:"Read the latest news, releases, and updates from the OCaml community." @@
+~description:"Read the latest news, releases, and updates from the OCaml community."
+~canonical:Url.news @@
 <div class="bg-white py-24">
   <div class="container-fluid">
     <div>

--- a/src/ocamlorg_frontend/pages/news.eml
+++ b/src/ocamlorg_frontend/pages/news.eml
@@ -2,7 +2,7 @@ let render ~pages_number ~page (news : Ood.News.t list) =
 Layout.render
 ~title:"OCaml News"
 ~description:"Read the latest news, releases, and updates from the OCaml community."
-~canonical:Url.news @@
+~canonical:(Url.news ^ if page = 1 then "" else "?p=" ^ string_of_int page) @@
 <div class="bg-white py-24">
   <div class="container-fluid">
     <div>

--- a/src/ocamlorg_frontend/pages/news_post.eml
+++ b/src/ocamlorg_frontend/pages/news_post.eml
@@ -1,7 +1,8 @@
 let render (news : Ood.News.t) =
 Layout.render
 ~title:news.title
-~description:news.description @@
+~description:news.description
+~canonical:(Url.news_post news.slug) @@
 <div class="bg-white py-24">
   <div class="container-fluid">
     <div class="mx-auto max-w-5xl">
@@ -13,7 +14,7 @@ Layout.render
         <div>Back to Blog</div>
       </a>
     </div>
-    
+
     <div class="prose prose-orange mx-auto max-w-5xl">
       <h1><%s news.title %></h1>
       <%s! news.body_html %>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -18,6 +18,7 @@ Package_layout.render
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)
 ~tab:Documentation
 ~package
+~canonical:(Url.package_docs_with_version package.name package.version)
 ~styles:["/css/main.css"; "/css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
   <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -12,13 +12,16 @@ let str_path =
         | `ModuleType s -> s
         | `FunctorArgument (_, s) -> s) path
 in
+let path_page = match str_path |> String.concat "/" with
+                | "" -> None
+                | path -> Some (path ^ if String.contains path '.' then "" else "/index.html") in
 Package_layout.render
 ~documentation_status
 ~title
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)
 ~tab:Documentation
 ~package
-~canonical:(Url.package_docs_with_version package.name package.version)
+~canonical:(Url.package_doc package.name package.version ?page:path_page)
 ~styles:["/css/main.css"; "/css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
   <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -86,7 +86,7 @@ Package_layout.render
         </div>
         <div class="flex flex-col mt-9 space-y-4 text-body-400">
             <% (match changes_filename with Some changes_filename -> %>
-            <a href="<%s Url.package_doc package.name package.version (changes_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
+            <a href="<%s Url.package_doc package.name package.version ~page:(changes_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -96,7 +96,7 @@ Package_layout.render
             </a>
             <% | _ -> ()); %>
             <% (match license_filename with Some license_filename -> %>
-            <a href="<%s Url.package_doc package.name package.version (license_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
+            <a href="<%s Url.package_doc package.name package.version ~page:(license_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -14,6 +14,7 @@ Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name package.version)
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)
 ~tab:Overview
+~canonical:(Url.package_with_version package.name package.version)
 ~package @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col xl:flex-row justify-between">
     <div class="flex-1 prose w-full xl:w-1/2 max-w-full">

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -5,7 +5,8 @@ let href_package pkg = Url.package_with_version pkg.name pkg.version
 let render (stats : packages_stats option) (featured_packages : package list) =
 Layout.render
 ~title:"OCaml Packages · Browse Community Packages"
-~description:"Discover thousands of community packages and browse their documentation." @@
+~description:"Discover thousands of community packages and browse their documentation."
+~canonical:Url.packages @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,6 +1,6 @@
 let render ~total ~search (packages : Package_intf.package list) = Layout.render ~title:"OCaml Packages · Search Result"
 ~description:"Find the package you need to build your application in the thousands of available OCaml packages."
-~canonical:Url.packages @@
+~canonical:(Url.packages_search ^ "?q=" ^ search) @@
 <div class="bg-white">
   <div class="py-10 lg:py-14">
     <div class="container-fluid">

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,5 +1,6 @@
 let render ~total ~search (packages : Package_intf.package list) = Layout.render ~title:"OCaml Packages · Search Result"
-~description:"Find the package you need to build your application in the thousands of available OCaml packages." @@
+~description:"Find the package you need to build your application in the thousands of available OCaml packages."
+~canonical:Url.packages @@
 <div class="bg-white">
   <div class="py-10 lg:py-14">
     <div class="container-fluid">

--- a/src/ocamlorg_frontend/pages/page.eml
+++ b/src/ocamlorg_frontend/pages/page.eml
@@ -1,5 +1,5 @@
-let render ~title ~description ~meta_title ~meta_description ~content =
-Layout.render ~title:meta_title ~description:meta_description @@
+let render ~title ~description ~meta_title ~meta_description ~content ~canonical =
+Layout.render ~title:meta_title ~description:meta_description ~canonical @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/papers.eml
+++ b/src/ocamlorg_frontend/pages/papers.eml
@@ -1,7 +1,8 @@
 let render ?(search = "") ~(recommended_papers : Ood.Paper.t list) (papers : Ood.Paper.t list) =
 Layout.render
 ~title:"OCaml Papers"
-~description:"A selection of papers grouped by popular categories." @@
+~description:"A selection of papers grouped by popular categories."
+~canonical:Url.papers @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -5,6 +5,7 @@ let render
 Learn_layout.render
 ~title:"OCaml Platform"
 ~description:"The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml."
+~canonical:Url.platform
 (Learn_sidebar.render ~current_tutorial:(Some "platform") ~tutorials) @@
 <div class="flex-1 flex flex-col md:pl-10 min-w-0">
   <h1 class="font-bold">The OCaml Platform</h1>

--- a/src/ocamlorg_frontend/pages/playground.eml
+++ b/src/ocamlorg_frontend/pages/playground.eml
@@ -14,6 +14,7 @@ let render () =
     <meta name="theme-color" content="#fff" />
     <meta name="color-scheme" content="white" />
     <meta name="”robots”" content="noindex, nofollow" />
+    <link rel="canonical" href="https://ocaml.org<%s Url.playground %>" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="stylesheet" href="/css/main.css" />

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -38,6 +38,7 @@ let render
 Learn_layout.render
 ~title:"Exercises"
 ~description:"A list of exercises to work on your OCaml skills."
+~canonical:Url.problems
 (problems_sidebar ~problems) @@
   <div class="prose prose-orange overflow-hidden z-0 lg:max-w-full lg:w-full mx-auto relative py-8 px-6 lg:pt-0 lg:pl-10">
     <h1 class="font-bold mb-8">Exercises</h1>

--- a/src/ocamlorg_frontend/pages/release.eml
+++ b/src/ocamlorg_frontend/pages/release.eml
@@ -1,7 +1,8 @@
 let render (release : Ood.Release.t) =
 Layout.render
 ~title:(Printf.sprintf "OCaml %s Release Notes" release.version)
-~description:(Printf.sprintf "OCaml %s was released on %s. Learn more about this in the release notes." release.version release.date) @@
+~description:(Printf.sprintf "OCaml %s was released on %s. Learn more about this in the release notes." release.version release.date)
+~canonical:(Url.release release.version) @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="flex md:flex-row md:px-10 lg:p-6 pb-20 items-center md:space-x-36 flex-col-reverse">

--- a/src/ocamlorg_frontend/pages/releases.eml
+++ b/src/ocamlorg_frontend/pages/releases.eml
@@ -1,7 +1,8 @@
 let render ?(search = "") (releases : Ood.Release.t list) =
 Layout.render
 ~title:"OCaml Releases"
-~description:"The history of OCaml releases with a summary and a complete changelog, as well as the manual at that time." @@
+~description:"The history of OCaml releases with a summary and a complete changelog, as well as the manual at that time."
+~canonical:Url.releases @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/success_story.eml
+++ b/src/ocamlorg_frontend/pages/success_story.eml
@@ -1,7 +1,8 @@
 let render (story : Ood.Success_story.t) =
 Layout.render
 ~title:(Printf.sprintf "%s · Success Stories" story.title)
-~description:story.synopsis @@
+~description:story.synopsis
+~canonical:(Url.success_story story.slug) @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="mx-auto px-4 sm:px-6">

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -1,9 +1,10 @@
 let render
 (tutorial : Ood.Tutorial.t)
 ~tutorials
+~canonical
 =
 Learn_layout.render ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title) ~description:tutorial.description
-(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
+(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials) ~canonical
 @@
 <div class="flex-1 flex overflow-hidden">
   <div class="prose prose-orange overflow-hidden z-0 z- lg:max-w-4xl mx-auto relative py-8 px-6">

--- a/src/ocamlorg_frontend/pages/workshop.eml
+++ b/src/ocamlorg_frontend/pages/workshop.eml
@@ -1,7 +1,8 @@
 let render ~(videos : (string, Ood.Watch.t) Hashtbl.t) (workshop : Ood.Workshop.t) =
 Layout.render
 ~title:workshop.title
-~description:(Printf.sprintf "A description of the workshop %s held on %s" workshop.title workshop.date) @@
+~description:(Printf.sprintf "A description of the workshop %s held on %s" workshop.title workshop.date)
+~canonical:(Url.workshop workshop.slug) @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="flex flex-col lg:flex-row justify-between items-center">

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -9,7 +9,8 @@ let package_with_version v version = "/p/" ^ v ^ "/" ^ version
 let package_with_hash_with_version hash v version =
   "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version
 
-let package_doc v ?(page = "index.html") version = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
+let package_doc v ?(page = "index.html") version =
+  "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
 let package_doc_with_hash hash v version page =
   "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version ^ "/doc/" ^ page

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -3,6 +3,7 @@ let packages = "/packages"
 let packages_search = "/packages/search"
 let package v = "/p/" ^ v
 let package_docs v = "/p/" ^ v ^ "/doc"
+let package_docs_with_version v version = "/p/" ^ v ^ "/" ^ version ^ "/doc/index.html"
 let package_with_univ hash v = "/u/" ^ hash ^ "/" ^ v
 let package_with_version v version = "/p/" ^ v ^ "/" ^ version
 

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -3,15 +3,13 @@ let packages = "/packages"
 let packages_search = "/packages/search"
 let package v = "/p/" ^ v
 let package_docs v = "/p/" ^ v ^ "/doc"
-let package_docs_with_version v version = "/p/" ^ v ^ "/" ^ version ^ "/doc/index.html"
 let package_with_univ hash v = "/u/" ^ hash ^ "/" ^ v
 let package_with_version v version = "/p/" ^ v ^ "/" ^ version
 
 let package_with_hash_with_version hash v version =
   "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version
 
-let package_doc v version page = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
-let package_license v version = package_doc v version "LICENSE.md.html"
+let package_doc v ?(page = "index.html") version = "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
 let package_doc_with_hash hash v version page =
   "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version ^ "/doc/" ^ page

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -209,15 +209,14 @@ let jobs req =
   in
   Dream.html (Ocamlorg_frontend.jobs ?location ~locations jobs)
 
-let page (page : Ood.Page.t) (_req : Dream.request) =
+let page (page : Ood.Page.t) canonical (_req : Dream.request) =
   Dream.html
     (Ocamlorg_frontend.page ~title:page.title ~description:page.description
        ~meta_title:page.meta_title ~meta_description:page.meta_description
-       ~content:page.body_html)
-
-let carbon_footprint = page Ood.Page.carbon_footprint
-let privacy_policy = page Ood.Page.privacy_policy
-let governance = page Ood.Page.governance
+       ~content:page.body_html ~canonical:canonical)
+let carbon_footprint = page Ood.Page.carbon_footprint Ocamlorg_frontend.Url.carbon_footprint
+let privacy_policy = page Ood.Page.privacy_policy Ocamlorg_frontend.Url.privacy_policy
+let governance = page Ood.Page.governance Ocamlorg_frontend.Url.governance
 let playground _req = Dream.html (Ocamlorg_frontend.playground ())
 
 let papers req =
@@ -266,7 +265,7 @@ let tutorial req =
   with
   | Some tutorial ->
       let tutorials = Ood.Tutorial.all in
-      Ocamlorg_frontend.tutorial ~tutorials tutorial |> Dream.html
+      Ocamlorg_frontend.tutorial ~tutorials ~canonical:(Ocamlorg_frontend.Url.tutorial tutorial.slug) tutorial |> Dream.html
   | None -> not_found req
 
 let best_practices _req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -213,9 +213,14 @@ let page (page : Ood.Page.t) canonical (_req : Dream.request) =
   Dream.html
     (Ocamlorg_frontend.page ~title:page.title ~description:page.description
        ~meta_title:page.meta_title ~meta_description:page.meta_description
-       ~content:page.body_html ~canonical:canonical)
-let carbon_footprint = page Ood.Page.carbon_footprint Ocamlorg_frontend.Url.carbon_footprint
-let privacy_policy = page Ood.Page.privacy_policy Ocamlorg_frontend.Url.privacy_policy
+       ~content:page.body_html ~canonical)
+
+let carbon_footprint =
+  page Ood.Page.carbon_footprint Ocamlorg_frontend.Url.carbon_footprint
+
+let privacy_policy =
+  page Ood.Page.privacy_policy Ocamlorg_frontend.Url.privacy_policy
+
 let governance = page Ood.Page.governance Ocamlorg_frontend.Url.governance
 let playground _req = Dream.html (Ocamlorg_frontend.playground ())
 
@@ -265,7 +270,10 @@ let tutorial req =
   with
   | Some tutorial ->
       let tutorials = Ood.Tutorial.all in
-      Ocamlorg_frontend.tutorial ~tutorials ~canonical:(Ocamlorg_frontend.Url.tutorial tutorial.slug) tutorial |> Dream.html
+      Ocamlorg_frontend.tutorial ~tutorials
+        ~canonical:(Ocamlorg_frontend.Url.tutorial tutorial.slug)
+        tutorial
+      |> Dream.html
   | None -> not_found req
 
 let best_practices _req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -386,7 +386,7 @@ let package_docs t req =
   | None -> not_found req
   | Some version ->
       let version = Ocamlorg_package.Version.to_string version in
-      let target = Ocamlorg_frontend.Url.package_docs_with_version package version in
+      let target = Ocamlorg_frontend.Url.package_doc package version in
       Dream.redirect req target
 
 let package_versioned t kind req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -386,7 +386,7 @@ let package_docs t req =
   | None -> not_found req
   | Some version ->
       let version = Ocamlorg_package.Version.to_string version in
-      let target = "/p/" ^ package ^ "/" ^ version ^ "/doc/index.html" in
+      let target = Ocamlorg_frontend.Url.package_docs_with_version package version in
       Dream.redirect req target
 
 let package_versioned t kind req =

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -69,7 +69,7 @@ let package_route t =
         (Url.package_with_hash_with_version ":hash" ":name" ":version")
         ((Handler.package_versioned t) Handler.Universe);
       Dream.get
-        (Url.package_doc ":name" ":version" "**")
+        (Url.package_doc ":name" ":version" ~page:"**")
         ((Handler.package_doc t) Handler.Package);
       Dream.get
         (Url.package_doc_with_hash ":hash" ":name" ":version" "**")


### PR DESCRIPTION
Pages accessible using different urls shall include a canonical
link, indicating which url is the best (search Google for “consolidate
duplicates urls”). This is useful for web crawlers. Ahrefs reports
“Duplicate pages without canonical” as an issue. This patch adds
canonical links to several pages.

Main tag generation takes place in layout.eml.

Often, it is sufficient to pass the right url to Layout.render. This is
the case for:

* about.eml
* academic_users.eml
* best_pratices.eml
* blog.eml
* books.eml
* community.eml
* industrial_users.eml
* jobs.eml
* learn.eml
* news.eml
* packages.eml
* papers.eml
* platform.eml
* problems.eml
* releases.eml
* tutorial.eml

A few others are almost the same, except some obvious path part needs
to be appended. This is the case for:

* news_post.eml
* release.eml
* success_story.eml
* workshop.eml

Other changes includes parameter forwarding:

* learn_layout.eml
* ocamlorg_frontend.ml
* page.eml
* tutorial.eml

In package_search.eml, the same canonical is used as in packages.eml.

In home.eml, the empty string is used to have "https://ocaml.org" be
the best url (without trailing slash)

In package_version.eml, package version is not used in order to
have the top level pages being referenced.

In handler.ml a combination of parameter forwarding and canonical
url setting takes place.

In playground.eml, the string "https://ocaml.org" is hardwired a
second time because it uses an ad-hoc layout.

No canonical link is generated in not_found.eml, on purpose.
