### PR TITLE
refactor+fix+improve learn layout to include optional right sidebar

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -33,18 +33,19 @@ let render ?(wide=false) () =
         </form>
       </div>
       <div class="hidden lg:flex">
-        <a href="<%s Url.getting_started %>"><button class="btn btn-sm">Get Started</button></a>
+        <a href="<%s Url.getting_started %>" class="btn btn-sm">Get Started</a>
       </div>
 
       <div
         class="hamburger lg:hidden flex h-12 w-12 hover:bg-primary-100 flex items-center justify-center rounded-full"
         x-on:click="open = ! open">
-        <dib class="text-body-400 dark:text-white">
+        <div class="text-body-400 dark:text-white">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24"
             stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M4 6h16M4 10h16M4 14h16M4 18h16" />
           </svg>
+        </div>
       </div>
     </div>
   </div>
@@ -66,8 +67,8 @@ let render ?(wide=false) () =
               stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
-            </i>
           </div>
+        </div>
       </li>
       <li>
         <form action="/packages/search" method="GET" class="form-input form-input-sm">
@@ -98,11 +99,10 @@ let render ?(wide=false) () =
         <a class="block" href="<%s Url.playground %>">Playground</a>
       </li>
       <li>
-        <a href="<%s Url.getting_started %>"><button class="btn w-full">Get started</button></a>
+        <a href="<%s Url.getting_started %>" class="btn w-full">Get started</a>
       </li>
 
       <li>
-
         <div class="space-x-6 text-2xl flex items-center">
           <a aria-label="OCaml's Discord" href="https://discord.gg/cCYQbqN" class="opacity-60 hover:opacity-100">
             <svg width="24" height="100%" viewBox="0 0 71 55" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -117,7 +117,6 @@ let render ?(wide=false) () =
                 </clipPath>
               </defs>
             </svg>
-
           </a>
           <a aria-label="The OCaml Compiler on GitHub" href="https://github.com/ocaml/ocaml" class="opacity-60 hover:opacity-100">
             <svg width="20" height="100%" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -2,38 +2,38 @@ let render ?(use_swiper=false) ?(banner = false) ?(wide=false) ?description ?sty
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta charset="utf-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" >
     <% (match description with | Some description -> %>
-    <meta name="description" content="<%s description %>" />
+    <meta name="description" content="<%s description %>" >
     <% | None -> ()); %>
-    <meta name="twitter:title" content="<%s title %>" />
+    <meta name="twitter:title" content="<%s title %>" >
     <% (match description with | Some description -> %>
-    <meta name="twitter:description" content="<%s description %>" />
+    <meta name="twitter:description" content="<%s description %>" >
     <% | None -> ()); %>
-    <meta property="og:site_name" content="OCaml" />
-    <meta property="og:type" content="object" />
-    <meta property="og:title" content="<%s title %>" />
+    <meta property="og:site_name" content="OCaml" >
+    <meta property="og:type" content="object" >
+    <meta property="og:title" content="<%s title %>" >
     <% (match description with | Some description -> %>
-    <meta property="og:description" content="<%s description %>" />
+    <meta property="og:description" content="<%s description %>" >
     <% | None -> ()); %>
-    <meta name="theme-color" content="#fff" />
-    <meta name="color-scheme" content="white" />
+    <meta name="theme-color" content="#fff" >
+    <meta name="color-scheme" content="white" >
     <% (match canonical with | Some canonical -> %>
-    <link rel="canonical" href="https://ocaml.org<%s canonical %>" />
+    <link rel="canonical" href="https://ocaml.org<%s canonical %>" >
     <% | None -> ()); %>
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" >
+    <link rel="manifest" href="/manifest.json" >
     <% (match styles with | Some styles -> styles |> List.iter (fun style -> %>
-    <link rel="stylesheet" href="<%s style %>" />
+    <link rel="stylesheet" href="<%s style %>" >
     <% ) | None -> %>
-    <link rel="stylesheet" href="/css/main.css" />
+    <link rel="stylesheet" href="/css/main.css" >
     <% ); %>
