### PR TITLE
Fix the broken link

### DIFF
--- a/data/problems/036_prime_factor_2.md
+++ b/data/problems/036_prime_factor_2.md
@@ -25,7 +25,7 @@ val factors : int -> (int * int) list = <fun>
 
 Construct a list containing the prime factors and their multiplicity.
 *Hint:* The problem is similar to problem 
-[Run-length encoding of a list (direct solution)](#Runlengthencodingofalistdirectsolutionmedium).
+[Run-length encoding of a list (direct solution)](#10).
 
 ```ocaml
 # factors 315;;


### PR DESCRIPTION
Previous link(`#Runlengthencodingofalistdirectsolutionmedium`) was directed to <https://ocaml.org/problems#Runlengthencodingofalistdirectsolutionmedium>, but actual link to the run-length problem was <https://ocaml.org/problems#10>.