### PR TITLE
on package overview, it's 'Published', not 'Last published'

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -95,7 +95,7 @@ Package_layout.render
         </div>
 
         <dl>
-          <dt class="mt-8 font-semibold text-base text-body-400">Last Published</dt>
+          <dt class="mt-8 font-semibold text-base text-body-400">Published</dt>
           <dd class="mt-3 text-sm text-gray-900">
             <%s Utils.human_date_of_timestamp package.publication %>
           </dd>


### PR DESCRIPTION
Mistakenly changed the wording on the overview page when I added "Last published" to the search results. This corrects it.