### PR TITLE
OCaml Workshop 2012 Videos, Copenhagen

### DIFF
--- a/data/workshops/2012.md
+++ b/data/workshops/2012.md
@@ -19,31 +19,31 @@ presentations:
   - title: Presenting Core
     authors: 
       - Yaron Minsky
-    link: http://www.youtube.com/watch?v=qFfS6-XKp9A&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/3159e115-948e-4f67-9d45-403bef003c35
   - title: 'Ocsigen/Eliom: The state of the art, and the prospects'
     authors: 
       - Benedikt Becker
       - Vincent Balat
-    link: http://www.youtube.com/watch?v=kk_o1QV9tQc&feature=plcp 
+    video: https://watch.ocaml.org/videos/watch/d010b30f-61d5-4d70-b10a-518a7a6e1e3f
   - title: Experiments in Generic Programming
     authors: 
       - Pierre Chambart
       - Grégoire Henry
-    link: http://www.youtube.com/watch?v=2EcucepyIyw&feature=plcp 
+    video: https://watch.ocaml.org/videos/watch/5ae26b10-9a5d-4395-89c6-a2e28e68d206
   - title: Async
     authors: 
       - Mark Shinwell
       - David House
-    link: http://www.youtube.com/watch?v=XhNBp46CpOk&feature=plcp 
+    video: https://watch.ocaml.org/videos/watch/8f50211a-1210-4849-a940-ea6e0bd1e022
   - title: OCamlCC -- Raising Low-Level Bytecode to High-Level C
     authors: 
       - Michel Mauny
       - Benoit Vaugon
-    link: http://www.youtube.com/watch?v=aHHKeWA88Xo&feature=plcp 
+    video: https://watch.ocaml.org/videos/watch/c31ec9fa-7c65-46f5-bbc9-77c6ac87bf0b
   - title: The State of OCaml
     authors: 
       - Xavier Leroy
-    link: http://www.youtube.com/watch?v=ANwpbkSxHZs&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/b04b10c1-b924-4f58-8aa9-4527dcc11d8a
   - title: 'OCamlPro: promoting OCaml use in industry'
     authors: 
       - Fabrice le Fessant
@@ -51,50 +51,51 @@ presentations:
   - title: Towards an OCaml Platform 
     authors: 
       - Yaron Minsky
-    link: http://www.youtube.com/watch?v=ZosM-KFOZ9s&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/96b1ab00-94a8-4059-aec6-a06a9c73c736
   - title: 'OPAM: an OCaml Package Manager'
     authors: 
       - Frederic Tuong
       - Fabrice le Fessant
       - Thomas Gazagnaire
-    link: http://www.youtube.com/watch?v=ivLqeRZJTGs&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/96b1ab00-94a8-4059-aec6-a06a9c73c736
   - title: An LLVM Backend for OCaml
     authors: 
       - Colin Benner
-    link: http://www.youtube.com/watch?v=wFsgHH297JE&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/3ede0b76-e250-4a43-af42-83c394cf4497
   - title: 'DragonKit: an extensible language oriented compiler'
     authors: 
       - Wojciech Meyer
+    video: https://watch.ocaml.org/videos/watch/8326a03e-02d5-4b32-8789-b7a76c30cf95
   - title: Programming the Xen cloud using OCaml 
     authors: 
       - David Scott
       - Richard Mortier
       - Anil Madhavapeddy
-    link: http://www.youtube.com/watch?v=dJlHBS7sP_c&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/360f8fe3-3268-44da-a0c4-b37c26aa7e36
   - title: 'Arakoon: a consistent distributed key value store'
     authors: 
       - Romain Slootmaekers
       - Nicolas Trangez
-    link: http://www.youtube.com/watch?v=9PFXV9OAN-s&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/5309b701-9def-47a4-8240-8a5b17a70b5a
   - title: 'gloc: Metaprogramming WebGL Shaders with OCaml'
     authors: 
       - David Sheets
-    link: http://www.youtube.com/watch?v=ll9z1ULtgqo&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/41ca2c8d-2238-44ca-8744-70f114fbd326
   - title: Real-world debugging in OCaml  
     authors: 
       - Mark Shinwell
-    link: http://www.youtube.com/watch?v=NF2WpWnB-nk&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/a8f4cf6b-9971-484b-ab5b-34a16fde1185
   - title: OCaml Companion Tools
     authors: 
       - Xavier Clerc
-    link: http://www.youtube.com/watch?v=V5MLwkrLfs8&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/4583b254-82f9-4176-9f39-2bc0bb6a9c22
   - title: Study of OCaml programs' memory behavior
     authors: 
       - Çagdas Bozman
       - Thomas Gazagnaire
       - Fabrice Le Fessant
       - Michel Mauny
-    link: http://www.youtube.com/watch?v=C2bZa6EYRyk&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/180ee1ea-6fa8-4dba-aa69-e3901cc3147f
   - title: Implementing an interval computation library for OCaml
     authors: 
       - Jean-Marc Alliot
@@ -102,11 +103,11 @@ presentations:
       - Jean-Baptiste Gotteland
       - Nicolas Durand
       - David Gianazza
-    link: http://www.youtube.com/watch?v=Bn0xSTmzZLA&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/e228951b-f544-4bd6-892a-2aca7e2065f9
   - title: Automatic Analysis of Industrial Robot Programs
     authors: 
       - Markus Weißmann
-    link: http://www.youtube.com/watch?v=2bURV8fh_v8&feature=plcp
+    video: https://watch.ocaml.org/videos/watch/3cebba55-4032-4de5-93b5-8f3f67c04736
   - title: 'Biocaml: The OCaml Bioinformatics Library'
     authors: 
       - Ashish Agarwal
@@ -114,7 +115,7 @@ presentations:
       - Philippe Veber
       - Christophe Troestler
       - Francois Berenger
-    link: http://www.youtube.com/watch?v=rzrqcTWc2V8&feature=plcp 
+    video: https://watch.ocaml.org/videos/watch/f9ce30b3-8143-4516-85f1-07c28f6337b2
 organising_committee: []
 program_committee: 
 


### PR DESCRIPTION
Replaced all but one YouTube Links by watch.ocaml.org
The video which was not replaced is the following:

* OCamlPro: promoting OCaml use in industry
