### PR TITLE
highlight the active menu item on the top nav bar

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -1,4 +1,25 @@
-let render ?(wide=false) () =
+type active_nav_item =
+  | Learn
+  | Packages
+  | Community
+  | Blog
+  | Playground
+
+let menu_link
+~(active: bool)
+~href
+~title
+?(_class="")
+()
+=
+  <a href="<%s href %>" class="<%s _class %> <%s if active then "underline" else "" %> hover:text-primary-600"><%s title %></a>
+
+
+let render
+?(wide=false)
+?(active_top_nav_item: active_nav_item option)
+()
+=
 <header 
   class="h-20 flex items-center text-white dark:bg-[#171717]"
   x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}"
@@ -10,11 +31,11 @@ let render ?(wide=false) () =
         <img src="/logo-with-name-white.svg" width="132" alt="OCaml logo" class="hidden dark:inline">
       </a>
       <ul class="space space-x-8 hidden lg:flex text-body-400 font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
-        <li><a href="<%s Url.learn %>" class="hover:text-primary-600">Learn</a></li>
-        <li><a href="<%s Url.packages %>" class="hover:text-primary-600">Packages</a></li>
-        <li><a href="<%s Url.community %>" class="hover:text-primary-600">Community</a></li>
-        <li><a href="<%s Url.blog %>" class="hover:text-primary-600">Blog</a></li>
-        <li><a href="<%s Url.playground %>" class="hover:text-primary-600">Playground</a></li>
+        <li><%s! menu_link ~active:(active_top_nav_item=Some Learn) ~href:Url.learn ~title:"Learn" () %></li>
+        <li><%s! menu_link ~active:(active_top_nav_item=Some Packages) ~href:Url.packages ~title:"Packages" () %></li>
+        <li><%s! menu_link ~active:(active_top_nav_item=Some Community) ~href:Url.community ~title:"Community" () %></li>
+        <li><%s! menu_link ~active:(active_top_nav_item=Some Blog) ~href:Url.blog ~title:"Blog" () %></li>
+        <li><%s! menu_link ~active:(active_top_nav_item=Some Playground) ~href:Url.playground ~title:"Playground" () %></li>
       </ul>
     </div>
     <div class="flex items-center space-x-8">
@@ -82,22 +103,12 @@ let render ?(wide=false) () =
           <input class="focus:ring-orange-500" type="search" id="q" name="q" placeholder="Search OCaml packages">
         </form>
       </li>
-      <li>
-        <a class="block" href="<%s Url.learn %>">Learn</a>
-      </li>
-      <li>
-        <a class="block" href="<%s Url.packages %>">Packages</a>
-      </li>
-      <li>
-        <a class="block" href="<%s Url.community %>">Community</a>
-      </li>
-      <li>
-      <li>
-        <a class="block" href="<%s Url.blog %>">Blog</a>
-      </li>
-      <li>
-        <a class="block" href="<%s Url.playground %>">Playground</a>
-      </li>
+
+      <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Learn) ~href:Url.learn ~title:"Learn" () %></li>
+      <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Packages) ~href:Url.packages ~title:"Packages" () %></li>
+      <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Community) ~href:Url.community ~title:"Community" () %></li>
+      <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Blog) ~href:Url.blog ~title:"Blog" () %></li>
+      <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Playground) ~href:Url.playground ~title:"Playground" () %></li>
       <li>
         <a href="<%s Url.getting_started %>" class="btn w-full">Get started</a>
       </li>

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -1,4 +1,13 @@
-let render ?(use_swiper=false) ?(banner = false) ?(wide=false) ?description ?styles ~title ?canonical inner =
+let render
+?(use_swiper=false)
+?(banner = false)
+?(wide=false)
+?description
+?styles
+~title
+?canonical
+?(active_top_nav_item: Header.active_nav_item option)
+inner =
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -59,7 +68,7 @@ let render ?(use_swiper=false) ?(banner = false) ?(wide=false) ?description ?sty
     </div>
     <% ); %>
     
-    <%s! Header.render ~wide () %>
+    <%s! Header.render ~wide ?active_top_nav_item () %>
 
     <main><%s! inner %></main>
 

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -82,6 +82,7 @@ let render
 ~title
 ~description
 ~canonical
+?active_top_nav_item
 ~(left_sidebar_html: string)
 ~(right_sidebar_html: string option)
 inner_html
@@ -92,7 +93,8 @@ inner_html
   ~wide:true
   ~title
   ~description
-  ~canonical @@
+  ~canonical
+  ?active_top_nav_item @@
   <div class="bg-white" x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024">
     <div role="button" class="bg-primary-600  p-3 z-30 rounded-r-xl text-white shadow-md top-2/4 fixed lg:hidden left-0"
       :class="sidebar ? 'pl-1 pr-2': ''" x-on:click="sidebar = ! sidebar">

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -15,7 +15,8 @@ Layout.render
 ~wide:true
 ~title
 ~description
