### PR TITLE
standard library API link in search dropdown

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -21,7 +21,7 @@ let render
 ()
 =
 <header 
-  class="h-20 flex items-center text-white dark:bg-[#171717]"
+  class="h-20 flex items-center dark:bg-[#171717]"
   x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}"
   @resize.window="sidebar = window.innerWidth > 1024">
   <nav class="container-fluid wide header flex justify-between items-center">
@@ -43,8 +43,8 @@ let render
     <ul class="hidden lg:flex items-center space-x-4 xl:space-x-8">
       <li class="relative">
         <form action="/packages/search" method="GET">
-          <div class="flex items-center justify-center">
-            <input type="search" name="q" class="header__search focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80" placeholder="Search OCaml Packages">
+          <div class="header__search relative flex items-center justify-center">
+            <input type="search" name="q" class="header__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80" placeholder="Search OCaml Packages">
             <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
               <svg class="w-6 h-6 text-white" fill="currentColor" xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24">
@@ -52,6 +52,13 @@ let render
                     d="M16.32 14.9l5.39 5.4a1 1 0 0 1-1.42 1.4l-5.38-5.38a8 8 0 1 1 1.41-1.41zM10 16a6 6 0 1 0 0-12 6 6 0 0 0 0 12z" />
               </svg>
             </button>
+            <div class="header__search__dropdown z-10 absolute rounded-b-md w-full top-0 mt-10 p-2 bg-white font-semibold border border-primary-600">
+              <span class="pl-2">Or go to:</span>
+              <a class="flex py-2 px-4 gap-4 hover:bg-primary-100 font-regular hover:font-semibold text-primary-600" href="<%s Url.api %>">
+                Standard Library API
+                <%s! Icons.arrow_top_right_on_square "w-6 h-6" %>
+              </a>
+            </div>
           </div>
         </form>
       </li>

--- a/src/ocamlorg_frontend/components/icons.eml
+++ b/src/ocamlorg_frontend/components/icons.eml
@@ -73,3 +73,8 @@ let thumb_up kind =
   <svg xmlns="http://www.w3.org/2000/svg" class="<%s _class_of_kind kind %>" fill="none" viewBox="0 0 24 24" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
   </svg>
+
+let arrow_top_right_on_square class_ =
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="<%s class_ %>" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+  </svg>

--- a/src/ocamlorg_frontend/css/partials/search.css
+++ b/src/ocamlorg_frontend/css/partials/search.css
@@ -1,7 +1,27 @@
-.header__search::placeholder, .package__search::placeholder {
+/* all search inputs */
+
+.header__search__input::placeholder, .package__search::placeholder {
   @apply text-gray-500;
 }
 
-.header__search:focus, .package__search:focus {
+.header__search__input:focus, .package__search:focus {
   box-shadow: none;
+}
+
+/* header search dropdown */
+
+.header__search__dropdown{
+  display:none;
+}
+
+.header__search:focus-within input {
+  border-bottom-left-radius: 0;
+}
+
+.header__search:focus-within button {
+  border-bottom-right-radius: 0;
+}
+
+.header__search:focus-within .header__search__dropdown{
+  display:block;
 }


### PR DESCRIPTION
Experimental draft: When the search box is focused, a quick link to the Standard Library API pops up.

Multiple people were asking for a quick way to go to the Standard Library. Since we don't have space left in the top nav bar, we extend the search box with a dropdown that opens when we focus within the search box of the top nav bar. 

I suppose, in the longer run, we might want to make the search box search more than just packages:
A dropdown like this could allow us to specify where to search (e.g. "... in packages", "... in learn area", "... in all of ocaml.org"). It's also a place where we could have for more shortcut links (like the one to Standard Library API)? We could filter an extended list of shortcut links and display them in the dropdown. :shrug:

|before|after|
|-|-|
|![Screenshot from 2023-02-09 13-21-00](https://user-images.githubusercontent.com/6594573/217811573-d4862ca1-8563-4cf5-876d-18e56fc7b66b.png)|![Screenshot from 2023-02-09 13-21-06](https://user-images.githubusercontent.com/6594573/217811593-d3166836-a902-4d3a-a9d7-562858174533.png)|
