### PR TITLE
collapse table of contents to sidebar on smaller-than-xl screens

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -1,6 +1,4 @@
 div.odoc {
-  margin-left: auto;
-  margin-right: auto;
   max-width: 56rem /* 896px */;
   position: relative;
 }

--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -9,28 +9,27 @@ type t = toc list
 let render (t : t) =
   <div>
     <% (match t with [] ->  %>
-    <span class="block py-2 text-gray-900">No table of content</span>
+    <span class="block py-2 text-gray-900">No table of contents</span>
     <% | _ -> %>
-    <ul class="text-gray-700 text-sm leading-6">
+    <ul class="leading-6 space-y-3 text-sm">
       <% t |> List.iter begin fun item -> %>
         <li>
-          <a href="<%s item.href %>" class="block py-1 font-medium text-gray-900 transition-colors duration-300">
+          <a href="<%s item.href %>" class="font-semibold text-gray-900 py-1 md:p-0 block transition-colors hover:text-orange-600">
             <%s! item.title %>
           </a>
             <% match item.children with [] -> () | items -> %>
-            <ul class="space-y-2">
+            <ul>
               <% items |> List.iter begin fun item -> %>
               <li class="ml-4">
-                <a href="<%s item.href %>" class="block transition-colors duration-300">
+                <a href="<%s item.href %>" class="font-regular text-body-600 py-1 md:p-0 block transition-colors hover:text-orange-600">
                   <%s! item.title %>
                 </a>
               </li>
               <% end; %>
             </ul>
             <% ; %>
-          </li>
           <% end; %>
-        </ul>
+        </li>
     </ul>
     <% ); %>
   </div>

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -119,7 +119,7 @@ table a:hover {
 }
 
 .right-sidebar a:hover {
-  @apply text-body-600 underline;
+  @apply text-orange-600;
 }
 
 .news-stories button:hover {

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -33,27 +33,31 @@ Package_layout.render
     </div>
   </button>
 
-  <div class="flex lg:space-x-14 flex-col lg:flex-row">
+  <div class="flex flex-col lg:flex-row md:gap-6">
     <div
-      class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed h-screen overflow-auto lg:flex left-0 top-0 lg:sticky lg:w-60 lg:p-0 font-normal text-body-400"
+      class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6 font-normal text-body-400"
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
       x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
       x-transition:leave-end="-translate-x-full">
+      <div class="xl:hidden mb-6 xl:mb-0">
+      <%s! if (toc != []) then Toc.render toc else "" %>
+      </div>
+
       <div class="space-y-2 flex flex-col">
-        <div class="text-sm font-semibold text-body-600 mb-6 py-2">IN THIS PACKAGE</div>
+        <div class="text-sm font-semibold text-gray-500 mb-6">IN THIS PACKAGE</div>
         <%s! Navmap.render ~path:str_path maptoc %>
       </div>
     </div>
-    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-4xl mx-auto relative md:px-6 md:pl-12">
+    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-3xl relative lg:pt-6">
       <%s! if (maptoc != []) && (List.length path != 0) then Breadcrumbs.render path else "" %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>
     </div>
-    <div class="hidden lg:flex top-0 sticky h-screen">
-      <div class="flex-col w-60">
+    <div class="hidden xl:flex top-0 sticky h-screen">
+      <div class="flex-col w-72">
         <div class="h-screen overflow-scroll p-6 right-sidebar">
-          <div class="font-semibold text-black text-sm mb-4">ON THIS PAGE</div>
+          <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
           <%s! Toc.render toc %>
         </div>
       </div>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -52,7 +52,7 @@ Learn_layout.render ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.titl
 <div class="hidden xl:flex top-0 sticky h-screen">
   <div class="flex-col w-60 py-6 pl-6">
     <div class="h-screen overflow-auto right-sidebar">
-      <div class="font-semibold text-black text-sm mb-4">ON THIS PAGE</div>
+      <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
       <div class="page-toc"><%s! tutorial.toc_html %></div>
     </div>
   </div>


### PR DESCRIPTION
On lg-screen, collapse the table of contents right sidebar and place table of contents in the left sidebar. This ensures that the content area is wide enough on all screen widths.

* includes minor style adjustments to ToC (spacing, font weight, hover color)
* left sidebar and content area now have the same padding-top as the right sidebar which means the alignment is no longer off

| screen| before | after |
|---|---|---|
| xl | ![Screenshot 2022-11-28 at 16-14-45 Irmin · irmin 3 4 3 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204314438-d39d3982-2d27-401e-b0c0-233df39bd71b.png) | ![Screenshot 2022-11-28 at 16-14-39 Irmin · irmin 3 4 3 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204314430-8f3a410e-c851-41c4-bca9-428f3a2014ad.png) | 
|lg | ![Screenshot 2022-11-28 at 16-15-01 Irmin · irmin 3 4 3 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204314445-01b74948-b749-4bee-b1dd-d853e90450d4.png) | ![Screenshot 2022-11-28 at 16-15-06 Irmin · irmin 3 4 3 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204314456-e1753127-3789-45a8-b6ff-503632b42844.png) |