-~canonical @@
+~canonical
+~active_top_nav_item:Header.Packages @@
 <div class="bg-white">
   <div class="py-5 lg:py-6">
     <div class="container-fluid wide">

--- a/src/ocamlorg_frontend/pages/best_practices.eml
+++ b/src/ocamlorg_frontend/pages/best_practices.eml
@@ -6,6 +6,7 @@ Learn_layout.render
 ~title:"OCaml Best Practices"
 ~description:"Some guides to commonly used tools in OCaml development workflows."
 ~canonical:Url.best_practices
+~active_top_nav_item:Header.Learn
 ~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some "best-practices") ~tutorials)
 ~right_sidebar_html: None @@
     <h1 class="font-bold mb-8">OCaml Best Practices</h1>

--- a/src/ocamlorg_frontend/pages/blog.eml
+++ b/src/ocamlorg_frontend/pages/blog.eml
@@ -3,7 +3,8 @@ Layout.render
 ~wide:true
 ~title:"OCaml Blog"
 ~description:"Recent news and blog posts from the OCaml community."
-~canonical:(Url.blog ^ if rss_page = 1 then "" else "?p=" ^ string_of_int rss_page) @@
+~canonical:(Url.blog ^ if rss_page = 1 then "" else "?p=" ^ string_of_int rss_page)
+~active_top_nav_item:Header.Blog @@
 <div class="bg-white py-10">
     <div class="container-fluid wide">
         <div>

--- a/src/ocamlorg_frontend/pages/books.eml
+++ b/src/ocamlorg_frontend/pages/books.eml
@@ -45,7 +45,8 @@ let render books =
 Layout.render
 ~title:"OCaml Books"
 ~description:"A selection of books to learn the OCaml programming language."
