### PR TITLE
add Standard Library API link in footer

### DIFF
--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -72,7 +72,11 @@ let render () =
               </li>
 
               <li>
-                <a href="<%s Url.manual %>" class="text-base leading-6 text-gray-600">Language Docs</a>
+                <a href="<%s Url.manual %>" class="text-base leading-6 text-gray-600">Language Manual</a>
+              </li>
+
+              <li>
+                <a href="<%s Url.api %>" class="text-base leading-6 text-gray-600">Standard Library API</a>
               </li>
 
               <li>


### PR DESCRIPTION
Adds a Standard Library API link to the footer as this is a commonly-needed resource.

Also keep wording consistent with Learn area: "Language Manual" instead of "Language Docs".

|before|after|
|-|-|
|![Screenshot 2023-02-07 at 18-08-23 Learn OCaml](https://user-images.githubusercontent.com/6594573/217315406-60b9b3ec-0dfd-4a12-b513-f8aa6d85acf5.png)|![Screenshot 2023-02-07 at 18-08-31 Learn OCaml](https://user-images.githubusercontent.com/6594573/217315428-717df90f-4cbe-46c8-8db8-7b507a0892b3.png)|
|![Screenshot 2023-02-07 at 18-11-23 Learn OCaml](https://user-images.githubusercontent.com/6594573/217315459-bde1fcc5-5638-4de6-b53d-ab388a153b27.png)|![Screenshot 2023-02-07 at 18-11-27 Learn OCaml](https://user-images.githubusercontent.com/6594573/217315486-50c8cae4-427d-421d-845b-8b4acf691949.png)|
