### PR TITLE
add OCamlPro spontaneous application job listing

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -1,4 +1,10 @@
 jobs:
+  - title: Spontaneous Application
+    link: https://ocamlpro.com/jobs/
+    location: France
+    publication_date: 2023-02-10
+    company: OCamlPro
+    company_logo: https://ocamlpro.com/assets/img/logo_ocamlpro.png
   - title: Cryptography Engineer
     link: https://boards.greenhouse.io/o1labs/jobs/4023646004
     location: Remote
@@ -7,7 +13,6 @@ jobs:
   - title: Spontaneous Application
     link: https://tarides.com/jobs/spontaneous-application
     location: Remote
-    publication_date: 2021-10-17
     company: Tarides
     company_logo: https://tarides.com/static/logo_tarides-52f91b59a8657d768e013129896b63e0.png
   - title: OCaml Developer


### PR DESCRIPTION
Adds OCamlPro listing from https://discuss.ocaml.org/t/list-your-open-ocaml-positions-on-the-ocaml-org-job-board/11377/5

Also removes publication date on Tarides' spontaneous application listing.

I think, in general, we should eventually not show publication dates on spontaneous application listings. However, it is nice to see the new spontaneous application listing at the top of the list for a while. That makes people aware that this is a listing that recently came in.

After some point it doesn't matter anymore when a spontaneous application listing was published - all that matters is that it is still relevant. So we should consider checking maybe every 6 months if the spontaneous application listings are still active.
