### PR TITLE
Add self-referencing links to headings

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -106,10 +106,33 @@ body {
   @apply text-primary-600 no-underline;
 }
 
+.prose [id] {
+  scroll-margin-top: 2rem;
+}
+
 .prose :is(h1, h2, h3, h4, h5, h6) > a,
-.prose :is(h1, h2, h3, h4, h5, h6) > a code {
+.prose :is(h1, h2, h3, h4, h5, h6) > a code,
+.prose :is(h1, h2, h3, h4, h5, h6) > a:hover,
+.prose :is(h1, h2, h3, h4, h5, h6) > a:hover code {
   color: unset;
-  font-weight: unset;
+  @apply no-underline;
+}
+
+.prose :is(h1:target, h2:target, h3:target, h4:target, h5:target, h6:target) {
+  position:relative;
+  background:rgb(255, 243, 173);
+  padding: 0.2rem 0rem;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) > a:hover::before,
+.prose :is(h1, h2, h3, h4, h5, h6) > a:hover code::before {
+  content: "#";
+  position: absolute;
+  color: rgb(90, 98, 111);
+  margin-left: -1.2em;
+  padding: 0.39em;
+  margin-top: -.37em;
+  font-weight: 500;
 }
 
 .prose a:hover {

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -109,6 +109,7 @@ body {
 .prose :is(h1, h2, h3, h4, h5, h6) > a,
 .prose :is(h1, h2, h3, h4, h5, h6) > a code {
   color: unset;
+  font-weight: unset;
 }
 
 .prose a:hover {

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -106,6 +106,11 @@ body {
   @apply text-primary-600 no-underline;
 }
 
+.prose :is(h1, h2, h3, h4, h5, h6) > a,
+.prose :is(h1, h2, h3, h4, h5, h6) > a code {
+  color: unset;
+}
+
 .prose a:hover {
   @apply underline;
 }

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -6,8 +6,8 @@ let render
 Learn_layout.render ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title) ~description:tutorial.description
 (Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials) ~canonical
 @@
-<div class="flex-1 flex overflow-hidden">
-  <div class="prose prose-orange overflow-hidden z-0 z- lg:max-w-4xl mx-auto relative py-8 px-6">
+<div class="flex-1 z-0 z- w-full lg:max-w-3xl mx-auto relative lg:pt-6">
+  <div class="prose prose-orange z-0 z- lg:max-w-3xl mx-auto relative lg:pt-6">
     <%s! tutorial.body_html %>
     <div class="pt-10 border-t border-slate-200 lg:grid lg:grid-cols-3 gap-4 text-slate-500">
       <div class="lg:col-span-1">

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -62,7 +62,7 @@ let doc_with_ids doc =
             Omd.destination = "#" ^ Utils.slugify (to_plain_text inline);
             Omd.title = None
           } in
-          Heading (attr, level, Omd.Link (attr, link))
+          Heading (attr, level, Omd.Link (("style", "all:unset") :: attr, link))
       | el -> el)
     doc
 

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -61,8 +61,7 @@ let doc_with_ids doc =
           let link : _ Omd.link =
             { label = inline; destination = "#" ^ id; title = None }
           in
-          Heading
-          (("id", id) :: attr, level, Link (attr, link))
+          Heading (("id", id) :: attr, level, Link (attr, link))
       | el -> el)
     doc
 

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -61,9 +61,7 @@ let doc_with_ids doc =
           let link : _ Omd.link =
             { label = inline; destination = "#" ^ id; title = None }
           in
-          let style =
-            "color: rgb(17 24 39)"
-          in
+          let style = "color: rgb(17 24 39)" in
           Heading
             (("id", id) :: attr, level, Link (("style", style) :: attr, link))
       | el -> el)

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -57,12 +57,14 @@ let doc_with_ids doc =
             | Some _ -> attr
             | None -> ("id", Utils.slugify (to_plain_text inline)) :: attr
           in
