### PR TITLE
OCaml Workshop 2018 Videos, St. Louis

### DIFF
--- a/data/workshops/2018.md
+++ b/data/workshops/2018.md
@@ -28,6 +28,7 @@ presentations:
       - Jordan Walke
       - Cheng Lou
       - Rick Vetter
+    video: https://watch.ocaml.org/videos/watch/af37368d-085d-431d-923f-cd1d81dfdbe9
   - title: "RFCs, all the way down!"
     authors:
       - Romain Calascibetta
@@ -35,6 +36,7 @@ presentations:
     authors: 
       - Charles Chamberlain
       - Cyrus Omar
+    video: https://watch.ocaml.org/videos/watch/f75acae0-c24d-4d19-958e-0c76ff51603f
   - title: The OCaml Platform 1.0
     authors:
       - Anil Madhavapeddy
@@ -52,9 +54,11 @@ presentations:
   - title: "Wall: rendering vector graphics with OCaml and OpenGL"
     authors:
       - Frédéric Bour
+    video: https://watch.ocaml.org/videos/watch/2472168c-04aa-497d-a931-f866c7036550
   - title: "Winning on Windows: porting the OCaml Platform"
     authors:
       - David Allsopp
+    video: https://watch.ocaml.org/videos/watch/5020256d-eeb0-4e0b-81db-cde8ba00e3d7
 program_committee: 
   - name: Andrew Kennedy
     affiliation: Facebook, London


### PR DESCRIPTION
Added (4):

* Winning on Windows: porting the OCaml Platform
* R&B: Towards bringing functional programming to everyday's web programmer
* Relit: Implementing Typed Literal Macros in Reason
* Wall: rendering vector graphics with OCaml and OpenGL

Still Missing (8):

* Abusing Format for fun and profits
* MLExplain
* OCaml on the ESP32 chip: Well-Typed Lightbulbs Await
* RFCs, all the way down!
* The OCaml Platform 1.0
* The OCaml Software Foundation
* The Vecosek Ecosystem
* This PDF is an OCaml bytecode
