### PR TITLE
make package documentation link more obvious

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -96,7 +96,7 @@ Package_layout.render
         <div class="flex flex-col mt-8 text-body-400">
             <% (match documentation_status with
             | `Success -> %>
-            <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
+            <a href="<%s Url.package_doc package.name package.version %>" class="px-4 h-10 items-center mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
               </svg>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -1,3 +1,32 @@
+let icon_homepage =
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+    </svg>
+
+let icon_changelog =
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+    </svg>
+
+let icon_license =
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
+        stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+    </svg>
+
+let icon_edit =
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+    </svg>
+
+let side_box_link ~href ~title ~icon_html =
+    <a href="<%s href %>" class="flex items-center py-2 px-4 hover:text-primary-600">
+        <%s! icon_html %>
+        <%s title %>
+    </a>
+
 let render
 ~documentation_status
 ~readme
@@ -64,17 +93,17 @@ Package_layout.render
             </div>
         </div>
         <% ); %>
-        <div class="flex flex-col mt-9 space-y-4 text-body-400">
+        <div class="flex flex-col mt-8 text-body-400">
             <% (match documentation_status with
             | `Success -> %>
-            <a href="<%s Url.package_doc package.name package.version %>" class="flex items-center text-primary-600 font-bold hover:underline mb-2">
+            <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
               </svg>
               Documentation
             </a>
             <% | `Unknown -> ( %>
-            <a href="<%s Url.package_doc package.name package.version %>" class="p-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#4b5563">
                 <path d="M0 0h24v24H0V0z" fill="none"/>
                 <path d="M15.32 3H8.68c-.26 0-.52.11-.7.29L3.29 7.98c-.18.18-.29.44-.29.7v6.63c0 .27.11.52.29.71l4.68 4.68c.19.19.45.3.71.3h6.63c.27 0 .52-.11.71-.29l4.68-4.68c.19-.19.29-.44.29-.71V8.68c0-.27-.11-.52-.29-.71l-4.68-4.68c-.18-.18-.44-.29-.7-.29zM12 17.3c-.72 0-1.3-.58-1.3-1.3s.58-1.3 1.3-1.3 1.3.58 1.3 1.3-.58 1.3-1.3 1.3zm0-4.3c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1z"/>
@@ -82,7 +111,7 @@ Package_layout.render
               Documentation status is unknown.
             </a><% )
             | `Failure -> ( %>
-            <a href="<%s Url.package_doc package.name package.version %>" class="p-4 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#4b5563">
                 <path d="M0 0h24v24H0V0z" fill="none"/>
                 <path d="M15.32 3H8.68c-.26 0-.52.11-.7.29L3.29 7.98c-.18.18-.29.44-.29.7v6.63c0 .27.11.52.29.71l4.68 4.68c.19.19.45.3.71.3h6.63c.27 0 .52-.11.71-.29l4.68-4.68c.19-.19.29-.44.29-.71V8.68c0-.27-.11-.52-.29-.71l-4.68-4.68c-.18-.18-.44-.29-.7-.29zM12 17.3c-.72 0-1.3-.58-1.3-1.3s.58-1.3 1.3-1.3 1.3.58 1.3 1.3-.58 1.3-1.3 1.3zm0-4.3c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1z"/>
@@ -90,38 +119,15 @@ Package_layout.render
               Documentation failed to build.
             </a><% ));%>
             <% homepages |> List.iter (fun homepage -> %>
-            <a href="<%s homepage %>" class="flex items-center hover:text-primary-600">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
-              </svg>
-              <%s Utils.host_of_uri homepage %>
-            </a>
+            <%s! side_box_link ~icon_html:icon_homepage ~href:homepage ~title:(Utils.host_of_uri homepage) %>
             <% ); %>
             <% (match changes_filename with Some changes_filename -> %>
-            <a href="<%s Url.package_doc package.name package.version ~page:(changes_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-                Changelog
-            </a>
+            <%s! side_box_link ~icon_html:icon_changelog ~href:(Url.package_doc package.name package.version ~page:(changes_filename ^ ".html")) ~title:"Changelog" %>
             <% | _ -> ()); %>
             <% (match license_filename with Some license_filename -> %>
-            <a href="<%s Url.package_doc package.name package.version ~page:(license_filename ^ ".html") %>" class="flex items-center hover:text-primary-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24"
-                    stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
-                </svg>
-                <%s package.license %> License
-            </a>
+            <%s! side_box_link ~icon_html:icon_license ~href:(Url.package_doc package.name package.version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
             <% | _ -> ()); %>
-            <a href="<%s Url.github_opam_file package.name package.version %>" class="flex items-center hover:text-primary-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline-block" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-                </svg>
-                Edit opam file
-            </a>
+            <%s! side_box_link ~icon_html:icon_license ~href:(Url.github_opam_file package.name package.version) ~title:"Edit opam file" %>
         </div>
         <div class="mt-8">
             <dt class="font-semibold text-base text-body-400">Published</dt>


### PR DESCRIPTION
Makes the documentation link on the package overview page more obvious. Somewhat addresses https://github.com/ocaml/ocaml.org/issues/826. Further improvements require a more radical change of layout.

Factors out the icons and side-box links in separate templates.

|before|after|
|-|-|
|![Screenshot 2023-01-19 at 14-17-13 irmin 3 5 1 · OCaml Package](https://user-images.githubusercontent.com/6594573/213452603-8a1f061b-f678-46e1-bf0d-baa0e9f69aed.png)|![Screenshot 2023-01-19 at 14-17-17 irmin 3 5 1 · OCaml Package](https://user-images.githubusercontent.com/6594573/213452618-d1d9e97d-744b-4579-8546-9f6f6c90d153.png)|
|![Screenshot 2023-01-19 at 14-17-54 irmin 0 9 1 · OCaml Package](https://user-images.githubusercontent.com/6594573/213452695-8366a4d8-2446-4cec-bc6e-4cf4e2596b85.png)|![Screenshot 2023-01-19 at 14-17-58 irmin 0 9 1 · OCaml Package](https://user-images.githubusercontent.com/6594573/213452703-6c47ac3e-042a-4da8-bc7e-f945adde9661.png)|
