### PR TITLE
Add job publication date, sort fresh first

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -38,7 +38,7 @@ jobs:
   - title: OCaml Developer
     link: https://functori.com/annonce-recrutement.pdf
     location: France
-    publication_date: 1970-01-01
+    publication_date: 2022-02-01
     company: Functori
     company_logo: https://functori.com/assets/img/brand/functori_logotype_square.svg
   - title: Build System Engineer
@@ -47,10 +47,10 @@ jobs:
     publication_date: 1970-01-01
     company: Jane Street
     company_logo: /logos/janestreet.svg
-  - title: Senior Software Engineer
+  - title: Software engineer senior
     link: https://www.marigold.dev/job-offers/software-engineer-senior-1
     location: France
-    publication_date: 1970-01-01
+    publication_date: 1921-11-20
     company: Marigold
     company_logo: https://uploads-ssl.webflow.com/616ab4741d375d1642c19027/61793ee65c891c190fcaa1d0_Vector(1).png
   - title: Software Engineer
@@ -74,7 +74,7 @@ jobs:
   - title: Computer Scientist
     link: https://frama-c.com/jobs/2022-02-01-permanent-computer-scientist-cyber-security-verification.html
     location: France
-    publication_date: 1970-01-01
+    publication_date: 1922-02-01
     company: CEA
     company_logo: https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/CEA_logo_nouveau.svg/1255px-CEA_logo_nouveau.svg.png
   - title: Senior Software Engineer

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -47,7 +47,7 @@ jobs:
   - title: Software engineer senior
     link: https://www.marigold.dev/job-offers/software-engineer-senior-1
     location: France
-    publication_date: 1921-11-20
+    publication_date: 2021-11-20
     company: Marigold
     company_logo: https://uploads-ssl.webflow.com/616ab4741d375d1642c19027/61793ee65c891c190fcaa1d0_Vector(1).png
   - title: Software Engineer
@@ -69,7 +69,7 @@ jobs:
   - title: Computer Scientist
     link: https://frama-c.com/jobs/2022-02-01-permanent-computer-scientist-cyber-security-verification.html
     location: France
-    publication_date: 1922-02-01
+    publication_date: 2022-02-01
     company: CEA
     company_logo: https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/CEA_logo_nouveau.svg/1255px-CEA_logo_nouveau.svg.png
   - title: Senior Software Engineer

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -84,13 +84,13 @@ jobs:
     location: Denmark
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
-  - title: Senior Software Engineer
-    link: https://www.simcorp.com/en/career/find-a-job/senior-software-engineer--c-ocaml-r203357
-    location: Ukraine
-    company: SimCorp
-    company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
-  - title: AI Pharma Developer
-    link: https://www.nobiastx.com/careers
+  - title: Formal Methods Engineer
+    link: https://trust-in-soft.com/trustinsoft-careers/
     location: United States
-    company: Nobias Therapeutics
-    company_logo: https://uploads-ssl.webflow.com/61532e32ca094ababec1dbc2/61a7150d2aebf25b6d9d1a35_nobias%20logo%20-%20transparent%20background.png
+    company: TrustInSoft
+    company_logo: https://trust-in-soft.com/wp-content/uploads/sites/5/2020/07/TIS-logo-Blck_No-Bckgrd.png
+  - title: Js_of_ocaml Developer
+    link: https://trust-in-soft.com/trustinsoft-careers/
+    location: United States
+    company: TrustInSoft
+    company_logo: https://trust-in-soft.com/wp-content/uploads/sites/5/2020/07/TIS-logo-Blck_No-Bckgrd.png

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -84,13 +84,4 @@ jobs:
     location: Denmark
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
-  - title: Formal Methods Engineer
-    link: https://trust-in-soft.com/trustinsoft-careers/
-    location: United States
-    company: TrustInSoft
-    company_logo: https://trust-in-soft.com/wp-content/uploads/sites/5/2020/07/TIS-logo-Blck_No-Bckgrd.png
-  - title: Js_of_ocaml Developer
-    link: https://trust-in-soft.com/trustinsoft-careers/
-    location: United States
-    company: TrustInSoft
-    company_logo: https://trust-in-soft.com/wp-content/uploads/sites/5/2020/07/TIS-logo-Blck_No-Bckgrd.png
+    

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -86,21 +86,25 @@ jobs:
   - title: Senior Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/senior-software-engineer--c-ocaml-r203826
     location: Poland
+    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
   - title: Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/software-engineer--c-ocaml-r203358
     location: Ukraine
+    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
   - title: Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/software-engineer---and-ocaml-r203759
     location: Denmark
+    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
   - title: Senior Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/senior-software-engineer--c-ocaml-r203357
     location: Ukraine
