### PR TITLE
News for OCaml 4.14.1 first release candidate

### DIFF
--- a/data/news/platform/ocaml-4.14.1.rc1.md
+++ b/data/news/platform/ocaml-4.14.1.rc1.md
@@ -65,7 +65,7 @@ In both cases, all available options can be listed with `opam search ocaml-optio
 
 ### Compiler User-Interface and Warnings:
 
-- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on created / installed libraries
+- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling `ranlib` on created / installed libraries
   (Sébastien Hinderer and Xavier Leroy, review by the same)
 
 ### Build System:
@@ -90,7 +90,7 @@ In both cases, all available options can be listed with `opam search ocaml-optio
 
 - [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: check whether `_MSC_VER` is defined
   before using it to ensure that the headers can always be used in code which
-  turns on -Wundef (or equivalent).
+  turns on `-Wundef` (or equivalent).
   (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
    Sébastien Hinderer)
 
@@ -133,17 +133,17 @@ In both cases, all available options can be listed with `opam search ocaml-optio
 - [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
-- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in Unix.stat under Windows in the presence of
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in `Unix.stat` under Windows in the presence of
   multiple threads.
   (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
 
 - [#11776](https://github.com/ocaml/ocaml/issues/11776): Extend environment with functor parameters in `strengthen_lazy`.
   (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 
-- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in #show_module_type
+- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in `#show_module_type`
   (this had stopped working in 4.14.0)
   (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
 
 - [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
-  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  no-naked-pointers mode caused by wrong initialization of `caml_global_data`
   (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)

--- a/data/news/platform/ocaml-4.14.1.rc1.md
+++ b/data/news/platform/ocaml-4.14.1.rc1.md
@@ -1,0 +1,149 @@
+---
+title: OCaml 4.14.1 - First release candidate
+description: First Release Candidate of OCaml 4.14.1
+date: "2022-12-08"
+tags: [ocaml, platform]
+---
+
+The release of OCaml version 4.14.1 is imminent.
+
+This companion release to the OCaml 5.0.0 release will backport many safe bug
+fixes from the currently experimental 5.0 branch to the stable 4.14 branch.
+A full list of bug fixes is available below.
+
+In order to ensure that the future release works as expected, we are testing
+a release candidate during the upcoming weeks.
+
+If you find any bugs, please report them here on [GitHub](https://github.com/ocaml/ocaml/issues).
+
+----
+
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1:
+```
+opam update
+opam switch create 4.14.1~rc1
+```
+For previous version of opam, the switch creation command line is slightly more verbose:
+```
+opam update
+opam switch create 4.14.1~rc1 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+It might be also interesting to check the new support for parallelism by installing the `domainslib` library with
+```
+opam install domainslib
+```
+The source code for the release candidate is available on
+
+- [GitHub](https://github.com/ocaml/ocaml/archive/4.14.1-rc1.tar.gz)
+- [Inria archives](https://caml.inria.fr/pub/distrib/ocaml-4.14.1/ocaml-4.14.1~rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.4.14.1~rc1+options <option_list>
+```
+where `<option_list>` is a comma-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 4.14.1~rc1+flambda+nffa ocaml-variants.4.14.1~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+The command line above is slightly more complicated for opam versions before 2.1:
+```bash
+opam update
+opam switch create <switch_name> --packages=ocaml-variants.4.14.1~rc1+options,<option_list> --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+In both cases, all available options can be listed with `opam search ocaml-option`.
+
+---
+
+## Changes Since OCaml 4.14.0
+
+
+### Compiler User-Interface and Warnings:
+
+- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on created / installed libraries
+  (Sébastien Hinderer and Xavier Leroy, review by the same)
+
+### Build System:
+
+- [#11370](https://github.com/ocaml/ocaml/issues/11370), [#11373](https://github.com/ocaml/ocaml/issues/11373): Don't pass CFLAGS to flexlink during configure.
+  (David Allsopp, report by William Hu, review by Xavier Leroy and
+   Sébastien Hinderer)
+
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+  (William Hu, review by David Allsopp and Sébastien Hinderer)
+
+### Bug Fixes:
+
+- [#10768](https://github.com/ocaml/ocaml/issues/10768), [#11340](https://github.com/ocaml/ocaml/issues/11340): Fix typechecking regression when combining first class
+  modules and GADTs.
+  (Jacques Garrigue, report by François Thiré, review by Matthew Ryan)
+
+- [#11204](https://github.com/ocaml/ocaml/issues/11204): Fix regression introduced in 4.14.0 that would trigger Warning 17 when
+  calling virtual methods introduced by constraining the self type from within
+  the class definition.
+  (Nicolás Ojeda Bär, review by Leo White)
+
+- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: check whether `_MSC_VER` is defined
+  before using it to ensure that the headers can always be used in code which
+  turns on -Wundef (or equivalent).
+  (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
+   Sébastien Hinderer)
+
+- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): fix non-informative error message for module inclusion
+  (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
+
+- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialization of bytecode threading,
+  This avoids a "dangling pointer" warning of GCC 12.1.
+  (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
+
+- [#11387](https://github.com/ocaml/ocaml/issues/11387), module type with constraints no longer crash the compiler in presence
+  of both shadowing warnings and the `-bin-annot` compiler flag.
+  (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
+
+- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): assertion failure with -rectypes and external definitions
+  (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)
+
+- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix regression allowing virtual methods in non-virtual classes.
+  (Leo White, review by Florian Angeletti)
+
+- [#11468](https://github.com/ocaml/ocaml/issues/11468): Fix regression from [#10186](https://github.com/ocaml/ocaml/issues/10186) (OCaml 4.13) detecting IPv6 on Windows for
+  mingw-w64 i686 port.
+  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
+
+- [#11489](https://github.com/ocaml/ocaml/issues/11489), [#11496](https://github.com/ocaml/ocaml/issues/11496): More prudent deallocation of alternate signal stack
+  (Xavier Leroy, report by @rajdakin, review by Florian Angeletti)
+
+- [#11516](https://github.com/ocaml/ocaml/issues/11516), [#11524](https://github.com/ocaml/ocaml/issues/11524): Fix the `deprecated_mutable` attribute.
+  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#11194](https://github.com/ocaml/ocaml/issues/11194), [#11609](https://github.com/ocaml/ocaml/issues/11609): Fix inconsistent type variable names in "unbound type var"
+  messages
+  (Ulysse Gérard and Florian Angeletti, review Florian Angeletti and
+   Gabriel Scherer)
+
+- [#11622](https://github.com/ocaml/ocaml/issues/11622): Prevent stack overflow when printing a constructor or record
+  mismatch error involving recursive types.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from packed modules are always generalised
+  (Stephen Dolan and Leo White, review by Jacques Garrigue)
+
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in Unix.stat under Windows in the presence of
+  multiple threads.
+  (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
+
+- [#11776](https://github.com/ocaml/ocaml/issues/11776): Extend environment with functor parameters in `strengthen_lazy`.
+  (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
+
+- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in #show_module_type
+  (this had stopped working in 4.14.0)
+  (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
+
+- [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
+  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)

--- a/data/news/platform/ocaml-4.14.1.rc1.md
+++ b/data/news/platform/ocaml-4.14.1.rc1.md
@@ -1,6 +1,6 @@
 ---
-title: OCaml 4.14.1 - First release candidate
-description: First Release Candidate of OCaml 4.14.1
+title: OCaml 4.14.1 - Release candidate
+description: Release Candidate of OCaml 4.14.1
 date: "2022-12-08"
 tags: [ocaml, platform]
 ---

--- a/data/news/platform/ocaml-4.14.1.rc1.md
+++ b/data/news/platform/ocaml-4.14.1.rc1.md
@@ -74,7 +74,7 @@ In both cases, all available options can be listed with `opam search ocaml-optio
   (David Allsopp, report by William Hu, review by Xavier Leroy and
    Sébastien Hinderer)
 
-- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimisation during configure
   (William Hu, review by David Allsopp and Sébastien Hinderer)
 
 ### Bug Fixes:
@@ -97,7 +97,7 @@ In both cases, all available options can be listed with `opam search ocaml-optio
 - [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): fix non-informative error message for module inclusion
   (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
 
-- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialization of bytecode threading,
+- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialisation of bytecode threading,
   This avoids a "dangling pointer" warning of GCC 12.1.
   (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
 
@@ -145,5 +145,5 @@ In both cases, all available options can be listed with `opam search ocaml-optio
   (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
 
 - [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
-  no-naked-pointers mode caused by wrong initialization of `caml_global_data`
+  no-naked-pointers mode caused by wrong initialisation of `caml_global_data`
   (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)


### PR DESCRIPTION
This PR adds the announce for the first release candidate of OCaml 4.14.1 (hopefully updated to ocaml.org format).