### PR TITLE
Add OCaml 5.0.0~beta1 announce to the news

### DIFF
--- a/data/news/platform/ocaml-5.0.beta1.md
+++ b/data/news/platform/ocaml-5.0.beta1.md
@@ -1,0 +1,201 @@
+---
+title: OCaml 5.0.0 - first beta
+description: First beta release of OCaml 5.0.0
+date: "2022-10-12"
+tags: [ocaml, platform]
+---
+
+
+The release of OCaml 5.0.0 is drawing near.
+The standard library has been stabilized and many opam packages already
+work with this release.
+After two alpha releases,  we have released a first beta version to help you update your softwares and libraries ahead of the release (see below for the installation instructions).
+
+If you find any bugs, please report them here:
+
+  https://github.com/ocaml/ocaml/issues
+
+Compared to the last alpha release, this beta contains many small internal
+runtime fixes (in particular in the systhreads library).
+
+At the user level, the interface of the Domain and Effect module has been tweaked to be (hopefully) more forward-compatible:
+
+- Exceptions related to effects are now defined in the Effecŧ module.
+- The value `Domain.recommended_domain_count` is no longer a constant and the function `Domain.at_each_spawn` has been removed.
+
+With those changes, the standard library should but stable now.
+
+If you are interested by the ongoing list of bug fixes, the
+updated change log for OCaml 5.0.0 is available at:
+
+  https://github.com/ocaml/ocaml/blob/5.0/Changes
+
+You can also follow the state of the opam ecosystem on
+
+  https://github.com/ocaml/opam-repository/issues/21526
+
+and
+
+  http://check.ocamllabs.io/
+
+A short summary of the changes since the last alpha release is also available
+below.
+
+
+Installation instructions
+-------------------------
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1:
+```bash
+opam update
+opam switch create 5.0.0~beta1
+```
+
+For previous version of opam, the switch creation command line is slightly more verbose:
+```bash
+opam update
+opam switch create 5.0.0~beta1 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+
+It might be also interesting to check the new support for parallelism by installing
+the domainslib library with
+
+```bash
+opam install domainslib
+```
+
+The source code for the beta release is also available at these addresses:
+
+ https://github.com/ocaml/ocaml/archive/5.0.0-beta1.tar.gz
+ https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~beta1.tar.gz
+
+## Fine-tuned compiler configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.0.0~beta1+options <option_list>
+```
+where `option_list` is a comma separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.0.0~beta1+flambda+nffa ocaml-variants.5.0.0~beta1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+The command line above is slightly more complicated for opam version anterior to 2.1:
+```bash
+opam update
+opam switch create <switch_name> --packages=ocaml-variants.5.0.0~beta1+options,<option_list> --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+
+In both cases, all available options can be listed with "opam search ocaml-option".
+
+## Optional opam alpha repository
+
+During the beta release, if your dependencies are not yet compatible with OCaml 5.0.0, 
+you might want to check the alpha opam repository:
+
+https://github.com/kit-ty-kate/opam-alpha-repository
+
+Which can be installed with
+```bash
+opam repo add alpha git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+```
+You can check that the alpha repository has been correctly installed with
+```bash
+$ opam repo
+<><> Repository configuration for switch 5.0.0~beta1 <><><><><><><><><><><><><>
+ 1 alpha   git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+ 2 default https://opam.ocaml.org
+```
+This alpha repository contains various fixes that are in the process of being upstreamed,
+but it should be less and less required with progress of the beta release.
+
+Changes since last alpha release
+--------------------------------
+
+# Stdlib changes
+
++ [#11309](https://github.com/ocaml/ocaml/issues/11309), [#11424](https://github.com/ocaml/ocaml/issues/11424), [#11427](https://github.com/ocaml/ocaml/issues/11427), +[#11545](https://github.com/ocaml/ocaml/issues/11545): Add Domain.recommended_domain_count.
+   (Christiano Haesbaert, Konstantin Belousov, review by David Allsopp,
+   KC Sivaramakrishnan, Gabriel Scherer, Nicolas Ojeda Bar)
+
+- [#11423](https://github.com/ocaml/ocaml/issues/11423): Move the effect exceptions to the Effect module
+  (KC Sivaramakrishnan, Xavier Leroy, Florian Angeletti, review by
+   Florian Angeletti, Xavier Leroy, and KC Sivaramakrishnan)
+
+- [#11593](https://github.com/ocaml/ocaml/issues/11593): Remove Domain.at_each_spawn
+  (Florian Angeletti, review by Guillaume Munch-Maccagnoni
+   and KC Sivaramakrishnan)
+
+# Bug fixes
+
+- [#11303](https://github.com/ocaml/ocaml/issues/11303): Ensure that GC is not invoked from bounds check failures
+  (Stephen Dolan, review by Sadiq Jaffer and Xavier Leroy)
+
+- [#5299](https://github.com/ocaml/ocaml/issues/5299), [#4787](https://github.com/ocaml/ocaml/issues/4787), [#11138](https://github.com/ocaml/ocaml/issues/11138), [#11272](https://github.com/ocaml/ocaml/issues/11272), [#11506](https://github.com/ocaml/ocaml/issues/11506): To help debugging, `Caml_state`
+  now dynamically checks that the domain lock is held, and fails
+  otherwise (with a fatal error at most entry points of the C API, or
+  systematically in debug mode). A new variable `Caml_state_opt` is
+  introduced, and is `NULL` when the domain lock is not held. This
+  allows to test from C code if the current thread holds the lock of
+  its domain.
+  (Guillaume Munch-Maccagnoni, review by Florian Angeletti, Damien
+  Doligez, Sadiq Jaffer, Xavier Leroy, and Gabriel Scherer)
+
+- [#11223](https://github.com/ocaml/ocaml/issues/11223): The serialization format of custom blocks changed in 4.08,
+  but the deserializer would still support the pre-4.08 format.  OCaml
+  5.x removed support for this old format; provide a clear error message
+  in this case.
+  (Hugo Heuzard, review by Gabriel Scherer)
+
+- [#11504](https://github.com/ocaml/ocaml/issues/11504), [#11522](https://github.com/ocaml/ocaml/issues/11522): Use static allocation in `caml_make_float_vect` in
+  no-flat-float-array mode, it's more efficient and avoids a a race condition
+  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by David Allsopp)
+
+- [#11461](https://github.com/ocaml/ocaml/issues/11461), [#11466](https://github.com/ocaml/ocaml/issues/11466): Fix gethostbyaddr for IPv6 arguments and make it domain-safe
+  (Olivier Nicole, Nicolás Ojeda Bär, David Allsopp and Xavier Leroy,
+   review by the same)
+
+- [#11479](https://github.com/ocaml/ocaml/issues/11479): Make Unix.symlink domain-safe on Windows
+  (Olivier Nicole, review by Xavier Leroy and David Allsopp)
+
+- [#11294](https://github.com/ocaml/ocaml/issues/11294): Switch minimum required autoconf to 2.71.
+  (David Allsopp, review by Xavier Leroy)
+
+- [#11370](https://github.com/ocaml/ocaml/issues/11370), [#11373](https://github.com/ocaml/ocaml/issues/11373): Don't pass CFLAGS to flexlink during configure.
+  (David Allsopp, report by William Hu, review by Xavier Leroy and
+   Sébastien Hinderer)
+
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+  (William Hu, review by David Allsopp and Sébastien Hinderer)
+
+- [#11468](https://github.com/ocaml/ocaml/issues/11468): Fix regression from [#10186](https://github.com/ocaml/ocaml/issues/10186) (OCaml 4.13) detecting IPv6 on Windows for
+  mingw-w64 i686 port.
+  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
+
+- [#11482](https://github.com/ocaml/ocaml/issues/11482), [#11542](https://github.com/ocaml/ocaml/issues/11542): Fix random crash in large closure allocation
+  (Damien Doligez, report by Thierry Martinez and Vincent Laviron, review by
+   Xavier Leroy)
+
+- [#11508](https://github.com/ocaml/ocaml/issues/11508), [#11509](https://github.com/ocaml/ocaml/issues/11509): make Bytes.escaped domain-safe
+  (Christiano Haesbaert and Gabriel Scherer,
+   review by Xavier Leroy,
+   report by Jan Midtgaard and Tom Kelly)
+
+- [#11516](https://github.com/ocaml/ocaml/issues/11516), [#11524](https://github.com/ocaml/ocaml/issues/11524): Fix the `deprecated_mutable` attribute.
+  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#11576](https://github.com/ocaml/ocaml/issues/11576): Fix bug in Bigarray.Genarray.init in the the case of zero-dimensional
+  arrays.
+  (Nicolás Ojeda Bär, Jeremy Yallop, report by Masayuki Takeda, review by Jeremy
+  Yallop and Florian Angeletti)
+
+- [#11587](https://github.com/ocaml/ocaml/issues/11587): Prevent integer comparison from being used on pointers
+  (Vincent Laviron, review by Gabriel Scherer)
+
+# Documentation changes
+
+- [#11093](https://github.com/ocaml/ocaml/issues/11093): Add tutorials on parallelism features and the relaxed memory model
+  (KC Sivaramakrishnan, review by Damien Doligez, Anil Madhavapeddy, Gabriel
+  Scherer, Thomas Leonard, Tom Ridge, Xavier Leroy, Luc Maranget, Fabrice
+  Buoro, Olivier Nicole, Guillaume Munch-Maccagnoni, Jacques-Henri Jourdan)


### PR DESCRIPTION
This PR adds a slightly modified version of the future announce for the first beta release of OCaml 5.0.0 to the news section of the site.