### PR TITLE
Revert "Upgrade package documentation to odoc 2.2.0 (#878)"

### DIFF
--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -5,7 +5,6 @@ type kind =
   | Leaf_page
   | Module_type
   | Parameter
-  | OLDParameter (* DEPRECATED FALLBACK *)
   | Class
   | Class_type
   | File
@@ -25,7 +24,6 @@ let kind_title = function
   | Module -> "Module"
   | Module_type -> "Module type"
   | Parameter -> "Parameter"
-  | OLDParameter -> "Parameter" (* DEPRECATED FALLBACK *)
   | Class -> "Class"
   | Class_type -> "Class type"
   | _ -> "?"
@@ -39,7 +37,6 @@ let icon_style = function
   | Module -> "navmap-tag module-tag"
   | Module_type -> "navmap-tag module-type-tag"
   | Parameter -> "navmap-tag parameter-tag"
-  | OLDParameter -> "navmap-tag parameter-tag" (* DEPRECATED FALLBACK *)
   | Class -> "navmap-tag class-tag"
   | Class_type -> "navmap-tag class-type-tag"
   | _ -> "navmap-tag"

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -1,5 +1,4 @@
 module Package_breadcrumbs = Package_breadcrumbs
-module Package_overview = Package_overview
 module Navmap = Navmap
 module Toc = Toc
 module Url = Url

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -1,8 +1,3 @@
-type documentation_status =
-  | Success
-  | Failure
-  | Unknown
-
 let side_box_link ~href ~title ~icon_html =
     <a href="<%s href %>" class="flex items-center py-2 px-4 hover:text-primary-600">
         <%s! icon_html %>
@@ -72,17 +67,17 @@ Package_layout.render
         <% ); %>
         <div class="flex flex-col mt-8 text-body-400">
             <% (match documentation_status with
-            | Success -> %>
+            | `Success -> %>
             <a href="<%s Url.package_doc package.name package.version %>" class="px-4 h-10 items-center mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
               <%s! Icons.documentation "w-6 h-6 mr-2 inline-block" %>
               Documentation
             </a>
-            <% | Unknown -> ( %>
+            <% | `Unknown -> ( %>
             <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <%s! Icons.error "" %>
               Documentation status is unknown.
             </a><% )
-            | Failure -> ( %>
+            | `Failure -> ( %>
             <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <%s! Icons.error "" %>
               Documentation failed to build.

--- a/src/ocamlorg_package/lib/module_map.ml
+++ b/src/ocamlorg_package/lib/module_map.ml
@@ -1,20 +1,19 @@
 module String_map = Map.Make (String)
 
 type kind =
+  | Library
   | Module
   | Page
   | Leaf_page
   | Module_type
-  | Parameter of int
-  | OLDParameter (* FALLBACK, DEPRECATED*)
+  | Parameter
   | Class
   | Class_type
   | File
 
 let prefix_of_kind = function
   | Module_type -> "module-type-"
-  | Parameter i -> "argument-" ^ Int.to_string i ^ "-"
-  | OLDParameter -> "argument-" (* FALLBACK, DEPRECATED*)
+  | Parameter -> "argument-"
   | Class -> "class-"
   | Class_type -> "class-type-"
   | _ -> ""
@@ -58,16 +57,10 @@ let kind_of_yojson v =
   | "module" -> Module
   | "leaf-page" -> Leaf_page
   | "module-type" -> Module_type
+  | "argument" -> Parameter
   | "class" -> Class
   | "class-type" -> Class_type
   | "file" -> File
-  | "argument" ->
-      OLDParameter
-      (* TODO: DEPRECATED, REMOVE when we no longer need to fall back to the old
-         format*)
-  | s when String.starts_with ~prefix:"argument-" s ->
-      let i = List.hd (List.tl (String.split_on_char '-' s)) in
-      Parameter (int_of_string i)
   | _ -> raise (Type_error ("Variant not supported", v))
 
 let rec module_of_yojson ?parent v : Module.t =

--- a/src/ocamlorg_package/lib/module_map.mli
+++ b/src/ocamlorg_package/lib/module_map.mli
@@ -9,12 +9,12 @@ module String_map : Map.S with type key = string
 
 (** Page kinds as defined by odoc. *)
 type kind =
+  | Library
   | Module
   | Page
   | Leaf_page
   | Module_type
-  | Parameter of int
-  | OLDParameter
+  | Parameter
   | Class
   | Class_type
   | File

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -67,25 +67,14 @@ end
 module Documentation : sig
   type toc = { title : string; href : string; children : toc list }
 
-  type breadcrumb_kind =
-    | Page
-    | LeafPage
-    | Module
-    | ModuleType
-    | Parameter of int
-    | Class
-    | ClassType
-    | File
+  type item =
+    [ `Module of string
+    | `ModuleType of string
+    | `Parameter of int * string
+    | `Class of string
+    | `ClassType of string ]
 
-  type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
-
-  type t = {
-    module_map : Module_map.t;
-    uses_katex : bool;
-    toc : toc list;
-    breadcrumbs : breadcrumb list;
-    content : string;
-  }
+  type t = { toc : toc list; module_path : item list; content : string }
 end
 
 module Module_map = Module_map
@@ -121,11 +110,14 @@ val changes_filename :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Get the changelog file name of a package *)
 
