### PR TITLE
Render self-referencing headings the same way as odoc

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -112,6 +112,10 @@ body {
   scroll-margin-top: 2rem;
 }
 
+.prose :is(h1, h2, h3, h4, h5, h6) {
+  position:relative;
+}
+
 .prose :is(h1, h2, h3, h4, h5, h6) > a,
 .prose :is(h1, h2, h3, h4, h5, h6) > a code,
 .prose :is(h1, h2, h3, h4, h5, h6) > a:hover,
@@ -121,12 +125,11 @@ body {
 }
 
 .prose :is(h1:target, h2:target, h3:target, h4:target, h5:target, h6:target) {
-  position:relative;
   background:rgb(255, 243, 173);
   padding: 0.2rem 0rem;
 }
 
-.prose :is(h1, h2, h3, h4, h5, h6) > a:hover::before {
+.prose :is(h1, h2, h3, h4, h5, h6)[id]:hover::before {
   content: "#";
   position: absolute;
   color: rgb(90, 98, 111);
@@ -134,6 +137,15 @@ body {
   padding: 0.39em;
   margin-top: -.37em;
   font-weight: 500;
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) > a.anchor {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  opacity: 0;
 }
 
 .prose a:hover {

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -111,7 +111,7 @@ inner_html
           x-transition:leave-end="-translate-x-full">
           <%s! left_sidebar_html %>
         </div>
-        <div class="flex-1 z-0 z- overflow-hidden lg:pt-6 <%s! if right_sidebar_html != None then "lg:max-w-3xl" else "" %>">
+        <div class="flex-1 z-0 z- min-w-0 lg:pt-6 <%s! if right_sidebar_html != None then "lg:max-w-3xl" else "" %>">
           <%s! inner_html %>
         </div>
         <% (match right_sidebar_html with

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -67,7 +67,7 @@ Package_layout.render
       x-transition:leave-end="-translate-x-full">
       <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
-    <div class="flex-1 z-0 z- overflow-hidden lg:max-w-3xl lg:pt-6">
+    <div class="flex-1 z-0 z- min-w-0 lg:max-w-3xl lg:pt-6">
       <% if (maptoc != []) && (List.length path > 1) then (%>
         <div class="text-body-400">
           <%s! Breadcrumbs.render path %>

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -54,9 +54,12 @@ let doc_with_ids doc =
             | (_, slug) :: _ -> slug (* Discard extra ids *)
           in
           let link : _ Omd.link =
-            { label = inline; destination = "#" ^ id; title = None }
+            { label = Text (attr, ""); destination = "#" ^ id; title = None }
           in
-          Heading (("id", id) :: attr, level, Link (attr, link))
+          Heading
+            ( ("id", id) :: attr,
+              level,
+              Concat ([], [ Link ([ ("class", "anchor") ], link); inline ]) )
       | el -> el)
     doc
 


### PR DESCRIPTION
Currently, the `a` tag CSS styles (coming from `tailwindcss-typography` via the `prose` class) override the font-weights of the headings in the Learn area

This patch changes the rendering of self-referencing headings to match `odoc` output.

Instead of generating `<h1 id="title"><a href="#title">TITLE</a></h1>` we generate `<h1 id="title"><a href="#title" class="anchor"></a>TITLE</h1>` and style that consistent with how the `odoc` output is styled.

|before|after|
|-|-|
| ![Screenshot 2023-01-11 at 17-45-09 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/211865611-20d34310-fc87-4b07-ab0f-f1cb521dc560.png) `font-weight` of `a` is applied on the heading| ![Screenshot 2023-01-11 at 17-45-15 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/211865626-0279b04d-3b5d-48ff-ad39-cc0263c1cf63.png) correct font-weight of the heading element is applied|
Other than that, it should behave identical.

Includes #786 (so that you are not irritated by cut-off hashtag-symbols).
