### PR TITLE
Ood: Use ppx_stable for data processing

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -74,6 +74,7 @@
   user-agent-parser
   digestif
   ppx_deriving_yojson
+  ppx_stable
   yojson
   (timedesc
    (>= 0.8.0))

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -51,6 +51,7 @@ depends: [
   "user-agent-parser"
   "digestif"
   "ppx_deriving_yojson"
+  "ppx_stable"
   "yojson"
   "timedesc" {>= "0.8.0"}
   "ppx_deriving_yaml"

--- a/tool/ood-gen/lib/academic_institution.ml
+++ b/tool/ood-gen/lib/academic_institution.ml
@@ -30,24 +30,16 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving stable_record ~version:metadata ~remove:[ body_md; body_html; slug ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.name
 let all () =
   Utils.map_files
     (fun content ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        name = metadata.name;
-        slug = Utils.slugify metadata.name;
-        description = metadata.description;
-        url = metadata.url;
-        logo = metadata.logo;
-        continent = metadata.continent;
-        courses = metadata.courses;
-        location = metadata.location;
-        body_md = body;
-        body_html = Omd.of_string body |> Omd.to_html;
-      })
+      let body_html = Omd.of_string body_md |> Omd.to_html in
+      of_metadata metadata ~body_md ~body_html)
     "academic_institutions"
 
 let pp_course ppf (v : course) =

--- a/tool/ood-gen/lib/academic_institution.ml
+++ b/tool/ood-gen/lib/academic_institution.ml
@@ -33,7 +33,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ body_md; body_html; slug ]]
 
-let of_metadata m = of_metadata m ~slug:m.name
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.name)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/academic_institution.ml
+++ b/tool/ood-gen/lib/academic_institution.ml
@@ -30,9 +30,11 @@ type t = {
   body_md : string;
   body_html : string;
 }
-[@@deriving stable_record ~version:metadata ~remove:[ body_md; body_html; slug ]]
+[@@deriving
+  stable_record ~version:metadata ~remove:[ body_md; body_html; slug ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.name
+let of_metadata m = of_metadata m ~slug:m.name
+
 let all () =
   Utils.map_files
     (fun content ->

--- a/tool/ood-gen/lib/book.ml
+++ b/tool/ood-gen/lib/book.ml
@@ -32,7 +32,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
-let of_metadata m = of_metadata m ~slug:m.title
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/book.ml
+++ b/tool/ood-gen/lib/book.ml
@@ -29,9 +29,10 @@ type t = {
   body_md : string;
   body_html : string;
 }
-[@@deriving stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
+[@@deriving
+  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+let of_metadata m = of_metadata m ~slug:m.title
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/book.ml
+++ b/tool/ood-gen/lib/book.ml
@@ -29,27 +29,18 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
+
+let of_metadata metadata = of_metadata metadata ~slug:metadata.title
 
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        title = metadata.title;
-        slug = Utils.slugify metadata.title;
-        description = metadata.description;
-        authors = metadata.authors;
-        language = metadata.language;
-        published = metadata.published;
-        cover = metadata.cover;
-        isbn = metadata.isbn;
-        links = metadata.links;
-        rating = metadata.rating;
-        featured = metadata.featured;
-        body_md = String.trim body;
-        body_html = Omd.of_string body |> Omd.to_html;
-      })
+      let body_md = String.trim body in
+      let body_html = Omd.of_string body |> Omd.to_html in
+      of_metadata metadata ~body_md ~body_html)
     "books/"
 
 let pp_link ppf (v : link) =

--- a/tool/ood-gen/lib/dune
+++ b/tool/ood-gen/lib/dune
@@ -13,9 +13,10 @@
   uri
   lambdasoup
   fpath
+  ppx_stable
   hilite)
  (preprocess
-  (pps ppx_deriving_yaml)))
+  (pps ppx_deriving_yaml ppx_stable)))
 
 (rule
  (targets data.ml)

--- a/tool/ood-gen/lib/industrial_user.ml
+++ b/tool/ood-gen/lib/industrial_user.ml
@@ -21,24 +21,17 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
 let all () =
   Utils.map_files
     (fun content ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        name = metadata.name;
-        slug = Utils.slugify metadata.name;
-        description = metadata.description;
-        logo = metadata.logo;
-        url = metadata.url;
-        consortium = metadata.consortium;
-        featured = metadata.featured;
-        locations = metadata.locations;
-        body_md = body;
-        body_html = Omd.of_string body |> Omd.to_html;
-      })
+      let slug = Utils.slugify metadata.name in
+      let body_html = Omd.of_string body_md |> Omd.to_html in
+      of_metadata metadata ~slug ~body_md ~body_html)
     "industrial_users"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/industrial_user.ml