-type documentation_status = Success | Failure | Unknown
-
 val documentation_status :
-  kind:[< `Package | `Universe of string ] -> t -> documentation_status Lwt.t
+  kind:[< `Package | `Universe of string ] ->
+  t ->
+  [ `Success | `Failure | `Unknown ] Lwt.t
 (** Get the build status of the documentation of a package *)
+
+val module_map :
+  kind:[< `Package | `Universe of string ] -> t -> Module_map.t Lwt.t
 
 val documentation_page :
   kind:[< `Package | `Universe of string ] ->

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -435,14 +435,8 @@ let package_versioned t kind req =
             (url.Ocamlorg_package.Info.uri, url.Ocamlorg_package.Info.checksum))
           package_info.Ocamlorg_package.Info.url
       in
-      let* package_documentation_status =
+      let* documentation_status =
         Ocamlorg_package.documentation_status ~kind package
-      in
-      let documentation_status =
-        match package_documentation_status with
-        | Ocamlorg_package.Success -> Ocamlorg_frontend.Package_overview.Success
-        | Failure -> Failure
-        | Unknown -> Unknown
       in
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme
@@ -487,9 +481,13 @@ let package_doc t kind req =
             |> Option.value ~default:[]
           in
           let canonical_module =
-            doc.breadcrumbs
-            |> List.map (fun (b : Ocamlorg_package.Documentation.breadcrumb) ->
-                   b.name)
+            doc.module_path
+            |> List.map (function
+                 | `Module s -> s
+                 | `ModuleType s -> s
+                 | `Parameter (_, s) -> s
+                 | `Class s -> s
+                 | `ClassType s -> s)
             |> String.concat "."
           in
           let title =
@@ -529,15 +527,15 @@ let package_doc t kind req =
             in
             let kind =
               match kind with
+              | Module_map.Library -> Ocamlorg_frontend.Navmap.Library
               | Module_map.Page -> Ocamlorg_frontend.Navmap.Page
-              | Module -> Module
-              | Leaf_page -> Leaf_page
-              | Module_type -> Module_type
-              | Parameter _ -> Parameter
-              | OLDParameter -> OLDParameter
-              | Class -> Class
-              | Class_type -> Class_type
-              | File -> File
+              | Module_map.Module -> Ocamlorg_frontend.Navmap.Module
+              | Module_map.Leaf_page -> Ocamlorg_frontend.Navmap.Leaf_page
+              | Module_map.Module_type -> Ocamlorg_frontend.Navmap.Module_type
+              | Module_map.Parameter -> Ocamlorg_frontend.Navmap.Parameter
+              | Module_map.Class -> Ocamlorg_frontend.Navmap.Class
+              | Module_map.Class_type -> Ocamlorg_frontend.Navmap.Class_type
+              | Module_map.File -> Ocamlorg_frontend.Navmap.File
             in
             Ocamlorg_frontend.Navmap.{ title; href; kind; children }
           in