+    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
 

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -84,4 +84,9 @@ jobs:
     location: Denmark
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
-    
+  - title: Senior Software Engineer
+    link: https://www.simcorp.com/en/career/find-a-job/senior-software-engineer--c-ocaml-r203357
+    location: Ukraine
+    company: SimCorp
+    company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
+

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -2,71 +2,85 @@ jobs:
   - title: Cryptography Engineer
     link: https://boards.greenhouse.io/o1labs/jobs/4023646004
     location: Remote
+    publication_date: 1970-01-01
     company: O(1) Labs
     company_logo: https://workshub.imgix.net/7b409fdc3bc46438b64686a627d56b2b?fit=clip&crop=entropy&auto=format&w=60&h=60&q=40&dpr=2
   - title: Team Lead - Software Engineering
     link: https://tarides.com/jobs/team-lead-software-engineering
     location: Remote
+    publication_date: 2022-05-20
     company: Tarides
     company_logo: https://tarides.com/static/logo_tarides-52f91b59a8657d768e013129896b63e0.png
   - title: Remote Senior Full Stack Engineer
     link: https://heliax.dev/jobs/senior-full-stack-engineer/
     location: Remote
+    publication_date: 1970-01-01
     company: Heliax
     company_logo: https://workshub.imgix.net/e52e257a6a9cdbc2bc868a5991ccd717?fit=clip&crop=entropy&auto=format
   - title: Senior Software Engineer - Tooling team
     link: https://tarides.com/jobs/senior-software-engineer-tooling-team
     location: Remote
+    publication_date: 2022-06-26
     company: Tarides
     company_logo: https://tarides.com/static/logo_tarides-52f91b59a8657d768e013129896b63e0.png
   - title: Spontaneous Application
     link: https://tarides.com/jobs/spontaneous-application
     location: Remote
+    publication_date: 2021-10-17
     company: Tarides
     company_logo: https://tarides.com/static/logo_tarides-52f91b59a8657d768e013129896b63e0.png
   - title: OCaml Developer
     link: https://ahrefs.com/jobs/ocaml-developer
     location: Remote
+    publication_date: 2020-09-22
     company: Ahrefs
     company_logo: /logos/ahrefs.svg
   - title: OCaml Developer
     link: https://functori.com/annonce-recrutement.pdf
     location: France
+    publication_date: 1970-01-01
     company: Functori
     company_logo: https://functori.com/assets/img/brand/functori_logotype_square.svg
   - title: Build System Engineer
     link: https://www.janestreet.com/join-jane-street/position/4274814002/
     location: United-Kingdom
+    publication_date: 1970-01-01
     company: Jane Street
     company_logo: /logos/janestreet.svg
   - title: Senior Software Engineer
     link: https://www.marigold.dev/job-offers/software-engineer-senior-1
     location: France
+    publication_date: 1970-01-01
     company: Marigold
     company_logo: https://uploads-ssl.webflow.com/616ab4741d375d1642c19027/61793ee65c891c190fcaa1d0_Vector(1).png
   - title: Software Engineer
     link: https://www.lexifi.com/careers/software_engineer/
     location: France
+    publication_date: 2021-04-22
     company: LexiFi
     company_logo: https://thewealthmosaic.s3.amazonaws.com/media/Logo_Lexifi.png
   - title: OCaml Programmer
     link: https://solvuu.com/company
     location: Remote
+    publication_date: 1970-01-01
     company: Solvuu
     company_logo: https://solvuu.com/static/media/logo-color.92a01b9f.svg
   - title: Senior Software Engineer
     link: https://solvuu.com/company
     location: France
+    publication_date: 1970-01-01
     company: Nomadic Labs
     company_logo: https://research-development.nomadic-labs.com/images/meanwhile_202107/nomadic-logo-new.png
   - title: Computer Scientist
     link: https://frama-c.com/jobs/2022-02-01-permanent-computer-scientist-cyber-security-verification.html
     location: France
+    publication_date: 1970-01-01
     company: CEA
     company_logo: https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/CEA_logo_nouveau.svg/1255px-CEA_logo_nouveau.svg.png
   - title: Senior Software Engineer
     link: https://cryptosense.com/vacancies/senior-software-engineer
     location: Remote
+    publication_date: 1970-01-01
     company: Cryptosense
     company_logo: https://global-uploads.webflow.com/5fb79f97eb305e5f85f6dff6/5fb7a15497f97810803970a0_CS%20logo_300px.png
   - title: Senior Software Engineer

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -97,4 +97,9 @@ jobs:
     location: Ukraine
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
-
+  - title: AI Pharma Developer
+    link: https://www.nobiastx.com/careers
+    location: United States
+    publication_date: 2022-12-02
+    company: Nobias Therapeutics
+    company_logo: https://uploads-ssl.webflow.com/61532e32ca094ababec1dbc2/61a7150d2aebf25b6d9d1a35_nobias%20logo%20-%20transparent%20background.png