-          let link = {
-            Omd.label = inline;
-            Omd.destination = "#" ^ Utils.slugify (to_plain_text inline);
-            Omd.title = None
+          let link = Omd.{
+            label = inline;
+            destination = "#" ^ List.assoc "id" attr;
+            title = None
           } in
-          Heading (attr, level, Omd.Link (("style", "all:unset") :: attr, link))
+          let style =
+            "color: rgb(17 24 39); font-size: 24px; font-weight: 700" in
+          Heading (attr, level, Omd.Link (("style", style) :: attr, link))
       | el -> el)
     doc
 

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -57,13 +57,16 @@ let doc_with_ids doc =
             | Some _ -> attr
             | None -> ("id", Utils.slugify (to_plain_text inline)) :: attr
           in
-          let link = Omd.{
-            label = inline;
-            destination = "#" ^ List.assoc "id" attr;
-            title = None
-          } in
+          let (link : _ Omd.link) =
+            {
+              label = inline;
+              destination = "#" ^ List.assoc "id" attr;
+              title = None;
+            }
+          in
           let style =
-            "color: rgb(17 24 39); font-size: 24px; font-weight: 700" in
+            "color: rgb(17 24 39); font-size: 24px; font-weight: 700"
+          in
           Heading (attr, level, Omd.Link (("style", style) :: attr, link))
       | el -> el)
     doc

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -62,7 +62,7 @@ let doc_with_ids doc =
             { label = inline; destination = "#" ^ id; title = None }
           in
           let style =
-            "color: rgb(17 24 39); font-size: 24px; font-weight: 700"
+            "color: rgb(17 24 39)"
           in
           Heading
             (("id", id) :: attr, level, Link (("style", style) :: attr, link))

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -57,7 +57,7 @@ let doc_with_ids doc =
             | Some _ -> attr
             | None -> ("id", Utils.slugify (to_plain_text inline)) :: attr
           in
-          let (link : _ Omd.link) =
+          let link : _ Omd.link =
             {
               label = inline;
               destination = "#" ^ List.assoc "id" attr;

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -52,22 +52,20 @@ let doc_with_ids doc =
   List.map
     (function
       | Heading (attr, level, inline) ->
-          let attr =
-            match List.assoc_opt "id" attr with
-            | Some _ -> attr
-            | None -> ("id", Utils.slugify (to_plain_text inline)) :: attr
+          let id, attr = List.partition (fun (key, _) -> key = "id") attr in
+          let id =
+            match id with
+            | [] -> Utils.slugify (to_plain_text inline)
+            | (_, slug) :: _ -> slug (* Discard extra ids *)
           in
           let link : _ Omd.link =
-            {
-              label = inline;
-              destination = "#" ^ List.assoc "id" attr;
-              title = None;
-            }
+            { label = inline; destination = "#" ^ id; title = None }
           in
           let style =
             "color: rgb(17 24 39); font-size: 24px; font-weight: 700"
           in
-          Heading (attr, level, Omd.Link (("style", style) :: attr, link))
+          Heading
+            (("id", id) :: attr, level, Link (("style", style) :: attr, link))
       | el -> el)
     doc
 

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -57,7 +57,12 @@ let doc_with_ids doc =
             | Some _ -> attr
             | None -> ("id", Utils.slugify (to_plain_text inline)) :: attr
           in
-          Heading (attr, level, inline)
+          let link = {
+            Omd.label = inline;
+            Omd.destination = "#" ^ Utils.slugify (to_plain_text inline);
+            Omd.title = None
+          } in
+          Heading (attr, level, Omd.Link (attr, link))
       | el -> el)
     doc
 

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -61,9 +61,8 @@ let doc_with_ids doc =
           let link : _ Omd.link =
             { label = inline; destination = "#" ^ id; title = None }
           in
-          let style = "color: rgb(17 24 39)" in
           Heading
-            (("id", id) :: attr, level, Link (("style", style) :: attr, link))
+          (("id", id) :: attr, level, Link (attr, link))
       | el -> el)
     doc
 


### PR DESCRIPTION
Markddown header are turned into headers with links refering to
themselves. This addresses issue:
https://github.com/ocaml/ocaml.org/issues/620
