### PR TITLE
arrow as svg instead of unicode character

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -21,8 +21,15 @@ Layout.render
     <div class="container-fluid wide">
       <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
         <div class="flex flex-col items-baseline mb-6">
-          <h4 class="font-bold md:whitespace-nowrap">
-            <a href="<%s Url.package_with_version package.name package.version %>"><%s! if tab != Overview then "&#129120; " else "" %><%s package.name %></a>
+          <h4 class="font-bold md:whitespace-nowrap flex items-center">
+            <a class="flex items-center" href="<%s Url.package_with_version package.name package.version %>">
+              <% if tab != Overview then ( %>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+                </svg>&nbsp;
+              <% ); %>
+              <%s package.name %>
+            </a>
             <select id="version" name="version" onchange="location = this.value;" class="appearance-none cursor-pointer py-0 pt-1 border rounded-md border-transparent pr-8">
               <% package.versions |> List.iter begin fun item -> %>
               <option value="/p/<%s package.name %>/<%s item %>"<%s if item = package.version then "selected" else "" %>>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -6,8 +6,8 @@ let sidebar
 =
   <div class="flex flex-col">
     <% if str_path != [] && toc != [] then ( %>
-    <a title="Package <%s package.name %>" class="xl:hidden py-1 font-semibold text-body-600 hover:text-orange-600 transition-colors mb-6" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">
-      &#129120; back to documentation root
+    <a title="Package <%s package.name %>" class="xl:hidden py-1 font-regular text-body-600 hover:text-orange-600 transition-colors mb-6" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">
+      back to documentation root
     </a>
     <% ); %>
     <% if (toc != []) then ( %>


### PR DESCRIPTION
Fixes problem with the unicode arrow character introduced in #641 not being available in our font. Arrow is a SVG now. Arrow on "back to documentation root" removed.

| before | after|
|-|-|
| <img width="1142" alt="image" src="https://user-images.githubusercontent.com/6594573/205660840-074dec7b-4aeb-444f-b8fb-377fb46ccbfa.png"> our font didn't have the unicode arrow character :see_no_evil:  | ![Screenshot 2022-12-05 at 15-24-33 Streaming · streaming 0 8 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/205660648-802ef8ac-85c4-4395-85a8-ba5a4e55581d.png) |

