### PR TITLE
Add a debugging back trace example

### DIFF
--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -9,12 +9,16 @@ date: 2021-05-27T21:07:30-00:00
 
 # Debugging
 
-This tutorial presents two techniques for debugging OCaml programs:
+This tutorial presents three techniques for debugging OCaml programs:
 
 * [Tracing functions calls](#tracing-functions-calls-in-the-toplevel),
   which works in the interactive toplevel.
 * The [OCaml debugger](#the-ocaml-debugger), which allows analysing programs
   compiled with `ocamlc`.
+* [How to get a back trace for an uncaught
+  exception](#printing-a-back-trace-for-an-uncaught-exception) in an
+  OCaml program
+
 
 ## Tracing Functions Calls in the Toplevel
 
@@ -339,3 +343,52 @@ Under Emacs you call the debugger using `ESC-x` `ocamldebug a.out`. Then Emacs
 will send you directly to the file and character reported by the debugger, and
 you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
 points using `CTRL-X space`, and so on...
+
+## Printing a back trace for an uncaught exception
+
+Getting a back trace for an uncaught exception can be informative to
+understand in which context a problem occurs. However, by default
+programs compiled with both `ocamlc` and `ocamlopt` will not print it:
+
+```
+ocamlc -g uncaught.ml
+./a.out
+Fatal error: exception Not_found
+ocamlopt -g uncaught.ml
+./a.out
+Fatal error: exception Not_found
+```
+
+By running with the environment variable `OCAMLRUNPARAM` set to `b`
+(for back trace) we get something more informative:
+
+```
+OCAMLRUNPARAM=b ./a.out
+Fatal error: exception Not_found
+Raised at Stdlib__List.assoc in file "list.ml", line 191, characters 10-25
+Called from Uncaught.find_address in file "uncaught.ml" (inlined), line 3, characters 24-42
+Called from Uncaught in file "uncaught.ml", line 8, characters 15-37
+```
+
+From this back trace it should be clear that we receive a `Not_found`
+exception in `List.assoc` from the `Stdlib` when calling
+`find_address` on line 8.
+
+
+The environment variable `OCAMLRUNPARAM` also works when working on a
+program built with `dune`:
+
+```
+;; file dune
+(executable
+ (name uncaught)
+ (modules uncaught)
+)
+```
+```
+OCAMLRUNPARAM=b dune exec ./uncaught.exe
+Fatal error: exception Not_found
+Raised at Stdlib__List.assoc in file "list.ml", line 191, characters 10-25
+Called from Dune__exe__Uncaught.find_address in file "uncaught.ml" (inlined), line 3, characters 24-42
+Called from Dune__exe__Uncaught in file "uncaught.ml", line 8, characters 15-37
+```

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -344,7 +344,7 @@ will send you directly to the file and character reported by the debugger, and
 you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
 points using `CTRL-X space`, and so on...
 
-## Printing a back trace for an uncaught exception
+## Printing a Back Trace for an Uncaught Exception
 
 Getting a back trace for an uncaught exception can be informative to
 understand in which context a problem occurs. However, by default

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -347,7 +347,7 @@ points using `CTRL-X space`, and so on...
 ## Printing a Back Trace for an Uncaught Exception
 
 Getting a back trace for an uncaught exception can be informative to
-understand in which context a problem occurs. However, by default
+understand in which context a problem occurs. However, by default,
 programs compiled with both `ocamlc` and `ocamlopt` will not print it:
 
 ```


### PR DESCRIPTION
To improve the debugging guide, this PR adds an example of how to print a back trace for an uncaught exception.
This is briefly mentioned in https://ocaml.org/docs/error-handling#stacktraces too, but I figured a spelled-out example could be useful to a newcomer.

Nit: The error handling page above calls these `stacktraces` (one word) where as the manual page https://v2.ocaml.org/manual/runtime.html calls them both `backtraces` (8 occurrences) and `back traces` (2 occurrences). 

I went with the `back trace` for now
- to side with the manual
- as it seems more correct English, and 
- because it also agrees with `OCAMLRUNPARAM`s `b` option