### PR TITLE
Fix editor slider order for Vim and Emacs

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -194,10 +194,10 @@ Layout.render
                   <img width="785" src="/img/home/vscode-preview.png" alt="An OCaml program being edited in VSCode" />
                 </div>
                 <div class="swiper-slide">
-                  <img width="785" src="/img/home/emac-preview.png" alt="Writing an OCaml program using emacs"/>
+                  <img width="785" src="/img/home/vim-preview.png" alt="Writing an OCaml program using vim" />
                 </div>
                 <div class="swiper-slide">
-                  <img width="785" src="/img/home/vim-preview.png" alt="Writing an OCaml program using vim" />
+                  <img width="785" src="/img/home/emac-preview.png" alt="Writing an OCaml program using emacs"/>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
There is wrong order of editor previews for Vim and Emacs on the ocaml.org homepage. When you click Vim slider icon it shows Emacs preview and vice versa.

Fixed that by changing order of editor previews to match the order of icons (VSCode, Vim, Emacs).