### PR TITLE
on htmx error, always navigate by window.location

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -144,5 +144,17 @@ inner_html
       window.pageYOffset = 0;
       evt.detail.elt.dispatchEvent(new CustomEvent('close-sidebar', { bubbles: true }));
     });
+    document.body.addEventListener('htmx:swapError', (evt) => {
+      window.location = evt.detail.requestConfig.path;
+    });
+    document.body.addEventListener('htmx:responseError', (evt) => {
+      window.location = evt.detail.requestConfig.path;
+    });
+    document.body.addEventListener('htmx:historyCacheMissError', (evt) => {
+      window.location = evt.detail.path;
+    });
+    document.body.addEventListener('htmx:onLoadError', (evt) => {
+      window.location = evt.detail.requestConfig.path;
+    });
   };
   </script>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -95,5 +95,17 @@ window.onload = (event) => {
     window.pageYOffset = 0;
     evt.detail.elt.dispatchEvent(new CustomEvent('close-sidebar', { bubbles: true }));
   });
+  document.body.addEventListener('htmx:swapError', (evt) => {
+    window.location = evt.detail.requestConfig.path;
+  });
+  document.body.addEventListener('htmx:responseError', (evt) => {
+    window.location = evt.detail.requestConfig.path;
+  });
+  document.body.addEventListener('htmx:historyCacheMissError', (evt) => {
+    window.location = evt.detail.path;
+  });
+  document.body.addEventListener('htmx:onLoadError', (evt) => {
+    window.location = evt.detail.requestConfig.path;
+  });
 };
 </script>


### PR DESCRIPTION
In case htmx errors for whatever reason, we should complete the navigation by means of `window.location`.