### PR TITLE
Capitalize Problem Titles

### DIFF
--- a/data/problems/001_tail.md
+++ b/data/problems/001_tail.md
@@ -1,5 +1,5 @@
 ---
-title: Tail of a list
+title: Tail of a List
 number: "1"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/002_tail_penultimate.md
+++ b/data/problems/002_tail_penultimate.md
@@ -1,5 +1,5 @@
 ---
-title: Last two elements of a list
+title: Last Two Elements of a List
 number: "2"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/003_nth_element.md
+++ b/data/problems/003_nth_element.md
@@ -1,5 +1,5 @@
 ---
-title: N'th element of a list
+title: N'th Element of a List
 number: "3"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/004_length_of_list.md
+++ b/data/problems/004_length_of_list.md
@@ -1,5 +1,5 @@
 ---
-title: Length of a list
+title: Length of a List
 number: "4"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/005_reverse_list.md
+++ b/data/problems/005_reverse_list.md
@@ -1,5 +1,5 @@
 ---
-title: Reverse a list
+title: Reverse a List
 number: "5"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/007_flatten_list.md
+++ b/data/problems/007_flatten_list.md
@@ -1,5 +1,5 @@
 ---
-title: Flatten a list
+title: Flatten a List
 number: "7"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/008_remove_duplicates.md
+++ b/data/problems/008_remove_duplicates.md
@@ -1,5 +1,5 @@
 ---
-title: Eliminate duplicates
+title: Eliminate Duplicates
 number: "8"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/009_pack_duplicates.md
+++ b/data/problems/009_pack_duplicates.md
@@ -1,5 +1,5 @@
 ---
-title: Pack consecutive duplicates
+title: Pack Consecutive Duplicates
 number: "9"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/010_run_length_encoding.md
+++ b/data/problems/010_run_length_encoding.md
@@ -1,5 +1,5 @@
 ---
-title: Run-length encoding
+title: Run-Length Encoding
 number: "10"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/011_modified_run_length.md
+++ b/data/problems/011_modified_run_length.md
@@ -1,5 +1,5 @@
 ---
-title: Modified run-length encoding
+title: Modified Run-Length Encoding
 number: "11"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/012_run_length_decoding.md
+++ b/data/problems/012_run_length_decoding.md
@@ -1,5 +1,5 @@
 ---
-title: Decode a run-length encoded list
+title: Decode a Run-Length Encoded List
 number: "12"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/013_run_decoding_direct.md
+++ b/data/problems/013_run_decoding_direct.md
@@ -1,5 +1,5 @@
 ---
-title: Run-length encoding of a list (direct solution)
+title: Run-Length Encoding of a List (Direct Solution)
 number: "13"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/014_duplicate_elements.md
+++ b/data/problems/014_duplicate_elements.md
@@ -1,5 +1,5 @@
 ---
-title: Duplicate the elements of a list
+title: Duplicate the Elements of a List
 number: "14"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/015_replicate_elements.md
+++ b/data/problems/015_replicate_elements.md
@@ -1,5 +1,5 @@
 ---
-title: Replicate the elements of a list a given number of times
+title: Replicate the Elements of a List a Given Number of Times
 number: "15"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/016_drop_elements.md
+++ b/data/problems/016_drop_elements.md
@@ -1,5 +1,5 @@
 ---
-title: Drop every N'th element from a list
+title: Drop Every N'th Element From a List
 number: "16"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/017_split_list.md
+++ b/data/problems/017_split_list.md
@@ -1,5 +1,5 @@
 ---
-title: Split a list into two parts; the length of the first part is given
+title: Split a List Into Two Parts; The Length of the First Part Is Given
 number: "17"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/018_extract_slice.md
+++ b/data/problems/018_extract_slice.md
@@ -1,5 +1,5 @@
 ---
-title: Extract a slice from a list
+title: Extract a Slice From a List
 number: "18"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/019_rotate_list.md
+++ b/data/problems/019_rotate_list.md
@@ -1,5 +1,5 @@
 ---
-title: Rotate a list N places to the left
+title: Rotate a List N Places to the Left
 number: "19"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/020_remove_nth_element.md
+++ b/data/problems/020_remove_nth_element.md
@@ -1,5 +1,5 @@
 ---
-title: Remove the K'th element from a list
+title: Remove the K'th Element From a List
 number: "20"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/021_insert_element.md