-    <link rel="stylesheet" href="/vendors/font-files/inter.css" />
+    <link rel="stylesheet" href="/vendors/font-files/inter.css" >
     <script defer src="/vendors/alpine.min.js"></script>
     <% if use_swiper then ( %>
-    <link rel="stylesheet" href="/vendors/swiper-bundle.min.css" />
-    <link rel="alternate" type="application/rss+xml" title="OCaml RSS Feed" href="/feed.xml"/>
+    <link rel="stylesheet" href="/vendors/swiper-bundle.min.css" >
+    <link rel="alternate" type="application/rss+xml" title="OCaml RSS Feed" href="/feed.xml">
     <script src="/vendors/swiper-bundle.min.js"></script>
     <% ); %>
     <title><%s title %></title>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -93,7 +93,7 @@ inner_html
   ~title
   ~description
   ~canonical @@
-  <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
+  <div class="bg-white" x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
     <div role="button" class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
       :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">
       <div class="transition-transform" :class='sidebar ? "" : "rotate-180" '>
@@ -102,29 +102,24 @@ inner_html
         </svg>
       </div>
     </div>
-    <div class="lg:py-24 bg-white pt-10 md:pt-16">
-      <div class="container-fluid wide">
-        <div class="flex gap-10">
-          <div
-            class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0  h-screen overflow-auto"
-            x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
-            x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
-            x-transition:leave-end="-translate-x-full">
-
-            <%s! left_sidebar_html %>
-          </div>
-
-          <div class="flex-1 flex flex-col min-w-0">
-            <%s! inner_html %>
-          </div>
-
-          <% (match right_sidebar_html with
-             | Some (html) -> %>
-            <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto right-sidebar">
-              <%s! html %>
-            </div>
-          <% | None -> () ); %>
+    <div class="container-fluid wide lg:py-24 pt-10 md:pt-16">
+      <div class="flex flex-col lg:flex-row md:gap-12">
+        <div
+          class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6 font-normal text-body-400"
+          x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
+          x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
+          x-transition:leave-end="-translate-x-full">
+          <%s! left_sidebar_html %>
         </div>
+        <div class="flex-1 z-0 z- w-full relative lg:pt-6">
+          <%s! inner_html %>
+        </div>
+        <% (match right_sidebar_html with
+            | Some (html) -> %>
+          <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto lg:pt-6 right-sidebar">
+            <%s! html %>
+          </div>
+        <% | None -> () ); %>
       </div>
     </div>
   </div>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -102,16 +102,16 @@ inner_html
         </svg>
       </div>
     </div>
-    <div class="container-fluid wide lg:py-24 pt-10 md:pt-16">
+    <div class="container-fluid wide lg:py-20 pt-10 md:pt-16">
       <div class="flex flex-col lg:flex-row md:gap-12">
         <div
-          class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6 font-normal text-body-400"
+          class="p-10 z-10 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"
           x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
           x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
           x-transition:leave-end="-translate-x-full">
           <%s! left_sidebar_html %>
         </div>
