### PR TITLE
enable compression for playground assets

### DIFF
--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -97,7 +97,9 @@ let router t =
       Dream.scope ""
         [ Dream_encoding.compress ]
         [ Dream.get "/media/**" (Dream.static ~loader:media_loader "") ];
-      Dream.get "/play/**" @@ Dream.static "playground/asset/";
+      Dream.scope ""
+        [ Dream_encoding.compress ]
+        [ Dream.get "/play/**" @@ Dream.static "playground/asset/" ];
       Dream.scope ""
         [ Dream_encoding.compress ]
         [ Dream.get "/**" (Dream.static ~loader:asset_loader "") ];


### PR DESCRIPTION
As reported in https://github.com/ocaml/ocaml.org/issues/838, the compression middleware was not applied to the playground assets. This patch enables it.