### PR TITLE
de-emphasize "Get Started" top nav button and hide it on package layout

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -16,6 +16,7 @@ let menu_link
 
 
 let render
+?(show_get_started=true)
 ?(wide=false)
 ?(active_top_nav_item: active_nav_item option)
 ()
@@ -53,9 +54,11 @@ let render
             placeholder="Search OCaml Packages">
         </form>
       </div>
+      <% if show_get_started then (%>
       <div class="hidden lg:flex">
-        <a href="<%s Url.getting_started %>" class="btn btn-sm">Get Started</a>
+        <a href="<%s Url.getting_started %>" class="btn btn-secondary btn-sm">Get Started</a>
       </div>
+      <% ); %>
 
       <div
         class="hamburger lg:hidden flex h-12 w-12 hover:bg-primary-100 flex items-center justify-center rounded-full"

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -1,4 +1,5 @@
 let render
+?(show_get_started=true)
 ?(use_swiper=false)
 ?(banner = false)
 ?(wide=false)
@@ -68,7 +69,7 @@ inner =
     </div>
     <% ); %>
     
-    <%s! Header.render ~wide ?active_top_nav_item () %>
+    <%s! Header.render ~wide ~show_get_started ?active_top_nav_item () %>
 
     <main><%s! inner %></main>
 

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -12,6 +12,7 @@ let render
 inner =
 Layout.render
 ?styles
+~show_get_started:false
 ~wide:true
 ~title
 ~description

--- a/src/ocamlorg_frontend/pages/playground.eml
+++ b/src/ocamlorg_frontend/pages/playground.eml
@@ -25,7 +25,7 @@ let render () =
   </head>
 
   <body class="dark">
-    <%s! Header.render ~wide:true ~active_top_nav_item:Header.Playground () %>
+    <%s! Header.render ~wide:true ~show_get_started:true ~active_top_nav_item:Header.Playground () %>
 
     <main>
       <div class="flex code-editor">


### PR DESCRIPTION
|before| after|
|-|-|
|![Screenshot 2023-01-20 at 14-49-45 Learn OCaml](https://user-images.githubusercontent.com/6594573/213712781-35e4d928-ec73-48cf-a47a-d1c77db8aebc.png) get started is too intense|![Screenshot 2023-01-20 at 14-49-48 Learn OCaml](https://user-images.githubusercontent.com/6594573/213712794-4c73fd92-b1f4-4e6b-a0e2-2bddcbb2de37.png) more subtle|
|![Screenshot 2023-01-20 at 14-50-28 irmin 3 5 1 · OCaml Package](https://user-images.githubusercontent.com/6594573/213712914-6b5afb58-069d-4c70-b74d-ace9ef5d0200.png)|![Screenshot 2023-01-20 at 14-50-31 irmin 3 5 1 · OCaml Package](https://user-images.githubusercontent.com/6594573/213712926-ccda8cdb-b3cf-443f-baaf-f1342ba198a8.png)|

Hides "Get started" in package layout. Following suggestions from Claire and @cuihtlauac.