### PR TITLE
UX improvements on package search results page

### DIFF
--- a/src/ocamlorg_frontend/css/partials/header.css
+++ b/src/ocamlorg_frontend/css/partials/header.css
@@ -1,7 +1,0 @@
-.header__search::placeholder {
-  @apply text-gray-500;
-}
-
-.header__search:focus {
-  box-shadow: none;
-}

--- a/src/ocamlorg_frontend/css/partials/search.css
+++ b/src/ocamlorg_frontend/css/partials/search.css
@@ -1,0 +1,7 @@
+.header__search::placeholder, .package__search::placeholder {
+  @apply text-gray-500;
+}
+
+.header__search:focus, .package__search:focus {
+  box-shadow: none;
+}

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -6,7 +6,7 @@
 @import "./partials/cards.css";
 @import "./partials/forms.css";
 @import "./partials/grid_logos.css";
-@import "./partials/header.css";
+@import "./partials/search.css";
 @import "./partials/shadows.css";
 @import "./partials/tags.css";
 @import "./partials/typography.css";

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -5,42 +5,52 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
 <div class="bg-white">
   <div class="py-10 lg:py-14">
     <div class="container-fluid">
-      <div class="flex justify-between items-center flex-col md:flex-row lg:px-28">
-        <h5 class="font-bold mb-5 md:mb-0"><%s string_of_int total ^ " Search Results" %></h5>
-        <div
-          class="flex items-center justify-between space-y-5 md:space-y-0 md:space-x-5 flex-col md:flex-row w-full md:w-auto"
-        >
-          <form class="relative h-14 w-full md:w-64" action="/packages/search" method="GET">
-            <label for="q2" class="sr-only">Search packages</label>
-            <div class="relative w-full text-gray-400 focus-within:text-gray-600">
+      <div class="flex flex-col lg:px-28">
+        <div class="max-w-prose space-y-6 mb-4">
+          <form action="/packages/search" method="GET">
+            <div class="flex items-center justify-center">
               <input
-                name="q"
-                id="q2"
-                class="w-full appearance-none focus:ring-orange-500 focus:border-primary-600 text-body-600 border rounded-md py-3 pr-6 border-gray-200 pl-14 h-full"
-                placeholder="Search packages"
                 type="search"
-                value="<%s search %>">
-              <div class="absolute h-full flex items-center pl-6 opacity-60 left-0 top-0">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-5 w-5 text-body-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="rgba(26, 32, 44, 1)"
-                >
+                name="q" id="q2"
+                class="package__search w-full focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1"
+                value="<%s search %>"
+                placeholder="Search OCaml Packages">
+              <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
+                <svg class="w-6 h-6 text-white" fill="currentColor" xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24">
                   <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                  />
+                      d="M16.32 14.9l5.39 5.4a1 1 0 0 1-1.42 1.4l-5.38-5.38a8 8 0 1 1 1.41-1.41zM10 16a6 6 0 1 0 0-12 6 6 0 0 0 0 12z" />
                 </svg>
-              </div>
+              </button>
             </div>
           </form>
+
+          <div class="prose">
+            <h1 class="font-bold text-3xl mb-5 md:mb-0">
+              <% (match total with 
+                | 0 -> %> No search results for "<%s search %>"
+              <% | 1 -> %> 1 search result for "<%s search %>"
+              <% | _ -> %> <%s string_of_int total ^ " search results for \"" ^ search ^ "\"" %>
+              <% ); %>
+            </h1>
+
+            <% if List.length packages = 0 then ( %>
+            <p>
+              We didn't find a match for "<%s search %>".
+            </p>
+            <p>
+              <strong>Search tips:</strong>
+            </p>
+            <ul>
+              <li>The search does not correct typos automatically (yet). Be sure to use correct spelling for keywords or package names.</li>
+              <li>Looking for a tutorial or guide, and not a package? Check out our <a href="<%s Url.learn %>">Learn area</a>.</li>
+              <li>Looking for the standard library API? It's <a href="<%s Url.api %>">here</a>.</li>
+            </ul>
+            </div>
+            <% ); %>
+          </div>
         </div>
-      </div>
-      <div class="flex flex-col lg:px-28">
+
         <% packages |> List.iter (fun (package : Package_intf.package) -> %>
         <div class="border-gray-200 border-t mt-4 pt-4 mb-2 space-y-2">
           <a


### PR DESCRIPTION
Following @Clairevanden's wireframes I've rearranged the search results page as follows:

|screen|before|after|
|-|-|-|
|sm many results|![Screenshot 2023-02-06 at 15-27-00 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216997880-06ebb99d-ba2b-4df1-9b54-fdf19c037676.png)|![Screenshot 2023-02-06 at 15-27-05 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216997891-1c498813-0228-44e2-8ebf-9511171fedba.png)|
|lg many results| ![Screenshot 2023-02-06 at 15-27-15 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216997943-d2deffdf-57f7-4b73-9dab-73b2546805a7.png)|![Screenshot 2023-02-06 at 15-27-19 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216997959-6c0dfaa8-5d03-4064-b9c3-f4c974353551.png)|
|lg one result|![Screenshot 2023-02-06 at 15-27-54 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216998054-a1997d6d-0e7d-4e36-9b12-d048c29f69b1.png)|![Screenshot 2023-02-06 at 15-27-57 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216998068-b4b2b3a5-d817-46ca-862b-3d9dbe0ba8a5.png)|
|lg no results|![Screenshot 2023-02-06 at 15-27-34 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216998132-0e87999f-a6b6-4275-921d-33690b4f90a8.png)|![Screenshot 2023-02-06 at 15-27-38 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/216998148-b0681407-5e08-430a-a2d4-380f4efd4c48.png)|