-~canonical:Url.books @@
+~canonical:Url.books
+~active_top_nav_item:Header.Learn @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -13,7 +13,8 @@ let upcoming_workshops = List.filter (fun (w : Ood.Workshop.t) -> w.date >= curr
 Layout.render
 ~title:"The OCaml Community"
 ~description:"Looking to interact with people who are also interested in OCaml? Find out about upcoming events, read up on blogs from the community, sign up for OCaml mailing lists, and discover even more places to engage with people from the community!"
-~canonical:Url.community @@
+~canonical:Url.community
+~active_top_nav_item:Header.Community @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/events.eml
+++ b/src/ocamlorg_frontend/pages/events.eml
@@ -14,7 +14,8 @@ let upcoming_workshops = List.filter (fun (w : Ood.Workshop.t) -> w.date >= curr
 Layout.render
 ~title:"OCaml Events"
 ~description:"Several events take place in the OCaml community over the course of each year, in countries all over the
-world. See past events and upcoming ones on this page." @@
+world. See past events and upcoming ones on this page."
+~active_nav_item:Header.Community @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/jobs.eml
+++ b/src/ocamlorg_frontend/pages/jobs.eml
@@ -3,7 +3,8 @@ Layout.render
 ~title:"OCaml Jobs"
 ~description:"This is a space where groups, companies, and organisations can advertise their projects directly to the
 OCaml community."
-~canonical:Url.jobs @@
+~canonical:Url.jobs
+~active_top_nav_item:Header.Community @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -7,6 +7,7 @@ Learn_layout.render
 ~title:"Learn OCaml"
 ~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual."
 ~canonical:Url.learn
+~active_top_nav_item:Header.Learn
 ~left_sidebar_html:(Learn_sidebar.render ~tutorials ~current_tutorial:None)
 ~right_sidebar_html:None @@
   <h1 class="font-bold mb-8">Learn OCaml</h1>

--- a/src/ocamlorg_frontend/pages/news.eml
+++ b/src/ocamlorg_frontend/pages/news.eml
@@ -2,7 +2,8 @@ let render ~pages_number ~page (news : Ood.News.t list) =
 Layout.render
 ~title:"OCaml News"
 ~description:"Read the latest news, releases, and updates from the OCaml community."
-~canonical:(Url.news ^ if page = 1 then "" else "?p=" ^ string_of_int page) @@
+~canonical:(Url.news ^ if page = 1 then "" else "?p=" ^ string_of_int page)
+~active_top_nav_item:Header.Blog @@
 <div class="bg-white py-24">
   <div class="container-fluid">
     <div>

--- a/src/ocamlorg_frontend/pages/news_post.eml
+++ b/src/ocamlorg_frontend/pages/news_post.eml
@@ -2,7 +2,8 @@ let render (news : Ood.News.t) =
 Layout.render
 ~title:news.title
 ~description:news.description
-~canonical:(Url.news_post news.slug) @@
+~canonical:(Url.news_post news.slug)
+~active_top_nav_item:Blog @@
 <div class="bg-white py-24">
   <div class="container-fluid">
     <div class="mx-auto max-w-5xl">

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -6,7 +6,8 @@ let render (stats : packages_stats option) (featured_packages : package list) =
 Layout.render
 ~title:"OCaml Packages · Browse Community Packages"
 ~description:"Discover thousands of community packages and browse their documentation."
-~canonical:Url.packages @@
+~canonical:Url.packages
+~active_top_nav_item:Header.Packages @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,6 +1,7 @@
 let render ~total ~search (packages : Package_intf.package list) = Layout.render ~title:"OCaml Packages · Search Result"
 ~description:"Find the package you need to build your application in the thousands of available OCaml packages."
-~canonical:(Url.packages_search ^ "?q=" ^ search) @@
+~canonical:(Url.packages_search ^ "?q=" ^ search)
+~active_top_nav_item:Header.Packages @@
 <div class="bg-white">
   <div class="py-10 lg:py-14">
     <div class="container-fluid">

--- a/src/ocamlorg_frontend/pages/papers.eml
+++ b/src/ocamlorg_frontend/pages/papers.eml
@@ -2,7 +2,8 @@ let render ?(search = "") ~(recommended_papers : Ood.Paper.t list) (papers : Ood
 Layout.render
 ~title:"OCaml Papers"
 ~description:"A selection of papers grouped by popular categories."
-~canonical:Url.papers @@
+~canonical:Url.papers
+~active_top_nav_item:Header.Learn @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -6,6 +6,7 @@ Learn_layout.render
 ~title:"OCaml Platform"
 ~description:"The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml."
 ~canonical:Url.platform
+~active_top_nav_item:Header.Learn
 ~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some "platform") ~tutorials)
 ~right_sidebar_html:None @@
   <div class="prose prose-orange max-w-none">

--- a/src/ocamlorg_frontend/pages/playground.eml
+++ b/src/ocamlorg_frontend/pages/playground.eml
@@ -25,7 +25,7 @@ let render () =
   </head>
 
   <body class="dark">
-    <%s! Header.render ~wide:true () %>
+    <%s! Header.render ~wide:true ~active_top_nav_item:Header.Playground () %>
 
     <main>
       <div class="flex code-editor">

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -39,6 +39,7 @@ Learn_layout.render
 ~title:"Exercises"
 ~description:"A list of exercises to work on your OCaml skills."
 ~canonical:Url.problems
+~active_top_nav_item:Header.Learn
 ~left_sidebar_html:(problems_sidebar ~problems)
 ~right_sidebar_html:None @@
   <div class="prose prose-orange max-w-full overflow-hidden">

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -13,6 +13,7 @@ Learn_layout.render
 ~title:(Printf.sprintf "%s · OCaml Tutorials" tutorial.title)
 ~description:tutorial.description
 ~canonical
+~active_top_nav_item:Learn
 ~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
 ~right_sidebar_html:(Some(right_sidebar tutorial)) @@
   <div class="prose prose-orange max-w-full">

--- a/src/ocamlorg_frontend/pages/workshop.eml
+++ b/src/ocamlorg_frontend/pages/workshop.eml
@@ -2,7 +2,8 @@ let render ~(videos : (string, Ood.Watch.t) Hashtbl.t) (workshop : Ood.Workshop.
 Layout.render
 ~title:workshop.title
 ~description:(Printf.sprintf "A description of the workshop %s held on %s" workshop.title workshop.date)
-~canonical:(Url.workshop workshop.slug) @@
+~canonical:(Url.workshop workshop.slug)
+~active_top_nav_item:Header.Community @@
 <div class="intro-section-simple">
   <div class="container-fluid">
     <div class="flex flex-col lg:flex-row justify-between items-center">


### PR DESCRIPTION
Patch adds subtle highlighting of the site area we are currently in by underlining the top nav bar item. This gives people a better sense of "where they are on the site".

|before|after|
|-|-|
|![Screenshot 2023-01-12 at 12-32-34 OCaml Playground](https://user-images.githubusercontent.com/6594573/212056067-09acab2e-e287-446f-ad67-5f0de6d78561.png)|![Screenshot 2023-01-12 at 12-32-40 OCaml Playground](https://user-images.githubusercontent.com/6594573/212056091-ea1af37a-6ae3-43fe-85fc-17f0f822cf6e.png)|
|![Screenshot 2023-01-12 at 12-33-33 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/212056237-fc8218dc-079c-4367-8738-508f412d9fc0.png)|![Screenshot 2023-01-12 at 12-33-36 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/212056243-4e43db0e-1091-40b7-a5e4-fe0b42443672.png)|
|![Screenshot 2023-01-12 at 12-34-19 Exercises](https://user-images.githubusercontent.com/6594573/212056397-bf3b48d6-1962-453f-a974-f088afa6f5a7.png)|![Screenshot 2023-01-12 at 12-34-22 Exercises](https://user-images.githubusercontent.com/6594573/212056412-a74bf5bb-bb60-475c-b08e-da448e8081c0.png)|