+++ b/data/problems/021_insert_element.md
@@ -1,5 +1,5 @@
 ---
-title: Insert an element at a given position into a list
+title: Insert an Element at a Given Position Into a List
 number: "21"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/022_create_list.md
+++ b/data/problems/022_create_list.md
@@ -1,5 +1,5 @@
 ---
-title: Create a list containing all integers within a given range
+title: Create a List Containing All Integers Within a Given Range
 number: "22"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/023_extract_random.md
+++ b/data/problems/023_extract_random.md
@@ -1,5 +1,5 @@
 ---
-title: Extract a given number of randomly selected elements from a list
+title: Extract a Given Number of Randomly Selected Elements From a List
 number: "23"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/024_lotto.md
+++ b/data/problems/024_lotto.md
@@ -1,5 +1,5 @@
 ---
-title: "Lotto: Draw N different random numbers from the set 1..M"
+title: "Lotto: Draw N Different Random Numbers From the Set 1..M"
 number: "24"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/025_generate_permutations.md
+++ b/data/problems/025_generate_permutations.md
@@ -1,5 +1,5 @@
 ---
-title: Generate a random permutation of the elements of a list
+title: Generate a Random Permutation of the Elements of a List
 number: "25"
 difficulty: beginner
 tags: [ "list" ]

--- a/data/problems/026_generate_combinations.md
+++ b/data/problems/026_generate_combinations.md
@@ -1,5 +1,5 @@
 ---
-title: Generate the combinations of K distinct objects chosen from the N elements of a list
+title: Generate the Combinations of K Distinct Objects Chosen From the N Elements of a List
 number: "26"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/027_group_elements.md
+++ b/data/problems/027_group_elements.md
@@ -1,5 +1,5 @@
 ---
-title: Group the elements of a set into disjoint subsets
+title: Group the Elements of a Set Into Disjoint Subsets
 number: "27"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/028_sort_list.md
+++ b/data/problems/028_sort_list.md
@@ -1,5 +1,5 @@
 ---
-title: Sorting a list of lists according to length of sublists
+title: Sorting a List of Lists According to Length of Sublists
 number: "28"
 difficulty: intermediate
 tags: [ "list" ]

--- a/data/problems/031_is_prime.md
+++ b/data/problems/031_is_prime.md
@@ -1,5 +1,5 @@
 ---
-title: Determine whether a given integer number is prime
+title: Determine Whether a Given Integer Number Is Prime
 number: "31"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/032_gcd.md
+++ b/data/problems/032_gcd.md
@@ -1,5 +1,5 @@
 ---
-title: Determine the greatest common divisor of two positive integer numbers
+title: Determine the Greatest Common Divisor of Two Positive Integer Numbers
 number: "32"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/033_is_coprime.md
+++ b/data/problems/033_is_coprime.md
@@ -1,5 +1,5 @@
 ---
-title: Determine whether two positive integer numbers are coprime
+title: Determine Whether Two Positive Integer Numbers Are Coprime
 number: "33"
 difficulty: beginner
 tags: [ "arithmetic" ]

--- a/data/problems/034_euler_totient.md
+++ b/data/problems/034_euler_totient.md
@@ -1,5 +1,5 @@
 ---
-title: Calculate Euler's totient function φ(m)
+title: Calculate Euler's Totient Function Φ(m)
 number: "34"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/035_prime_factor.md
+++ b/data/problems/035_prime_factor.md
@@ -1,5 +1,5 @@
 ---
-title: Determine the prime factors of a given positive integer
+title: Determine the Prime Factors of a Given Positive Integer
 number: "35"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/036_prime_factor_2.md
+++ b/data/problems/036_prime_factor_2.md
@@ -1,5 +1,5 @@
 ---
-title: Determine the prime factors of a given positive integer (2)
+title: Determine the Prime Factors of a Given Positive Integer (2)
 number: "36"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/037_euler_totent_improved.md
+++ b/data/problems/037_euler_totent_improved.md
@@ -1,5 +1,5 @@
 ---
-title: Calculate Euler's totient function φ(m) (improved)
+title: Calculate Euler's Totient Function Φ(m) (Improved)
 number: "37"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/038_compare_totient.md
+++ b/data/problems/038_compare_totient.md
@@ -1,5 +1,5 @@
 ---
-title: Compare the two methods of calculating Euler's totient function
+title: Compare the Two Methods of Calculating Euler's Totient Function
 number: "38"
 difficulty: beginner
 tags: [ "arithmetic" ]

