### PR TITLE
Rename "algebraic effects" to "effect handlers" in the banner

### DIFF
--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -56,7 +56,7 @@ inner =
         <div class="pr-16 sm:px-16 sm:text-center">
           <p class="font-medium text-white">
             <span class="md:hidden">OCaml 5.0 is available!</span>
-            <span class="hidden md:inline">OCaml 5.0 is available! This release of OCaml comes with support for shared-memory parallelism through domains and direct-style concurrency through algebraic effects!</span>
+            <span class="hidden md:inline">OCaml 5.0 is available! This release of OCaml comes with support for shared-memory parallelism through domains and direct-style concurrency through effect handlers!</span>
             <span class="block sm:ml-2 sm:inline-block">
               <a href="<%s Url.news_post "ocaml-5.0" %>" class="font-bold text-white underline">
                 Try it now


### PR DESCRIPTION
Effect handlers in OCaml do not have equations associated with operations. Hence, it is better to use "effect handlers" rather than "algebraic effects". 

For a more detailed discussion, see What's Algebraic about Algebraic Effects? [1] (see Section 6). 

[1] https://arxiv.org/pdf/1807.05923.pdf