### PR TITLE
Change OCamlPro's logo on the job listing

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -13,7 +13,7 @@ jobs:
       - France
     publication_date: 2023-02-10
     company: OCamlPro
-    company_logo: https://ocamlpro.com/assets/img/logo_ocamlpro.png
+    company_logo: https://ocamlpro.com/assets/img/logo_ocamlpro_orange.png
   - title: Cryptography Engineer
     link: https://boards.greenhouse.io/o1labs/jobs/4023646004
     locations:


### PR DESCRIPTION
- With orange text instead of white