-        <div class="flex-1 z-0 z- w-full relative lg:pt-6">
+        <div class="flex-1 z-0 z- overflow-hidden lg:pt-6 <%s! if right_sidebar_html != None then "lg:max-w-3xl" else "" %>">
           <%s! inner_html %>
         </div>
         <% (match right_sidebar_html with

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -94,14 +94,14 @@ inner_html
   ~description
   ~canonical @@
   <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
-    <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
+    <div role="button" class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
       :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">
       <div class="transition-transform" :class='sidebar ? "" : "rotate-180" '>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
         </svg>
       </div>
-    </button>
+    </div>
     <div class="lg:py-24 bg-white pt-10 md:pt-16">
       <div class="container-fluid wide">
         <div class="flex gap-10">

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -106,7 +106,7 @@ inner_html
       <div class="container-fluid wide">
         <div class="flex gap-10">
           <div
-            class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0 md:py-4 h-screen overflow-auto"
+            class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0  h-screen overflow-auto"
             x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
             x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
             x-transition:leave-end="-translate-x-full">

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -120,7 +120,7 @@ inner_html
 
           <% (match right_sidebar_html with
              | Some (html) -> %>
-            <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 py-6 pl-6 overflow-auto right-sidebar">
+            <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto right-sidebar">
               <%s! html %>
             </div>
           <% | None -> () ); %>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -82,7 +82,8 @@ let render
 ~title
 ~description
 ~canonical
-sidebar_html
+~(left_sidebar_html: string)
+~(right_sidebar_html: string option)
 inner_html
 =
   Layout.render
@@ -103,16 +104,26 @@ inner_html
     </button>
     <div class="lg:py-24 bg-white pt-10 md:pt-16">
       <div class="container-fluid wide">
-        <div class="flex">
+        <div class="flex gap-10">
           <div
             class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed md:flex left-0 top-0 md:sticky md:w-72 md:p-0 md:py-4 h-screen overflow-auto"
             x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
             x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
             x-transition:leave-end="-translate-x-full">
 
-            <%s! sidebar_html %>
+            <%s! left_sidebar_html %>
           </div>
-          <%s! inner_html %>
+
+          <div class="flex-1 flex flex-col min-w-0">
+            <%s! inner_html %>
+          </div>
+
+          <% (match right_sidebar_html with
+             | Some (html) -> %>
+            <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 py-6 pl-6 overflow-auto right-sidebar">
+              <%s! html %>
+            </div>
+          <% | None -> () ); %>
         </div>
       </div>
     </div>

--- a/src/ocamlorg_frontend/pages/best_practices.eml
+++ b/src/ocamlorg_frontend/pages/best_practices.eml
@@ -6,13 +6,13 @@ Learn_layout.render
 ~title:"OCaml Best Practices"
 ~description:"Some guides to commonly used tools in OCaml development workflows."
 ~canonical:Url.best_practices
-(Learn_sidebar.render ~current_tutorial:(Some "best-practices") ~tutorials) @@
-<div class="flex-1 flex overflow-hidden flex-col md:pl-10">
+~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some "best-practices") ~tutorials)
+~right_sidebar_html: None @@
     <h1 class="font-bold mb-8">OCaml Best Practices</h1>
     <div class="prose prose-orange max-w-full">
-      <p>
+        <p>
         Workflows presented on this page assume <a href="<%s Url.getting_started %>">OCaml is Up and Running</a>.
-      </p>
+        </p>
     </div>
     <% best_practices |> List.iter (fun (item : Ood.Workflow.t) -> %>
     <div class="outline-none accordion-section mt-6" x-data="{accordion: false}">
@@ -37,4 +37,3 @@ Learn_layout.render
         </div>
     </div>
     <% ); %>
-</div>

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -7,8 +7,8 @@ Learn_layout.render
 ~title:"Learn OCaml"
 ~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual."
 ~canonical:Url.learn
-(Learn_sidebar.render ~tutorials ~current_tutorial:None) @@
-<div class="flex-1 flex flex-col md:pl-10 min-w-0">
+~left_sidebar_html:(Learn_sidebar.render ~tutorials ~current_tutorial:None)
+~right_sidebar_html:None @@
   <h1 class="font-bold mb-8">Learn OCaml</h1>
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10">
     <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white">
@@ -172,4 +172,3 @@ Learn_layout.render
       </button>
     </a>
   </div>
-</div>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -77,13 +77,9 @@ Package_layout.render
         <%s! content %>
       </div>
     </div>
-    <div class="hidden xl:flex top-0 sticky h-screen">
-      <div class="flex-col w-60">
-        <div class="h-screen overflow-scroll right-sidebar pt-6">
-          <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
-          <%s! Toc.render toc %>
-        </div>
-      </div>
+    <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto right-sidebar">
+      <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
+      <%s! Toc.render toc %>
     </div>
   </div>
 </div>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -4,7 +4,7 @@ let sidebar
 ~maptoc
 (package : Package_intf.package)
 =
