### PR TITLE
Show how to use Dune to compile examples

### DIFF
--- a/data/tutorials/examples/amodule2.ml
+++ b/data/tutorials/examples/amodule2.ml
@@ -1,1 +1,3 @@
-let hello () = print_endline "Hello"
+let message = "Hello 2"
+
+let hello () = print_endline message

--- a/data/tutorials/examples/amodule2.ml
+++ b/data/tutorials/examples/amodule2.ml
@@ -1,3 +1,2 @@
 let message = "Hello 2"
-
 let hello () = print_endline message

--- a/data/tutorials/examples/bmodule2.ml
+++ b/data/tutorials/examples/bmodule2.ml
@@ -1,0 +1,1 @@
+let () = Amodule2.hello ()

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -141,7 +141,6 @@ to something called `amodule2.ml`:
 <!-- $MDX file=examples/amodule2.ml -->
 ```ocaml
 let message = "Hello 2"
-
 let hello () = print_endline message
 ```
 
@@ -150,7 +149,6 @@ As it is, `Amodule2` has the following interface:
 <!-- $MDX skip -->
 ```ocaml
 val message : string
-
 val hello : unit -> unit
 ```
 

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -11,7 +11,7 @@ date: 2021-05-27T21:07:30-00:00
 
 ## Basic usage
 
-### Files defines modules
+### Files Define Modules
 
 In OCaml, every piece of code is wrapped into a module. Optionally, a module
 itself can be a submodule of another module, pretty much like directories in a
@@ -36,25 +36,25 @@ And here is what we have in `bmodule.ml`:
 let () = Amodule.hello ()
 ```
 
-### Automatized compilation
+### Automatized Compilation
 
 In order to compile them using the [Dune](https://dune.build/) build system,
 which is now the standard on OCaml, at least two configuration files are
 required:
 
-* File `dune-project` which contains project-wide configuration data. Here very
+* The `dune-project` file, which contains project-wide configuration data. Here's very
   minimal one:
   ```
    (lang dune 3.4)
   ```
-* File `dune` which contains actual build directives, a project may have several
+* The `dune` file, which contains actual build directives. A project may have several
   of them, depending on the organization of the source. This is sufficient for
   this example:
   ```
   (executable (name bmodule))
   ```
 
-Here is how to create the configuration files, build the source and run the
+Here is how to create the configuration files, build the source, and run the
 executable.
 <!-- $MDX dir=examples -->
 ```bash
@@ -65,20 +65,20 @@ $ dune exec ./bmodule.exe
 Hello
 ```
 
-Actually, `dune build` is optional, simply running `dune exec` would have
-triggered the compilation. Beware in the `dune exec` command, the parameter
+Actually, `dune build` is optional. Simply running `dune exec` would have
+triggered the compilation. Beware in the `dune exec` command, as the parameter
 `./bmodule.exe` is not a file path. This command means “execute the content of
 the file `./bmodule.ml`”. However, the actual executable file is stored and
 named differently.
 
-In a real world project, it is preferable to start by creating the Dune
+In a real world project, it is preferable to start by creating the `dune`
 configuration files and directory structure using the `dune init project`
 command.
 
-### Manual compilation
+### Manual Compilation
 
 Alternatively, it is possible, but not recommended, to compile the files by
-directly calling the compiler, using a single command:
+directly calling the compiler by using a single command:
 
 <!-- $MDX dir=examples -->
 ```sh
@@ -105,7 +105,7 @@ $ ./hello
 Hello
 ```
 
-### Naming and scoping
+### Naming and Scoping
 
 Now we have an executable that prints "Hello". As you can see, if you want to
 access anything from a given module, use the name of the module (always
@@ -183,7 +183,7 @@ val hello : unit -> unit
 ```
 
 Let's assume that accessing the `message` value directly is none of the others
-modules' business, we want it to be a private definition. We can hide it by
+modules' business; we want it to be a private definition. We can hide it by
 defining a restricted interface. This is our `amodule2.mli` file:
 
 <!-- $MDX file=examples/amodule2.mli -->
@@ -193,7 +193,7 @@ val hello : unit -> unit
 ```
 
 (note the double asterisk at the beginning of the comment - it is a good habit
-to document .mli files using the format supported by
+to document `.mli` files using the format supported by
 [ocamldoc](/releases/4.14/htmlman/ocamldoc.html))
 
 The corresponding module `Bmodule2` is defined in file `bmodule2.ml`:
@@ -203,7 +203,7 @@ The corresponding module `Bmodule2` is defined in file `bmodule2.ml`:
 let () = Amodule2.hello ()
 ```
 
