### PR TITLE
OCaml Workshop 2017 Videos, Cambridge

### DIFF
--- a/data/workshops/2017.md
+++ b/data/workshops/2017.md
@@ -29,14 +29,14 @@ presentations:
     authors:
       - Runhang Li
       - Jeremy Yallop  
-    video: https://www.youtube.com/watch?v=rxCMop-dTuc&index=4&list=TLGGpj_CrU7rr7MxMjAxMjAxOA
+    video: https://watch.ocaml.org/videos/watch/8d5a83f5-ad98-4f45-9259-c84194134c20
     link: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__runhang-li_jeremy-yallop__extending-ocaml-s-open.pdf
     additional_links:
       - https://github.com/objmagic/ocaml-workshop-17-open-ext-talk
   - title: "Genspio: Generating Shell Phrases In OCaml"
     authors: 
       - Sebastien Mondet  
-    video: https://www.youtube.com/watch?v=prwLcBUoYiA&index=3&list=TLGGpj_CrU7rr7MxMjAxMjAxOA
+    video: https://watch.ocaml.org/videos/watch/9a7bf8cc-38c5-4f67-ab25-0ea1388100d3
     link: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__sebastien-mondet__genspio-generating-shell-phrases-in-ocaml.pdf
     slides: http://wr.mondet.org/slides/OCaml2017-Genspio/
     additional_links: 
@@ -44,7 +44,7 @@ presentations:
   - title: "Owl: A General-Purpose Numerical Library in OCaml"
     authors:  
       - Liang Wang  
-    video: https://www.youtube.com/watch?v=Jyv3tJD1N3o&index=7&list=TLGGpj_CrU7rr7MxMjAxMjAxOA
+    video: https://watch.ocaml.org/videos/watch/d258fa91-ddb6-40d8-96de-e9ac97e8c899
     link: https://arxiv.org/abs/1707.09616
     slides: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__liang_wang__owl-a-general-purpose-numerical-library-in-ocaml.pdf
   - title: "ROTOR: First Steps Towards a Refactoring Tool for OCaml"
@@ -72,7 +72,7 @@ presentations:
   - title: "The State of the OCaml Platform: September 2017"
     authors:
       - Anil Madhavapeddy  
-    video: https://www.youtube.com/watch?v=y-1Zrzdd9KM&index=6&list=TLGGpj_CrU7rr7MxMjAxMjAxOA
+    video: https://watch.ocaml.org/videos/watch/3940b98a-6b33-41f7-b0e7-4b7ae5ec2b4b
     slides: https://speakerdeck.com/avsm/ocaml-platform-2017
     link: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__anil-madhavapeddy__the-state-of-the-ocaml-platform-september-2017.pdf
   - title: "Wodan: a pure OCaml, flash-aware filesystem library" 
@@ -133,11 +133,11 @@ organising_committee: []
 OCaml 2017 will open with an invited talk by three frequent
 contributors that recently became maintainers of the OCaml
 implementation: David Allsopp
-([video](https://www.youtube.com/watch?v=10OQHsnyg64&index=2&list=TLGGpj_CrU7rr7MxMjAxMjAxOA)),
+([video](https://watch.ocaml.org/videos/watch/efbfd4c3-8e73-464b-a14c-c8de9f58a984)),
 Florian Angeletti
-([video](https://www.youtube.com/watch?v=HOfdGDSypP4&list=TLGGpj_CrU7rr7MxMjAxMjAxOA&index=5)),
+([video](https://watch.ocaml.org/videos/watch/9f9ea4a5-4d6a-4da5-9080-833b25c26511)),
 and Sébastien Hinderer
-([video](https://www.youtube.com/watch?v=SvnyQWZkHS8&list=TLGGpj_CrU7rr7MxMjAxMjAxOA&index=1)).
+([video](https://watch.ocaml.org/videos/watch/8fe8d294-ae8c-4f55-9750-c69fabfc8d34)).
 
 Due to the high number of high-quality submissions, we had to have
 more posters than in previous editions to fit a one-day


### PR DESCRIPTION
Replaced links to YouTube by Links to watch.ocaml.org

* Extending OCaml's open
* Genspio: Generating Shell Phrases In OCaml
* Owl: A General-Purpose Numerical Library in OCaml
* The State of the OCaml Platform: September 2017
* New contributors to OCaml (invited talk)
* OCaml on Windows in 2017 (invited talk)
* Documenting OCaml (invited talk)

Still Missing (7):

* A B-tree library for OCaml
* A memory model for multicore OCaml
* Component-based Program Synthesis in OCaml
* ROTOR: First Steps Towards a Refactoring Tool for OCaml
* Testing with Crowbar
* Tezos: the OCaml Crypto-Ledger
* Wodan: a pure OCaml, flash-aware filesystem library