--- a/data/problems/039_list_prime.md
+++ b/data/problems/039_list_prime.md
@@ -1,5 +1,5 @@
 ---
-title: A list of prime numbers
+title: A List of Prime Numbers
 number: "39"
 difficulty: beginner
 tags: [ "arithmetic" ]

--- a/data/problems/040_goldbach_conjecture.md
+++ b/data/problems/040_goldbach_conjecture.md
@@ -1,5 +1,5 @@
 ---
-title: Goldbach's conjecture
+title: Goldbach's Conjecture
 number: "40"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/041_goldbach_composition.md
+++ b/data/problems/041_goldbach_composition.md
@@ -1,5 +1,5 @@
 ---
-title: A list of Goldbach compositions
+title: A List of Goldbach Compositions
 number: "41"
 difficulty: intermediate
 tags: [ "arithmetic" ]

--- a/data/problems/046_truth_table.md
+++ b/data/problems/046_truth_table.md
@@ -1,5 +1,5 @@
 ---
-title:  Truth tables for logical expressions (2 variables)
+title: Truth Tables for Logical Expressions (2 Variables)
 number: "46"
 difficulty: intermediate
 tags: [ "logic" ]

--- a/data/problems/048_truth_table_2.md
+++ b/data/problems/048_truth_table_2.md
@@ -1,5 +1,5 @@
 ---
-title: Truth tables for logical expressions
+title: Truth Tables for Logical Expressions
 number: "48"
 difficulty: intermediate
 tags: [ "logic" ]

--- a/data/problems/049_gray_code.md
+++ b/data/problems/049_gray_code.md
@@ -1,5 +1,5 @@
 ---
-title: Gray code
+title: Gray Code
 number: "49"
 difficulty: intermediate
 tags: [ "logic" ]

--- a/data/problems/050_huffman_code.md
+++ b/data/problems/050_huffman_code.md
@@ -1,5 +1,5 @@
 ---
-title: Huffman code
+title: Huffman Code
 number: "50"
 difficulty: advanced
 tags: [ "logic" ]

--- a/data/problems/055_balanced_btree.md
+++ b/data/problems/055_balanced_btree.md
@@ -1,5 +1,5 @@
 ---
-title: Construct completely balanced binary trees
+title: Construct Completely Balanced Binary Trees
 number: "55"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/056_symmetric_btree.md
+++ b/data/problems/056_symmetric_btree.md
@@ -1,5 +1,5 @@
 ---
-title: Symmetric binary trees
+title: Symmetric Binary Trees
 number: "56"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/057_bst.md
+++ b/data/problems/057_bst.md
@@ -1,5 +1,5 @@
 ---
-title: Binary search trees (dictionaries)
+title: Binary Search Trees (Dictionaries)
 number: "57"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/058_generate_and_test.md
+++ b/data/problems/058_generate_and_test.md
@@ -1,5 +1,5 @@
 ---
-title: Generate-and-test paradigm
+title: Generate-and-Test Paradigm
 number: "58"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/059_height_balanced_btree.md
+++ b/data/problems/059_height_balanced_btree.md
@@ -1,5 +1,5 @@
 ---
-title: Construct height-balanced binary trees
+title: Construct Height-Balanced Binary Trees
 number: "59"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/060_height_balanced_btree_2.md
+++ b/data/problems/060_height_balanced_btree_2.md
@@ -1,5 +1,5 @@
 ---
-title: Construct height-balanced binary trees with a given number of nodes
+title: Construct Height-Balanced Binary Trees With a Given Number of Nodes
 number: "60"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/061A_count_leaves.md
+++ b/data/problems/061A_count_leaves.md
@@ -1,5 +1,5 @@
 ---
-title: Count the leaves of a binary tree
+title: Count the Leaves of a Binary Tree
 number: "61A"
 difficulty: beginner
 tags: [ "binary-tree" ]

--- a/data/problems/061B_collect_leaves.md
+++ b/data/problems/061B_collect_leaves.md
@@ -1,5 +1,5 @@
 ---
-title: Collect the leaves of a binary tree in a list
+title: Collect the Leaves of a Binary Tree in a List
 number: "61B"
 difficulty: beginner
 tags: [ "binary-tree" ]

--- a/data/problems/062A_collect_nodes.md
+++ b/data/problems/062A_collect_nodes.md
@@ -1,5 +1,5 @@
 ---
