### PR TITLE
make code tags render in the same font size as surrounding body text

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,15 +7,28 @@ module.exports = {
     extend: {
       typography: {
         DEFAULT: {
-          css: {
+          css: [{
             'code::before': {
               content: '""',
             },
             'code::after': {
               content: '""',
             },
-          }
-        }
+          },{
+            h1: {
+              fontWeight: 700,
+            },
+            code: {
+              fontSize: "1em",
+            },
+            'h2 code': {
+              fontSize: "1em",
+            },
+            'h3 code': {
+              fontSize: "1em",
+            },
+          }]
+        },
       },
       maxWidth: {
         '8xl': '90rem',


### PR DESCRIPTION
It has been identified in #673 that the `<code>` tags (particularly within headers, but also throughout the site) are misaligned with the rest of the text (due to different font size).

This patch proposes changes the font size of `<code>` tags to be the same as the surrounding text.

| before | after |
|-|-|
| ![Screenshot 2023-01-11 at 13-58-20 Documentation · opam-monorepo 0 3 5 · OCaml Packages](https://user-images.githubusercontent.com/6594573/211812871-1527a0ca-4403-4470-afb7-f8d7460e9105.png) | ![Screenshot 2023-01-11 at 13-58-23 Documentation · opam-monorepo 0 3 5 · OCaml Packages](https://user-images.githubusercontent.com/6594573/211812882-ed4c0444-30b9-436e-8614-b8625cb0341a.png) |