-The .mli files must be compiled before the matching .ml files. This is done
+The .`mli` files must be compiled before the matching `.ml` files. This is done
 automatically by Dune. We update the `dune` file to allow the compilation
 of this example aside of the previous one.
 
@@ -218,8 +218,8 @@ Hello 2
 ```
 
 There how the same result can be acheived by calling the compiler manually.
-Notice the .mli file is compiled using byte-code compiler `ocamlc` , while if
-.ml files are compiled to native code using `ocamlopt`:
+Notice the `.mli` file is compiled using byte-code compiler `ocamlc` , while if
+`.ml` files are compiled to native code using `ocamlopt`:
 
 <!-- $MDX dir=examples -->
 ```sh
@@ -233,7 +233,7 @@ $ ./hello2
 Hello 2
 ```
 
-## Abstract types
+## Abstract Types
 
 What about type definitions? We saw that values such as functions can be
 exported by placing their name and their type in a .mli file, e.g.

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -52,7 +52,30 @@ Or, as a build system might do, one by one:
 $ ocamlopt -c amodule.ml
 $ ocamlopt -c bmodule.ml
 $ ocamlopt -o hello amodule.cmx bmodule.cmx
+$ ./hello
+Hello
 ```
+
+Nowadays, the [Dune](https://dune.build) tool has become the standard for
+building OCaml projects. Here is how it can be minimally used to build this
+example:
+
+<!-- $MDX dir=examples -->
+```bash
+$ echo "(lang dune 3.4)" > dune-project
+$ echo "(executable (name bmodule))" > dune
+$ dune build
+$ dune exec ./bmodule.exe
+Hello
+```
+
+Beware in the `dune exec` command, the parameter `./bmodule.exe` is not a file
+path. This command means “execute the content of the file `./bmodule.ml`”.
+However, the actual executable file is stored and named differently.
+
+In a real world project, it is preferable to start by creating the Dune
+configuration files and directory structure using the `dune init project`
+command.
 
 Now we have an executable that prints "Hello". As you can see, if you want to
 access anything from a given module, use the name of the module (always
@@ -117,10 +140,12 @@ to something called `amodule2.ml`:
 
 <!-- $MDX file=examples/amodule2.ml -->
 ```ocaml
-let hello () = print_endline "Hello"
+let message = "Hello 2"
+
+let hello () = print_endline message
 ```
 
-As it is, `Amodule` has the following interface:
+As it is, `Amodule2` has the following interface:
 
 <!-- $MDX skip -->
 ```ocaml
@@ -130,8 +155,8 @@ val hello : unit -> unit
 ```
 
 Let's assume that accessing the `message` value directly is none of the others
-modules' business. We want to hide it by defining a restricted interface. This
-is our `amodule2.mli` file:
+modules' business, we want it to be a private definition. We can hide it by
+defining a restricted interface. This is our `amodule2.mli` file:
 
 <!-- $MDX file=examples/amodule2.mli -->
 ```ocaml
@@ -143,7 +168,14 @@ val hello : unit -> unit
 to document .mli files using the format supported by
 [ocamldoc](/releases/4.14/htmlman/ocamldoc.html))
 
-Such .mli files must be compiled just before the matching .ml files. They are
+The corresponding module `Bmodule2` is defined in file `bmodule2.ml`:
+
+<!-- $MDX file=examples/bmodule2.ml -->
+```ocaml
+let () = Amodule2.hello ()
+```
+
+The .mli files must be compiled just before the matching .ml files. They are
 compiled using `ocamlc`, even if .ml files are compiled to native code using
 `ocamlopt`:
 
@@ -151,6 +183,24 @@ compiled using `ocamlc`, even if .ml files are compiled to native code using
 ```sh
 $ ocamlc -c amodule2.mli
 $ ocamlopt -c amodule2.ml
+$ ocamlopt -c bmodule2.ml
+$ ocamlopt -o hello2 amodule2.cmx bmodule2.cmx
+$ ./hello
+Hello
+$ ./hello2
+Hello 2
+```
+
+When using Dune, this is done automatically:
+
+<!-- $MDX dir=examples -->
+```bash
+$ echo "(executables (names bmodule bmodule2))" > dune
+$ dune build
+$ dune exec ./bmodule.exe
+Hello
+$ dune exec ./bmodule2.exe
+Hello 2
 ```
 
 ## Abstract types

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -68,7 +68,7 @@ Hello
 Actually, `dune build` is optional. Simply running `dune exec` would have
 triggered the compilation. Beware in the `dune exec` command, as the parameter
 `./bmodule.exe` is not a file path. This command means “execute the content of
-the file `./bmodule.ml`”. However, the actual executable file is stored and
+the file `./bmodule.ml`." However, the actual executable file is stored and
 named differently.
 
 In a real world project, it is preferable to start by creating the `dune`

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -504,7 +504,7 @@ module List :
     val mem : 'a -> 'a t -> bool
     val memq : 'a -> 'a t -> bool
     val find : ('a -> bool) -> 'a t -> 'a
-    val find_opt : ('a -> bool) -> 'a t -> 'a optionDefine
+    val find_opt : ('a -> bool) -> 'a t -> 'a option
     val find_map : ('a -> 'b option) -> 'a t -> 'b option
     val filter : ('a -> bool) -> 'a t -> 'a t
     val find_all : ('a -> bool) -> 'a t -> 'a t

--- a/data/tutorials/lg_03_modules.md
+++ b/data/tutorials/lg_03_modules.md
@@ -11,7 +11,7 @@ date: 2021-05-27T21:07:30-00:00
 
 ## Basic usage
 
-### Files Define Modules
+### File-Based Modules
 
 In OCaml, every piece of code is wrapped into a module. Optionally, a module
 itself can be a submodule of another module, pretty much like directories in a
@@ -42,13 +42,13 @@ In order to compile them using the [Dune](https://dune.build/) build system,
 which is now the standard on OCaml, at least two configuration files are
 required:
 
-* The `dune-project` file, which contains project-wide configuration data. Here's very
-  minimal one:
+* The `dune-project` file, which contains project-wide configuration data.
+  Here's a very minimal one:
   ```
    (lang dune 3.4)
   ```
 * The `dune` file, which contains actual build directives. A project may have several
-  of them, depending on the organization of the source. This is sufficient for
+  of them, depending on the organization of the sources. This is sufficient for
   this example:
   ```
   (executable (name bmodule))
@@ -68,7 +68,7 @@ Hello
 Actually, `dune build` is optional. Simply running `dune exec` would have
 triggered the compilation. Beware in the `dune exec` command, as the parameter
 `./bmodule.exe` is not a file path. This command means “execute the content of
-the file `./bmodule.ml`." However, the actual executable file is stored and
+the file `./bmodule.ml`.” However, the actual executable file is stored and
 named differently.
 
 In a real world project, it is preferable to start by creating the `dune`
@@ -78,7 +78,7 @@ command.
 ### Manual Compilation
 
 Alternatively, it is possible, but not recommended, to compile the files by
-directly calling the compiler by using a single command:
+directly calling the compiler. Either using a single command:
 
 <!-- $MDX dir=examples -->
 ```sh
@@ -107,7 +107,7 @@ Hello
 
 ### Naming and Scoping
 
-Now we have an executable that prints "Hello". As you can see, if you want to
+Now we have an executable that prints `Hello`. As you can see, if you want to
 access anything from a given module, use the name of the module (always
 starting with a capital) followed by a dot and the thing that you want to use.
 It may be a value, a type constructor, or anything else that a given module can
@@ -504,7 +504,7 @@ module List :
     val mem : 'a -> 'a t -> bool
     val memq : 'a -> 'a t -> bool
     val find : ('a -> bool) -> 'a t -> 'a
-    val find_opt : ('a -> bool) -> 'a t -> 'a option
+    val find_opt : ('a -> bool) -> 'a t -> 'a optionDefine
     val find_map : ('a -> 'b option) -> 'a t -> 'b option
     val filter : ('a -> bool) -> 'a t -> 'a t
     val find_all : ('a -> bool) -> 'a t -> 'a t


### PR DESCRIPTION
Fix: https://github.com/ocaml/ocaml.org/issues/506

Usage of ocamlc and ocamlopt remains. Text is added showing how
to achieve the same result using dune with a minimum set up.
