### PR TITLE
style changes for docs pages

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -92,7 +92,9 @@ div.odoc *:hover > a.anchor:hover {
 
 /* selected anchor target highlighting */
 
-div.odoc .spec:target,
+div.odoc .spec:target {
+  background: rgb(255, 248, 206);
+}
 div.odoc .anchored:target,
 div.odoc h1:target,
 div.odoc h2:target,
@@ -106,6 +108,10 @@ div.odoc h6:target {
 div.odoc .spec:target a,
 div.odoc .anchored:target a {
   color: rgb(204, 48, 0);
+}
+
+div.odoc *[id] {
+  scroll-margin-top: 2rem;
 }
 
 /* ----- */
@@ -170,4 +176,16 @@ div.odoc-include summary:hover {
 
 div.odoc span[class*="keyword"] {
   color: rgba(17, 24, 39, 1);
+}
+
+div.odoc ul.at-tags {
+  margin: 0.5em 0;
+}
+
+div.odoc ul.at-tags p {
+  margin: 0;
+}
+
+div.odoc span.at-tag {
+  font-weight: bold;
 }


### PR DESCRIPTION
* minor color adjustment wrt background color of spec items and anchor target (marginally lighter color)
* scroll-margin-top to better position the anchor target (so it doesn't end up right at the very top of the page, but leaves a bit of space)
* style odoc's at-tags

| before  | after |
| ------------- | ------------- |
| ![Screenshot 2022-11-28 at 15-18-49 PrintBox_text · printbox 0 4 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204300813-6deb484b-b6e1-4c82-bd2e-667960b962c2.png) @-tags were unstyled  | ![Screenshot 2022-11-28 at 15-19-10 PrintBox_text · printbox 0 4 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204300923-8ef9aacb-310f-48e8-ac29-be399814074e.png) @-tags styled a bit|
|![Screenshot 2022-11-28 at 15-30-28 PrintBox_text · printbox 0 4 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204303364-cf8103e3-490b-4268-bcbd-f3c4b713a1b7.png) when clicking on anchor link, the target ends up at the very top of the screen | ![Screenshot 2022-11-28 at 15-30-24 PrintBox_text · printbox 0 4 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204303322-e218c83c-1896-4f4d-bc42-1ca158e69fc1.png) there is a little gap between the top of the screen and the anchor target. Background of targeted spec item is slightly lighter|
