### PR TITLE
Add outreachy data

### DIFF
--- a/data/outreachy.yml
+++ b/data/outreachy.yml
@@ -97,7 +97,18 @@ rounds:
   - name: Summer 2022
     projects:
       - title: "Expand OCaml 5.0 Parallel Benchmark suite"
-        description: ""
+        description: >
+          OCaml 5.0 will be live soon! It ships with support for shared-memory parallelism and concurrency
+          OCaml has missed all these years. This will be accompanied by a robust set of Multicore libraries
+          useful for parallel programming. The Multicore compiler and libraries are under active development
+          and will continue to evolve as the OCaml ecosystem moves towards Multicore.
+
+          For assessing the impact of new features in the OCaml compiler and Multicore libraries, we have a
+          set of sequential and parallel benchmarks present in our benchmark suite. While the sequential benchmarks
+          contain many real-world applications, a wider set of parallel benchmarks would be useful.
+
+          This project entails gathering the parallel benchmarks available at various places like
+          https://github.com/ckoparkar/ocaml-benchmarks and making them available in the benchmark suite.
         mentee: "Moazzam Moriani"
         blog: "https://moazzammoriani.github.io/mm/"
         mentors:

--- a/data/outreachy.yml
+++ b/data/outreachy.yml
@@ -82,7 +82,26 @@ rounds:
         mentors:
          - Thibaut Mattio
       - title: "Improve the OCaml meta-programming ecosystem"