--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -2,7 +2,6 @@ jobs:
   - title: Cryptography Engineer
     link: https://boards.greenhouse.io/o1labs/jobs/4023646004
     location: Remote
-    publication_date: 1970-01-01
     company: O(1) Labs
     company_logo: https://workshub.imgix.net/7b409fdc3bc46438b64686a627d56b2b?fit=clip&crop=entropy&auto=format&w=60&h=60&q=40&dpr=2
   - title: Team Lead - Software Engineering
@@ -14,7 +13,6 @@ jobs:
   - title: Remote Senior Full Stack Engineer
     link: https://heliax.dev/jobs/senior-full-stack-engineer/
     location: Remote
-    publication_date: 1970-01-01
     company: Heliax
     company_logo: https://workshub.imgix.net/e52e257a6a9cdbc2bc868a5991ccd717?fit=clip&crop=entropy&auto=format
   - title: Senior Software Engineer - Tooling team
@@ -44,7 +42,6 @@ jobs:
   - title: Build System Engineer
     link: https://www.janestreet.com/join-jane-street/position/4274814002/
     location: United-Kingdom
-    publication_date: 1970-01-01
     company: Jane Street
     company_logo: /logos/janestreet.svg
   - title: Software engineer senior
@@ -62,13 +59,11 @@ jobs:
   - title: OCaml Programmer
     link: https://solvuu.com/company
     location: Remote
-    publication_date: 1970-01-01
     company: Solvuu
     company_logo: https://solvuu.com/static/media/logo-color.92a01b9f.svg
   - title: Senior Software Engineer
     link: https://solvuu.com/company
     location: France
-    publication_date: 1970-01-01
     company: Nomadic Labs
     company_logo: https://research-development.nomadic-labs.com/images/meanwhile_202107/nomadic-logo-new.png
   - title: Computer Scientist
@@ -80,31 +75,26 @@ jobs:
   - title: Senior Software Engineer
     link: https://cryptosense.com/vacancies/senior-software-engineer
     location: Remote
-    publication_date: 1970-01-01
     company: Cryptosense
     company_logo: https://global-uploads.webflow.com/5fb79f97eb305e5f85f6dff6/5fb7a15497f97810803970a0_CS%20logo_300px.png
   - title: Senior Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/senior-software-engineer--c-ocaml-r203826
     location: Poland
-    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
   - title: Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/software-engineer--c-ocaml-r203358
     location: Ukraine
-    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
   - title: Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/software-engineer---and-ocaml-r203759
     location: Denmark
-    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
   - title: Senior Software Engineer
     link: https://www.simcorp.com/en/career/find-a-job/senior-software-engineer--c-ocaml-r203357
     location: Ukraine
-    publication_date: 1970-01-01
     company: SimCorp
     company_logo: https://www.simcorp.com/dist/global/images/simcorp-logo-md.svg
 

--- a/src/ocamlorg_data/ood.mli
+++ b/src/ocamlorg_data/ood.mli
@@ -67,7 +67,7 @@ module Job : sig
     title : string;
     link : string;
     location : string;
-    publication_date : string;
+    publication_date : string option;
     company : string;
     company_logo : string;
   }

--- a/src/ocamlorg_data/ood.mli
+++ b/src/ocamlorg_data/ood.mli
@@ -67,6 +67,7 @@ module Job : sig
     title : string;
     link : string;
     location : string;
+    publication_date : string;
     company : string;
     company_logo : string;
   }

--- a/src/ocamlorg_frontend/pages/jobs.eml
+++ b/src/ocamlorg_frontend/pages/jobs.eml
@@ -73,7 +73,7 @@ OCaml community."
                         <%s item.location %>
                     </div>
                 </div>
-                <% match item.publication_date with None -> () | Some date -> %>
+                <% (match item.publication_date with None -> () | Some date -> %>
                 <div class="flex items-center space-x-2 mt-2">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
@@ -82,6 +82,7 @@ OCaml community."
                         <%s date %>
                     </div>
                 </div>
+                <% ); %>
             </a>
             <% ); %>
         </div>

--- a/src/ocamlorg_frontend/pages/jobs.eml
+++ b/src/ocamlorg_frontend/pages/jobs.eml
@@ -73,6 +73,15 @@ OCaml community."
                         <%s item.location %>
                     </div>
                 </div>
