### PR TITLE
Fixed example dune exec bin path

### DIFF
--- a/data/tutorials/gs_00_up_and_running.md
+++ b/data/tutorials/gs_00_up_and_running.md
@@ -338,7 +338,7 @@ When we change our program, we can type `dune build` again to make a new
 executable. To run the program, we can use:
 
 ```
-$ dune exec ./bin/main.exe
+$ dune exec ./_build/default/bin/main.exe
 Hello, World!
 ```
 


### PR DESCRIPTION
Trivial correction to the **Get Up and Running With OCaml** document. 

As mentioned later on in the documentation:
>All the build outputs generated by Dune go in the `_build` directory.  
>The `main.exe` executable is generated inside the `_build/default/bin/` subdirectory.

By default the `main.exe` executable generated by `dune build` on the previous line is found in `./_build/default/bin`, not in `./bin`