### PR TITLE
more compact package layout header, removes package layout tabs

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -1,30 +1,10 @@
-type tab = 
-  | Overview
-  | Documentation
-  
 let render
 ?styles
-?(extra_nav="")
 ~title
 ~description
-~tab
-~documentation_status
 ~canonical
 ~(package : Package_intf.package)
 inner =
-let tab_class = "border-transparent border-b-2 hover:border-primary-600 p-4 font-medium relative text-body-400" in
-let unavailable_tab_class = "border-transparent border-b-2 p-4 font-medium relative text-gray-400" in
-let current_tab_class = "border-b-2 hover:border-primary-600 p-4 font-medium border-primary-600 relative text-primary-600" in
-let documentation_dot = match documentation_status with 
-  | `Failure -> "<span class=\"bg-red-500 ml-2 absolute top-2 p-1 rounded-full inline-block\"></span>"
-  | `Success -> "<span class=\"bg-green-500 ml-2 absolute top-2 p-1 rounded-full inline-block\"></span>"
-  | `Unknown -> "<span class=\"bg-orange-300 ml-2 absolute top-2 p-1 rounded-full inline-block\"></span>"
-in
-let doc_status_tooltip = match documentation_status with
-  | `Failure -> "title=\"documentation failed to build\""
-  | `Unknown -> "title=\"failed to fetch documentation\""
-  | _ -> ""
-in
 Layout.render
 ?styles
 ~wide:true
@@ -32,58 +12,26 @@ Layout.render
 ~description
 ~canonical @@
 <div class="bg-white">
-  <div class="py-5 lg:py-12">
+  <div class="py-5 lg:py-6">
     <div class="container-fluid wide">
-      <div class="flex justify-between flex-col md:flex-row">
-        <div class="flex flex-col">
-          <h4 class="font-bold mb-3">
+      <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
+        <div class="flex flex-col items-baseline mb-6">
+          <h4 class="font-bold md:whitespace-nowrap">
             <%s package.name %>
+            <select id="version" name="version" onchange="location = this.value;" class="appearance-none cursor-pointer py-0 pt-1 border rounded-md border-transparent pr-8">
+              <% package.versions |> List.iter begin fun item -> %>
+              <option value="/p/<%s package.name %>/<%s item %>"<%s if item = package.version then "selected" else "" %>>
+                <%s item %>
+              </option>
+              <% end; %>
+            </select>
           </h4>
           <div class="text-body-400">
             <%s package.description %>
           </div>
         </div>
-        <div
-          class="flex justify-between space-y-5 md:space-y-0 md:space-x-5 flex-col md:flex-row w-full md:w-auto my-6 md:my-0">
-          <div class=" h-14 w-full md:w-auto flex-col flex">
-            <label class="font-semibold mb-2">Version</label>
-            <div class="relative">
-              <select id="version" name="version" onchange="location = this.value;" class="w-full lg:w-auto appearance-none text-body-600 border rounded-md py-3 pl-6 border-gray-200 pr-14 h-full">
-                <% package.versions |> List.iter begin fun item -> %>
-                <option value="/p/<%s package.name %>/<%s item %>"<%s if item = package.version then "selected" else "" %>>
-                  <%s item %>
-                </option>
-                <% end; %>
-              </select>
-            </div>
-          </div>
-        </div>
       </div>
-      <div class="flex flex-col">
-        <div class="flex mt-8 gap-x-6 border-b border-gray-200 items-stretch flex-wrap">
-          <a href="<%s Url.package_with_version package.name package.version %>" class="<%s if tab = Overview then current_tab_class else tab_class %>">
-            Overview
-          </a>
-
-          <% (match documentation_status with
-            | `Unknown -> %>
-            <span class="<%s unavailable_tab_class %>" <%s! doc_status_tooltip %>>
-            Documentation
-              <%s! documentation_dot %>
-            </span>
-          <% | _ -> %>
-            <a href="<%s Url.package_doc package.name package.version %>"
-              class="<%s if tab = Documentation then current_tab_class else tab_class %>"
-              <%s! doc_status_tooltip %>>
-                Documentation
-                <%s! documentation_dot %>
-            </a>
-          <% ); %>
-          
-          <%s! extra_nav %>
-        </div>
-      </div>
-      <div class="py-12">
+      <div class="py-6">
         <%s! inner %>
       </div>
     </div>

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -17,7 +17,7 @@ Layout.render
       <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
         <div class="flex flex-col items-baseline mb-6">
           <h4 class="font-bold md:whitespace-nowrap">
-            <%s package.name %>
+            <a href="<%s Url.package_with_version package.name package.version %>"><%s package.name %></a>
             <select id="version" name="version" onchange="location = this.value;" class="appearance-none cursor-pointer py-0 pt-1 border rounded-md border-transparent pr-8">
               <% package.versions |> List.iter begin fun item -> %>
               <option value="/p/<%s package.name %>/<%s item %>"<%s if item = package.version then "selected" else "" %>>

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -31,10 +31,8 @@ let package_overview ~documentation_status ~readme ~readme_title ~dependencies
     ~dependencies ~rev_dependencies ~homepages ~source ~changes_filename
     ~license_filename package
 
-let package_documentation ~documentation_status ~title ~path ~toc ~maptoc
-    ~content package =
-  Package_documentation.render ~documentation_status ~title ~path ~toc ~maptoc
-    ~content package
+let package_documentation ~title ~path ~toc ~maptoc ~content package =
+  Package_documentation.render ~title ~path ~toc ~maptoc ~content package
 
 let packages stats = Packages.render stats
 let packages_search ~total packages = Packages_search.render ~total packages

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -1,5 +1,4 @@
 let render