+++ b/tool/ood-gen/lib/industrial_user.ml
@@ -24,7 +24,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.name
+let of_metadata m = of_metadata m ~slug:m.name
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/industrial_user.ml
+++ b/tool/ood-gen/lib/industrial_user.ml
@@ -24,14 +24,15 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.name
+
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let slug = Utils.slugify metadata.name in
       let body_html = Omd.of_string body_md |> Omd.to_html in
-      of_metadata metadata ~slug ~body_md ~body_html)
+      of_metadata metadata ~body_md ~body_html)
     "industrial_users"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/industrial_user.ml
+++ b/tool/ood-gen/lib/industrial_user.ml
@@ -24,7 +24,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
-let of_metadata m = of_metadata m ~slug:m.name
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.name)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/meetup.ml
+++ b/tool/ood-gen/lib/meetup.ml
@@ -15,9 +15,9 @@ type t = {
   textual_location : string;
   location : location;
 }
+[@@deriving stable_record ~version:metadata ~remove:[slug]]
 
-let of_metadata ({ title; url; textual_location; location } : metadata) =
-  { title; slug = Utils.slugify title; url; textual_location; location }
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in

--- a/tool/ood-gen/lib/meetup.ml
+++ b/tool/ood-gen/lib/meetup.ml
@@ -15,7 +15,7 @@ type t = {
   textual_location : string;
   location : location;
 }
-[@@deriving stable_record ~version:metadata ~remove:[slug]]
+[@@deriving stable_record ~version:metadata ~remove:[ slug ]]
 
 let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -13,8 +13,10 @@ type t = {
   date : string;
   slug : string;
   tags : string list;
+  authors : string list option;
   body_html : string;
 }
+[@@deriving stable_record ~version:metadata ~remove:[ slug; body_html ]]
 
 let all () =
   Utils.map_files_with_names
@@ -22,15 +24,10 @@ let all () =
       let slug = Filename.basename (Filename.remove_extension fname) in
       let metadata, body = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        title = metadata.title;
-        slug;
-        description = metadata.description;
-        date = metadata.date;
-        tags = metadata.tags;
-        body_html =
-          Omd.to_html (Hilite.Md.transform (Omd.of_string (String.trim body)));
-      })
+      let body_html =
+        Omd.to_html (Hilite.Md.transform (Omd.of_string (String.trim body)))
+      in
+      of_metadata metadata ~slug ~body_html)
     "news/*/*.md"
   |> List.sort (fun a b -> String.compare b.date a.date)
 

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -13,10 +13,10 @@ type t = {
   date : string;
   slug : string;
   tags : string list;
-  authors : string list option;
   body_html : string;
 }
-[@@deriving stable_record ~version:metadata ~remove:[ slug; body_html ]]
+[@@deriving
+  stable_record ~version:metadata ~add:[ authors ] ~remove:[ slug; body_html ]]
 
 let all () =
   Utils.map_files_with_names

--- a/tool/ood-gen/lib/page.ml
+++ b/tool/ood-gen/lib/page.ml
@@ -16,20 +16,20 @@ type t = {
   body_html : string;
 }
 [@@deriving
-  stable_record ~version:metadata ~remove:[ fname; body_md; body_html ]]
+  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
 let all () =
   Utils.map_files_with_names
     (fun (file, content) ->
       let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let omd = Omd.of_string body in
+      let omd = Omd.of_string body_md in
       let body_html = Omd.to_html (Hilite.Md.transform omd) in
       let slug =
         file |> Filename.basename |> Filename.remove_extension
         |> String.map (function '_' -> '-' | c -> c)
       in
-      of_metadata metadata ~fname ~body_md ~body_html)
+      of_metadata metadata ~slug ~body_md ~body_html)
     "pages/*.md"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/page.ml
