### PR TITLE
remove wide parameter from layout, header is always wide

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -17,7 +17,6 @@ let menu_link
 
 let render
 ?(show_get_started=true)
-?(wide=false)
 ?(active_top_nav_item: active_nav_item option)
 ()
 =
@@ -25,7 +24,7 @@ let render
   class="h-20 flex items-center text-white dark:bg-[#171717]"
   x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}"
   @resize.window="sidebar = window.innerWidth > 1024">
-  <nav class="container-fluid header <%s if wide then "wide" else "" %> flex justify-between items-center">
+  <nav class="container-fluid wide header flex justify-between items-center">
     <ul class="space space-x-5 xl:space-x-8 items-center flex text-body-400 font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
       <li style="width:132px">
         <a href="<%s Url.index %>" class="block pb-2">

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -2,7 +2,6 @@ let render
 ?(show_get_started=true)
 ?(use_swiper=false)
 ?(banner = false)
-?(wide=false)
 ?description
 ?styles
 ~title
@@ -70,7 +69,7 @@ inner =
     </div>
     <% ); %>
     
-    <%s! Header.render ~wide ~show_get_started ?active_top_nav_item () %>
+    <%s! Header.render ~show_get_started ?active_top_nav_item () %>
 
     <main><%s! inner %></main>
 

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -94,7 +94,6 @@ inner_html
   Layout.render
   ?use_swiper
   ?styles
-  ~wide:true
   ~title
   ~description
   ~canonical

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -13,7 +13,6 @@ inner =
 Layout.render
 ?styles
 ~show_get_started:false
-~wide:true
 ~title
 ~description
 ~canonical

--- a/src/ocamlorg_frontend/pages/blog.eml
+++ b/src/ocamlorg_frontend/pages/blog.eml
@@ -1,6 +1,5 @@
 let render ~(featured : Ood.Rss.t list) ~(rss : Ood.Rss.t list) ~rss_pages_number ~rss_page ~(news : Ood.News.t list) =
 Layout.render
-~wide:true
 ~title:"OCaml Blog"
 ~description:"Recent news and blog posts from the OCaml community."
 ~canonical:(Url.blog ^ if rss_page = 1 then "" else "?p=" ^ string_of_int rss_page)

--- a/src/ocamlorg_frontend/pages/playground.eml
+++ b/src/ocamlorg_frontend/pages/playground.eml
@@ -25,7 +25,7 @@ let render () =
   </head>
 
   <body class="dark">
-    <%s! Header.render ~wide:true ~show_get_started:true ~active_top_nav_item:Header.Playground () %>
+    <%s! Header.render ~show_get_started:true ~active_top_nav_item:Header.Playground () %>
 
     <main>
       <div class="flex code-editor">


### PR DESCRIPTION
The top navbar jumping between narrow and wide was bothersome. The top navbar is now always "wide". The `wide` parameter on the header and layouts has been removed.

Does not change the widths of the content areas. Every page defines its own container (regular or wide) according to the content it hosts. Reason: some of the layouts did not look so great when "stretched out" to wide.

|before|after|
|-|-|
|![Screenshot 2023-01-25 at 18-00-02 The OCaml Community](https://user-images.githubusercontent.com/6594573/214629594-bb3be5b9-8ddc-4d67-ad47-b960a7f7d9b0.png)|![Screenshot 2023-01-25 at 18-00-06 The OCaml Community](https://user-images.githubusercontent.com/6594573/214629634-6c2d3241-b7a6-4009-ab3e-bc0de5e867c6.png)|