-        description: ""
+        description: |
+          It’s common for programming languages to provide some way to meta-program
+          in order to preprocess code before reaching the last compilation step,
+          for example, in the form of macros or templates. The OCaml compiler
+          doesn't provide a full built-in macro system, but the OCaml parser does
+          provide syntax for preprocessing purposes: attributes
+          (https://v3.ocaml.org/docs/metaprogramming#attributes-and-derivers) and
+          extension points
+          (https://v3.ocaml.org/docs/metaprogramming#extension-nodes-and-extenders).
+          We -the OCaml community- also have an official framework, called
+          `ppxlib`, to write preprocessors -called PPXs- based on that syntax and
+          integrate them into the compilation process.
+
+          However, it's on the OCaml community to write and provide important PPXs
+          to the OCaml developers. We've noticed that having the most important
+          PPXs under the official PPX github organization -next to `ppxlib`- is
+          helpful: developers can easily find them; developers can trust them;
+          they're well-written and hygienic, so that developers can use them as
+          how-to guides for writing other PPXs. In this project, you'll write
+          one or some of those official standard PPXs.
         mentee: "Aya Sharaf"
         blog: "https://outreachyxocaml.wordpress.com"
         mentors:

--- a/data/outreachy.yml
+++ b/data/outreachy.yml
@@ -1,0 +1,127 @@
+rounds:
+  - name: Summer 2019
+    projects:
+      - title: "Test the OCaml compiler with code coverage tools"
+        description: ""
+        mentee: "Oxana Kostikova"
+        blog: "https://lereenadem.wixsite.com/personal"
+        mentors:
+         - Sébastien Hinderer
+         - Florian Angeletti
+      - title: "Test the OCaml compiler with random tests and a reference interpreter"
+        description: >
+          The aim of this project is to extend an existing testcase-generator for the OCaml compiler,
+          using a reference interpreter (existing or newly developed) to find a lot of bugs in the compiler,
+          and fix as much of them as possible.
+        mentee: "Ulugbek Abdullaev"
+        blog: "https://ulugbekna.github.io"
+        mentors:
+         - Gabriel Scherer
+  - name: Summer 2020
+    projects:
+      - title: "Reducing global mutable state in the OCaml compiler codebase"
+        description: ""
+        mentee: "Anukriti Kumar"
+        blog: "https://anukriti12.github.io"
+        mentors:
+         - Guillaume Bury
+         - Vincent Laviron
+      - title: "Structured output format for the OCaml compiler messages"
+        description: >
+          Usually, the output messages from the compiler are a bit more difficult to read for a machine
+          and hence it's more time consuming to find the warnings, errors, etc. and their origin. By producing
+          a structured output for compiler messages, other tools can more easily interoperate with them and
+          provide tooling on top of the messages.
+        mentee: "Muskan Garg"
+        blog: "https://medium.com/@muskangarg994/outreachy-101-d285507c54f7"
+        mentors:
+         - Florian Angeletti
+  - name: Summer 2021
+    projects:
+      - title: "Create opam package search"
+        description: >
+          opam is the source-based package manager for OCaml code. This project comprises of writing a new web
+          client for rendering output from the opam package database. There is a JSON endpoint on opam.ocaml.org
+          which provides information about packages which would provide metadata about the packages.  We can extend
+          this JSON metadata to include all the opam packages (not just the top 10) and use that to power a search
+          frontend for the website. This may include presenting the data as a GraphQL endpoint with the frontend
+          querying that endpoint using GraphQL.
+        mentee: "Odinaka Joy"
+        blog: "https://www.dinakajoy.com"
+        mentors:
+         - Sonja Heinze
+         - Patrick Ferris
+      - title: "Improve the ocaml.org website"
+        description: >
+          OCaml.org is the main website for OCaml, a functional, typed, high-level programming language. This project
+          revolves around improving the website on multiple different fronts including: layout, accessibility and content.
+        mentee: "Diksha Gupta"
+        blog: "https://dikshagupta99.wordpress.com/blog/"
+        mentors:
+         - Isabella Leandersson
+         - Patrick Ferris
+         - Gargi Sharma
+      - title: "Improve the ocaml.org website"
+        description: >
+          OCaml.org is the main website for OCaml, a functional, typed, high-level programming language. This project
+          revolves around improving the website on multiple different fronts including: layout, accessibility and content.
+        mentee: "Shreya kumari Gupta"
+        blog: "https://shreyaswikriti693235797.wordpress.com/blog/"
+        mentors:
+         - Isabella Leandersson
+         - Anil Madhavapeddy
+         - Patrick Ferris
+         - Gargi Sharma
+  - name: Winter 2021
+    projects:
+      - title: "Build a monitoring dashboard for OCaml.org"
+        description: ""
+        mentee: "Jiae Kam"
+        blog: "https://jiaek.wordpress.com"
+        mentors:
+         - Thibaut Mattio
+      - title: "Improve the OCaml meta-programming ecosystem"
+        description: ""
+        mentee: "Aya Sharaf"
+        blog: "https://outreachyxocaml.wordpress.com"
+        mentors:
+         - Shon Feder
+         - Sonja Heinze
+      - title: "Support .eml files in OCaml's VSCode extension"
+        description: ""
+        mentee: "Sayo Bamigbade"
+        blog: "https://saysayoblog.wordpress.com"
+        mentors:
+         - Thibaut Mattio
+         - Gargi Sharma
+  - name: Summer 2022
+    projects:
+      - title: "Expand OCaml 5.0 Parallel Benchmark suite"
+        description: ""
+        mentee: "Moazzam Moriani"
+        blog: "https://moazzammoriani.github.io/mm/"
+        mentors:
+         - Sudha Parimala
+      - title: "Extend OCaml's GeoJSON library to support TopoJSON"
+        description: >
+          TopoJSON is an extension to GeoJSON to encode topology. This allows for redundant data
+          to be removed and file sizes to be greatly reduced. This is often very desirable especially
+          when working with data in the browser. This project looks to extend ocaml-geojson to support TopoJSON.
+        mentee: "Jay Dev Jha"
+        blog: "https://jaydevdotcom.wordpress.com/home/"
+        mentors:
+         - Patrick Ferris
+  - name: Winter 2022
+    projects:
+      - title: "Implement a non-blocking, streaming codec for TopoJSON"
+        description: >
+          TopoJSON is an extension to GeoJSON to encode topology. This allows for redundant data to be removed and file
+          sizes to be greatly reduced. This is often very desirable especially when working with data in the browser. In a previous
+          Outreachy internship a new OCaml library was implemented to provide an OCaml library for TopoJSON, this project will
+          build on this adding more functionality to the library and providing a non-blocking, streaming codec version similar
+          to the geojsone library.
+        mentee: "Prisca Chidimma Maduka"
+        blog: "https://prisca-chidimma.dreamwidth.org"
+        mentors:
+         - Patrick Ferris
+

--- a/data/outreachy.yml
+++ b/data/outreachy.yml
@@ -1,10 +1,68 @@
 rounds:
+  - name: Summer 2014
+    projects:
+      - title: "MirageOS contributions and improvements"
+        description: ""
+        mentee: "Mindy Preston"
+        blog: http://www.somerandomidiot.com/blog/2014/08/22/opw-fin/
+        source: https://github.com/mirage
+        mentors:
+          - Richard Mortier
+          - Anil Madhavapeddy
+      - title: "MirageOS cloud API support"
+        description: |
+          MirageOS (see http://xenproject.org/developers/teams/mirage-os.html,
+          http://www.openmirage.org/) is a type-safe unikernel written in OCaml
+          which generates highly specialised "appliance" VMs that run directly
+          on Xen without requiring an intervening kernel. A MirageOS
+          application typically runs via several communicating kernel instances
+          on the cloud. Today these instances are difficult to manage; we would
+          like to explore strategies for managing these distributed
+          computations using common public cloud APIs such as those exposed by
+          Amazon EC2 and Rackspace.
+
+          First we need to create pure OCaml API bindings for (e.g.) EC2 and
+          Rackspace (purity is needed to ensure portability). These API
+          bindings can then be used to provide operating-system-level
+          abstractions to the unikernels. For example, a traditional VM might
+          hotplug a vCPU; while a MirageOS application would request a "VM create"
+          using the cloud API and "connect" the new instance to the existing
+          network. We should be able to spin up 1000s of "CPUs" by using such
+          APIs in a cluster environment.
+
+          As well as helping Xen/Mirage, the public cloud API bindings will be
+          very useful to other people in other contexts -- a nice side-effect.
+        mentee: "Jyotsna Prakash"
+        blog: http://www.somerandomidiot.com/blog/2014/08/22/opw-fin/
+        source: https://github.com/moonlightdrive/ocaml-ec2
+        mentors:
+          - David Scott
+          - Anil Madhavapeddy
+  - name: Winter 2015
+    projects:
+      - title: "NTP Support for MirageOS"
+        description: ""
+        mentee: "Kia"
+        blog: "https://matildah.github.io"
+        source: https://github.com/softminus/mirage-ntp
+        mentors:
+          - Hannes Mehnert
+  - name: Summer 2016
+    projects:
+      - title: "MirageOS"
+        description: ""
+        mentee: Gina Marie Maini
+        blog: https://github.com/wiredsister
+        source: https://github.com/verbosemode/syslogd-mirage
+        mentors:
+          - Mindy Preston
   - name: Summer 2019
     projects:
       - title: "Test the OCaml compiler with code coverage tools"
         description: ""
         mentee: "Oxana Kostikova"
         blog: "https://lereenadem.wixsite.com/personal"
+        source: https://github.com/ocaml/ocaml
         mentors:
          - Sébastien Hinderer
          - Florian Angeletti
@@ -14,6 +72,7 @@ rounds:
           using a reference interpreter (existing or newly developed) to find a lot of bugs in the compiler,
           and fix as much of them as possible.
         mentee: "Ulugbek Abdullaev"
+        source: https://github.com/ocaml/ocaml
         blog: "https://ulugbekna.github.io"
         mentors:
          - Gabriel Scherer
@@ -24,6 +83,7 @@ rounds:
         description: ""
         mentee: "Anukriti Kumar"
         blog: "https://anukriti12.github.io"
+        source: https://github.com/ocaml/ocaml
         mentors:
          - Guillaume Bury
          - Vincent Laviron
@@ -34,6 +94,7 @@ rounds:
           a structured output for compiler messages, other tools can more easily interoperate with them and
           provide tooling on top of the messages.
         mentee: "Muskan Garg"
+        source: https://github.com/ocaml/ocaml
         blog: "https://medium.com/@muskangarg994/outreachy-101-d285507c54f7"
         mentors:
          - Florian Angeletti
@@ -49,6 +110,7 @@ rounds:
           querying that endpoint using GraphQL.
         mentee: "Odinaka Joy"
         blog: "https://www.dinakajoy.com"
+        source: https://github.com/ocaml/ocaml.org
         mentors:
          - Sonja Heinze
          - Patrick Ferris
@@ -58,6 +120,7 @@ rounds:
           revolves around improving the website on multiple different fronts including: layout, accessibility and content.
         mentee: "Diksha Gupta"
         blog: "https://dikshagupta99.wordpress.com/blog/"
+        source: https://github.com/ocaml/ocaml.org
         mentors:
          - Isabella Leandersson
          - Patrick Ferris
@@ -67,6 +130,7 @@ rounds:
           OCaml.org is the main website for OCaml, a functional, typed, high-level programming language. This project
           revolves around improving the website on multiple different fronts including: layout, accessibility and content.
         mentee: "Shreya kumari Gupta"
+        source: https://github.com/ocaml/ocaml.org
         blog: "https://shreyaswikriti693235797.wordpress.com/blog/"
         mentors:
          - Isabella Leandersson
@@ -78,12 +142,14 @@ rounds:
       - title: "Build a monitoring dashboard for OCaml.org"
         description: ""
         mentee: "Jiae Kam"
+        source: https://github.com/ocaml/ocaml.org
         blog: "https://jiaek.wordpress.com"
         mentors:
          - Thibaut Mattio
+         - Patrik Keller
       - title: "Improve the OCaml meta-programming ecosystem"
         description: |
-          It’s common for programming languages to provide some way to meta-program
+          It's common for programming languages to provide some way to meta-program
           in order to preprocess code before reaching the last compilation step,
           for example, in the form of macros or templates. The OCaml compiler
           doesn't provide a full built-in macro system, but the OCaml parser does
@@ -103,17 +169,21 @@ rounds:
           how-to guides for writing other PPXs. In this project, you'll write
           one or some of those official standard PPXs.
         mentee: "Aya Sharaf"
+        source: https://github.com/ocaml-ppx/ppxlib
         blog: "https://outreachyxocaml.wordpress.com"
         mentors:
          - Shon Feder
          - Sonja Heinze
+         - Patrik Keller
       - title: "Support .eml files in OCaml's VSCode extension"
         description: ""
+        source: https://github.com/ocamllabs/vscode-ocaml-platform
         mentee: "Sayo Bamigbade"
         blog: "https://saysayoblog.wordpress.com"
         mentors:
          - Thibaut Mattio
          - Gargi Sharma
+         - Patrik Keller
   - name: Summer 2022
     projects:
       - title: "Expand OCaml 5.0 Parallel Benchmark suite"
@@ -131,6 +201,7 @@ rounds:
           https://github.com/ckoparkar/ocaml-benchmarks and making them available in the benchmark suite.
         mentee: "Moazzam Moriani"
         blog: "https://moazzammoriani.github.io/mm/"
+        source: https://github.com/ocaml-bench/sandmark
         mentors:
          - Sudha Parimala
       - title: "Extend OCaml's GeoJSON library to support TopoJSON"
@@ -140,6 +211,7 @@ rounds:
           when working with data in the browser. This project looks to extend ocaml-geojson to support TopoJSON.
         mentee: "Jay Dev Jha"
         blog: "https://jaydevdotcom.wordpress.com/home/"
+        source: https://github.com/geocaml/ocaml-topojson
         mentors:
          - Patrick Ferris
   - name: Winter 2022
@@ -152,7 +224,8 @@ rounds:
           build on this adding more functionality to the library and providing a non-blocking, streaming codec version similar
           to the geojsone library.
         mentee: "Prisca Chidimma Maduka"
+        source: https://github.com/geocaml/ocaml-topojson
         blog: "https://prisca-chidimma.dreamwidth.org"
         mentors:
          - Patrick Ferris
-
+         - Odinaka Joy

--- a/data/outreachy.yml
+++ b/data/outreachy.yml
@@ -17,6 +17,7 @@ rounds:
         blog: "https://ulugbekna.github.io"
         mentors:
          - Gabriel Scherer
+         - Jan Midtgaard
   - name: Summer 2020
     projects:
       - title: "Reducing global mutable state in the OCaml compiler codebase"

--- a/src/ocamlorg_data/dune
+++ b/src/ocamlorg_data/dune
@@ -124,6 +124,14 @@
 
 (rule
  (deps ../../tool/ood-gen/bin/gen.exe)
+ (targets outreachy.ml)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps} outreachy))))
+
+(rule
+ (deps ../../tool/ood-gen/bin/gen.exe)
  (targets workshop.ml)
  (action
   (with-stdout-to

--- a/src/ocamlorg_data/ood.ml
+++ b/src/ocamlorg_data/ood.ml
@@ -26,6 +26,7 @@ module Industrial_user = struct
   let get_by_slug slug = List.find_opt (fun x -> String.equal slug x.slug) all
 end
 
+module Outreachy = Outreachy
 module Packages = Packages
 
 module Paper = struct

--- a/src/ocamlorg_data/ood.mli
+++ b/src/ocamlorg_data/ood.mli
@@ -75,6 +75,20 @@ module Meetup : sig
   val get_by_slug : string -> t option
 end
 
+module Outreachy : sig
+  type project = {
+    title : string;
+    description : string;
+    mentee : string;
+    blog : string;
+    mentors : string list;
+  }
+
+  type t = { name : string; projects : project list }
+
+  val all : t list
+end
+
 module Industrial_user : sig
   type t = {
     name : string;

--- a/src/ocamlorg_data/ood.mli
+++ b/src/ocamlorg_data/ood.mli
@@ -80,7 +80,8 @@ module Outreachy : sig
     title : string;
     description : string;
     mentee : string;
-    blog : string;
+    blog : string option;
+    source : string;
     mentors : string list;
   }
 

--- a/tool/ood-gen/bin/gen.ml
+++ b/tool/ood-gen/bin/gen.ml
@@ -8,6 +8,7 @@ let term_templates =
     ("meetup", Ood_gen.Meetup.template);
     ("news", Ood_gen.News.template);
     ("industrial_user", Ood_gen.Industrial_user.template);
+    ("outreachy", Ood_gen.Outreachy.template);
     ("packages", Ood_gen.Packages.template);
     ("paper", Ood_gen.Paper.template);
     ("problems", Ood_gen.Problem.template);

--- a/tool/ood-gen/lib/outreachy.ml
+++ b/tool/ood-gen/lib/outreachy.ml
@@ -2,12 +2,13 @@ type project = {
   title : string;
   description : string;
   mentee : string;
-  blog : string;
+  blog : string option;
+  source : string;
   mentors : string list;
 }
 [@@deriving of_yaml]
 
-type metadata = { name : string; projects : project list } [@@deriving yaml]
+type metadata = { name : string; projects : project list } [@@deriving of_yaml]
 type t = metadata
 
 let decode s =
@@ -28,10 +29,12 @@ let pp_project ppf v =
   ; description = %a
   ; mentee = %a
   ; blog = %a
+  ; source = %a
   ; mentors = %a
   }|}
-    Pp.string v.title Pp.string v.description Pp.string v.mentee Pp.string
-    v.blog (Pp.list Pp.string) v.mentors
+    Pp.string v.title Pp.string v.description Pp.string v.mentee
+    Pp.(option string)
+    v.blog Pp.string v.source (Pp.list Pp.string) v.mentors
 
 let pp ppf v =
   Fmt.pf ppf {|
@@ -50,7 +53,8 @@ type project =
   { title : string
   ; description : string
   ; mentee : string
-  ; blog : string
+  ; blog : string option
+  ; source : string
   ; mentors : string list
   }
 

--- a/tool/ood-gen/lib/outreachy.ml
+++ b/tool/ood-gen/lib/outreachy.ml
@@ -1,0 +1,64 @@
+type project = {
+  title : string;
+  description : string;
+  mentee : string;
+  blog : string;
+  mentors : string list;
+}
+[@@deriving yaml]
+
+type metadata = { name : string; projects : project list } [@@deriving yaml]
+type t = metadata
+
+let decode s =
+  let yaml = Utils.decode_or_raise Yaml.of_string s in
+  match yaml with
+  | `O [ ("rounds", `A xs) ] ->
+      Ok (List.map (Utils.decode_or_raise metadata_of_yaml) xs)
+  | _ -> Error (`Msg "expected a list of opam-users")
+
+let all () =
+  let content = Data.read "outreachy.yml" |> Option.get in
+  Utils.decode_or_raise decode content
+
+let pp_project ppf v =
+  Fmt.pf ppf
+    {|
+  { title = %a
+  ; description = %a
+  ; mentee = %a
+  ; blog = %a
+  ; mentors = %a
+  }|}
+    Pp.string v.title Pp.string v.description Pp.string v.mentee Pp.string
+    v.blog (Pp.list Pp.string) v.mentors
+
+let pp ppf v =
+  Fmt.pf ppf {|
+  { name = %a
+  ; projects = %a
+  }|} Pp.string v.name
+    Pp.(list pp_project)
+    v.projects
+
+let pp_list = Pp.list pp
+
+let template () =
+  Format.asprintf
+    {|
+type project =
+  { title : string
+  ; description : string
+  ; mentee : string
+  ; blog : string
+  ; mentors : string list
+  }
+
+type t =
+  { name : string
+  ; projects : project list
+  }
+
+let all = %a
+|}
+    pp_list (all ())

--- a/tool/ood-gen/lib/outreachy.ml
+++ b/tool/ood-gen/lib/outreachy.ml
@@ -5,7 +5,7 @@ type project = {
   blog : string;
   mentors : string list;
 }
-[@@deriving yaml]
+[@@deriving of_yaml]
 
 type metadata = { name : string; projects : project list } [@@deriving yaml]
 type t = metadata


### PR DESCRIPTION
This is a start to record all of the OCaml community's Outreachy projects, I think it would be nice for us to keep our own record and then display that somewhere on OCaml.org.

This PR only adds information and all of the Ood code for the data, I'm hoping someone with more design skills can take this and actually show it on the frontend :)) I've done my best to add project descriptions but you can't actually see them on the Outreachy site unless you mentored the project.