### PR TITLE
Add OCaml 5.0.0~beta2 announce to the news

### DIFF
--- a/data/news/platform/ocaml-5.0.beta2.md
+++ b/data/news/platform/ocaml-5.0.beta2.md
@@ -11,9 +11,7 @@ In order to test the most recent bug fixes and to help you update your software
 and libraries ahead of the release, we have released a second beta version of
 OCaml 5.0.0, (see below for the installation instructions).
 
-If you find any bugs, please report them here:
-
-[Issues · ocaml/ocaml · GitHub](https://github.com/ocaml/ocaml/issues).
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
 
 Compared to the first beta release, this second beta contains many small
 internal standard library fixes, one configuration fix and many small bug fixes.
@@ -26,14 +24,10 @@ are disabled by default, but are available for interested users.
 The first release candidate for OCaml 5.0.0 is expected to follow closely this
 second beta release.
 
-If you are interested by the ongoing list of bug fixes, the updated change log
-for OCaml 5.0.0 is available at:
+If you are interested in the ongoing list of bug fixes, the updated change log
+for OCaml 5.0.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.0/Changes).
 
-[ocaml/Changes at 5.0 · ocaml/ocaml · GitHub](https://github.com/ocaml/ocaml/blob/5.0/Changes)
-
-You can also follow the state of the opam ecosystem on
-
-http://check.ocamllabs.io/
+You can also follow the state of the opam ecosystem on [http://check.ocamllabs.io/](http://check.ocamllabs.io/).
 
 A short summary of the changes since the first beta release is also available below.
 
@@ -55,7 +49,6 @@ opam switch create 5.0.0~beta2 --repositories=default,beta=git+https://github.co
 
 It might also be interesting to check the new support for parallelism by installing
 the `domainslib` library with
-
 ```bash
 opam install domainslib
 ```
@@ -85,6 +78,7 @@ opam switch create <switch_name> --packages=ocaml-variants.5.0.0~beta2+options,<
 In both cases, all available options can be listed with `opam search ocaml-option`.
 
 ---
+
 ## Changes since the first beta
 
 ### Configuration changes
@@ -100,39 +94,31 @@ fiber stacks and sigaltstacks with mmap(MAP_STACK) instead of malloc. This is
 exposed via a configure –enable-mmap-map-stack option, and is enabled by default
 on OpenBSD where it is mandatory. (Anil Madhavapeddy, review by Gabriel Scherer,
 Tom Kelly, Michael Hendricks and KC Sivaramakrishnan).
-
 - [#11652](https://github.com/ocaml/ocaml/issues/11652): Fix benign off-by-one
 error in Windows implementation of caml_mem_map. (David Allsopp, review by
 Gabriel Scherer)
-
 - [#11669](https://github.com/ocaml/ocaml/issues/11669),
 [#11704](https://github.com/ocaml/ocaml/issues/11704): Fix construction of
 Effect.Unhandled exceptions in the bytecode interpreter. (David Allsopp and
 Xavier Leroy, report by Samuel Hym, review by Xavier Leroy and Gabriel Scherer)
-
 - [#11184](https://github.com/ocaml/ocaml/issues/11184),
 +[#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on
 created / installed libraries (Sébastien Hinderer and Xavier Leroy, review by
 the same)
-
 - [#11194](https://github.com/ocaml/ocaml/issues/11194),
 [#11609](https://github.com/ocaml/ocaml/issues/11609): Fix inconsistent type
 variable names in “unbound type var” messages (Ulysse Gérard and Florian
 Angeletti, review Florian Angeletti and Gabriel Scherer)
-
 - [#11622](https://github.com/ocaml/ocaml/issues/11622): Prevent stack overflow
 when printing a constructor or record mismatch error involving recursive types.
 (Florian Angeletti, review by Gabriel Scherer)
-
 - [#11662](https://github.com/ocaml/ocaml/issues/11662),
 [#11673](https://github.com/ocaml/ocaml/issues/11673): fix a memory leak when
 using Dynlink, the bug was only present in development version of OCaml 5.
 (Stephen Dolan, report by Andre Maroneze, review by Gabriel Scherer)
-
 - [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from
 packed modules are always generalised (Stephen Dolan and Leo White, review by
 Jacques Garrigue)
-
 - [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition
 in Unix.stat under Windows in the presence of multiple threads. (Marc Lasson,
 Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
@@ -145,11 +131,9 @@ concurrency safety for mutable data types and states in the standard library. A
 unsynchronized_access alert have been added for functions that require user
 synchronizations on concurrent access. The new alert is diabled by default.
 (Florian Angeletti, review by François Pottier and KC Sivaramakrishnan )
-
 - [#11526](https://github.com/ocaml/ocaml/issues/11526), add a unstable alert to
 the Domain and Effect modules. The new alert is disabled by default. (Florian
 Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli, and Kate Deplaix)
-
 - [#11640](https://github.com/ocaml/ocaml/issues/11640): Add Flambda
 commonly-used options to the ocamlopt manpage (Amandine Nangah, review by David
 Allsopp, Florian Angeletti, Sébastien Hinderer, and Vincent Laviron)

--- a/data/news/platform/ocaml-5.0.beta2.md
+++ b/data/news/platform/ocaml-5.0.beta2.md
@@ -1,0 +1,155 @@
+---
+title: OCaml 5.0.0 - Second Beta
+description: Second beta release of OCaml 5.0.0
+date: "2022-11-28"
+tags: [ocaml, platform]
+---
+
+The release of OCaml 5.0.0 is drawing close.
+
+In order to test the most recent bug fixes and to help you update your software
+and libraries ahead of the release, we have released a second beta version of
+OCaml 5.0.0, (see below for the installation instructions).
+
+If you find any bugs, please report them here:
+
+[Issues · ocaml/ocaml · GitHub](https://github.com/ocaml/ocaml/issues).
+
+Compared to the first beta release, this second beta contains many small
+internal standard library fixes, one configuration fix and many small bug fixes.
+
+We also have few updates of the documentation, which introduce two new alerts:
+one for the unstable modules Domain and Effect, and another for functions doing
+unsynchronized_access to mutable state in the standard library. Those two alerts
+are disabled by default, but are available for interested users.
+
+The first release candidate for OCaml 5.0.0 is expected to follow closely this
+second beta release.
+
+If you are interested by the ongoing list of bug fixes, the updated change log
+for OCaml 5.0.0 is available at:
+
+[ocaml/Changes at 5.0 · ocaml/ocaml · GitHub](https://github.com/ocaml/ocaml/blob/5.0/Changes)
+
+You can also follow the state of the opam ecosystem on
+
+http://check.ocamllabs.io/
+
+A short summary of the changes since the first beta release is also available below.
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1:
+```bash
+opam update
+opam switch create 5.0.0~beta2
+```
+
+For previous versions of opam, the switch creation command line is slightly more verbose:
+```bash
+opam update
+opam switch create 5.0.0~beta2 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+
+It might also be interesting to check the new support for parallelism by installing
+the `domainslib` library with
+
+```bash
+opam install domainslib
+```
+
+The source code for the beta release is also available at these addresses:
+
+* [https://github.com/ocaml/ocaml/archive/5.0.0-beta2.tar.gz](https://github.com/ocaml/ocaml/archive/5.0.0-beta2.tar.gz)
+* [https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~beta2.tar.gz](https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~beta2.tar.gz)
+
+## Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.0.0~beta2+options <option_list>
+```
+where `option_list` is a comma-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.0.0~beta2+flambda+nffa ocaml-variants.5.0.0~beta2+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+The command line above is slightly more complicated for opam versions before 2.1:
+```bash
+opam update
+opam switch create <switch_name> --packages=ocaml-variants.5.0.0~beta2+options,<option_list> --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+
+In both cases, all available options can be listed with `opam search ocaml-option`.
+
+---
+## Changes since the first beta
+
+### Configuration changes
+
+- [#11097](https://github.com/ocaml/ocaml/issues/11097): Build native-code
+compilers on NetBSD/aarch64 (Kate Deplaix, review by Anil Madhavapeddy)
+
+### Bug fixes
+
+- [#10875](https://github.com/ocaml/ocaml/issues/10875),
++[#11731](https://github.com/ocaml/ocaml/issues/11731): Add option to allocate
+fiber stacks and sigaltstacks with mmap(MAP_STACK) instead of malloc. This is
+exposed via a configure –enable-mmap-map-stack option, and is enabled by default
+on OpenBSD where it is mandatory. (Anil Madhavapeddy, review by Gabriel Scherer,
+Tom Kelly, Michael Hendricks and KC Sivaramakrishnan).
+
+- [#11652](https://github.com/ocaml/ocaml/issues/11652): Fix benign off-by-one
+error in Windows implementation of caml_mem_map. (David Allsopp, review by
+Gabriel Scherer)
+
+- [#11669](https://github.com/ocaml/ocaml/issues/11669),
+[#11704](https://github.com/ocaml/ocaml/issues/11704): Fix construction of
+Effect.Unhandled exceptions in the bytecode interpreter. (David Allsopp and
+Xavier Leroy, report by Samuel Hym, review by Xavier Leroy and Gabriel Scherer)
+
+- [#11184](https://github.com/ocaml/ocaml/issues/11184),
++[#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on
+created / installed libraries (Sébastien Hinderer and Xavier Leroy, review by
+the same)
+
+- [#11194](https://github.com/ocaml/ocaml/issues/11194),
+[#11609](https://github.com/ocaml/ocaml/issues/11609): Fix inconsistent type
+variable names in “unbound type var” messages (Ulysse Gérard and Florian
+Angeletti, review Florian Angeletti and Gabriel Scherer)
+
+- [#11622](https://github.com/ocaml/ocaml/issues/11622): Prevent stack overflow
+when printing a constructor or record mismatch error involving recursive types.
+(Florian Angeletti, review by Gabriel Scherer)
+
+- [#11662](https://github.com/ocaml/ocaml/issues/11662),
+[#11673](https://github.com/ocaml/ocaml/issues/11673): fix a memory leak when
+using Dynlink, the bug was only present in development version of OCaml 5.
+(Stephen Dolan, report by Andre Maroneze, review by Gabriel Scherer)
+
+- [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from
+packed modules are always generalised (Stephen Dolan and Leo White, review by
+Jacques Garrigue)
+
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition
+in Unix.stat under Windows in the presence of multiple threads. (Marc Lasson,
+Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
+
+### Documentation
+
+- [#11193](https://github.com/ocaml/ocaml/issues/11193),
+[#11227](https://github.com/ocaml/ocaml/issues/11227): documentation on
+concurrency safety for mutable data types and states in the standard library. A
+unsynchronized_access alert have been added for functions that require user
+synchronizations on concurrent access. The new alert is diabled by default.
+(Florian Angeletti, review by François Pottier and KC Sivaramakrishnan )
+
+- [#11526](https://github.com/ocaml/ocaml/issues/11526), add a unstable alert to
+the Domain and Effect modules. The new alert is disabled by default. (Florian
+Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli, and Kate Deplaix)
+
+- [#11640](https://github.com/ocaml/ocaml/issues/11640): Add Flambda
+commonly-used options to the ocamlopt manpage (Amandine Nangah, review by David
+Allsopp, Florian Angeletti, Sébastien Hinderer, and Vincent Laviron)

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -47,7 +47,7 @@ let render ?(use_swiper=false) ?(banner = false) ?(wide=false) ?description ?sty
             <span class="md:hidden">OCaml 5.0 is in beta!</span>
             <span class="hidden md:inline">OCaml 5.0 is beta! OCaml 5.0 is the next major release of OCaml, which comes with support for shared-memory parallelism through domains and direct-style concurrency through algebraic effects!</span>
             <span class="block sm:ml-2 sm:inline-block">
-              <a href="<%s Url.news_post "ocaml-5.0.beta1" %>" class="font-bold text-white underline">
+              <a href="<%s Url.news_post "ocaml-5.0.beta2" %>" class="font-bold text-white underline">
                 Try it now
                 <span aria-hidden="true"> &rarr;</span>
               </a>

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -40,12 +40,12 @@ let render ?(use_swiper=false) ?(banner = false) ?(wide=false) ?description ?sty
 
   <body class="light">
     <% if banner then ( %>
-    <div class="relative bg-primary-600">
+    <div class="relative bg-green-800">
       <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
         <div class="pr-16 sm:px-16 sm:text-center">
           <p class="font-medium text-white">
             <span class="md:hidden">OCaml 5.0 is in beta!</span>
-            <span class="hidden md:inline">OCaml 5.0 is beta! OCaml 5.0 is the next major release of OCaml, which comes with support for shared-memory parallelism through domains and direct-style concurrency through algebraic effects!</span>
+            <span class="hidden md:inline">OCaml 5.0 beta 2 is available! OCaml 5.0 is the next major release of OCaml, which comes with support for shared-memory parallelism through domains and direct-style concurrency through algebraic effects!</span>
             <span class="block sm:ml-2 sm:inline-block">
               <a href="<%s Url.news_post "ocaml-5.0.beta2" %>" class="font-bold text-white underline">
                 Try it now


### PR DESCRIPTION
Copied & translated into markdown @Octachron announce: 

https://discuss.ocaml.org/t/ocaml-5-0-0-second-beta-release/10871

Processed issue links using:
```
sed -i 's/#\([1-9][0-9]*\)/[#\1](https:\/\/github.com\/ocaml\/ocaml\/issues\/\1)/g'
```

Fix: https://github.com/ocaml/ocaml.org/issues/644