### PR TITLE
Forbid upgrade of mirage-kv-mem beyond 3.1.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,8 @@
   cohttp-lwt-unix
   bos
   crunch
-  mirage-kv-mem
+  (mirage-kv-mem
+    (<= 3.1.0))
   (dream
    (>= 1.0.0~alpha3))
   dream-accept

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -24,7 +24,7 @@ depends: [
   "cohttp-lwt-unix"
   "bos"
   "crunch"
-  "mirage-kv-mem"
+  "mirage-kv-mem" {<= "3.1.0"}
   "dream" {>= "1.0.0~alpha3"}
   "dream-accept"
   "dream-encoding"


### PR DESCRIPTION
Urgent kludge fix.

Allowing upgrade to 3.2.0 and beyond breaks the build. 

https://github.com/ocaml/ocaml.org/actions/runs/3706242982/jobs/6281210233

Here is the error message:

```
opam exec -- dune build --root .
File "src/ocamlorg_web/lib/router.ml", lines 11-12, characters 6-54:
11 | ......let* store = store in
12 |       Asset.last_modified store (Mirage_kv.Key.v path).
Error: This expression has type (Ptime.t, Asset.error) result Lwt.t
       but an expression was expected of type (int * int64, 'a) result Lwt.t
       Type Ptime.t is not compatible with type int * int64
make: *** [Makefile:25: build] Error 1
```

Despite appearances, ptime does not seem to be the faulty dependency.
Preventing upgrade of ptime beyond 1.0.0 does not solve the issue.
