### PR TITLE
5.0.0 release: add more links to the manual in the release page

### DIFF
--- a/data/releases/5.0.0.md
+++ b/data/releases/5.0.0.md
@@ -9,13 +9,13 @@ intro: |
   This release is available as an [opam](/p/ocaml/5.0.0) package.
 highlights: |
   OCaml 5.0.0 introduces a completely new runtime system
-  with support for shared memory parallelism and effect handlers. 
+  with support for [shared memory parallelism](https://v2.ocaml.org/releases/5.0/manual/parallelism.html) and [effect handlers](https://v2.ocaml.org/releases/5.0/manual/effects.html).
 ---
 
 ## What's new
 
 OCaml 5.0.0 introduces a completely new runtime system
-with support for shared memory parallelism and effect handlers. 
+with support for [shared memory parallelism](https://v2.ocaml.org/releases/5.0/manual/parallelism.html) and [effect handlers](https://v2.ocaml.org/releases/5.0/manual/effects.html).
 
 As a language,  OCaml 5 is fully compatible with OCaml 4 down to the performance
 characteristics of your programs. In other words, any code that works with OCaml 4 should work the same with OCaml 5. 


### PR DESCRIPTION
This PR adds the links to the manual to the release page, in particular in the highlights for readers interested in the new features that are not intimately familiar with the organization of the OCaml manual. 