### PR TITLE
Collapse Learn page links only in sm layout

### DIFF
--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -11,8 +11,8 @@ Learn_layout.render
 ~left_sidebar_html:(Learn_sidebar.render ~tutorials ~current_tutorial:None)
 ~right_sidebar_html:None @@
   <h1 class="font-bold mb-8">Learn OCaml</h1>
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 xl:gap-8 border-b border-gray-200 pb-10">
-    <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white lg:max-h-96 overflow-hidden">
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 xl:gap-8 border-b border-gray-200 pb-10">
+    <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white md:max-h-96 overflow-hidden">
       <div class="p-6 xl:p-8 h-full xl:h-auto flex flex-col">
         <h2 class="font-bold mb-2">Get Started</h2>
         <div class="font-medium mb-4 opacity-80">Learn how to get OCaml set up in your project.</div>
@@ -25,7 +25,7 @@ Learn_layout.render
       </div>
     </div>
 
-    <div class="relative flex-1 bg-gradient-to-br from-purple-400 to-purple-700 rounded-xl text-white lg:max-h-96 overflow-hidden">
+    <div class="relative flex-1 bg-gradient-to-br from-purple-400 to-purple-700 rounded-xl text-white md:max-h-96 overflow-hidden">
       <div class="p-6 xl:p-8 h-full xl:h-auto flex flex-col">
         <h2 class="font-bold mb-2">Solve Exercises</h2>
         <div class="font-medium mb-4 opacity-80">
@@ -40,7 +40,7 @@ Learn_layout.render
       </div>
     </div>
 
-    <div class="relative flex-1 bg-gradient-to-br from-emerald-400 to-emerald-700 rounded-xl text-white lg:max-h-96 overflow-hidden">
+    <div class="relative flex-1 bg-gradient-to-br from-emerald-400 to-emerald-700 rounded-xl text-white md:max-h-96 overflow-hidden">
       <div class="p-6 xl:p-8 h-full xl:h-auto flex flex-col">
         <h2 class="font-bold mb-2">Language Manual</h2>
         <div class="font-medium mb-4 opacity-80">Acquire a deeper understanding!</div>


### PR DESCRIPTION
Lean page links collapse only in sm layout, not already in md layout. Overlooked that last time.

md-screen:
|before|after|
|-|-|
|![Screenshot 2023-01-25 at 12-44-01 Learn OCaml](https://user-images.githubusercontent.com/6594573/214556322-5c9f15f2-60fa-4f70-9697-0635ac107966.png)|![Screenshot 2023-01-25 at 12-44-05 Learn OCaml](https://user-images.githubusercontent.com/6594573/214556327-6ca55e8e-43a7-45e8-af39-ed859f78cb13.png)|

other screens unchanged