### PR TITLE
Drop extra slashes

### DIFF
--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -1,11 +1,12 @@
 let no_trailing_slash next_handler request =
-  let target = Dream.target request in
-  match target with
-  | "/" -> next_handler request
-  | _ ->
-      if String.ends_with ~suffix:"/" target then
-        Dream.redirect request (String.sub target 0 (String.length target - 1))
-      else next_handler request
+  let target = "///" ^ Dream.target request in (* FIXME: https://github.com/aantron/dream/issues/248 *)
+  let path, query = target |> Dream.split_target in
+  let path = path |> Dream.from_path |> Dream.drop_trailing_slash |> Dream.to_path in
+  let target = path ^ if query = "" then "" else "?" ^ query in
+  if Dream.target request = target then
+    next_handler request
+  else
+    Dream.redirect request target
 
 let head handler request =
   match Dream.method_ request with

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -1,12 +1,13 @@
 let no_trailing_slash next_handler request =
-  let target = "///" ^ Dream.target request in (* FIXME: https://github.com/aantron/dream/issues/248 *)
+  let target = "///" ^ Dream.target request in
+  (* FIXME: https://github.com/aantron/dream/issues/248 *)
   let path, query = target |> Dream.split_target in
-  let path = path |> Dream.from_path |> Dream.drop_trailing_slash |> Dream.to_path in
+  let path =
+    path |> Dream.from_path |> Dream.drop_trailing_slash |> Dream.to_path
+  in
   let target = path ^ if query = "" then "" else "?" ^ query in
-  if Dream.target request = target then
-    next_handler request
-  else
-    Dream.redirect request target
+  if Dream.target request = target then next_handler request
+  else Dream.redirect request target
 
 let head handler request =
   match Dream.method_ request with


### PR DESCRIPTION
Handle the request unchanged if the target seems canonical, otherwise:

  * Turns repeated slashes into a single one
  * Drop the last slash
  * Redirect to the resulting target

Issue: https://github.com/ocaml/ocaml.org/issues/820

Note: Is `Dream.split_target` bugged? When passed a string beginning with exactly two slashes, `split_target` drops everything before the third slash. See: https://github.com/aantron/dream/issues/248 As a workaround; three slashes are prepended to all targets
