### PR TITLE
Remove backticks around inline code fragments

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -18,11 +18,6 @@ div.odoc-include .spec {
   margin-top: 1rem /* 16px */;
 }
 
-div.odoc div.spec code::before,
-div.odoc div.spec code::after {
-  content: "";
-}
-
 div.odoc div.spec code {
   white-space: pre-wrap;
 }
@@ -133,14 +128,6 @@ div.odoc div.spec tbody td.def {
 
 div.odoc div.spec tbody tr {
   border-width: 0px;
-}
-
-div.odoc code::before {
-  content: "";
-}
-
-div.odoc code::after {
-  content: "";
 }
 
 div.odoc td.def-doc .comment-delim {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,18 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            'code::before': {
+              content: '""',
+            },
+            'code::after': {
+              content: '""',
+            },
+          }
+        }
+      },
       maxWidth: {
         '8xl': '90rem',
       },


### PR DESCRIPTION
By default taiwind css surounds inline code with backticks. In
order to have a more GitHub-like experience, as suggested by
@MisterDA in https://github.com/ocaml/ocaml.org/issues/612 the
tailwind configuration needs to be changed as explained here:

https://github.com/tailwindlabs/tailwindcss-typography/issues/18