+++ b/tool/ood-gen/lib/page.ml
@@ -15,26 +15,21 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~remove:[ fname; body_md; body_html ]]
 
 let all () =
   Utils.map_files_with_names
     (fun (file, content) ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
       let omd = Omd.of_string body in
+      let body_html = Omd.to_html (Hilite.Md.transform omd) in
       let slug =
         file |> Filename.basename |> Filename.remove_extension
         |> String.map (function '_' -> '-' | c -> c)
       in
-      {
-        slug;
-        title = metadata.title;
-        description = metadata.description;
-        meta_title = metadata.title;
-        meta_description = metadata.description;
-        body_md = body;
-        body_html = Omd.to_html (Hilite.Md.transform omd);
-      })
+      of_metadata metadata ~fname ~body_md ~body_html)
     "pages/*.md"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/paper.ml
+++ b/tool/ood-gen/lib/paper.ml
@@ -23,21 +23,9 @@ type t = {
   links : link list;
   featured : bool;
 }
+[@@deriving stable_record ~version:metadata ~remove:[slug]]
 
-let of_metadata
-    ({ title; publication; authors; abstract; tags; year; links; featured } :
-      metadata) =
-  {
-    title;
-    slug = Utils.slugify title;
-    publication;
-    authors;
-    abstract;
-    tags;
-    year;
-    links;
-    featured;
-  }
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in

--- a/tool/ood-gen/lib/paper.ml
+++ b/tool/ood-gen/lib/paper.ml
@@ -23,7 +23,7 @@ type t = {
   links : link list;
   featured : bool;
 }
-[@@deriving stable_record ~version:metadata ~remove:[slug]]
+[@@deriving stable_record ~version:metadata ~remove:[ slug ]]
 
 let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 

--- a/tool/ood-gen/lib/problem.ml
+++ b/tool/ood-gen/lib/problem.ml
@@ -5,7 +5,7 @@ module Proficiency = struct
     | "beginner" -> Ok `Beginner
     | "intermediate" -> Ok `Intermediate
     | "advanced" -> Ok `Advanced
-    | s -> Error (`Msg ("Unknown proficiency type: " ^ s)
+    | s -> Error (`Msg ("Unknown proficiency type: " ^ s))
 end
 
 type metadata = {

--- a/tool/ood-gen/lib/problem.ml
+++ b/tool/ood-gen/lib/problem.ml
@@ -55,7 +55,9 @@ type t = {
   stable_record ~version:metadata ~modify:[ difficulty ]
     ~remove:[ statement; solution ]]
 
-let of_metadata = of_metadata ~modify_difficulty:(fun d -> d |> Proficiency.of_string |> Result.get_ok)
+let of_metadata =
+  of_metadata ~modify_difficulty:(fun d ->
+      d |> Proficiency.of_string |> Result.get_ok)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -1,6 +1,6 @@
 type kind = [ `Compiler ]
 
-let kind_of_string = function
+let modify_kind = function
   | "compiler" -> `Compiler
   | _ -> raise (Exn.Decode_error "Unknown release kind")
 
@@ -26,6 +26,12 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~modify:[ kind ] ~add:[ intro; highlights ]
+    ~remove:
+      [
+        intro_md; intro_html; highlights_md; highlights_html; body_md; body_html;
+      ]]
 
 let sort_by_decreasing_version x y =
   let to_list s = List.map int_of_string_opt @@ String.split_on_char '.' s in
@@ -34,24 +40,19 @@ let sort_by_decreasing_version x y =
 let all () =
   Utils.map_files
     (fun content ->
-      let metadata, body = Utils.extract_metadata_body content in
-      let metadata =
-        try Utils.decode_or_raise metadata_of_yaml metadata
-        with _ -> failwith content
+      let metadata, body_md = Utils.extract_metadata_body content in
+      let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
+      let intro_md = metadata.intro in
+      let intro_html = Omd.of_string metadata.intro |> Omd.to_html in
+      let highlights_md = metadata.highlights in
+      let highlights_html =
+        Omd.of_string metadata.highlights |> Hilite.Md.transform |> Omd.to_html
       in
-      {
-        kind = kind_of_string metadata.kind;
-        version = metadata.version;
-        date = metadata.date;
-        intro_md = metadata.intro;
-        intro_html = Omd.of_string metadata.intro |> Omd.to_html;
-        highlights_md = metadata.highlights;
-        highlights_html =
-          Omd.of_string metadata.highlights
-          |> Hilite.Md.transform |> Omd.to_html;
-        body_md = body;
-        body_html = Omd.of_string body |> Hilite.Md.transform |> Omd.to_html;
-      })
+      let body_html =
+        Omd.of_string body_md |> Hilite.Md.transform |> Omd.to_html
+      in
+      of_metadata metadata ~modify_kind ~intro_md ~intro_html ~highlights_md
+        ~highlights_html ~body_md ~body_html)
     "releases/"
   |> List.sort sort_by_decreasing_version
 

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -1,6 +1,6 @@
 type kind = [ `Compiler ]
 
