### PR TITLE
add a background-blurring overlay and make the sidebar not cover the full screen

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -102,10 +102,13 @@ inner_html
         </svg>
       </div>
     </div>
+    <div class="fixed z-10 inset-0 bg-background-dark-blue/20 backdrop-blur-sm lg:hidden"
+      :class='sidebar ? "" : "hidden"' aria-hidden="true" x-on:click="sidebar = ! sidebar"></div>
+
     <div class="container-fluid wide py-10">
       <div class="flex flex-col lg:flex-row md:gap-12">
         <div
-          class="p-10 z-10 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"
+          class="p-10 z-20 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky w-72 lg:p-0 lg:pt-6"
           x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
           x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
           x-transition:leave-end="-translate-x-full">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -50,18 +50,20 @@ Package_layout.render
 ~styles:["/css/main.css"; "/css/doc.css"]
 ~tab:Documentation @@
 <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
-  <button class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
+  <div role="button" class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
     :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">
     <div class="transform transition-transform" :class='sidebar ? "" : "rotate-180" '>
       <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
       </svg>
     </div>
-  </button>
+  </div>
+  <div class="fixed z-10 inset-0 bg-background-dark-blue/20 backdrop-blur-sm lg:hidden"
+    :class='sidebar ? "" : "hidden"' aria-hidden="true" x-on:click="sidebar = ! sidebar"></div>
 
   <div class="flex flex-col lg:flex-row md:gap-12">
     <div
-      class="p-10 z-10 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"
+      class="p-10 z-20 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky w-72 lg:p-0 lg:pt-6"
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
       x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
       x-transition:leave-end="-translate-x-full">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -61,7 +61,7 @@ Package_layout.render
 
   <div class="flex flex-col lg:flex-row md:gap-12">
     <div
-      class="p-10 z-10 w-full bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"
+      class="p-10 z-10 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
       x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
       x-transition:leave-end="-translate-x-full">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,7 @@ module.exports = {
         },
         background: {
           default: "#FAF8F3",
+          "dark-blue": "#0e1531", // one of the colors from the blue patterned background used in various parts of the site
         },
         body: {
           700: "#0A0C11",


### PR DESCRIPTION
On the package documentation page, there was a stray `w-full` in the sidebar styles which made the sidebar (on md- and smaller screens) cover the full screen when opened.

This patch also adds an overlay to blur and darken the background when the site is open.

|before|after|
|-|-|
|![Screenshot from 2023-01-12 10-11-26](https://user-images.githubusercontent.com/6594573/212025632-20a6eb66-6ff8-4e5e-b0e8-b4907763d82b.png)|![Screenshot from 2023-01-12 10-11-15](https://user-images.githubusercontent.com/6594573/212025645-5c42ea15-cdba-42e9-92c7-14278c1d95f3.png)|

