### PR TITLE
use min-w-0 instead of overflow-hidden

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -111,7 +111,7 @@ inner_html
           x-transition:leave-end="-translate-x-full">
           <%s! left_sidebar_html %>
         </div>
-        <div class="flex-1 z-0 z- overflow-hidden lg:pt-6 <%s! if right_sidebar_html != None then "lg:max-w-3xl" else "" %>">
+        <div class="flex-1 z-0 z- min-w-0 lg:pt-6 <%s! if right_sidebar_html != None then "lg:max-w-3xl" else "" %>">
           <%s! inner_html %>
         </div>
         <% (match right_sidebar_html with

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -67,7 +67,7 @@ Package_layout.render
       x-transition:leave-end="-translate-x-full">
       <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
-    <div class="flex-1 z-0 z- overflow-hidden lg:max-w-3xl lg:pt-6">
+    <div class="flex-1 z-0 z- min-w-0 lg:max-w-3xl lg:pt-6">
       <% if (maptoc != []) && (List.length path > 1) then (%>
         <div class="text-body-400">
           <%s! Breadcrumbs.render path %>


### PR DESCRIPTION
We can't use `overflow-hidden` on the main content area because the hashtag-symbol that appears when hovering over a heading on the learn page or the package documentation will be "cut off".

In this context, `min-w-0` serves the same purpose as `overflow-hidden`: It ensures that the flexbox layout does not horizontally overflow its container.