-  <div class="flex flex-col">
+  <div class="flex flex-col font-normal text-body-400">
     <% if str_path != [] && toc != [] then ( %>
     <a title="Package <%s package.name %>" class="xl:hidden py-1 font-regular text-body-600 hover:text-orange-600 transition-colors mb-6" href="<%s Url.package_doc package.name package.version %>">
       back to documentation root
@@ -61,13 +61,13 @@ Package_layout.render
 
   <div class="flex flex-col lg:flex-row md:gap-12">
     <div
-      class="p-10 z-10 w-full bg-white flex-shrink-0 flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6 font-normal text-body-400"
+      class="p-10 z-10 w-full bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
       x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
       x-transition:leave-end="-translate-x-full">
       <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
-    <div class="flex-1 z-0 z- w-full lg:max-w-3xl relative lg:pt-6">
+    <div class="flex-1 z-0 z- overflow-hidden lg:max-w-3xl lg:pt-6">
       <% if (maptoc != []) && (List.length path > 1) then (%>
         <div class="text-body-400">
           <%s! Breadcrumbs.render path %>

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -6,8 +6,8 @@ Learn_layout.render
 ~title:"OCaml Platform"
 ~description:"The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml."
 ~canonical:Url.platform
-(Learn_sidebar.render ~current_tutorial:(Some "platform") ~tutorials) @@
-<div class="flex-1 flex flex-col md:pl-10 min-w-0">
+~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some "platform") ~tutorials)
+~right_sidebar_html:None @@
   <div class="prose prose-orange max-w-none">
     <h1>The OCaml Platform</h1>
     <p>
@@ -165,16 +165,15 @@ Learn_layout.render
       </div>
     </div>
   </div>
-</div>
-<script>
-  function videoFullWidth() {
-    return {
-      isPlaying: false,
-      embed_url: "https://watch.ocaml.org/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516",
-      iframe_param: "?autoplay=1&mute=1",
-      iframe_url() {
-        return this.embed_url + this.iframe_param;
-      },
-    };
-  }
-</script>
+  <script>
+    function videoFullWidth() {
+      return {
+        isPlaying: false,
+        embed_url: "https://watch.ocaml.org/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516",
+        iframe_param: "?autoplay=1&mute=1",
+        iframe_url() {
+          return this.embed_url + this.iframe_param;
+        },
+      };
+    }
+  </script>

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -39,8 +39,9 @@ Learn_layout.render
 ~title:"Exercises"
 ~description:"A list of exercises to work on your OCaml skills."
 ~canonical:Url.problems
-(problems_sidebar ~problems) @@
-  <div class="prose prose-orange overflow-hidden z-0 lg:max-w-full lg:w-full mx-auto relative py-8 px-6 lg:pt-0 lg:pl-10">
+~left_sidebar_html:(problems_sidebar ~problems)
+~right_sidebar_html:None @@
+  <div class="prose prose-orange max-w-full overflow-hidden">
     <h1 class="font-bold mb-8">Exercises</h1>
     <div class="prose prose-orange max-w-full mb-5">
       <p>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -15,7 +15,7 @@ Learn_layout.render
 ~canonical
 ~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
 ~right_sidebar_html:(Some(right_sidebar tutorial)) @@
-  <div class="prose prose-orange max-w-full lg:max-w-3xl">
+  <div class="prose prose-orange max-w-full">
     <%s! tutorial.body_html %>
     <div class="pt-10 border-t border-slate-200 lg:grid lg:grid-cols-3 gap-4 text-slate-500">
       <div class="lg:col-span-1">

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -1,13 +1,21 @@
+let right_sidebar
+(tutorial : Ood.Tutorial.t)
+=
+  <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
+  <div class="page-toc"><%s! tutorial.toc_html %></div>
+
 let render
 (tutorial : Ood.Tutorial.t)
 ~tutorials
 ~canonical
 =
-Learn_layout.render ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title) ~description:tutorial.description
-(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials) ~canonical
-@@
-<div class="flex-1 z-0 z- w-full lg:max-w-3xl mx-auto relative lg:pt-6">
-  <div class="prose prose-orange z-0 z- lg:max-w-3xl mx-auto relative lg:pt-6">
+Learn_layout.render
+~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title)
+~description:tutorial.description
+~canonical
+~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
+~right_sidebar_html:(Some(right_sidebar tutorial)) @@
+  <div class="prose prose-orange max-w-full">
     <%s! tutorial.body_html %>
     <div class="pt-10 border-t border-slate-200 lg:grid lg:grid-cols-3 gap-4 text-slate-500">
       <div class="lg:col-span-1">