+                <% match item.publication_date with None -> () | Some date -> %>
+                <div class="flex items-center space-x-2 mt-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                    </svg>
+                    <div>
+                        <%s date %>
+                    </div>
+                </div>
             </a>
             <% ); %>
         </div>

--- a/tool/ood-gen/lib/job.ml
+++ b/tool/ood-gen/lib/job.ml
@@ -2,6 +2,7 @@ type metadata = {
   title : string;
   link : string;
   location : string;
+  publication_date: string;
   company : string;
   company_logo : string;
 }
@@ -11,6 +12,7 @@ type t = {
   title : string;
   link : string;
   location : string;
+  publication_date: string;
   company : string;
   company_logo : string;
 }
@@ -31,6 +33,7 @@ let decode s =
                         title = raw.title;
                         link = raw.link;
                         location = raw.location;
+                        publication_date = raw.publication_date;
                         company = raw.company;
                         company_logo = raw.company_logo;
                       }
@@ -50,11 +53,13 @@ let pp ppf v =
   { title = %a
   ; link = %a
   ; location = %a
+  ; publication_date = %a
   ; company = %a
   ; company_logo = %a
   }|}
-    Pp.string v.title Pp.string v.link Pp.string v.location Pp.string v.company
-    Pp.string v.company_logo
+    Pp.string v.title Pp.string v.link
+    Pp.string v.location Pp.string v.publication_date
+    Pp.string v.company Pp.string v.company_logo
 
 let pp_list = Pp.list pp
 
@@ -65,10 +70,11 @@ type t =
   { title : string
   ; link : string
   ; location : string
+  ; publication_date : string
   ; company : string
   ; company_logo : string
   }
   
-let all = %a
+let all = List.sort (fun j1 j2 -> compare j2.publication_date j1.publication_date) %a
 |}
     pp_list (all ())

--- a/tool/ood-gen/lib/job.ml
+++ b/tool/ood-gen/lib/job.ml
@@ -2,7 +2,7 @@ type metadata = {
   title : string;
   link : string;
   location : string;
-  publication_date: string option;
+  publication_date : string option;
   company : string;
   company_logo : string;
 }
@@ -12,7 +12,7 @@ type t = {
   title : string;
   link : string;
   location : string;
-  publication_date: string option;
+  publication_date : string option;
   company : string;
   company_logo : string;
 }
@@ -57,9 +57,9 @@ let pp ppf v =
   ; company = %a
   ; company_logo = %a
   }|}
-    Pp.string v.title Pp.string v.link
-    Pp.string v.location (Pp.option Pp.string) v.publication_date
-    Pp.string v.company Pp.string v.company_logo
+    Pp.string v.title Pp.string v.link Pp.string v.location
+    (Pp.option Pp.string) v.publication_date Pp.string v.company Pp.string
+    v.company_logo
 
 let pp_list = Pp.list pp
 

--- a/tool/ood-gen/lib/job.ml
+++ b/tool/ood-gen/lib/job.ml
@@ -2,7 +2,7 @@ type metadata = {
   title : string;
   link : string;
   location : string;
-  publication_date: string;
+  publication_date: string option;
   company : string;
   company_logo : string;
 }
@@ -12,7 +12,7 @@ type t = {
   title : string;
   link : string;
   location : string;
-  publication_date: string;
+  publication_date: string option;
   company : string;
   company_logo : string;
 }
@@ -58,7 +58,7 @@ let pp ppf v =
   ; company_logo = %a
   }|}
     Pp.string v.title Pp.string v.link
-    Pp.string v.location Pp.string v.publication_date
+    Pp.string v.location (Pp.option Pp.string) v.publication_date
     Pp.string v.company Pp.string v.company_logo
 
 let pp_list = Pp.list pp
@@ -70,11 +70,13 @@ type t =
   { title : string
   ; link : string
   ; location : string
-  ; publication_date : string
+  ; publication_date : string option
   ; company : string
   ; company_logo : string
   }
   
-let all = List.sort (fun j1 j2 -> compare j2.publication_date j1.publication_date) %a
+let all =
+  let job_date j = Option.value ~default:"1970-01-01" j.publication_date in
+  List.sort (fun j1 j2 -> compare (job_date j2) (job_date j1)) %a
 |}
     pp_list (all ())


### PR DESCRIPTION
- Remove obviously closed positions
- Remove TrustInSoft jobs
- Update SimCorp Jobs
- Sort jobs by publication date
- Add dates to functori, Marigold and CEA positions
- Add dummy dates to SimCorp jobs
- Make publication date optional
- Add Nobias Pharma job publication date
- Fix typos in dates
- Show pub date in board, if available
