### PR TITLE
adjust styling of hero links on learn page

### DIFF
--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -10,12 +10,12 @@ Learn_layout.render
 ~left_sidebar_html:(Learn_sidebar.render ~tutorials ~current_tutorial:None)
 ~right_sidebar_html:None @@
   <h1 class="font-bold mb-8">Learn OCaml</h1>
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 xl:gap-8 border-b border-gray-200 pb-10">
     <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white lg:max-h-96 overflow-hidden">
-      <div class="p-6 lg:p-8">
+      <div class="p-6 xl:p-8 h-full xl:h-auto flex flex-col">
         <h2 class="font-bold mb-2">Get Started</h2>
         <div class="font-medium mb-4 opacity-80">Learn how to get OCaml set up in your project.</div>
-        <a href="<%s Url.getting_started %>">
+        <a class="mt-auto" href="<%s Url.getting_started %>">
           <button
             class="bg-black font-semibold h-12 px-5 rounded-md bg-opacity-10 hover:bg-opacity-20 transition-colors"
           >
@@ -29,13 +29,12 @@ Learn_layout.render
     </div>
 
     <div class="relative flex-1 bg-gradient-to-br from-purple-400 to-purple-700 rounded-xl text-white lg:max-h-96 overflow-hidden">
-      <div class="p-6 lg:p-8">
-        <h2 class="font-bold mb-2">Learn with Exercises</h2>
+      <div class="p-6 xl:p-8 h-full xl:h-auto flex flex-col">
+        <h2 class="font-bold mb-2">Solve Exercises</h2>
         <div class="font-medium mb-4 opacity-80">
-          Learning by doing, or do by <br />
-          learning!
+          Learning by doing, or do by learning!
         </div>
-        <a href="<%s Url.problems %>">
+        <a class="mt-auto" href="<%s Url.problems %>">
           <button
             class="bg-black font-semibold h-12 px-5 rounded-md bg-opacity-10 hover:bg-opacity-20 transition-colors"
           >
@@ -49,12 +48,12 @@ Learn_layout.render
     </div>
 
     <div class="relative flex-1 bg-gradient-to-br from-emerald-400 to-emerald-700 rounded-xl text-white lg:max-h-96 overflow-hidden">
-      <div class="p-6 lg:p-8">
+      <div class="p-6 xl:p-8 h-full xl:h-auto flex flex-col">
         <h2 class="font-bold mb-2">Language Manual</h2>
-        <div class="font-medium mb-4 opacity-80">Read the language manual to get a deeper understanding!</div>
-        <a href="<%s Url.manual %>">
+        <div class="font-medium mb-4 opacity-80">Acquire a deeper understanding!</div>
+        <a class="mt-auto" href="<%s Url.manual %>">
           <button
-            class="bg-black font-semibold h-12 px-5 rounded-md bg-opacity-10 hover:bg-opacity-20 transition-colors"
+            class="whitespace-nowrap bg-black font-semibold h-12 px-5 rounded-md bg-opacity-10 hover:bg-opacity-20 transition-colors"
           >
             Take Me There
           </button>

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -11,8 +11,8 @@ Learn_layout.render
 ~right_sidebar_html:None @@
   <h1 class="font-bold mb-8">Learn OCaml</h1>
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 border-b border-gray-200 pb-10">
-    <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white">
-      <div class="p-8">
+    <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white lg:max-h-96 overflow-hidden">
+      <div class="p-6 lg:p-8">
         <h2 class="font-bold mb-2">Get Started</h2>
         <div class="font-medium mb-4 opacity-80">Learn how to get OCaml set up in your project.</div>
         <a href="<%s Url.getting_started %>">
@@ -23,13 +23,13 @@ Learn_layout.render
           </button>
         </a>
       </div>
-      <div class="flex justify-end pl-8">
+      <div class="hidden xl:flex justify-end pl-8">
         <img src="/img/learn/learn-get-started.svg" class="w-full" alt="Get Started background" />
       </div>
     </div>
 
-    <div class="relative flex-1 bg-gradient-to-br from-purple-400 to-purple-700 rounded-xl text-white">
-      <div class="p-8">
+    <div class="relative flex-1 bg-gradient-to-br from-purple-400 to-purple-700 rounded-xl text-white lg:max-h-96 overflow-hidden">
+      <div class="p-6 lg:p-8">
         <h2 class="font-bold mb-2">Learn with Exercises</h2>
         <div class="font-medium mb-4 opacity-80">
           Learning by doing, or do by <br />
@@ -43,13 +43,13 @@ Learn_layout.render
           </button>
         </a>
       </div>
-      <div class="flex justify-end pl-8">
+      <div class="hidden xl:flex justify-end pl-8">
         <img src="/img/learn/learn-exercise.svg" class="w-full" alt="Exercises Background" />
       </div>
     </div>
 
-    <div class="relative flex-1 bg-gradient-to-br from-emerald-400 to-emerald-700 rounded-xl text-white">
-      <div class="p-8">
+    <div class="relative flex-1 bg-gradient-to-br from-emerald-400 to-emerald-700 rounded-xl text-white lg:max-h-96 overflow-hidden">
+      <div class="p-6 lg:p-8">
         <h2 class="font-bold mb-2">Language Manual</h2>
         <div class="font-medium mb-4 opacity-80">Read the language manual to get a deeper understanding!</div>
         <a href="<%s Url.manual %>">
@@ -60,7 +60,7 @@ Learn_layout.render
           </button>
         </a>
       </div>
-      <div class="flex justify-end pl-8">
+      <div class="hidden xl:flex justify-end pl-8">
         <img src="/img/learn/learn-language.svg" class="w-full" alt="Manual background" />
       </div>
     </div>


### PR DESCRIPTION
Addresses https://github.com/ocaml/ocaml.org/issues/823 by compacting the hero links on lg- and below screens.

Minor adjustments to wording to better fit the space.

|screen|before|after|
|-|-|-|
|sm|![Screenshot 2023-01-17 at 13-46-33 Learn OCaml](https://user-images.githubusercontent.com/6594573/212902999-67fe5516-8b26-4422-99d7-773050a471c5.png)|![Screenshot 2023-01-17 at 13-46-37 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903010-2e0640ac-6ccb-49f2-a0fc-4981cbd06ba7.png)|
|md|![Screenshot 2023-01-17 at 13-46-21 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903053-fd1e3965-f66e-4934-8604-cf94e734a9a7.png)|![Screenshot 2023-01-17 at 13-46-27 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903060-b4b13ef5-f530-41f6-8717-6fb7cc8f504b.png)|
|lg|![Screenshot 2023-01-17 at 13-47-29 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903099-81402e17-a83f-4bcd-8ffa-f0af7f8fec17.png)|![Screenshot 2023-01-17 at 13-47-32 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903114-f0613243-0faf-48f0-abe6-509fafe90e50.png)|
|xl|![Screenshot 2023-01-17 at 13-50-46 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903473-8333c289-814a-46fd-89b1-31953fc30d80.png)|![Screenshot 2023-01-17 at 13-50-50 Learn OCaml](https://user-images.githubusercontent.com/6594573/212903489-dc8f647d-168e-4ae6-ad14-17068d77455d.png)|