-let modify_kind = function
+let kind_of_string = function
   | "compiler" -> `Compiler
   | _ -> raise (Exn.Decode_error "Unknown release kind")
 
@@ -34,7 +34,7 @@ type t = {
       ]]
 
 let of_metadata metadata =
-  of_metadata metadata ~modify_kind ~intro_md:metadata.intro
+  of_metadata metadata ~modify_kind:kind_of_string ~intro_md:metadata.intro
     ~highlights_md:metadata.highlights
 
 let sort_by_decreasing_version x y =

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -33,6 +33,10 @@ type t = {
         intro_md; intro_html; highlights_md; highlights_html; body_md; body_html;
       ]]
 
+let of_metadata metadata =
+  of_metadata metadata ~modify_kind ~intro_md:metadata.intro
+    ~highlights_md:metadata.highlights
+
 let sort_by_decreasing_version x y =
   let to_list s = List.map int_of_string_opt @@ String.split_on_char '.' s in
   compare (to_list y.version) (to_list x.version)
@@ -42,17 +46,14 @@ let all () =
     (fun content ->
       let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let intro_md = metadata.intro in
       let intro_html = Omd.of_string metadata.intro |> Omd.to_html in
-      let highlights_md = metadata.highlights in
       let highlights_html =
         Omd.of_string metadata.highlights |> Hilite.Md.transform |> Omd.to_html
       in
       let body_html =
         Omd.of_string body_md |> Hilite.Md.transform |> Omd.to_html
       in
-      of_metadata metadata ~modify_kind ~intro_md ~intro_html ~highlights_md
-        ~highlights_html ~body_md ~body_html)
+      of_metadata metadata ~intro_html ~highlights_html ~body_md ~body_html)
     "releases/"
   |> List.sort sort_by_decreasing_version
 

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -33,9 +33,9 @@ type t = {
         intro_md; intro_html; highlights_md; highlights_html; body_md; body_html;
       ]]
 
-let of_metadata metadata =
-  of_metadata metadata ~modify_kind:kind_of_string ~intro_md:metadata.intro
-    ~highlights_md:metadata.highlights
+let of_metadata m =
+  of_metadata m ~modify_kind:kind_of_string ~intro_md:m.intro
+    ~highlights_md:m.highlights
 
 let sort_by_decreasing_version x y =
   let to_list s = List.map int_of_string_opt @@ String.split_on_char '.' s in

--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -117,15 +117,17 @@ type t = {
   stable_record ~version:metadata ~modify:[ featured ]
     ~remove:[ slug; body_html ]]
 
+let of_metadata metadata =
+  of_metadata metadata ~slug:metadata.title
+    ~modify_featured:(Option.value ~default:false)
+
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let slug = Utils.slugify metadata.title in
-      let modify_featured = Option.value ~default:false in
       let body_html = String.trim body in
-      of_metadata metadata ~modify_featured ~slug ~body_html)
+      of_metadata metadata ~body_html)
     "rss/*/*.md"
   |> List.sort (fun a b -> String.compare b.date a.date)
 

--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -113,22 +113,19 @@ type t = {
   featured : bool;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~modify:[ featured ]
+    ~remove:[ slug; body_html ]]
 
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        title = metadata.title;
-        slug = Utils.slugify metadata.title;
-        description = metadata.description;
-        url = metadata.url;
-        date = metadata.date;
-        preview_image = metadata.preview_image;
-        featured = Option.value metadata.featured ~default:false;
-        body_html = String.trim body;
-      })
+      let slug = Utils.slugify metadata.title in
+      let modify_featured = Option.value ~default:false in
+      let body_html = String.trim body in
+      of_metadata metadata ~modify_featured ~slug ~body_html)
     "rss/*/*.md"
   |> List.sort (fun a b -> String.compare b.date a.date)
 

--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -117,9 +117,8 @@ type t = {
   stable_record ~version:metadata ~modify:[ featured ]
     ~remove:[ slug; body_html ]]
 
-let of_metadata metadata =
-  of_metadata metadata ~slug:metadata.title
-    ~modify_featured:(Option.value ~default:false)
+let of_metadata m =
+  of_metadata m ~slug:m.title ~modify_featured:(Option.value ~default:false)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -118,7 +118,8 @@ type t = {
     ~remove:[ slug; body_html ]]
 
 let of_metadata m =
-  of_metadata m ~slug:m.title ~modify_featured:(Option.value ~default:false)
+  of_metadata m ~slug:(Utils.slugify m.title)
+    ~modify_featured:(Option.value ~default:false)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/success_story.ml
+++ b/tool/ood-gen/lib/success_story.ml
@@ -22,14 +22,15 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let slug = Utils.slugify metadata.title in
       let body_html = Omd.of_string body_md |> Omd.to_html in
-      of_metadata metadata ~slug ~body_md ~body_html)
+      of_metadata metadata ~body_md ~body_html)
     "success_stories"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/success_story.ml
+++ b/tool/ood-gen/lib/success_story.ml
@@ -19,23 +19,17 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
 let all () =
   Utils.map_files
     (fun content ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        title = metadata.title;
-        slug = Utils.slugify metadata.title;
-        logo = metadata.logo;
-        background = metadata.background;
-        theme = metadata.theme;
-        synopsis = metadata.synopsis;
-        url = metadata.url;
-        body_md = body;
-        body_html = Omd.of_string body |> Omd.to_html;
-      })
+      let slug = Utils.slugify metadata.title in
+      let body_html = Omd.of_string body_md |> Omd.to_html in
+      of_metadata metadata ~slug ~body_md ~body_html)
     "success_stories"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/success_story.ml
+++ b/tool/ood-gen/lib/success_story.ml
@@ -22,7 +22,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
-let of_metadata m = of_metadata m ~slug:m.title
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/success_story.ml
+++ b/tool/ood-gen/lib/success_story.ml
@@ -22,7 +22,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+let of_metadata m = of_metadata m ~slug:m.title
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -38,6 +38,8 @@ type t = {
   stable_record ~version:metadata ~modify:[ lifecycle; description ]
     ~remove:[ slug ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.name
+
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in
   match yaml with
@@ -46,10 +48,9 @@ let decode s =
         (List.map
            (fun x ->
              let metadata = Utils.decode_or_raise metadata_of_yaml x in
-             let slug = Utils.slugify metadata.name in
              let modify_lifecycle = Utils.decode_or_raise Lifecycle.of_string in
              let modify_description v = Omd.of_string v |> Omd.to_html in
-             of_metadata metadata ~modify_lifecycle ~modify_description ~slug)
+             of_metadata metadata ~modify_lifecycle ~modify_description)
            xs)
   | _ -> Error (`Msg "expected a list of tools")
 

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -38,7 +38,10 @@ type t = {
   stable_record ~version:metadata ~modify:[ lifecycle; description ]
     ~remove:[ slug ]]
 
