### PR TITLE
fix for #680 until we can properly distinguish mld and module pages

### DIFF
--- a/src/ocamlorg_frontend/components/breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/breadcrumbs.eml
@@ -1,4 +1,5 @@
 type path_item = 
+  | Manual
   | Page of string
   | Library of string
   | Module of string
@@ -8,6 +9,7 @@ type path_item =
   | ClassType of string
 
 let kind_tag (m : path_item) = match m with
+  | Manual -> ""
   | Page _ -> ""
   | Library _ -> ""
   | Module _ ->
@@ -22,6 +24,7 @@ let kind_tag (m : path_item) = match m with
     <span class="breadcrumbs-tag class-type-tag text-white">Class type</span>
 
 let path_item_name (m: path_item) = match m with
+  | Manual -> ""
   | Page name
   | Library name
   | Module name
@@ -42,26 +45,19 @@ let rec breadcrumbs_from_path (reversed_module_path: path_item list) prefix : ( 
     let new_prefix = prefix ^ "../" in
     { text = path_item_name x ; href = prefix ^ "index.html" } :: breadcrumbs_from_path xs new_prefix
 
-let render_sidebar_breadcrumbs (module_path : path_item list) =
-  let (reversed_module_path : path_item list) = List.rev module_path in
-  let breadcrumbs = breadcrumbs_from_path reversed_module_path "" in
-  let render_breadcrumb b = 
-    <span>
-      <a href="<%s! b.href %>" class="font-medium text-gray-800 transition-colors hover:text-orange-600"><%s b.text %></a>
-    </span>
-  in
-  <div class="flex flex-wrap">
-    <%s! String.concat "<span>.</span>" (breadcrumbs |> List.rev |> List.map render_breadcrumb)  %>
-  </div>
-
 let render (module_path:path_item list) =
-  let (reversed_module_path : path_item list) = List.rev module_path in
+  let (reversed_module_path : path_item list) = List.rev (List.tl module_path) in
   let breadcrumbs = breadcrumbs_from_path reversed_module_path "" in
   let render_breadcrumb b =
     <span>
       <a href="<%s! b.href %>" class="ml-1 text-2xl font-medium text-gray-800 transition-colors hover:text-orange-600"><%s b.text %></a>
     </span>
   in
+  <% if Manual = List.hd module_path then ( %>
+    <span title="Manual">Manual</span>
+    <% ) else ( %>
+    <span title="Library <%s path_item_name (List.hd module_path) %>">Library <%s path_item_name (List.hd module_path) %></span>
+  <% ); %>
   <div class="flex flex-wrap pb-4">
     <%s! if module_path != [] then kind_tag (List.hd reversed_module_path) else "" %>
     <%s! String.concat "<span class=\"ml-1 text-2xl\">.</span>" (breadcrumbs |> List.rev |> List.map render_breadcrumb); %>

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -1,6 +1,6 @@
 type kind =
-  | Library
   | Page
+  | Library
   | Module
   | Leaf_page
   | Module_type
@@ -19,8 +19,8 @@ type toc = {
 type t = toc list
 
 let kind_title = function
-  | Library -> "Library"
   | Page -> "Page"
+  | Library -> "Library"
   | Module -> "Module"
   | Module_type -> "Module type"
   | Parameter -> "Parameter"
@@ -65,12 +65,13 @@ let rec nested_render ~path (item : toc) =
     </div>
   | children ->
     let default_open, path, fragment = match path with
-      | v :: rest when v = item.title || v == "" -> (true, rest, v) (* TODO: we need a way to know that the path item is a standalone page *)
+      | v :: _ when v = "" -> (true, [], v) (* if we are on a mld page (empty string), we ignore the rest of the path *)
+      | v :: rest when v = item.title -> (true, rest, v)
       | v :: _ -> (false, [], v)
       | [] -> (item.kind = Library && (List.length item.children <= 2), [], "")
     in
     let active_style = if item.title = fragment then (if List.length path = 0 then "bg-gray-200 border-gray-500 font-medium" else "border-transparent bg-gray-100 font-medium") else "border-transparent" in
-    if fragment != "" && item.kind = Library && fragment != item.title then "" else
+    if (String.length fragment != 0) && (item.kind = Library) && (fragment != item.title) then "" else
     <div x-data="{ open: <%s if default_open then "true" else "false" %> }">
       <div class="box-border border <%s active_style %> cursor-pointer ml-1 pl-1">
         <div class="flex flex-nowrap" title="<%s kind_title item.kind ^ " " ^ item.title %>">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -30,12 +30,13 @@ let render
 (package : Package_intf.package) =
 let str_path =
   List.map (function
-        | Breadcrumbs.Module s -> s
+        | Breadcrumbs.Library s -> s
+        | Module s -> s
         | ModuleType s -> s
         | Parameter (number, s) -> Int.to_string number ^ "-" ^ s
         | Class s -> s
         | ClassType s -> s
-        | Library s -> s
+        | Manual -> ""
         | Page s -> s) path
 in
 let path_page = match str_path |> String.concat "/" with
@@ -69,8 +70,7 @@ Package_layout.render
     <div class="flex-1 z-0 z- w-full lg:max-w-3xl relative lg:pt-6">
       <% if (maptoc != []) && (List.length path > 1) then (%>
         <div class="text-body-400">
-          <span title="Library <%s Breadcrumbs.path_item_name (List.hd path) %>">Library <%s Breadcrumbs.path_item_name (List.hd path) %></span>
-          <%s! Breadcrumbs.render (List.tl path) %>
+          <%s! Breadcrumbs.render path %>
         </div>
       <% ); %>
       <div class="odoc prose prose-orange">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -602,9 +602,7 @@ let package_doc t kind req =
               in
               match library_path_item with
               | Some item -> Library item.title :: path
-              | None -> Page "manual" :: path
-              (* TODO: replace "manual" by a more specific name for standalone
-                 docs pages, when we can distinguish them. *)
+              | None -> Manual :: path
             else []
           in
           let package_meta = package_meta t package in


### PR DESCRIPTION
Show the module browser on mld pages. The path-related code will get a cleanup when `odoc html --as-json` is applied to the pipeline and we know exactly what kind of page a path item is. Fixes the problem of missing the module browser on mld pages #680.

Minor cleanups included.

| before | after |
|-|-|
| ![Screenshot 2022-12-06 at 12-07-17 manual html · ppxlib 0 28 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/205895540-c6dedb77-4acb-4db2-a950-bd307a49d45b.png) | ![Screenshot 2022-12-06 at 12-07-21 manual html · ppxlib 0 28 0 · OCaml Packages](https://user-images.githubusercontent.com/6594573/205895529-9022166e-bece-400b-975a-fd3f4957f2ec.png) |
