### PR TITLE
Added Arch aarch64

### DIFF
--- a/src/dream_dashboard/info.ml
+++ b/src/dream_dashboard/info.ml
@@ -56,6 +56,7 @@ let platform_of_string = function
 let arch_of_string = function
   | "arm" -> Arm
   | "arm64" -> Arm64
+  | "aarch64" -> Arm64
   | "ia32" -> Ia32
   | "mips" -> Mips
   | "mipsel" -> Mipsel


### PR DESCRIPTION
The system architecture is checked during the initialisation phase, effectively running `uname -m`.  If the architecture is not listed in `arch_of_string`, the application exits on an `assert`.  ARMv8 reports as `aarch64`, while Apple M1 reports as `arm64`.