### PR TITLE
honor user's prefers-reduced-motion setting wrt smooth scroll

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -13,8 +13,10 @@
 
 @import "./other/syntax.css";
 
-html {
-  scroll-behavior: smooth;
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 
 body {


### PR DESCRIPTION
Honoring the user's reduced motion setting is an accessibility best practice. Wrapping the `scroll-behavior: smooth;` declaration in a `prefers-reduced-motion` media query enables the user to turn off smooth scroll via their browser or OS.