### PR TITLE
Use mirror url of caml-list archive

### DIFF
--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -59,7 +59,7 @@ Layout.render
           <div class="text-base font-semibold"><img src="/img/community/reddit.svg" alt="" class="h-8 w-8 mr-2 inline-block" /> Reddit</div>
           <div class="font-normal text-xs mt-4">“join the OCaml subreddit and posts discussions and memes, talk about your projects, and share interesting articles and news from the web.</div>
         </a>
-        <a href="https://inbox.ocaml.org/caml-list/" class="border-gray-200 border p-8 rounded-xl card-hover">
+        <a href="https://inbox.vuxu.org/caml-list/" class="border-gray-200 border p-8 rounded-xl card-hover">
           <div class="text-base font-semibold"><img src="/img/community/mail.svg" alt="" class="h-8 w-8 mr-2 inline-block" /> Mailing List</div>
           <div class="font-normal text-xs mt-4">Share experience, exchange ideas and code, and report on applications of the OCaml language.</div>
         </a>


### PR DESCRIPTION
Point to the mirror of the caml-list archive provided by
Leah Neukirchen at https://inbox.vuxu.org/caml-list/ as
https://inbox.ocaml.org/caml-list/ is down.

Related issues:
* https://github.com/ocaml/ocaml.org/issues/706
* https://github.com/ocaml/ocaml.org/issues/550
* https://github.com/ocaml/infrastructure/issues/15