@@ -48,12 +56,3 @@ Learn_layout.render ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.titl
       </div>
     </div>
   </div>
-</div>
-<div class="hidden xl:flex top-0 sticky h-screen">
-  <div class="flex-col w-60 py-6 pl-6">
-    <div class="h-screen overflow-auto right-sidebar">
-      <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
-      <div class="page-toc"><%s! tutorial.toc_html %></div>
-    </div>
-  </div>
-</div>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -15,7 +15,7 @@ Learn_layout.render
 ~canonical
 ~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
 ~right_sidebar_html:(Some(right_sidebar tutorial)) @@
-  <div class="prose prose-orange max-w-full">
+  <div class="prose prose-orange max-w-full lg:max-w-3xl">
     <%s! tutorial.body_html %>
     <div class="pt-10 border-t border-slate-200 lg:grid lg:grid-cols-3 gap-4 text-slate-500">
       <div class="lg:col-span-1">


### PR DESCRIPTION
Now all layout-related styles live in `learn_layout.eml`, instead of being spread across all consumers of `learn_layout.eml`.

screen-xl:
|page| before | after |
|-|-|-|
|learn| ![Screenshot 2023-01-06 at 20-17-34 Learn OCaml](https://user-images.githubusercontent.com/6594573/211083771-382df2b6-624b-4a78-bbdd-76e0ba354c76.png) | ![Screenshot 2023-01-06 at 20-17-38 Learn OCaml](https://user-images.githubusercontent.com/6594573/211083782-37f1c75c-95b4-42f1-9cf3-ba1671ce688e.png) |
| tutorial | ![Screenshot 2023-01-06 at 20-18-07 A First Hour with OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/211083843-39997934-18eb-4f39-a0af-9924971f16fe.png) | ![Screenshot 2023-01-06 at 20-18-10 A First Hour with OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/211083855-38e01e61-36f9-4a39-a77b-2ac3121278a9.png) |
| exercises | ![Screenshot 2023-01-06 at 20-18-39 Exercises](https://user-images.githubusercontent.com/6594573/211083913-4065d51a-d7f2-4170-9a71-4c530dd60ed2.png)| ![Screenshot 2023-01-06 at 20-18-42 Exercises](https://user-images.githubusercontent.com/6594573/211083924-3b7677b1-8f07-4003-9705-855ff826b48b.png)|
| platform | ![Screenshot 2023-01-06 at 20-19-12 OCaml Platform](https://user-images.githubusercontent.com/6594573/211083991-d9952f7a-db9c-4dab-88bf-76f47aa044d8.png)|![Screenshot 2023-01-06 at 20-19-15 OCaml Platform](https://user-images.githubusercontent.com/6594573/211083995-9966bd85-8b70-4568-bac0-e323919588df.png)|
| best_practices |![Screenshot 2023-01-06 at 20-19-43 OCaml Best Practices](https://user-images.githubusercontent.com/6594573/211084066-fa0f1e55-9123-446d-b6a4-d10469a9fba9.png)|![Screenshot 2023-01-06 at 20-19-47 OCaml Best Practices](https://user-images.githubusercontent.com/6594573/211084074-bc40c838-fdc4-4003-9a38-c54fd76407c0.png)|


This happens to fix the alignment problem of the content section on the tutorial page and a problem with the content being too wide on the tutorial page.

Prerequisite to fixing the problems with #761.

tutorial on screen-lg:
| before | after|
|-|-|
| ![Screenshot 2023-01-06 at 20-16-08 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/211083576-272d373a-9423-4b8c-ba36-9aa24f2953b2.png) | ![Screenshot 2023-01-06 at 20-16-12 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/211083593-a602ffac-7939-4eed-8382-9243959c52fd.png) |
