### PR TITLE
Preserve newlines and exceptions in playground

### DIFF
--- a/src/ocamlorg_playground/main.ml
+++ b/src/ocamlorg_playground/main.ml
@@ -52,12 +52,28 @@ let get_el_by_id s =
       Console.warn [ Jstr.v "Failed to get elemented by id" ];
       invalid_arg s
 
-let cyan el = El.set_inline_style (Jstr.v "color") (Jstr.v "cyan") el
+let cyan = "cyan"
+let red = "red"
+
+let render_output color = function
+  | None -> None
+  | Some output ->
+      let el =
+        El.p
+          ~at:[ At.v (Jstr.v "style") (Jstr.v "white-space: pre-wrap;") ]
+          [ El.txt' output ]
+      in
+      El.set_inline_style (Jstr.v "color") (Jstr.v color) el;
+      Some el
 
 let handle_output (o : Toplevel_api.exec_result) =
   let output = get_el_by_id "output" in
-  let out = El.(p [ txt' (Option.value ~default:"" o.stdout) ]) in
-  cyan out;
+  let output_elements =
+    List.filter_map
+      (fun (c, o) -> render_output c o)
+      [ (cyan, o.stdout); (red, o.stderr); (red, o.caml_ppf) ]
+  in
+  let out = El.div output_elements in
   El.append_children output [ out ]
 
 module Codec = struct


### PR DESCRIPTION
Currently the output section of the playground doesn't show exceptions or render newlines. This PR tries to fix both of these issues. 

(Fix https://github.com/ocaml/ocaml.org/issues/650)

**Before**

<img width="1432" alt="Screenshot 2022-12-04 at 12 17 13" src="https://user-images.githubusercontent.com/20166594/205489969-057f9683-a7f5-4a71-8f40-03de351e4b90.png">

**After**

<img width="1435" alt="Screenshot 2022-12-04 at 12 16 03" src="https://user-images.githubusercontent.com/20166594/205489972-5f85def6-76e5-46b7-8bec-94e03c9f8372.png">

