### PR TITLE
Use packages aliases instead of fully qualified packages

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -16,21 +16,21 @@ let create ~name ~version info = { name; version; info }
 type state = {
   version : string;
   mutable opam_repository_commit : string option;
-  mutable packages : Info.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t;
+  mutable packages : Info.t OpamPackage.Version.Map.t Name.Map.t;
   mutable stats : Packages_stats.t option;
   mutable featured_packages : t list option;
 }
 
 let state_of_package_list (pkgs : t list) =
-  let map = OpamPackage.Name.Map.empty in
+  let map = Name.Map.empty in
   let add_version (pkg : t) map =
     let new_map =
-      match OpamPackage.Name.Map.find_opt pkg.name map with
+      match Name.Map.find_opt pkg.name map with
       | None -> OpamPackage.Version.Map.(add pkg.version pkg.info empty)
       | Some version_map ->
           OpamPackage.Version.Map.add pkg.version pkg.info version_map
     in
-    OpamPackage.Name.Map.add pkg.name new_map map
+    Name.Map.add pkg.name new_map map
   in
   let packages = List.fold_left (fun map v -> add_version v map) map pkgs in
   {
@@ -58,7 +58,7 @@ let read_packages () =
   let open Lwt.Syntax in
   Lwt_list.fold_left_s
     (fun acc (package_name, versions) ->
-      match OpamPackage.Name.of_string package_name with
+      match Name.of_string package_name with
       | exception ex ->
           Logs.err (fun m ->
               m "Invalid package name %S: %s" package_name
@@ -66,8 +66,8 @@ let read_packages () =
           Lwt.return acc
       | _name ->
           let+ versions = read_versions package_name versions in
-          OpamPackage.Name.Map.add (Name.of_string package_name) versions acc)
-    OpamPackage.Name.Map.empty
+          Name.Map.add (Name.of_string package_name) versions acc)
+    Name.Map.empty
     (Opam_repository.list_packages_and_versions ())
 
 let try_load_state () =
@@ -81,7 +81,7 @@ let try_load_state () =
         if Info.version <> v.version then raise Invalid_version;
         Logs.info (fun f ->
             f "Package state loaded (%d packages, opam commit %s)"
-              (OpamPackage.Name.Map.cardinal v.packages)
+              (Name.Map.cardinal v.packages)
               (Option.value ~default:"" v.opam_repository_commit));
         v)
       ~finally:(fun () -> close_in channel)
@@ -90,7 +90,7 @@ let try_load_state () =
     {
       opam_repository_commit = None;
       version = Info.version;
-      packages = OpamPackage.Name.Map.empty;
+      packages = Name.Map.empty;
       stats = None;
       featured_packages = None;
     }
@@ -104,7 +104,7 @@ let save_state t =
     ~finally:(fun () -> close_out channel)
 
 let get_package_latest' packages name =
-  OpamPackage.Name.Map.find_opt name packages
+  Name.Map.find_opt name packages
   |> Option.map (fun versions ->
          let version, info = OpamPackage.Version.Map.max_binding versions in
          { version; info; name })
@@ -128,8 +128,7 @@ let update ~commit t =
   t.packages <- packages;
   t.stats <- Some stats;
   t.featured_packages <- Some featured_packages;
-  Logs.info (fun m ->
-      m "Loaded %d packages" (OpamPackage.Name.Map.cardinal packages))
+  Logs.info (fun m -> m "Loaded %d packages" (Name.Map.cardinal packages))
 
 let maybe_update t =
   let open Lwt.Syntax in
@@ -172,28 +171,26 @@ let init ?(disable_polling = false) () =
 
 let all_packages_latest t =
   t.packages
-  |> OpamPackage.Name.Map.map OpamPackage.Version.Map.max_binding
-  |> OpamPackage.Name.Map.bindings
+  |> Name.Map.map OpamPackage.Version.Map.max_binding
+  |> Name.Map.bindings
   |> List.map (fun (name, (version, info)) -> { name; version; info })
 
 let packages_stats t = t.stats
 
 let get_packages_with_name t name =
-  t.packages
-  |> OpamPackage.Name.Map.find_opt name
+  t.packages |> Name.Map.find_opt name
   |> Option.map OpamPackage.Version.Map.bindings
   |> Option.map (List.map (fun (version, info) -> { name; version; info }))
 
 let get_package_versions t name =
-  t.packages
-  |> OpamPackage.Name.Map.find_opt name
+  t.packages |> Name.Map.find_opt name
   |> Option.map OpamPackage.Version.Map.bindings
   |> Option.map (List.map fst)
 
 let get_package_latest t name = get_package_latest' t.packages name
 
 let get_package t name version =
-  t.packages |> OpamPackage.Name.Map.find_opt name |> fun x ->
+  t.packages |> Name.Map.find_opt name |> fun x ->
   Option.bind x (OpamPackage.Version.Map.find_opt version)
   |> Option.map (fun info -> { version; info; name })
 


### PR DESCRIPTION
- Use Name instead of Package.Name
- Use Version instead of Package.Version
