### PR TITLE
also swap <head> element on htmx navigation

### DIFF
--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -30,7 +30,7 @@ let kind_title = function
 
 let title_style = "flex-1 flex-nowrap py-1 md:py-0.5 pr-1 text-gray-600"
 
-let htmx_attributes = "hx-boost=\"true\" hx-ext=\"multi-swap\" hx-swap=\"multi:#htmx-sidebar,#htmx-content,#htmx-right-sidebar\" hx-push-url=\"true\""
+let htmx_attributes = "hx-boost=\"true\" hx-ext=\"multi-swap\" hx-swap=\"multi:#htmx-head,#htmx-sidebar,#htmx-content,#htmx-right-sidebar\" hx-push-url=\"true\""
 
 let icon_style = function
   | Library -> "navmap-tag library-tag"

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -10,7 +10,7 @@ let render
 inner =
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+  <head id="htmx-head">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <% (match description with | Some description -> %>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -53,7 +53,7 @@ let sidebar_icon_link_block
 
 let htmx_attributes href
 =
-  <% if String.get href 0 != '#' then ( %> hx-boost="true" hx-ext="multi-swap" hx-swap="multi:#htmx-sidebar,#htmx-content,#htmx-right-sidebar" hx-push-url="true" <% ); %>
+  <% if String.get href 0 != '#' then ( %> hx-boost="true" hx-ext="multi-swap" hx-swap="multi:#htmx-head,#htmx-sidebar,#htmx-content,#htmx-right-sidebar" hx-push-url="true" <% ); %>
 
 let sidebar_link
 ~title


### PR DESCRIPTION
Resolves https://github.com/ocaml/ocaml.org/issues/892 by making htmx swap the `<head>` element when navigating via htmx.