-let of_metadata m = of_metadata m ~slug:m.name
+let of_metadata m =
+  of_metadata m ~slug:m.name
+    ~modify_lifecycle:(Utils.decode_or_raise Lifecycle.of_string)
+    ~modify_description:(fun v -> Omd.of_string v |> Omd.to_html)
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in
@@ -48,9 +51,7 @@ let decode s =
         (List.map
            (fun x ->
              let metadata = Utils.decode_or_raise metadata_of_yaml x in
-             let modify_lifecycle = Utils.decode_or_raise Lifecycle.of_string in
-             let modify_description v = Omd.of_string v |> Omd.to_html in
-             of_metadata metadata ~modify_lifecycle ~modify_description)
+             of_metadata metadata)
            xs)
   | _ -> Error (`Msg "expected a list of tools")
 

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -34,6 +34,9 @@ type t = {
   description : string;
   lifecycle : Lifecycle.t;
 }
+[@@deriving
+  stable_record ~version:metadata ~modify:[ lifecycle; description ]
+    ~remove:[ slug ]]
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in
@@ -43,22 +46,10 @@ let decode s =
         (List.map
            (fun x ->
              let metadata = Utils.decode_or_raise metadata_of_yaml x in
-             let lifecycle =
-               Utils.decode_or_raise Lifecycle.of_string metadata.lifecycle
-             in
-             let description =
-               Omd.of_string metadata.description |> Omd.to_html
-             in
-             ({
-                name = metadata.name;
-                slug = Utils.slugify metadata.name;
-                source = metadata.source;
-                license = metadata.license;
-                synopsis = metadata.synopsis;
-                description;
-                lifecycle;
-              }
-               : t))
+             let slug = Utils.slugify metadata.name in
+             let modify_lifecycle = Utils.decode_or_raise Lifecycle.of_string in
+             let modify_description v = Omd.of_string v |> Omd.to_html in
+             of_metadata metadata ~modify_lifecycle ~modify_description ~slug)
            xs)
   | _ -> Error (`Msg "expected a list of tools")
 

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -39,7 +39,7 @@ type t = {
     ~remove:[ slug ]]
 
 let of_metadata m =
