### PR TITLE
Update 013_run_decoding_direct.md

### DIFF
--- a/data/problems/013_run_decoding_direct.md
+++ b/data/problems/013_run_decoding_direct.md
@@ -23,7 +23,7 @@ type 'a rle =
                               else aux 0 (rle count a :: acc) t
     in
       List.rev (aux 0 [] list);;
-val encode : 'a list -> 'a rle list = <fun>
+val encode : int list -> int rle list = <fun>
 ```
 
 # Statement


### PR DESCRIPTION
In my environment(OCaml 4.14.0), the type of `encode` is `int list -> int rle list = <fun>`.

<img width="909" alt="Screenshot 2023-01-08 at 23 26 59" src="https://user-images.githubusercontent.com/37092773/211201685-229204cf-4229-4f88-bab8-15fd098e46ea.png">
