### PR TITLE
Turn hash into an optional parameter

### DIFF
--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -4,7 +4,9 @@ let packages_search = "/packages/search"
 let with_hash = function None -> "/p" | Some hash -> "/u/" ^ hash
 let package ?hash v = with_hash hash ^ "/" ^ v
 let package_docs v = "/p/" ^ v ^ "/doc"
-let package_with_version ?hash v version = with_hash hash ^ "/" ^ v ^ "/" ^ version
+
+let package_with_version ?hash v version =
+  with_hash hash ^ "/" ^ v ^ "/" ^ version
 
 let package_doc ?hash ?(page = "index.html") v version =
   with_hash hash ^ "/" ^ v ^ "/" ^ version ^ "/doc/" ^ page

--- a/src/ocamlorg_frontend/url.ml
+++ b/src/ocamlorg_frontend/url.ml
@@ -1,19 +1,13 @@
 let index = "/"
 let packages = "/packages"
 let packages_search = "/packages/search"
-let package v = "/p/" ^ v
+let with_hash = function None -> "/p" | Some hash -> "/u/" ^ hash
+let package ?hash v = with_hash hash ^ "/" ^ v
 let package_docs v = "/p/" ^ v ^ "/doc"
-let package_with_univ hash v = "/u/" ^ hash ^ "/" ^ v
-let package_with_version v version = "/p/" ^ v ^ "/" ^ version
+let package_with_version ?hash v version = with_hash hash ^ "/" ^ v ^ "/" ^ version
 
-let package_with_hash_with_version hash v version =
-  "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version
-
-let package_doc v ?(page = "index.html") version =
-  "/p/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
-
-let package_doc_with_hash hash page v version =
-  "/u/" ^ hash ^ "/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
+let package_doc ?hash ?(page = "index.html") v version =
+  with_hash hash ^ "/" ^ v ^ "/" ^ version ^ "/doc/" ^ page
 
 let community = "/community"
 let success_story v = "/success-stories/" ^ v

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -469,7 +469,7 @@ let package_doc t kind req =
       let root =
         let make =
           match kind with
-          | `Package -> Ocamlorg_frontend.Url.package_doc ~page:""
+          | `Package -> Ocamlorg_frontend.Url.package_doc ?hash:None ~page:""
           | `Universe u -> Ocamlorg_frontend.Url.package_doc ~hash:u ~page:""
         in
         make

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -469,8 +469,8 @@ let package_doc t kind req =
       let root =
         let make =
           match kind with
-          | `Package -> Ocamlorg_frontend.Url.package_doc ~page:""
-          | `Universe u -> Ocamlorg_frontend.Url.package_doc_with_hash u ""
+          | `Package -> Ocamlorg_frontend.Url.package_doc ?hash:None ~page:""
+          | `Universe u -> Ocamlorg_frontend.Url.package_doc ~hash:u ~page:""
         in
         make
           (Ocamlorg_package.Name.to_string name)

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -469,7 +469,7 @@ let package_doc t kind req =
       let root =
         let make =
           match kind with
-          | `Package -> Ocamlorg_frontend.Url.package_doc ?hash:None ~page:""
+          | `Package -> Ocamlorg_frontend.Url.package_doc ~page:""
           | `Universe u -> Ocamlorg_frontend.Url.package_doc ~hash:u ~page:""
         in
         make

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -61,18 +61,18 @@ let package_route t =
       Dream.get Url.packages_search (Handler.packages_search t);
       Dream.get (Url.package ":name") (Handler.package t);
       Dream.get (Url.package_docs ":name") (Handler.package_docs t);
-      Dream.get (Url.package_with_univ ":hash" ":name") (Handler.package t);
+      Dream.get (Url.package ~hash:":hash" ":name") (Handler.package t);
       Dream.get
         (Url.package_with_version ":name" ":version")
         ((Handler.package_versioned t) Handler.Package);
       Dream.get
-        (Url.package_with_hash_with_version ":hash" ":name" ":version")
+        (Url.package_with_version ~hash:":hash" ":name" ":version")
         ((Handler.package_versioned t) Handler.Universe);
       Dream.get
         (Url.package_doc ":name" ":version" ~page:"**")
         ((Handler.package_doc t) Handler.Package);
       Dream.get
-        (Url.package_doc_with_hash ":hash" "**" ":name" ":version")
+        (Url.package_doc ~hash:":hash" ~page:"**" ":name" ":version")
         ((Handler.package_doc t) Handler.Universe);
     ]
 


### PR DESCRIPTION
* Define helper function with_hash, allowing to deal with
  optional hash parameter in applicable functions
* Add hash as optional parameter in functions:
  + package,
  + package_with_version
  + package_doc
* Remove corresponding with_{hash|univ} functions (in order):
  + package_with_univ
  + package_with_hash_with_version
  + package_doc_with_hash
