### PR TITLE
minor improvements to package docs odoc styles

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -174,6 +174,7 @@ div.odoc-include summary:hover {
 
 div.odoc span[class*="keyword"] {
   color: rgba(17, 24, 39, 1);
+  font-weight:normal;
 }
 
 div.odoc ul.at-tags {
@@ -186,6 +187,19 @@ div.odoc ul.at-tags p {
 
 div.odoc span.at-tag {
   font-weight: bold;
+}
+
+div.odoc a {
+  font-weight: bold;
+  color: #cc4e0c;
+}
+
+div.odoc code span > span {
+  font-weight: normal;
+}
+
+div.odoc .arrow {
+  font-weight: normal;
 }
 
 /* package explorer navmap and breadcrumb tag */


### PR DESCRIPTION
It was [brought up here](https://discuss.ocaml.org/t/looking-for-participants-for-user-survey-on-ocaml-org-package-documentation-and-learn-area/11128/37) that the current styles of odoc are much better to read than what we have on OCaml.org.

Here's a quick patch that adjusts our styles (more improvements will be possible after https://github.com/ocaml/ocaml.org/pull/878):

|before|after|
|-|-|
|![Screenshot 2023-02-06 at 09-24-26 Oplot Plt · oplot 0 71 · OCaml Packages](https://user-images.githubusercontent.com/6594573/216921503-3d89031b-8a53-4979-9cdf-531c8664de64.png)|![Screenshot 2023-02-06 at 09-24-30 Oplot Plt · oplot 0 71 · OCaml Packages](https://user-images.githubusercontent.com/6594573/216921513-5a4d8252-b4fd-4e01-b3dd-703ab22d6b5f.png)|

I also adjusted the contrast on the orange links. They are a bit darker now (yet still do not meet WCAG guidelines), but are hopefully a bit more readable. We need to address and resolve this once and for all in an overall overhaul of colors on the site at a later time.
