### PR TITLE
Highlight search terms in package search results

### DIFF
--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -2,7 +2,7 @@ let highlight_search_terms
 ~search
 (text: string)
 =
-  let render_item i = match i with
+  let render_item = function 
     | Str.Delim s -> {|<span class="bg-background-light-blue">|} ^ Dream.html_escape s ^ {|</span>|}
     | Text s -> Dream.html_escape s
   in

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -8,7 +8,7 @@ let highlight_search_terms
   in
   let r = Str.global_replace (Str.regexp "[ \t]+") "\\|" search in
   let split = Str.full_split (Str.regexp_case_fold r) text in
-  String.concat "" (List.map render_item split)
+  List.fold_left (fun a b -> a ^ render_item b) "" split
 
 let render ~total ~search (packages : Package_intf.package list) = Layout.render ~title:"OCaml Packages · Search Result"
 ~description:"Find the package you need to build your application in the thousands of available OCaml packages."

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,3 +1,16 @@
+let highlight_search_terms
+~search
+(text: string)
+=
+  let render_item i = match i with
+    | Str.Delim s -> {|<strong class="bg-default">|} ^ Dream.html_escape s ^ {|</strong>|}
+    | Text s -> Dream.html_escape s
+  in
+  let terms = Str.split (Str.regexp "[ \t]+") search in
+  let r = String.concat "\\|" terms in
+  let split = Str.full_split (Str.regexp_case_fold r) text in
+  String.concat "" (List.map render_item split)
+
 let render ~total ~search (packages : Package_intf.package list) = Layout.render ~title:"OCaml Packages · Search Result"
 ~description:"Find the package you need to build your application in the thousands of available OCaml packages."
 ~canonical:(Url.packages_search ^ "?q=" ^ search)
@@ -59,14 +72,14 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
           >
             <%s package.name %>
           </a>
-          <div><%s package.description %></div>
+          <div><%s! highlight_search_terms ~search package.description %></div>
           <div class="flex flex-wrap">
             <% package.tags |> List.iter (fun (tag : string) -> %>
             <a
               href="<%s Url.packages_search %>?q=tag%3A%22<%s Dream.to_percent_encoded tag %>%22"
               class="px-2 py-1 text-body-400 font-medium bg-gray-100 rounded hover:underline mr-3 mb-2 mt-1 text-sm"
             >
-              <%s tag %>
+              <%s! highlight_search_terms ~search tag %>
             </a>
             <% ); %>
           </div>
@@ -77,7 +90,7 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
                 href="<%s Url.packages_search %>?q=author%3A%22<%s Dream.to_percent_encoded author.name %>%22"
                 class="text-sm hover:underline mr-3"
               >
-                <%s author.name %>
+                <%s! highlight_search_terms ~search author.name %>
               </a>
               <% ); %>
             </div>

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -3,7 +3,7 @@ let highlight_search_terms
 (text: string)
 =
   let render_item i = match i with
-    | Str.Delim s -> {|<strong class="bg-default">|} ^ Dream.html_escape s ^ {|</strong>|}
+    | Str.Delim s -> {|<span class="bg-background-light-blue">|} ^ Dream.html_escape s ^ {|</span>|}
     | Text s -> Dream.html_escape s
   in
   let terms = Str.split (Str.regexp "[ \t]+") search in

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -6,8 +6,7 @@ let highlight_search_terms
     | Str.Delim s -> {|<span class="bg-background-light-blue">|} ^ Dream.html_escape s ^ {|</span>|}
     | Text s -> Dream.html_escape s
   in
-  let terms = Str.split (Str.regexp "[ \t]+") search in
-  let r = String.concat "\\|" terms in
+  let r = Str.global_replace (Str.regexp "[ \t]+") "\\|" search in
   let split = Str.full_split (Str.regexp_case_fold r) text in
   String.concat "" (List.map render_item split)
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ module.exports = {
           default: "#FAF8F3",
           beige: "#FAF8F3",
           "dark-blue": "#0e1531", // one of the colors from the blue patterned background used in various parts of the site
+          "light-blue": "rgb(221, 232, 251)",
         },
         body: {
           700: "#0A0C11",


### PR DESCRIPTION
Patch adds subtle highlighting on search terms on the package search results page. Ty @Clairevanden.

|before|after|
|-|-|
|![Screenshot 2023-02-07 at 10-38-10 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/217207608-372d34ce-7976-4014-b7d4-d2e07fb85b69.png)|![Screenshot 2023-02-07 at 10-38-02 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/217207622-abde3243-54f1-4200-bc65-6add1767742c.png)|
