### PR TITLE
Set h4 font size smaller than h3

### DIFF
--- a/src/ocamlorg_frontend/css/partials/typography.css
+++ b/src/ocamlorg_frontend/css/partials/typography.css
@@ -26,13 +26,13 @@ h3 {
 }
 
 h4 {
-  font-size: 24px;
+  font-size: 18px;
   line-height: 110%;
 }
 
 @media (min-width: 1024px) {
   h4 {
-    font-size: 28px;
+    font-size: 18px;
   }
 }
 


### PR DESCRIPTION
Fix issue: https://github.com/ocaml/ocaml.org/issues/778
