### PR TITLE
update ahrefs job

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -13,7 +13,6 @@ jobs:
   - title: OCaml Developer
     link: https://ahrefs.com/jobs/ocaml-developer
     location: Remote
-    publication_date: 2020-09-22
     company: Ahrefs
     company_logo: /logos/ahrefs.svg
   - title: OCaml Developer


### PR DESCRIPTION
The https://ahrefs.com/jobs/ocaml-developer position is evergreen, publication date is not relevant in that case.