### PR TITLE
Reverse result of get_package_versions

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -183,8 +183,7 @@ let get_packages_with_name t name =
 
 let get_package_versions t name =
   t.packages |> Name.Map.find_opt name
-  |> Option.map Version.Map.bindings
-  |> Option.map (List.map fst)
+  |> Option.map (fun p -> p |> Version.Map.bindings |> List.rev_map fst)
 
 let get_package_latest t name = get_package_latest' t.packages name
 
@@ -380,7 +379,7 @@ let latest_documented_version t name =
   in
   match get_package_versions t name with
   | None -> Lwt.return None
-  | Some vlist -> aux (List.rev vlist)
+  | Some vlist -> aux vlist
 
 module Search : sig
   type search_request

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -145,7 +145,7 @@ val get_packages_with_name : state -> Name.t -> t list option
 (** Get the list of packages with the given name. *)
 
 val get_package_versions : state -> Name.t -> Version.t list option
-(** Get the list of versions for a package name. *)
+(** Get the reversed list of versions for a package name. *)
 
 val get_package_latest : state -> Name.t -> t option
 (** Get the latest version of a package given a package name. *)

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -145,7 +145,7 @@ val get_packages_with_name : state -> Name.t -> t list option
 (** Get the list of packages with the given name. *)
 
 val get_package_versions : state -> Name.t -> Version.t list option
-(** Get the reversed list of versions for a package name. *)
+(** Get the list of versions for a package name, newest coming first. *)
 
 val get_package_latest : state -> Name.t -> t option
 (** Get the latest version of a package given a package name. *)


### PR DESCRIPTION
Function was called in three different places:

* In Ocamlorg_package.latest_documented_version, its result was reversed
* In Handler.package_doc, its result was ignored
* In Handler.package_version, its result was sorted

Therefore, it is simpler to always returned a reversed result.
