### PR TITLE
Repair build broken by mirage-kv 6.0.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,8 +37,7 @@
   cohttp-lwt-unix
   bos
   crunch
-  (mirage-kv-mem
-    (<= 3.1.0))
+  mirage-kv-mem
   (dream
    (>= 1.0.0~alpha3))
   dream-accept

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -24,7 +24,7 @@ depends: [
   "cohttp-lwt-unix"
   "bos"
   "crunch"
-  "mirage-kv-mem" {<= "3.1.0"}
+  "mirage-kv-mem"
   "dream" {>= "1.0.0~alpha3"}
   "dream-accept"
   "dream-encoding"

--- a/src/ocamlorg_web/lib/static.ml
+++ b/src/ocamlorg_web/lib/static.ml
@@ -44,9 +44,7 @@ let loader ~read ~last_modified ?(not_cached = []) local_root path request =
   match last_modified with
   | Error _ -> Handler.not_found request
   | Ok last_modified -> (
-      let last_modified =
-        Last_modified.ptime_to_http_date last_modified
-      in
+      let last_modified = Last_modified.ptime_to_http_date last_modified in
       if not_modified ~last_modified request then
         Dream.respond ~status:`Not_Modified ""
       else

--- a/src/ocamlorg_web/lib/static.ml
+++ b/src/ocamlorg_web/lib/static.ml
@@ -45,7 +45,7 @@ let loader ~read ~last_modified ?(not_cached = []) local_root path request =
   | Error _ -> Handler.not_found request
   | Ok last_modified -> (
       let last_modified =
-        Last_modified.ptime_to_http_date (Ptime.v last_modified)
+        Last_modified.ptime_to_http_date last_modified
       in
       if not_modified ~last_modified request then
         Dream.respond ~status:`Not_Modified ""


### PR DESCRIPTION
In mirage-kv 5.0.0 the function `last_modified` returned a result of
type:
```ocaml
  (int * int64, error) result Lwt.t
```

This was changed in 6.0.0, where it returns a result of type:
```ocaml
  (Ptime.t, error) result Lwt.t
```

See: https://github.com/mirage/mirage-kv/commit/9161b54b13411d740151d9e7bf7f403dbcc61583 from PR https://github.com/mirage/mirage-kv/pull/34

This caused a typing error. Removing the call to function
```ocaml
  Ptime.v : int * int64 -> Ptime.t
```

solved the issue.
