### PR TITLE
reduce whitespace on the learn area and blog page, minor visual impro…

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -102,7 +102,7 @@ inner_html
         </svg>
       </div>
     </div>
-    <div class="container-fluid wide lg:py-20 pt-10 md:pt-16">
+    <div class="container-fluid wide py-10">
       <div class="flex flex-col lg:flex-row md:gap-12">
         <div
           class="p-10 z-10 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky lg:w-72 lg:p-0 lg:pt-6"

--- a/src/ocamlorg_frontend/pages/blog.eml
+++ b/src/ocamlorg_frontend/pages/blog.eml
@@ -4,14 +4,14 @@ Layout.render
 ~title:"OCaml Blog"
 ~description:"Recent news and blog posts from the OCaml community."
 ~canonical:(Url.blog ^ if rss_page = 1 then "" else "?p=" ^ string_of_int rss_page) @@
-<div class="bg-white py-24">
+<div class="bg-white py-10">
     <div class="container-fluid wide">
         <div>
             <h2 class="font-bold">Blog</h2>
             <p class="text-lg text-body-400 mt-6">This is where you'll find the latest stories from the OCaml Community!</p>
         </div>
 
-        <div class="mt-20 grid grid-cols-1 md:grid-cols-3 gap-16">
+        <div class="mt-10 grid grid-cols-1 md:grid-cols-3 gap-16">
             <div class="col-span-2">
                 <div>
                     <div class="text-lg font-semibold border-b border-current text-primary-600 pb-3">Featured</div>
@@ -63,9 +63,9 @@ Layout.render
                     <%s! Pagination.render ~total_page_count:rss_pages_number ~page_number:rss_page ~base_url:Url.blog %>
                 </div>
             </div>
-            <div class="lg:border-l border-gray-200 lg:pl-16 space-y-12">
+            <div class="lg:pl-16 space-y-12">
 
-                <div class="text-lg font-semibold border-b border-gray-200 text-body-600 pb-3">News</div>
+                <div class="text-lg font-semibold border-b border-body-400 text-body-400 pb-3">News</div>
 
                 <% news |> List.iter (fun (item : Ood.News.t) -> %>
                 <div class="flex lg:space-x-12">


### PR DESCRIPTION
This patch
- reduces the whitespace around the content on the learn area pages and the blog page,
- removes the vertical divider on the blog page (due to good use of white space, it is unnecessary), and
- adjust the color of the "News" heading and the corresponding border so that visual hierarchy wrt to the "Featured" heading is established.

|page|before | after|
|-|-|-|
|learn| ![Screenshot 2023-01-12 at 10-51-00 Learn OCaml](https://user-images.githubusercontent.com/6594573/212034600-9c62ade8-7c48-4832-8f35-e4fe0eb18991.png) | ![Screenshot 2023-01-12 at 10-51-03 Learn OCaml](https://user-images.githubusercontent.com/6594573/212034610-c4c97d42-8d53-4ba3-9a76-2e69cad1abea.png)|
|exercises | ![Screenshot 2023-01-12 at 10-50-48 Exercises](https://user-images.githubusercontent.com/6594573/212034653-fcb76d04-69be-4a8f-9a56-49a970893da1.png) | ![Screenshot 2023-01-12 at 10-50-53 Exercises](https://user-images.githubusercontent.com/6594573/212034666-9591bd41-f921-4fb5-9af6-4575aaf743f7.png) |
| blog | ![Screenshot 2023-01-12 at 10-51-09 OCaml Blog](https://user-images.githubusercontent.com/6594573/212035417-101f6638-89c9-42e2-a3f5-9d49b568e775.png) | ![Screenshot 2023-01-12 at 10-58-54 OCaml Blog](https://user-images.githubusercontent.com/6594573/212036531-16d1e9e0-7aa9-4566-bb92-1d9dfd5921e1.png) |
