### PR TITLE
Fix issues caused by hilite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM ocaml/opam:alpine-3.13-ocaml-4.14 as build
+FROM ocaml/opam:alpine-3.17-ocaml-4.14 as build
 
 # Install system dependencies
 RUN sudo apk update && sudo apk add --update libev-dev openssl-dev gmp-dev oniguruma-dev
 
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 473aa3921da4e79b0fa2926a78ceacf888ec809c && opam update
+# Set opam repo at: 6496b2727e Merge pull request #22580 from patricoferris/release-hilite-v0.2.0
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 6496b2727e && opam update
 
 WORKDIR /home/opam
 
@@ -15,7 +16,7 @@ RUN opam install . --deps-only
 COPY --chown=opam:opam . .
 RUN opam exec -- dune build @install --profile=release
 
-FROM alpine:3.12 as run
+FROM alpine:3.17 as run
 
 RUN apk update && apk add --update libev gmp git
 

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,7 @@ utop: ## Run a REPL and link with the project's libraries
 scrape: ## Generate the po files
 	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe rss
 	opam exec -- dune exec --root . tool/ood-gen/bin/watch_scrape.exe
+
+.PHONY: docker
+docker: ## Generate docker container
+	docker build -f Dockerfile . -t ocamlorg:latest


### PR DESCRIPTION
Fix: https://github.com/ocaml/ocaml.org/issues/496
Fix: https://github.com/ocaml/ocaml.org/issues/559
Fix: https://github.com/ocaml/ocaml.org/issues/638

- Add docker rule in Makefile
- Update Opam repo to update Hilite to 0.2.0

In order to update hilite from 0.1.0 to 0.2.0 the hash used to
point to a sufficient and known-to-work commit in opam-repository
had to be refreshed. Merge of hilite-v0.2.0 was used.

However, lifting opam repo hash caused a docker image compilation
failure at stage 6: opam install . --deps-only
This was worked around by raising alpine from 3.14 to 3.17
at stage 1.

However, this caused a crash when running the built container.
This was worked around by raising alpine from 3.12 to 3.17
at stage 8.

Further investigation are required in order to understand the
failures, which are likely to kick-in again. I will file an issue
describing the problem.