@@ -559,47 +557,48 @@ let package_doc t kind req =
                      { title; href; kind = Library; children })
           in
           let toc = toc_of_toc doc.toc in
+          let* map = Ocamlorg_package.module_map ~kind package in
           let (maptoc : Ocamlorg_frontend.Navmap.toc list) =
-            toc_of_map ~root doc.module_map
+            toc_of_map ~root map
           in
           let (path : Ocamlorg_frontend.Package_breadcrumbs.path) =
-            let breadcrumbs = doc.breadcrumbs in
-            if breadcrumbs != [] then
-              let first_path_item = List.hd breadcrumbs in
-              let doc_breadcrumb_to_library_path_item
-                  (p : Ocamlorg_package.Documentation.breadcrumb) =
-                match p.kind with
-                | Module -> Ocamlorg_frontend.Package_breadcrumbs.Module p.name
-                | ModuleType -> ModuleType p.name
-                | Parameter i -> Parameter (i, p.name)
-                | Class -> Class p.name
-                | ClassType -> ClassType p.name
-                | Page | LeafPage | File ->
-                    failwith
-                      "library paths do not contain Page, LeafPage or File"
-              in
-
-              match first_path_item.kind with
-              | Page | LeafPage | File ->
-                  Ocamlorg_frontend.Package_breadcrumbs.Documentation
-                    (Page first_path_item.name)
-              | Module | ModuleType | Parameter _ | Class | ClassType ->
-                  let library =
-                    List.find
-                      (fun (toc : Ocamlorg_frontend.Navmap.toc) ->
-                        List.exists
-                          (fun (t : Ocamlorg_frontend.Navmap.toc) ->
-                            t.title = first_path_item.name)
-                          toc.children)
-                      maptoc
-                  in
-
-                  Ocamlorg_frontend.Package_breadcrumbs.Documentation
-                    (Library
-                       ( library.title,
-                         List.map doc_breadcrumb_to_library_path_item
-                           breadcrumbs ))
-            else Ocamlorg_frontend.Package_breadcrumbs.Documentation Index
+            Ocamlorg_frontend.Package_breadcrumbs.Documentation
+              (if doc.module_path != [] then
+               let module_path_to_breadcrumb_path_item p =
+                 match p with
+                 | `Module s -> Ocamlorg_frontend.Package_breadcrumbs.Module s
+                 | `ModuleType s -> ModuleType s
+                 | `Parameter (i, s) -> Parameter (i, s)
+                 | `Class s -> Class s
+                 | `ClassType s -> ClassType s
+               in
+               let first_path_item = List.hd doc.module_path in
+               let first_path_item_title =
+                 match first_path_item with
+                 | `Module s | `ModuleType s | `Parameter (_, s) -> s
+                 | `Class s -> s
+                 | `ClassType s -> s
+               in
+               (* NOTE: if it's a standalone page, there is no library path
+                  item. TODO: update this when the docs pipeline provides
+                  breadcrumbs. *)
+               let library_path_item =
+                 List.find_opt
+                   (fun (toc : Ocamlorg_frontend.Navmap.toc) ->
+                     List.exists
+                       (fun (t : Ocamlorg_frontend.Navmap.toc) ->
+                         t.title = first_path_item_title)
+                       toc.children)
+                   maptoc
+               in
+               match library_path_item with
+               | Some item ->
+                   Library
+                     ( item.title,
+                       List.map module_path_to_breadcrumb_path_item
+                         doc.module_path )
+               | None -> Page first_path_item_title
+              else Index)
           in
           let package_meta = package_meta t package in
           Dream.html


### PR DESCRIPTION
This reverts commit 3309f3156299fc081070a83009d2d54e339defd9.

Users have reported seeing 404 when navigating the documentation. We'll merge the change on staging first and make sure it works there before pushing to production.