### PR TITLE
add the last publication date to package search results

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -131,7 +131,7 @@ Package_layout.render
         </div>
 
         <dl>
-          <dt class="mt-8 font-semibold text-base text-body-400">Published</dt>
+          <dt class="mt-8 font-semibold text-base text-body-400">Last Published</dt>
           <dd class="mt-3 text-sm text-gray-900">
             <%s Utils.human_date_of_timestamp package.publication %>
           </dd>

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -144,6 +144,9 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
               </svg>
               <div>Used by <%d List.length package.rev_deps %> other packages</div>
             </div>
+            <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
+              Last published <%s Utils.human_date_of_timestamp package.publication %>
+            </div>
           </div>
         </div>
         <% ); %>


### PR DESCRIPTION
When looking for packages, it can be helpful to know when the last version was published.

This patch adds the last publication date of a package to the package search results.

|before|after|
|-|-|
|![Screenshot 2023-02-08 at 16-04-02 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/217567738-cce8d9ef-72a8-4277-ad65-285e025eeba4.png)|![Screenshot 2023-02-08 at 16-04-06 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/217567754-cfb04ee7-1709-4809-8968-170373b262af.png)|
