### PR TITLE
adjust whitespace on package docs to get the #-symbol on anchor tags to show properly

### DIFF
--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -30,7 +30,7 @@ Package_layout.render
     </div>
   </button>
 
-  <div class="flex flex-col lg:flex-row md:gap-6">
+  <div class="flex flex-col lg:flex-row md:gap-12">
     <div
       class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6 font-normal text-body-400"
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
@@ -45,15 +45,15 @@ Package_layout.render
         <%s! Navmap.render ~path:str_path maptoc %>
       </div>
     </div>
-    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-3xl relative lg:pt-6">
+    <div class="flex-1 z-0 z- w-full lg:max-w-3xl relative lg:pt-6">
       <%s! if (maptoc != []) && (List.length path != 0) then Breadcrumbs.render path else "" %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>
     </div>
     <div class="hidden xl:flex top-0 sticky h-screen">
-      <div class="flex-col w-72">
-        <div class="h-screen overflow-scroll p-6 right-sidebar">
+      <div class="flex-col w-60">
+        <div class="h-screen overflow-scroll right-sidebar pt-6">
           <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
           <%s! Toc.render toc %>
         </div>


### PR DESCRIPTION
There used to be the issue of the #-symbol of the anchors in headings being either cut off or not showing (due to `overflow-hidden` and padding-left on the content area not being large enough to avoid the cutoff).

This patch removes `overflow-hidden` on the content area (so that we do not need to rely on padding to show the #-symbol) and adjusts the gap between left sidebar, content, and right sidebar. Right sidebar's padding is reduced to only padding-top and width is reduced.

| before | after |
|-|-|
| ![Screenshot 2022-11-30 at 12-04-04 Documentation · streaming 0 8 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204781370-024eb1fa-0fd7-4030-adbd-6f44d4355df4.png) | ![Screenshot 2022-11-30 at 12-03-56 Documentation · streaming 0 8 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/204781382-e3ebbdc9-4520-4567-938e-47615679926e.png) |
| ![Screenshot from 2022-11-30 12-05-09](https://user-images.githubusercontent.com/6594573/204781709-503f6e96-b163-4367-97d9-45502d48d645.png) hovering over the heading, the #-symbol does not show because of `overflow-hidden`| ![Screenshot from 2022-11-30 12-04-59](https://user-images.githubusercontent.com/6594573/204781704-232902c3-db1b-46df-b491-a73b35cdf2dc.png) #-symbol is visible when hovering and there is enough gap between left sidebar and content area to guarantee no overlap between sidebar and #-symbol|
