### PR TITLE
do not show empty table of contents

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -9,8 +9,8 @@ type t = toc list
 let render (t : t) =
   <div>
     <% (match t with [] ->  %>
-    <span class="block py-2 text-gray-900">No table of contents</span>
     <% | _ -> %>
+    <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
     <ul class="leading-6 space-y-3 text-sm">
       <% t |> List.iter begin fun item -> %>
         <li>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -80,7 +80,6 @@ Package_layout.render
       </div>
     </div>
     <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto right-sidebar" id="htmx-right-sidebar">
-      <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
       <%s! Toc.render toc %>
     </div>
   </div>


### PR DESCRIPTION
People were irritated by seeing "ON THIS PAGE" followed by "No table of contents".

This patch omits rendering this (admittedly useless) text when there is no TOC available.

|before|after|
|-|-|
|![Screenshot 2023-02-06 at 13-26-17 Oplot Plt · oplot 0 71 · OCaml Packages](https://user-images.githubusercontent.com/6594573/216971007-1a696b2c-b3b1-4e3b-8329-352daa6f99e8.png)|![Screenshot 2023-02-06 at 13-26-21 Oplot Plt · oplot 0 71 · OCaml Packages](https://user-images.githubusercontent.com/6594573/216971020-c3999e21-7fc7-4876-a6a6-9ce1205cdb0a.png)|