-~documentation_status
 ~title
 ~path
 ~toc
@@ -16,10 +15,8 @@ let path_page = match str_path |> String.concat "/" with
                 | "" -> None
                 | path -> Some (path ^ if String.contains path '.' then "" else "/index.html") in
 Package_layout.render
-~documentation_status
 ~title
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)
-~tab:Documentation
 ~package
 ~canonical:(Url.package_doc package.name package.version ?page:path_page)
 ~styles:["/css/main.css"; "/css/doc.css"] @@

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -10,10 +10,8 @@ let render
 ~license_filename
 (package : Package_intf.package) =
 Package_layout.render
-~documentation_status
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name package.version)
 ~description:(Printf.sprintf "%s %s: %s" package.name package.version package.description)
-~tab:Overview
 ~canonical:(Url.package_with_version package.name package.version)
 ~package @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col xl:flex-row justify-between">
@@ -66,6 +64,15 @@ Package_layout.render
             <br />
             <% ); %>
         </div>
+        <% (match documentation_status with
+            | `Success -> %>
+            <div class="mt-4"><a class="btn btn-sm" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">Documentation</a></div>
+            <% | `Unknown -> ( %><a href="<%s Url.package_doc package.name package.version ~page:"index.html" %>" class="p-4 mt-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#4b5563"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15.32 3H8.68c-.26 0-.52.11-.7.29L3.29 7.98c-.18.18-.29.44-.29.7v6.63c0 .27.11.52.29.71l4.68 4.68c.19.19.45.3.71.3h6.63c.27 0 .52-.11.71-.29l4.68-4.68c.19-.19.29-.44.29-.71V8.68c0-.27-.11-.52-.29-.71l-4.68-4.68c-.18-.18-.44-.29-.7-.29zM12 17.3c-.72 0-1.3-.58-1.3-1.3s.58-1.3 1.3-1.3 1.3.58 1.3 1.3-.58 1.3-1.3 1.3zm0-4.3c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1z"/></svg>
+            Documentation status is unknown. Sorry about that.</a><% )
+            | `Failure -> ( %><a href="<%s Url.package_doc package.name package.version ~page:"index.html" %>" class="p-4 mt-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#4b5563"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15.32 3H8.68c-.26 0-.52.11-.7.29L3.29 7.98c-.18.18-.29.44-.29.7v6.63c0 .27.11.52.29.71l4.68 4.68c.19.19.45.3.71.3h6.63c.27 0 .52-.11.71-.29l4.68-4.68c.19-.19.29-.44.29-.71V8.68c0-.27-.11-.52-.29-.71l-4.68-4.68c-.18-.18-.44-.29-.7-.29zM12 17.3c-.72 0-1.3-.58-1.3-1.3s.58-1.3 1.3-1.3 1.3.58 1.3 1.3-.58 1.3-1.3 1.3zm0-4.3c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1z"/></svg>
+            Documentation failed to build! Sorry about that.</a><% ));%>
         <% (match package.tags with [] -> () | _ ->  %>
         <div class="mt-4">
             <div class="flex mt-5 flex-wrap">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -563,11 +563,7 @@ let package_doc t kind req =
           let toc = toc_of_toc doc.toc in
           let* map = Ocamlorg_package.module_map ~kind package in
           let maptoc = toc_of_map ~root map in
-          let* documentation_status =
-            Ocamlorg_package.documentation_status ~kind package
-          in
           let package_meta = package_meta t package in
           Dream.html
-            (Ocamlorg_frontend.package_documentation ~documentation_status
-               ~path:doc.module_path ~title ~toc ~maptoc ~content:doc.content
-               package_meta))
+            (Ocamlorg_frontend.package_documentation ~path:doc.module_path
+               ~title ~toc ~maptoc ~content:doc.content package_meta))


### PR DESCRIPTION
Reduces the height of the package layout's header by applying a different layout for the package name, version and description.

Update: Tabs are removed in favor of a "Documentation" button below the package repository URL (or error in case the package documentation failed to build or its state is unknown). See large screen for the button, and small- and md-screen for the error box. Error box is also a link to the "Documentation" URL of the package, because, sometimes, there are error messages available under that URL.
| screen | before | after|
|-|-|-|
| small |![Screenshot 2022-11-28 at 21-24-35 irmin 0 9 0 · OCaml Package](https://user-images.githubusercontent.com/6594573/204373841-f1272a2f-5dd1-4715-a16a-baf01a53b408.png) | ![Screenshot 2022-11-28 at 21-24-39 irmin 0 9 0 · OCaml Package](https://user-images.githubusercontent.com/6594573/204373838-616c1daf-3164-45a6-a522-ebe66fb72307.png) |
| md | ![Screenshot 2022-11-28 at 21-24-20 irmin 0 9 0 · OCaml Package](https://user-images.githubusercontent.com/6594573/204374108-45cc3d4e-aced-4b18-9732-4e592f3b1f84.png) | ![Screenshot 2022-11-28 at 21-24-24 irmin 0 9 0 · OCaml Package](https://user-images.githubusercontent.com/6594573/204374101-cfeff128-d693-45f8-a46e-7d5e8ca25004.png) |
| lg | ![Screenshot 2022-11-28 at 21-26-07 irmin 3 4 2 · OCaml Package](https://user-images.githubusercontent.com/6594573/204374128-947d8d79-1df4-4b2d-b2d3-f7bf5d255140.png) | ![Screenshot 2022-11-28 at 21-26-11 irmin 3 4 2 · OCaml Package](https://user-images.githubusercontent.com/6594573/204374123-4379b56d-2291-413a-82fd-c34dcc07b675.png) |


