### PR TITLE
OCaml 4.14.1 release

### DIFF
--- a/data/news/platform/ocaml-4.14.1.md
+++ b/data/news/platform/ocaml-4.14.1.md
@@ -1,0 +1,122 @@
+---
+title: Release of OCaml 4.14.1
+description: Release of OCaml 4.14.1
+date: "2022-12-20"
+tags: [ocaml, platform]
+---
+We have the pleasure of celebrating the birthday of Oronce Finé by announcing the release of OCaml version 4.14.1.
+
+This release is a collection of safe bug fixes, cherry-picked from the OCaml 5.0.0 release. If you were using OCaml 4.14.0 and cannot yet upgrade to OCaml 5, this release is for you.
+
+The 4.14 branch is expected to receive more backported fixes during the maturation of OCaml 5. Thus don't hesitate to report any bugs on the [OCaml issue tracker](https://github.com/ocaml/ocaml/issues).
+
+See the list of changes below for more details.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+
+```bash
+opam update
+opam switch create 4.14.1
+```
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz)
+* [Inria archive](https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.1.tar.gz)
+
+---
+
+## Changes in OCaml 4.14.1 (20 December 2022)
+
+### Compiler User-Interface and Warnings:
+
+- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on created / installed libraries
+  (Sébastien Hinderer and Xavier Leroy, review by the same)
+
+### Build System:
+
+- [#11370](https://github.com/ocaml/ocaml/issues/11370), [#11373](https://github.com/ocaml/ocaml/issues/11373): Don't pass CFLAGS to flexlink during configure.
+  (David Allsopp, report by William Hu, review by Xavier Leroy and
+   Sébastien Hinderer)
+
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+  (William Hu, review by David Allsopp and Sébastien Hinderer)
+
+### Bug Fixes:
+
+- [#10768](https://github.com/ocaml/ocaml/issues/10768), [#11340](https://github.com/ocaml/ocaml/issues/11340): Fix typechecking regression when combining first class
+  modules and GADTs.
+  (Jacques Garrigue, report by François Thiré, review by Matthew Ryan)
+
+- [#11204](https://github.com/ocaml/ocaml/issues/11204): Fix regression introduced in 4.14.0 that would trigger Warning 17 when
+  calling virtual methods introduced by constraining the self type from within
+  the class definition.
+  (Nicolás Ojeda Bär, review by Leo White)
+
+- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: check whether `_MSC_VER` is defined
+  before using it to ensure that the headers can always be used in code which
+  turns on -Wundef (or equivalent).
+  (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
+   Sébastien Hinderer)
+
+- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): fix non-informative error message for module inclusion
+  (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
+
+- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialization of bytecode threading,
+  This avoids a "dangling pointer" warning of GCC 12.1.
+  (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
+
+- [#11387](https://github.com/ocaml/ocaml/issues/11387), module type with constraints no longer crash the compiler in presence
+  of both shadowing warnings and the `-bin-annot` compiler flag.
+  (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
+
+- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): assertion failure with -rectypes and external definitions
+  (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)
+
+- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix regression allowing virtual methods in non-virtual classes.
+  (Leo White, review by Florian Angeletti)
+
+- [#11468](https://github.com/ocaml/ocaml/issues/11468): Fix regression from [#10186](https://github.com/ocaml/ocaml/issues/10186) (OCaml 4.13) detecting IPv6 on Windows for
+  mingw-w64 i686 port.
+  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
+
+- [#11489](https://github.com/ocaml/ocaml/issues/11489), [#11496](https://github.com/ocaml/ocaml/issues/11496): More prudent deallocation of alternate signal stack
+  (Xavier Leroy, report by @rajdakin, review by Florian Angeletti)
+
+- [#11516](https://github.com/ocaml/ocaml/issues/11516), [#11524](https://github.com/ocaml/ocaml/issues/11524): Fix the `deprecated_mutable` attribute.
+  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#11194](https://github.com/ocaml/ocaml/issues/11194), [#11609](https://github.com/ocaml/ocaml/issues/11609): Fix inconsistent type variable names in "unbound type var"
+  messages
+  (Ulysse Gérard and Florian Angeletti, review Florian Angeletti and
+   Gabriel Scherer)
+
+- [#11622](https://github.com/ocaml/ocaml/issues/11622): Prevent stack overflow when printing a constructor or record
+  mismatch error involving recursive types.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from packed modules are always generalised
+  (Stephen Dolan and Leo White, review by Jacques Garrigue)
+
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in Unix.stat under Windows in the presence of
+  multiple threads.
+  (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
+
+- [#11776](https://github.com/ocaml/ocaml/issues/11776): Extend environment with functor parameters in `strengthen_lazy`.
+  (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
+
+- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in #show_module_type
+  (this had stopped working in 4.14.0)
+  (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
+
+- [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
+  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)
+
+- [#11803](https://github.com/ocaml/ocaml/issues/11803), [#11808](https://github.com/ocaml/ocaml/issues/11808): on x86, the destination of an integer comparison must be
+  a register, it cannot be a stack slot.
+  (Vincent Laviron, review by Xavier Leroy, report by
+   Emilio Jesús Gallego Arias)

--- a/data/news/platform/ocaml-4.14.1.md
+++ b/data/news/platform/ocaml-4.14.1.md
@@ -33,7 +33,7 @@ The source code for the release candidate is also directly available on:
 
 ### Compiler User-Interface and Warnings:
 
-- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on created / installed libraries
+- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling `ranlib` on created / installed libraries
   (Sébastien Hinderer and Xavier Leroy, review by the same)
 
 ### Build System:
@@ -42,7 +42,7 @@ The source code for the release candidate is also directly available on:
   (David Allsopp, report by William Hu, review by Xavier Leroy and
    Sébastien Hinderer)
 
-- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimisation during configure
   (William Hu, review by David Allsopp and Sébastien Hinderer)
 
 ### Bug Fixes:
@@ -56,31 +56,31 @@ The source code for the release candidate is also directly available on:
   the class definition.
   (Nicolás Ojeda Bär, review by Leo White)
 
-- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: check whether `_MSC_VER` is defined
+- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: Check whether `_MSC_VER` is defined
   before using it to ensure that the headers can always be used in code which
-  turns on -Wundef (or equivalent).
+  turns on `-Wundef` (or equivalent).
   (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
    Sébastien Hinderer)
 
-- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): fix non-informative error message for module inclusion
+- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): Fix non-informative error message for module inclusion
   (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
 
-- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialization of bytecode threading,
+- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialisation of bytecode threading,
   This avoids a "dangling pointer" warning of GCC 12.1.
   (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
 
-- [#11387](https://github.com/ocaml/ocaml/issues/11387), module type with constraints no longer crash the compiler in presence
+- [#11387](https://github.com/ocaml/ocaml/issues/11387): Module type with constraints no longer crash the compiler in presence
   of both shadowing warnings and the `-bin-annot` compiler flag.
   (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
 
-- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): assertion failure with -rectypes and external definitions
+- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): Assertion failure with `-rectypes` and external definitions
   (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)
 
-- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix regression allowing virtual methods in non-virtual classes.
+- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix a regression which allowed virtual methods in non-virtual classes.
   (Leo White, review by Florian Angeletti)
 
 - [#11468](https://github.com/ocaml/ocaml/issues/11468): Fix regression from [#10186](https://github.com/ocaml/ocaml/issues/10186) (OCaml 4.13) detecting IPv6 on Windows for
-  mingw-w64 i686 port.
+  Mingw-w64 i686 port.
   (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
 
 - [#11489](https://github.com/ocaml/ocaml/issues/11489), [#11496](https://github.com/ocaml/ocaml/issues/11496): More prudent deallocation of alternate signal stack
@@ -101,22 +101,22 @@ The source code for the release candidate is also directly available on:
 - [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
-- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in Unix.stat under Windows in the presence of
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in `Unix.stat` under Windows in the presence of
   multiple threads.
   (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
 
 - [#11776](https://github.com/ocaml/ocaml/issues/11776): Extend environment with functor parameters in `strengthen_lazy`.
   (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 
-- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in #show_module_type
+- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): Follow synonyms again in `#show_module_type`
   (this had stopped working in 4.14.0)
   (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
 
 - [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
-  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  no-naked-pointers mode caused by wrong initialisation of `caml_global_data`
   (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)
 
-- [#11803](https://github.com/ocaml/ocaml/issues/11803), [#11808](https://github.com/ocaml/ocaml/issues/11808): on x86, the destination of an integer comparison must be
-  a register, it cannot be a stack slot.
+- [#11803](https://github.com/ocaml/ocaml/issues/11803), [#11808](https://github.com/ocaml/ocaml/issues/11808): On x86, the destination of an integer comparison must be
+  a register; it cannot be a stack slot.
   (Vincent Laviron, review by Xavier Leroy, report by
    Emilio Jesús Gallego Arias)

--- a/data/releases/4.14.1.md
+++ b/data/releases/4.14.1.md
@@ -21,7 +21,7 @@ opam switch create 4.14.1
 
 ### Configuration Options
 
-The configuration of the installed opam switch can be tuned with the
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
 following options:
 
 - `ocaml-option-afl`: sets OCaml to be compiled with `afl-fuzz` instrumentation

--- a/data/releases/4.14.1.md
+++ b/data/releases/4.14.1.md
@@ -19,20 +19,21 @@ opam update
 opam switch create 4.14.1
 ```
 
-### Configuration options
+### Configuration Options
 
 The configuration of the installed opam switch can be tuned with the
 following options:
 
-- ocaml-option-afl: set OCaml to be compiled with afl-fuzz instrumentation
-- ocaml-option-bytecode-only: compile OCaml without the native-code compiler
-- ocaml-option-flambda: set OCaml to be compiled with flambda activated
-- ocaml-option-musl: set OCaml to be compiled with musl-gcc
-- ocaml-option-no-flat-float-array: set OCaml to be compiled with --disable-flat-float-array
-- ocaml-option-static :set OCaml to be compiled with musl-gcc -static
-- ocaml-option-address-sanitizer: set OCaml to be compiled with address sanitizer
-- ocaml-option-leak-sanitizer: set OCaml to be compiled with leak sanitizer
-
+- `ocaml-option-afl`: sets OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: compiles OCaml without the native-code compiler
+- `ocaml-option-flambda`: sets OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: sets OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: sets OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: sets OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-32bit`: sets OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts
+- `ocaml-option-nnp`: sets OCaml to be compiled with `--disable-naked-pointers`
+- `ocaml-option-nnpchecker`: set OCaml to be compiled with `--enable-naked-pointers-checker`
+- `ocaml-option-fp`: sets OCaml to be compiled with frame-pointers enabled
 
 For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with
 
@@ -53,12 +54,12 @@ Source Distribution
 
 - [Source
   tarball](https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz)
-  (.tar.gz) for compilation under Unix (including Linux and MacOS X)
+  (.tar.gz) for compilation under Unix (including Linux and macOS X)
   and Microsoft Windows (including Cygwin).
 - Also available in
   [.zip](https://github.com/ocaml/ocaml/archive/4.14.1.zip)
   format.
-- [OPAM](https://opam.ocaml.org/) is a source-based distribution of
+- [opam](https://opam.ocaml.org/) is a source-based distribution of
   OCaml and many companion libraries and tools. Compilation and
   installation are automated by powerful package managers.
 - The official development repo is hosted on
@@ -67,7 +68,7 @@ Source Distribution
 The
 [INSTALL](https://v2.ocaml.org/releases/4.14/notes/INSTALL.adoc) file
 of the distribution provides detailed compilation and installation
-instructions — see also the [Windows release
+instructions. See also the [Windows release
 notes](https://v2.ocaml.org/releases/4.14/notes/README.win32.adoc) for
 instructions on how to build under Windows.
 
@@ -80,7 +81,7 @@ This is the
 
 ### Compiler User-Interface and Warnings:
 
-- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on created / installed libraries
+- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling `ranlib` on created / installed libraries
   (Sébastien Hinderer and Xavier Leroy, review by the same)
 
 ### Build System:
@@ -89,7 +90,7 @@ This is the
   (David Allsopp, report by William Hu, review by Xavier Leroy and
    Sébastien Hinderer)
 
-- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimisation during configure
   (William Hu, review by David Allsopp and Sébastien Hinderer)
 
 ### Bug Fixes:
@@ -103,31 +104,31 @@ This is the
   the class definition.
   (Nicolás Ojeda Bär, review by Leo White)
 
-- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: check whether `_MSC_VER` is defined
+- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: Check whether `_MSC_VER` is defined
   before using it to ensure that the headers can always be used in code which
-  turns on -Wundef (or equivalent).
+  turns on `-Wundef` (or equivalent).
   (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
    Sébastien Hinderer)
 
-- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): fix non-informative error message for module inclusion
+- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): Fix non-informative error message for module inclusion
   (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
 
-- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialization of bytecode threading,
+- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialisation of bytecode threading,
   This avoids a "dangling pointer" warning of GCC 12.1.
   (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
 
-- [#11387](https://github.com/ocaml/ocaml/issues/11387), module type with constraints no longer crash the compiler in presence
+- [#11387](https://github.com/ocaml/ocaml/issues/11387): Module type with constraints no longer crash the compiler in presence
   of both shadowing warnings and the `-bin-annot` compiler flag.
   (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
 
-- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): assertion failure with -rectypes and external definitions
+- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): Assertion failure with `-rectypes` and external definitions
   (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)
 
-- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix regression allowing virtual methods in non-virtual classes.
+- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix a regression which allowed virtual methods in non-virtual classes.
   (Leo White, review by Florian Angeletti)
 
 - [#11468](https://github.com/ocaml/ocaml/issues/11468): Fix regression from [#10186](https://github.com/ocaml/ocaml/issues/10186) (OCaml 4.13) detecting IPv6 on Windows for
-  mingw-w64 i686 port.
+  Mingw-w64 i686 port.
   (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
 
 - [#11489](https://github.com/ocaml/ocaml/issues/11489), [#11496](https://github.com/ocaml/ocaml/issues/11496): More prudent deallocation of alternate signal stack
@@ -148,25 +149,22 @@ This is the
 - [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from packed modules are always generalised
   (Stephen Dolan and Leo White, review by Jacques Garrigue)
 
-- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in Unix.stat under Windows in the presence of
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in `Unix.stat` under Windows in the presence of
   multiple threads.
   (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
 
 - [#11776](https://github.com/ocaml/ocaml/issues/11776): Extend environment with functor parameters in `strengthen_lazy`.
   (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
 
-- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in #show_module_type
+- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): Follow synonyms again in `#show_module_type`
   (this had stopped working in 4.14.0)
   (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
 
 - [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
-  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  no-naked-pointers mode caused by wrong initialisation of `caml_global_data`
   (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)
 
-- [#11803](https://github.com/ocaml/ocaml/issues/11803), [#11808](https://github.com/ocaml/ocaml/issues/11808): on x86, the destination of an integer comparison must be
-  a register, it cannot be a stack slot.
+- [#11803](https://github.com/ocaml/ocaml/issues/11803), [#11808](https://github.com/ocaml/ocaml/issues/11808): On x86, the destination of an integer comparison must be
+  a register; it cannot be a stack slot.
   (Vincent Laviron, review by Xavier Leroy, report by
    Emilio Jesús Gallego Arias)
-
-
-

--- a/data/releases/4.14.1.md
+++ b/data/releases/4.14.1.md
@@ -1,0 +1,172 @@
+---
+kind: compiler
+version: 4.14.1
+date: 2022-12-20
+intro: |
+  This page describes OCaml version **4.14.1**, released on
+  Dec 20, 2022. Go [here](/releases) for a list of all releases.
+
+  This is a bug-fix release of [OCaml 4.14.0](/releases/4.14.0).
+highlights: |
+  - Bug fixes for 4.14.1
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 4.14.1
+```
+
+### Configuration options
+
+The configuration of the installed opam switch can be tuned with the
+following options:
+
+- ocaml-option-afl: set OCaml to be compiled with afl-fuzz instrumentation
+- ocaml-option-bytecode-only: compile OCaml without the native-code compiler
+- ocaml-option-flambda: set OCaml to be compiled with flambda activated
+- ocaml-option-musl: set OCaml to be compiled with musl-gcc
+- ocaml-option-no-flat-float-array: set OCaml to be compiled with --disable-flat-float-array
+- ocaml-option-static :set OCaml to be compiled with musl-gcc -static
+- ocaml-option-address-sanitizer: set OCaml to be compiled with address sanitizer
+- ocaml-option-leak-sanitizer: set OCaml to be compiled with leak sanitizer
+
+
+For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with
+
+```
+opam switch create 4.14.1+flambda+nnpchecker --package=ocaml-variants.4.14.1+options,ocaml-option-flambda,ocaml-option-nnpchecker
+```
+
+or with opam 2.1:
+
+```
+opam switch create 4.14.1+flambda+nnpchecker ocaml-variants.4.14.1+options ocaml-option-flambda ocaml-option-nnpchecker
+```
+
+---
+
+Source Distribution
+-------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.14.1.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and MacOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.14.1.zip)
+  format.
+- [OPAM](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://v2.ocaml.org/releases/4.14/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions — see also the [Windows release
+notes](https://v2.ocaml.org/releases/4.14/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+---
+
+## Changes in OCaml 4.14.1 (20 December 2022)
+
+This is the
+[changelog](https://v2.ocaml.org/releases/4.14/notes/Changes).
+
+### Compiler User-Interface and Warnings:
+
+- [#11184](https://github.com/ocaml/ocaml/issues/11184), [#11670](https://github.com/ocaml/ocaml/issues/11670): Stop calling ranlib on created / installed libraries
+  (Sébastien Hinderer and Xavier Leroy, review by the same)
+
+### Build System:
+
+- [#11370](https://github.com/ocaml/ocaml/issues/11370), [#11373](https://github.com/ocaml/ocaml/issues/11373): Don't pass CFLAGS to flexlink during configure.
+  (David Allsopp, report by William Hu, review by Xavier Leroy and
+   Sébastien Hinderer)
+
+- [#11487](https://github.com/ocaml/ocaml/issues/11487): Thwart FMA test optimization during configure
+  (William Hu, review by David Allsopp and Sébastien Hinderer)
+
+### Bug Fixes:
+
+- [#10768](https://github.com/ocaml/ocaml/issues/10768), [#11340](https://github.com/ocaml/ocaml/issues/11340): Fix typechecking regression when combining first class
+  modules and GADTs.
+  (Jacques Garrigue, report by François Thiré, review by Matthew Ryan)
+
+- [#11204](https://github.com/ocaml/ocaml/issues/11204): Fix regression introduced in 4.14.0 that would trigger Warning 17 when
+  calling virtual methods introduced by constraining the self type from within
+  the class definition.
+  (Nicolás Ojeda Bär, review by Leo White)
+
+- [#11263](https://github.com/ocaml/ocaml/issues/11263), [#11267](https://github.com/ocaml/ocaml/issues/11267): caml/{memory,misc}.h: check whether `_MSC_VER` is defined
+  before using it to ensure that the headers can always be used in code which
+  turns on -Wundef (or equivalent).
+  (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
+   Sébastien Hinderer)
+
+- [#11314](https://github.com/ocaml/ocaml/issues/11314), [#11416](https://github.com/ocaml/ocaml/issues/11416): fix non-informative error message for module inclusion
+  (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)
+
+- [#11358](https://github.com/ocaml/ocaml/issues/11358), [#11379](https://github.com/ocaml/ocaml/issues/11379): Refactor the initialization of bytecode threading,
+  This avoids a "dangling pointer" warning of GCC 12.1.
+  (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)
+
+- [#11387](https://github.com/ocaml/ocaml/issues/11387), module type with constraints no longer crash the compiler in presence
+  of both shadowing warnings and the `-bin-annot` compiler flag.
+  (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
+
+- [#11392](https://github.com/ocaml/ocaml/issues/11392), [#11392](https://github.com/ocaml/ocaml/issues/11392): assertion failure with -rectypes and external definitions
+  (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)
+
+- [#11417](https://github.com/ocaml/ocaml/issues/11417): Fix regression allowing virtual methods in non-virtual classes.
+  (Leo White, review by Florian Angeletti)
+
+- [#11468](https://github.com/ocaml/ocaml/issues/11468): Fix regression from [#10186](https://github.com/ocaml/ocaml/issues/10186) (OCaml 4.13) detecting IPv6 on Windows for
+  mingw-w64 i686 port.
+  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)
+
+- [#11489](https://github.com/ocaml/ocaml/issues/11489), [#11496](https://github.com/ocaml/ocaml/issues/11496): More prudent deallocation of alternate signal stack
+  (Xavier Leroy, report by @rajdakin, review by Florian Angeletti)
+
+- [#11516](https://github.com/ocaml/ocaml/issues/11516), [#11524](https://github.com/ocaml/ocaml/issues/11524): Fix the `deprecated_mutable` attribute.
+  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#11194](https://github.com/ocaml/ocaml/issues/11194), [#11609](https://github.com/ocaml/ocaml/issues/11609): Fix inconsistent type variable names in "unbound type var"
+  messages
+  (Ulysse Gérard and Florian Angeletti, review Florian Angeletti and
+   Gabriel Scherer)
+
+- [#11622](https://github.com/ocaml/ocaml/issues/11622): Prevent stack overflow when printing a constructor or record
+  mismatch error involving recursive types.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#11732](https://github.com/ocaml/ocaml/issues/11732): Ensure that types from packed modules are always generalised
+  (Stephen Dolan and Leo White, review by Jacques Garrigue)
+
+- [#11737](https://github.com/ocaml/ocaml/issues/11737): Fix segfault condition in Unix.stat under Windows in the presence of
+  multiple threads.
+  (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)
+
+- [#11776](https://github.com/ocaml/ocaml/issues/11776): Extend environment with functor parameters in `strengthen_lazy`.
+  (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)
+
+- [#11533](https://github.com/ocaml/ocaml/issues/11533), [#11534](https://github.com/ocaml/ocaml/issues/11534): follow synonyms again in #show_module_type
+  (this had stopped working in 4.14.0)
+  (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)
+
+- [#11768](https://github.com/ocaml/ocaml/issues/11768), [#11788](https://github.com/ocaml/ocaml/issues/11788): Fix crash at start-up of bytecode programs in
+  no-naked-pointers mode caused by wrong initialization of caml_global_data
+  (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)
+
+- [#11803](https://github.com/ocaml/ocaml/issues/11803), [#11808](https://github.com/ocaml/ocaml/issues/11808): on x86, the destination of an integer comparison must be
+  a register, it cannot be a stack slot.
+  (Vincent Laviron, review by Xavier Leroy, report by
+   Emilio Jesús Gallego Arias)
+
+
+

--- a/data/releases/5.0.0.md
+++ b/data/releases/5.0.0.md
@@ -4,7 +4,7 @@ version: 5.0.0
 date: 2022-12-16
 intro: |
   This page describes OCaml version **5.0.0**, released on
-  2022-03-28. Go [here](/releases) for a list of all releases.
+  2022-12-16. Go [here](/releases) for a list of all releases.
 
   This release is available as an [opam](/p/ocaml/5.0.0) package.
 highlights: |

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -33,6 +33,10 @@ type t = {
   body_html : string;
 }
 
+let sort_version x y =
+  let to_list s = List.map int_of_string_opt @@ String.split_on_char '.' s in
+  compare (to_list x.version) (to_list y.version)
+
 let all () =
   Utils.map_files
     (fun content ->
@@ -55,7 +59,7 @@ let all () =
         body_html = Omd.of_string body |> Hilite.Md.transform |> Omd.to_html;
       })
     "releases/"
-  |> List.sort (fun a b -> String.compare a.date b.date)
+  |> List.sort sort_version
   |> List.rev
 
 let pp_kind ppf v = Fmt.pf ppf "%s" (match v with `Compiler -> "`Compiler")

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -33,9 +33,9 @@ type t = {
   body_html : string;
 }
 
-let sort_version x y =
+let sort_by_decreasing_version x y =
   let to_list s = List.map int_of_string_opt @@ String.split_on_char '.' s in
-  compare (to_list x.version) (to_list y.version)
+  compare (to_list y.version) (to_list x.version)
 
 let all () =
   Utils.map_files
@@ -59,8 +59,7 @@ let all () =
         body_html = Omd.of_string body |> Hilite.Md.transform |> Omd.to_html;
       })
     "releases/"
-  |> List.sort sort_version
-  |> List.rev
+  |> List.sort sort_by_decreasing_version
 
 let pp_kind ppf v = Fmt.pf ppf "%s" (match v with `Compiler -> "`Compiler")
 


### PR DESCRIPTION
This PR adds the release page and the announce for OCaml 4.14.1.
Along the way, it fixes a mistake on the OCaml 5.0.0 release date.

More importantly, this PR fixes the display order of the releases to show the latest version first rather than the latest published version. For this release, this avoids switching to OCaml 4.14.1 release as the highlighted last release. In general, this order seemed slightly more readable to me.