-title: Collect the internal nodes of a binary tree in a list
+title: Collect the Internal Nodes of a Binary Tree in a List
 number: "62A"
 difficulty: beginner
 tags: [ "binary-tree" ]

--- a/data/problems/062B_collect_nodes_2.md
+++ b/data/problems/062B_collect_nodes_2.md
@@ -1,5 +1,5 @@
 ---
-title: Collect the nodes at a given level in a list
+title: Collect the Nodes at a Given Level in a List
 number: "62B"
 difficulty: beginner
 tags: [ "binary-tree" ]

--- a/data/problems/063_create_btree.md
+++ b/data/problems/063_create_btree.md
@@ -1,5 +1,5 @@
 ---
-title: Construct a complete binary tree
+title: Construct a Complete Binary Tree
 number: "63"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/064_btree_layout_1.md
+++ b/data/problems/064_btree_layout_1.md
@@ -1,5 +1,5 @@
 ---
-title: Layout a binary tree (1)
+title: Layout a Binary Tree (1)
 number: "64"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/065_btree_layout_2.md
+++ b/data/problems/065_btree_layout_2.md
@@ -1,5 +1,5 @@
 ---
-title: Layout a binary tree (2)
+title: Layout a Binary Tree (2)
 number: "65"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/066_btree_layout_3.md
+++ b/data/problems/066_btree_layout_3.md
@@ -1,5 +1,5 @@
 ---
-title: Layout a binary tree (3)
+title: Layout a Binary Tree (3)
 number: "66"
 difficulty: advanced
 tags: [ "binary-tree" ]

--- a/data/problems/067_string_of_btree.md
+++ b/data/problems/067_string_of_btree.md
@@ -1,5 +1,5 @@
 ---
-title: A string representation of binary trees
+title: A String Representation of Binary Trees
 number: "67"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/068_sort_btree.md
+++ b/data/problems/068_sort_btree.md
@@ -1,5 +1,5 @@
 ---
-title: Preorder and inorder sequences of binary trees
+title: Preorder and Inorder Sequences of Binary Trees
 number: "68"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/069_dotstring_of_btree.md
+++ b/data/problems/069_dotstring_of_btree.md
@@ -1,5 +1,5 @@
 ---
-title: Dotstring representation of binary trees
+title: Dotstring Representation of Binary Trees
 number: "69"
 difficulty: intermediate
 tags: [ "binary-tree" ]

--- a/data/problems/070A_create_mtree.md
+++ b/data/problems/070A_create_mtree.md
@@ -1,5 +1,5 @@
 ---
-title: Tree construction from a node string
+title: Tree Construction From a Node String
 number: "70A"
 difficulty: intermediate
 tags: [ "multiway-tree" ]

--- a/data/problems/070B_count_mtree_nodes.md
+++ b/data/problems/070B_count_mtree_nodes.md
@@ -1,5 +1,5 @@
 ---
-title: Count the nodes of a multiway tree
+title: Count the Nodes of a Multiway Tree
 number: "70B"
 difficulty: beginner
 tags: [ "multiway-tree" ]

--- a/data/problems/071_internal_path.md
+++ b/data/problems/071_internal_path.md
@@ -1,5 +1,5 @@
 ---
-title: Determine the internal path length of a tree
+title: Determine the Internal Path Length of a Tree
 number: "71"
 difficulty: beginner
 tags: [ "multiway-tree" ]

--- a/data/problems/072_bottom_up_seq.md
+++ b/data/problems/072_bottom_up_seq.md
@@ -1,5 +1,5 @@
 ---
-title: Construct the bottom-up order sequence of the tree nodes
+title: Construct the Bottom-Up Order Sequence of the Tree Nodes
 number: "72"
 difficulty: beginner
 tags: [ "multiway-tree" ]

--- a/data/problems/073_lisp_of_mtree.md
+++ b/data/problems/073_lisp_of_mtree.md
@@ -1,5 +1,5 @@
 ---
-title: Lisp-like tree representation
+title: Lisp-Like Tree Representation
 number: "73"
 difficulty: intermediate
 tags: [ "multiway-tree" ]

--- a/data/problems/081_node_path.md
+++ b/data/problems/081_node_path.md
@@ -1,5 +1,5 @@
 ---
-title: Path from one node to another one
+title: Path From One Node to Another One
 number: "81"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/082_node_cycle.md
