### PR TITLE
Remove useless parameter

### DIFF
--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -106,7 +106,7 @@ let render
     <% (match maptoc with [] ->  %>
     <span class="block py-2 text-gray-700">Package contains no libraries</span>
     <% | _ -> %>
-      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">
+      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name package.version %>">
         package <%s package.name %>
       </a>
     <ul>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -6,7 +6,7 @@ let sidebar
 =
   <div class="flex flex-col">
     <% if str_path != [] && toc != [] then ( %>
-    <a title="Package <%s package.name %>" class="xl:hidden py-1 font-regular text-body-600 hover:text-orange-600 transition-colors mb-6" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">
+    <a title="Package <%s package.name %>" class="xl:hidden py-1 font-regular text-body-600 hover:text-orange-600 transition-colors mb-6" href="<%s Url.package_doc package.name package.version %>">
       back to documentation root
     </a>
     <% ); %>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -67,11 +67,11 @@ Package_layout.render
         </div>
         <% (match documentation_status with
             | `Success -> %>
-            <div class="mt-4"><a class="btn btn-sm" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">Documentation</a></div>
-            <% | `Unknown -> ( %><a href="<%s Url.package_doc package.name package.version ~page:"index.html" %>" class="p-4 mt-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <div class="mt-4"><a class="btn btn-sm" href="<%s Url.package_doc package.name package.version %>">Documentation</a></div>
+            <% | `Unknown -> ( %><a href="<%s Url.package_doc package.name package.version %>" class="p-4 mt-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
             <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#4b5563"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15.32 3H8.68c-.26 0-.52.11-.7.29L3.29 7.98c-.18.18-.29.44-.29.7v6.63c0 .27.11.52.29.71l4.68 4.68c.19.19.45.3.71.3h6.63c.27 0 .52-.11.71-.29l4.68-4.68c.19-.19.29-.44.29-.71V8.68c0-.27-.11-.52-.29-.71l-4.68-4.68c-.18-.18-.44-.29-.7-.29zM12 17.3c-.72 0-1.3-.58-1.3-1.3s.58-1.3 1.3-1.3 1.3.58 1.3 1.3-.58 1.3-1.3 1.3zm0-4.3c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1z"/></svg>
             Documentation status is unknown. Sorry about that.</a><% )
-            | `Failure -> ( %><a href="<%s Url.package_doc package.name package.version ~page:"index.html" %>" class="p-4 mt-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            | `Failure -> ( %><a href="<%s Url.package_doc package.name package.version %>" class="p-4 mt-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
             <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#4b5563"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M15.32 3H8.68c-.26 0-.52.11-.7.29L3.29 7.98c-.18.18-.29.44-.29.7v6.63c0 .27.11.52.29.71l4.68 4.68c.19.19.45.3.71.3h6.63c.27 0 .52-.11.71-.29l4.68-4.68c.19-.19.29-.44.29-.71V8.68c0-.27-.11-.52-.29-.71l-4.68-4.68c-.18-.18-.44-.29-.7-.29zM12 17.3c-.72 0-1.3-.58-1.3-1.3s.58-1.3 1.3-1.3 1.3.58 1.3 1.3-.58 1.3-1.3 1.3zm0-4.3c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1z"/></svg>
             Documentation failed to build! Sorry about that.</a><% ));%>
         <% (match package.tags with [] -> () | _ ->  %>


### PR DESCRIPTION
By default, when `~page` is not provided to `Url.package_doc`, its value is `"index.html"`. Therefore, there's no need to pass it that value when called.