-  of_metadata m ~slug:m.name
+  of_metadata m ~slug:(Utils.slugify m.name)
     ~modify_lifecycle:(Utils.decode_or_raise Lifecycle.of_string)
     ~modify_description:(fun v -> Omd.of_string v |> Omd.to_html)
 

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -38,7 +38,7 @@ type t = {
   stable_record ~version:metadata ~modify:[ lifecycle; description ]
     ~remove:[ slug ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.name
+let of_metadata m = of_metadata m ~slug:m.name
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -22,7 +22,7 @@ type t = {
   stable_record ~version:metadata ~add:[ id ]
     ~remove:[ slug; fpath; toc_html; body_md; body_html ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.id
+let of_metadata m = of_metadata m ~slug:m.id
 
 (* Copied from ocaml/omd, html.ml *)
 let to_plain_text t =

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -22,6 +22,8 @@ type t = {
   stable_record ~version:metadata ~add:[ id ]
     ~remove:[ slug; fpath; toc_html; body_md; body_html ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.id
+
 (* Copied from ocaml/omd, html.ml *)
 let to_plain_text t =
   let buf = Buffer.create 1024 in
@@ -66,15 +68,14 @@ let filter_heading_1 doc =
 
 let all () =
   Utils.map_files_with_names
-    (fun (file, content) ->
+    (fun (fpath, content) ->
       let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
       let omd = doc_with_ids (Omd.of_string body_md) in
       let toc_doc = filter_heading_1 omd in
       let toc_html = Omd.to_html (Omd.toc ~depth:4 toc_doc) in
       let body_html = Omd.to_html (Hilite.Md.transform omd) in
-      of_metadata metadata ~fpath:file ~slug:metadata.id ~toc_html ~body_md
-        ~body_html)
+      of_metadata metadata ~fpath ~toc_html ~body_md ~body_html)
     "tutorials/*.md"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -18,6 +18,9 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~add:[ id ]
+    ~remove:[ slug; fpath; toc_html; body_md; body_html ]]
 
 (* Copied from ocaml/omd, html.ml *)
 let to_plain_text t =
@@ -64,21 +67,14 @@ let filter_heading_1 doc =
 let all () =
   Utils.map_files_with_names
     (fun (file, content) ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let omd = doc_with_ids (Omd.of_string body) in
+      let omd = doc_with_ids (Omd.of_string body_md) in
       let toc_doc = filter_heading_1 omd in
-      {
-        title = metadata.title;
-        fpath = file;
-        slug = metadata.id;
-        description = metadata.description;
-        date = metadata.date;
-        category = metadata.category;
-        toc_html = Omd.to_html (Omd.toc ~depth:4 toc_doc);
-        body_md = body;
-        body_html = Omd.to_html (Hilite.Md.transform omd);
-      })
+      let toc_html = Omd.to_html (Omd.toc ~depth:4 toc_doc) in
+      let body_html = Omd.to_html (Hilite.Md.transform omd) in
+      of_metadata metadata ~fpath:file ~slug:metadata.id ~toc_html ~body_md
+        ~body_html)
     "tutorials/*.md"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -40,7 +40,7 @@ type t = {
 }
 [@@deriving stable_record ~version:metadata ~modify:[ kind ] ~remove:[ slug ]]
 
-let of_metadata m = of_metadata m ~slug:m.title
+let of_metadata m = of_metadata m ~slug:m.title ~modify_kind:(Utils.decode_or_raise Kind.of_string)
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in
@@ -50,8 +50,7 @@ let decode s =
         (List.map
            (fun x ->
              let metadata = Utils.decode_or_raise metadata_of_yaml x in
-             let modify_kind = Utils.decode_or_raise Kind.of_string in
-             of_metadata metadata ~modify_kind)
+             of_metadata metadata)
            xs)
   | _ -> Error (`Msg "expected a list of videos")
 

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -40,7 +40,9 @@ type t = {
 }
 [@@deriving stable_record ~version:metadata ~modify:[ kind ] ~remove:[ slug ]]
 
-let of_metadata m = of_metadata m ~slug:m.title ~modify_kind:(Utils.decode_or_raise Kind.of_string)
+let of_metadata m =
+  of_metadata m ~slug:m.title
+    ~modify_kind:(Utils.decode_or_raise Kind.of_string)
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -41,7 +41,7 @@ type t = {
 [@@deriving stable_record ~version:metadata ~modify:[ kind ] ~remove:[ slug ]]
 
 let of_metadata m =
-  of_metadata m ~slug:m.title
+  of_metadata m ~slug:(Utils.slugify m.title)
     ~modify_kind:(Utils.decode_or_raise Kind.of_string)
 
 let decode s =

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -40,7 +40,7 @@ type t = {
 }
 [@@deriving stable_record ~version:metadata ~modify:[ kind ] ~remove:[ slug ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+let of_metadata m = of_metadata m ~slug:m.title
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -38,6 +38,7 @@ type t = {
   embed : string option;
   year : int;
 }
+[@@deriving stable_record ~version:metadata ~modify:[ kind ] ~remove:[ slug ]]
 
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in
@@ -47,20 +48,9 @@ let decode s =
         (List.map
            (fun x ->
              let metadata = Utils.decode_or_raise metadata_of_yaml x in
-             let kind = Utils.decode_or_raise Kind.of_string metadata.kind in
-             ({
-                title = metadata.title;
-                slug = Utils.slugify metadata.title;
-                description = metadata.description;
-                people = metadata.people;
-                kind;
-                tags = metadata.tags;
-                paper = metadata.paper;
-                link = metadata.link;
-                embed = metadata.embed;
-                year = metadata.year;
-              }
-               : t))
+             let slug = Utils.slugify metadata.title in
+             let modify_kind = Utils.decode_or_raise Kind.of_string in
+             of_metadata metadata ~slug ~modify_kind)
            xs)
   | _ -> Error (`Msg "expected a list of videos")
 

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -40,6 +40,8 @@ type t = {
 }
 [@@deriving stable_record ~version:metadata ~modify:[ kind ] ~remove:[ slug ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+
 let decode s =
   let yaml = Utils.decode_or_raise Yaml.of_string s in
   match yaml with
@@ -48,9 +50,8 @@ let decode s =
         (List.map
            (fun x ->
              let metadata = Utils.decode_or_raise metadata_of_yaml x in
-             let slug = Utils.slugify metadata.title in
              let modify_kind = Utils.decode_or_raise Kind.of_string in
-             of_metadata metadata ~slug ~modify_kind)
+             of_metadata metadata ~modify_kind)
            xs)
   | _ -> Error (`Msg "expected a list of videos")
 

--- a/tool/ood-gen/lib/workflow.ml
+++ b/tool/ood-gen/lib/workflow.ml
@@ -2,18 +2,15 @@ type metadata = { title : string } [@@deriving of_yaml]
 type t = { title : string; body_md : string; body_html : string }
 [@@deriving stable_record ~version:metadata ~remove:[ body_md; body_html ]]
 
-let of_metadata ({ title } : metadata) body_md body_html =
-  { title; body_md; body_html }
-
 let all () =
   Utils.map_files
     (fun content ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
       let body_html =
-        Omd.of_string body |> Hilite.Md.transform |> Omd.to_html
+        Omd.of_string body_md |> Hilite.Md.transform |> Omd.to_html
       in
-      of_metadata metadata body body_html)
+      of_metadata metadata ~body_md ~body_html)
     "workflows/*.md"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/workflow.ml
+++ b/tool/ood-gen/lib/workflow.ml
@@ -1,4 +1,5 @@
 type metadata = { title : string } [@@deriving of_yaml]
+
 type t = { title : string; body_md : string; body_html : string }
 [@@deriving stable_record ~version:metadata ~remove:[ body_md; body_html ]]
 

--- a/tool/ood-gen/lib/workflow.ml
+++ b/tool/ood-gen/lib/workflow.ml
@@ -1,16 +1,19 @@
 type metadata = { title : string } [@@deriving of_yaml]
 type t = { title : string; body_md : string; body_html : string }
+[@@deriving stable_record ~version:metadata ~remove:[ body_md; body_html ]]
+
+let of_metadata ({ title } : metadata) body_md body_html =
+  { title; body_md; body_html }
 
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      {
-        title = metadata.title;
-        body_md = body;
-        body_html = Omd.of_string body |> Hilite.Md.transform |> Omd.to_html;
-      })
+      let body_html =
+        Omd.of_string body |> Hilite.Md.transform |> Omd.to_html
+      in
+      of_metadata metadata body body_html)
     "workflows/*.md"
 
 let pp ppf v =

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -61,7 +61,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; toc_html; body_md; body_html ]]
 
-let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+let of_metadata m = of_metadata m ~slug:m.title
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -58,26 +58,19 @@ type t = {
   body_md : string;
   body_html : string;
 }
+[@@deriving
+  stable_record ~version:metadata ~remove:[ slug; toc_html; body_md; body_html ]]
 
 let all () =
   Utils.map_files
     (fun content ->
-      let metadata, body = Utils.extract_metadata_body content in
+      let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let omd = Omd.of_string body in
-      {
-        title = metadata.title;
-        slug = Utils.slugify metadata.title;
-        location = metadata.location;
-        date = metadata.date;
-        important_dates = metadata.important_dates;
-        presentations = metadata.presentations;
-        program_committee = metadata.program_committee;
-        organising_committee = metadata.organising_committee;
-        toc_html = Omd.to_html (Omd.toc ~depth:4 omd);
-        body_md = body;
-        body_html = Omd.to_html omd;
-      })
+      let slug = Utils.slugify metadata.title in
+      let omd = Omd.of_string body_md in
+      let toc_html = Omd.to_html (Omd.toc ~depth:4 omd) in
+      let body_html = Omd.to_html omd in
+      of_metadata metadata ~slug ~toc_html ~body_md ~body_html)
     "workshops/*.md"
   |> List.sort (fun w1 w2 -> String.compare w2.date w1.date)
 

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -61,7 +61,7 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; toc_html; body_md; body_html ]]
 
-let of_metadata m = of_metadata m ~slug:m.title
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 
 let all () =
   Utils.map_files

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -61,16 +61,17 @@ type t = {
 [@@deriving
   stable_record ~version:metadata ~remove:[ slug; toc_html; body_md; body_html ]]
 
+let of_metadata metadata = of_metadata metadata ~slug:metadata.title
+
 let all () =
   Utils.map_files
     (fun content ->
       let metadata, body_md = Utils.extract_metadata_body content in
       let metadata = Utils.decode_or_raise metadata_of_yaml metadata in
-      let slug = Utils.slugify metadata.title in
       let omd = Omd.of_string body_md in
       let toc_html = Omd.to_html (Omd.toc ~depth:4 omd) in
       let body_html = Omd.to_html omd in
-      of_metadata metadata ~slug ~toc_html ~body_md ~body_html)
+      of_metadata metadata ~toc_html ~body_md ~body_html)
     "workshops/*.md"
   |> List.sort (fun w1 w2 -> String.compare w2.date w1.date)
 


### PR DESCRIPTION
Use PPX library [ppx_stable](https://github.com/janestreet/ppx_stable) to generate functions translating
metadata read from Yaml into ood data: `of_metadata`

Files using ppx_stable:
* `tool/ood-gen/lib/academic_institution.ml`
* `tool/ood-gen/lib/book.ml`
* `tool/ood-gen/lib/industrial_user.ml`
* `tool/ood-gen/lib/meetup.ml`
* `tool/ood-gen/lib/news.ml`
* `tool/ood-gen/lib/page.ml`
* `tool/ood-gen/lib/paper.ml`
* `tool/ood-gen/lib/problem.ml`
* `tool/ood-gen/lib/release.ml`
* `tool/ood-gen/lib/rss.ml`
* `tool/ood-gen/lib/success_story.ml`
* `tool/ood-gen/lib/tool.ml`
* `tool/ood-gen/lib/tutorial.ml`
* `tool/ood-gen/lib/video.ml`
* `tool/ood-gen/lib/workflow.ml`
* `tool/ood-gen/lib/workshop.ml`

Files not using ppx_stable:
* `tool/ood-gen/lib/job.ml`
* `tool/ood-gen/lib/opam_user.ml`
* `tool/ood-gen/lib/packages.ml`
* `tool/ood-gen/lib/watch.ml`

Note:

* This ppx can be used to generate conversion functions between
almost identical records.
* Adds base as a transitive dependency
