### PR TITLE
fix Chrome scrolling, fix video iframe after introduction of HTMX

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -137,11 +137,12 @@ inner_html
   </div>
   <script>
   window.onload = (event) => {
-    document.body.addEventListener('htmx:afterRequest', (evt) => {
+    document.body.addEventListener('htmx:afterSwap', (evt) => {
       if (evt.detail.error || evt.detail.failed) {
         window.location = evt.detail.requestConfig.path;
+        return;
       }
-      window.scrollTo(0, 0);
+      window.pageYOffset = 0;
       evt.detail.elt.dispatchEvent(new CustomEvent('close-sidebar', { bubbles: true }));
     });
   };

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -87,11 +87,12 @@ Package_layout.render
 </div>
 <script>
 window.onload = (event) => {
-  document.body.addEventListener('htmx:afterRequest', (evt) => {
+  document.body.addEventListener('htmx:afterSwap', (evt) => {
     if (evt.detail.error || evt.detail.failed) {
       window.location = evt.detail.requestConfig.path;
+      return;
     }
-    window.scrollTo(0, 0);
+    window.pageYOffset = 0;
     evt.detail.elt.dispatchEvent(new CustomEvent('close-sidebar', { bubbles: true }));
   });
 };

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -41,7 +41,14 @@ Learn_layout.render
   </div>
   <div
     class="mt-12 cursor-pointer z-0 relative rounded-2xl h-[413px] w-full overflow-hidden border-4 border-primary-100 video-shadow md:w-[640px]"
-    x-data="videoFullWidth()"
+    x-data='{
+        isPlaying: false,
+        embed_url: "https://watch.ocaml.org/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516",
+        iframe_param: "?autoplay=1&mute=1",
+        iframe_url() {
+          return this.embed_url + this.iframe_param;
+        },
+      }'
   >
     <div
       class="bg-white text-center relative aspect-w-16 aspect-h-9 h-full"
@@ -167,15 +174,3 @@ Learn_layout.render
       </div>
     </div>
   </div>
-  <script>
-    function videoFullWidth() {
-      return {
-        isPlaying: false,
-        embed_url: "https://watch.ocaml.org/videos/embed/0e2070fd-798b-47f7-8e69-ef75e967e516",
-        iframe_param: "?autoplay=1&mute=1",
-        iframe_url() {
-          return this.embed_url + this.iframe_param;
-        },
-      };
-    }
-  </script>


### PR DESCRIPTION
Chrome would not scroll to top after navigating via swapping in content via htmx. Patch is to be more defensive about when to trigger scroll after a swap-in, and to choosing an older method of scrolling.

There was a bad interaction between htmx and alpinejs regarding the video on https://ocaml.org/docs/platform because alpinejs tried to execute a function that would only be defined after swapping in the script tag to the DOM. This patch fixes the problem.