+++ b/data/problems/082_node_cycle.md
@@ -1,5 +1,5 @@
 ---
-title: Cycle from a given node
+title: Cycle From a Given Node
 number: "82"
 difficulty: beginner
 tags: [ "graph" ]

--- a/data/problems/083_spanning_trees.md
+++ b/data/problems/083_spanning_trees.md
@@ -1,5 +1,5 @@
 ---
-title: Construct all spanning trees
+title: Construct All Spanning Trees
 number: "83"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/084_minimal_splanning_tree.md
+++ b/data/problems/084_minimal_splanning_tree.md
@@ -1,5 +1,5 @@
 ---
-title: Construct the minimal spanning tree
+title: Construct the Minimal Spanning Tree
 number: "84"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/085_graph_isomorphism.md
+++ b/data/problems/085_graph_isomorphism.md
@@ -1,5 +1,5 @@
 ---
-title: Graph isomorphism
+title: Graph Isomorphism
 number: "85"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/086_node_degree.md
+++ b/data/problems/086_node_degree.md
@@ -1,5 +1,5 @@
 ---
-title: Node degree and graph coloration
+title: Node Degree and Graph Coloration
 number: "86"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/087_depth_first_traversal.md
+++ b/data/problems/087_depth_first_traversal.md
@@ -1,5 +1,5 @@
 ---
-title: Depth-first order graph traversal
+title: Depth-First Order Graph Traversal
 number: "87"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/088_connected_components.md
+++ b/data/problems/088_connected_components.md
@@ -1,5 +1,5 @@
 ---
-title: Connected components
+title: Connected Components
 number: "88"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/089_bipartite_graphs.md
+++ b/data/problems/089_bipartite_graphs.md
@@ -1,5 +1,5 @@
 ---
-title: Bipartite graphs
+title: Bipartite Graphs
 number: "89"
 difficulty: intermediate
 tags: [ "graph" ]

--- a/data/problems/090_generate_graph.md
+++ b/data/problems/090_generate_graph.md
@@ -1,5 +1,5 @@
 ---
-title: Generate K-regular simple graphs with N nodes
+title: Generate K-Regular Simple Graphs With N Nodes
 number: "90"
 difficulty: advanced
 tags: [ "graph" ]

--- a/data/problems/091_eight_queens.md
+++ b/data/problems/091_eight_queens.md
@@ -1,5 +1,5 @@
 ---
-title: Eight queens problem
+title: Eight Queens Problem
 number: "91"
 difficulty: intermediate
 tags: []

--- a/data/problems/092_knights_tour.md
+++ b/data/problems/092_knights_tour.md
@@ -1,5 +1,5 @@
 ---
-title: Knight's tour
+title: Knight's Tour
 number: "92"
 difficulty: intermediate
 tags: []

--- a/data/problems/093_von_koch.md
+++ b/data/problems/093_von_koch.md
@@ -1,5 +1,5 @@
 ---
-title: Von Koch's conjecture
+title: Von Koch's Conjecture
 number: "93"
 difficulty: advanced
 tags: []

--- a/data/problems/094_arithmetic_puzzle.md
+++ b/data/problems/094_arithmetic_puzzle.md
@@ -1,5 +1,5 @@
 ---
-title: An arithmetic puzzle
+title: An Arithmetic Puzzle
 number: "94"
 difficulty: advanced
 tags: []

--- a/data/problems/095_english_number_words.md
+++ b/data/problems/095_english_number_words.md
@@ -1,5 +1,5 @@
 ---
-title: English number words
+title: English Number Words
 number: "95"
 difficulty: intermediate
 tags: []

--- a/data/problems/096_syntax_checker.md
+++ b/data/problems/096_syntax_checker.md
@@ -1,5 +1,5 @@
 ---
-title: Syntax checker
+title: Syntax Checker
 number: "96"
 difficulty: intermediate
 tags: []

--- a/data/problems/099_crosswords.md
+++ b/data/problems/099_crosswords.md
@@ -1,5 +1,5 @@
 ---
-title: Crossword puzzle
+title: Crossword Puzzle
 number: "99"
 difficulty: advanced
 tags: []


### PR DESCRIPTION
- minor improvements to package docs odoc styles (#884)
- Improve usage of spaces in footer (#883)
- do not show empty table of contents (#886)
- Capitalize Exercices Titles
