### PR TITLE
OCaml Workshop 2016 Videos, Nara

### DIFF
--- a/data/workshops/2016.md
+++ b/data/workshops/2016.md
@@ -14,34 +14,41 @@ presentations:
     authors: 
       - Hannes Mehnert 
       - Louis Gesbert
+    video: https://watch.ocaml.org/videos/watch/70fbf7db-28dc-4798-b068-460b5d93df4e
   - title: Generic Programming in OCaml
     authors:
       - Florent Balestrieri
       - Michel Mauny
+    video: https://watch.ocaml.org/videos/watch/0aae98b9-3d0c-427b-af09-802b671dd66e
   - title: 'Improving the OCaml Web Stack: Motivations and Progress'
     authors: 
       - Spiridon Eliopoulos
+    video: https://watch.ocaml.org/videos/watch/513a2157-6844-4823-bef7-b26f3b635fbe
   - title: 'Learn OCaml: An Online Learning Center for OCaml'
     authors:
       - Benjamin Canou
       - Grégoire Henry
       - Çagdas Bozman
       - Fabrice Le Fessant
+    video: https://watch.ocaml.org/videos/watch/ea643e64-2393-4c24-9ccf-7216e3ded2ce
   - title: Lock-free programming for the masses
     authors:
       - Kc Sivaramakrishnan
       - Theo Laurent
+    video: https://watch.ocaml.org/videos/watch/4435adfc-e97e-42c5-8bb7-1578bd76e42b
   - title: 'OCaml inside: a drop-in replacement for libtls'
     authors: 
       - Enguerrand Decorne
       - Jeremy Yallop
       - David Kaloper Meršinjak
+    video: https://watch.ocaml.org/videos/watch/68a11315-f7ca-4c0e-a043-98008694671d
   - title: 'OPAM-builder: Continuous Monitoring of OPAM Repositories'
     authors: 
       - Fabrice Le Fessant
   - title: Semantics of the Lambda intermediate language
     authors: 
       - Pierre Chambart
+    video: https://watch.ocaml.org/videos/watch/90d9b62f-f9d6-4dd5-a7fc-f584e45ef0b7
   - title: Statistically profiling memory in OCaml
     authors: 
       - Jacques-Henri Jourdan
@@ -50,12 +57,15 @@ presentations:
       - Timothy Bourke
       - Jun Inoue
       - Marc Pouzet
+    video: https://watch.ocaml.org/videos/watch/3a00e727-45da-4c4a-a446-927cb28bb6bc
   - title: 'The State of the OCaml Platform: September 2016'
     authors: 
       - Louis Gesbert, on behalf of the OCaml Platform team
+    video: https://watch.ocaml.org/videos/watch/c386fc95-092e-4ea7-9317-91edf287fea6
   - title: "Who's got your Mail? Mr. Mime"
     authors: 
       - Romain Calascibetta
+    video: https://watch.ocaml.org/videos/watch/98a7972d-9323-46b3-81cc-dd86a4cc1ab3
   - title: 'Inuit library: from printf to interactive user-interfaces'
     authors:
       - Frédéric Bour


### PR DESCRIPTION
Added (10):

* Conex - establishing trust into data repositories
* Generic Programming in OCaml
* Improving the OCaml Web Stack: Motivations and Progress
* Learn OCaml: An Online Learning Center for OCaml
* Lock-free programming for the masses
* OCaml inside: a drop-in replacement for libtls
* Semantics of the Lambda intermediate language
* Sundials/ML: interfacing with numerical solvers
* The State of the OCaml Platform: September 2016
* Who's got your Mail? Mr. Mime

Still Missing (2):

* OPAM-builder: Continuous Monitoring of OPAM Repositories
* Statistically profiling memory in OCaml

Extra (1):

* What's new in OCamls 4.03: https://watch.ocaml.org/videos/watch/b967996a-3dab-415f-8e51-d8908361b2b2
