### PR TITLE
Upgrade to odoc html as json 

### DIFF
--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -5,6 +5,7 @@ type kind =
   | Leaf_page
   | Module_type
   | Parameter
+  | OLDParameter (* DEPRECATED FALLBACK *)
   | Class
   | Class_type
   | File
@@ -24,6 +25,7 @@ let kind_title = function
   | Module -> "Module"
   | Module_type -> "Module type"
   | Parameter -> "Parameter"
+  | OLDParameter -> "Parameter" (* DEPRECATED FALLBACK *)
   | Class -> "Class"
   | Class_type -> "Class type"
   | _ -> "?"
@@ -37,6 +39,7 @@ let icon_style = function
   | Module -> "navmap-tag module-tag"
   | Module_type -> "navmap-tag module-type-tag"
   | Parameter -> "navmap-tag parameter-tag"
+  | OLDParameter -> "navmap-tag parameter-tag" (* DEPRECATED FALLBACK *)
   | Class -> "navmap-tag class-tag"
   | Class_type -> "navmap-tag class-type-tag"
   | _ -> "navmap-tag"

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -1,4 +1,5 @@
 module Package_breadcrumbs = Package_breadcrumbs
+module Package_overview = Package_overview
 module Navmap = Navmap
 module Toc = Toc
 module Url = Url

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -18,6 +18,7 @@ let sidebar
 
 let render
 ~title
+~old_doc (* FALLBACK REMOVE *)
 ~(path: Package_breadcrumbs.path)
 ~toc
 ~maptoc
@@ -65,6 +66,7 @@ Package_layout.render
       <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
     <div class="flex-1 z-0 z- min-w-0 lg:max-w-3xl lg:pt-6" id="htmx-content">
+      <%s if old_doc then "Falling back to pre-odoc.2.2.0 documentation page..." else "" %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -1,3 +1,8 @@
+type documentation_status =
+  | Success
+  | Failure
+  | Unknown
+
 let side_box_link ~href ~title ~icon_html =
     <a href="<%s href %>" class="flex items-center py-2 px-4 hover:text-primary-600">
         <%s! icon_html %>
@@ -67,17 +72,17 @@ Package_layout.render
         <% ); %>
         <div class="flex flex-col mt-8 text-body-400">
             <% (match documentation_status with
-            | `Success -> %>
+            | Success -> %>
             <a href="<%s Url.package_doc package.name package.version %>" class="px-4 h-10 items-center mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
               <%s! Icons.documentation "w-6 h-6 mr-2 inline-block" %>
               Documentation
             </a>
-            <% | `Unknown -> ( %>
+            <% | Unknown -> ( %>
             <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <%s! Icons.error "" %>
               Documentation status is unknown.
             </a><% )
-            | `Failure -> ( %>
+            | Failure -> ( %>
             <a href="<%s Url.package_doc package.name package.version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <%s! Icons.error "" %>
               Documentation failed to build.

--- a/src/ocamlorg_package/lib/module_map.mli
+++ b/src/ocamlorg_package/lib/module_map.mli
@@ -9,12 +9,12 @@ module String_map : Map.S with type key = string
 
 (** Page kinds as defined by odoc. *)
 type kind =
-  | Library
   | Module
   | Page
   | Leaf_page
   | Module_type
-  | Parameter
+  | Parameter of int
+  | OLDParameter
   | Class
   | Class_type
   | File

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -225,6 +225,7 @@ module Documentation = struct
   type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
 
   type t = {
+    old: bool; (* FALLBACK REMOVE *)
     module_map : Module_map.t;
     uses_katex : bool;
     toc : toc list;
@@ -266,6 +267,7 @@ module Documentation = struct
           | _ -> failwith "Not enough breadcrumbs"
         in
         {
+          old = false;
           module_map;
           uses_katex;
           breadcrumbs;
@@ -317,6 +319,7 @@ module Documentation = struct
       else []
     in
     {
+      old = true;
       module_map;
       uses_katex = false;
       toc;

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -197,14 +197,40 @@ let featured_packages t = t.featured_packages
 module Documentation = struct
   type toc = { title : string; href : string; children : toc list }
 
-  type item =
-    [ `Module of string
-    | `ModuleType of string
-    | `Parameter of int * string
-    | `Class of string
-    | `ClassType of string ]
+  type breadcrumb_kind =
+    | Page
+    | LeafPage
+    | Module
+    | ModuleType
+    | Parameter of int
+    | Class
+    | ClassType
+    | File
 
-  type t = { toc : toc list; module_path : item list; content : string }
+  let breadcrumb_kind_from_string s =
+    match s with
+    | "page" -> Page
+    | "leaf-page" -> LeafPage
+    | "module" -> Module
+    | "module-type" -> ModuleType
+    | "class" -> Class
+    | "class-type" -> ClassType
+    | "file" -> File
+    | _ ->
+        if String.starts_with ~prefix:"argument-" s then
+          let i = List.hd (List.tl (String.split_on_char '-' s)) in
+          Parameter (int_of_string i)
+        else raise (Invalid_argument ("kind not recognized: " ^ s))
+
+  type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
+
+  type t = {
+    module_map : Module_map.t;
+    uses_katex : bool;
+    toc : toc list;
+    breadcrumbs : breadcrumb list;
+    content : string;
+  }
 
   let rec toc_of_json = function
     | `Assoc
@@ -214,44 +240,110 @@ module Documentation = struct
           ("children", `List children);
         ] ->
         { title; href; children = List.map toc_of_json children }
-    | _ -> raise (Invalid_argument "malformed toc file")
+    | _ -> raise (Invalid_argument "malformed toc field")
 
-  let toc_from_string s =
+  let breadcrumb_from_json = function
+    | `Assoc
+        [
+          ("name", `String name); ("href", `String href); ("kind", `String kind);
+        ] ->
+        { name; href; kind = breadcrumb_kind_from_string kind }
+    | _ -> raise (Invalid_argument "malformed breadcrumb field")
+
+  let doc_from_string ~module_map s =
+    match Yojson.Safe.from_string s with
+    | `Assoc
+        [
+          ("uses_katex", `Bool uses_katex);
+          ("breadcrumbs", `List json_breadcrumbs);
+          ("toc", `List json_toc);
+          ("preamble", `String preamble);
+          ("content", `String content);
+        ] ->
+        let breadcrumbs =
+          match List.map breadcrumb_from_json json_breadcrumbs with
+          | _ :: _ :: _ :: _ :: breadcrumbs -> breadcrumbs
+          | _ -> failwith "Not enough breadcrumbs"
+        in
+        {
+          module_map;
+          uses_katex;
+          breadcrumbs;
+          toc = List.map toc_of_json json_toc;
+          content = preamble ^ content;
+        }
+    | _ -> raise (Invalid_argument "malformed .html.json file")
+
+  (* FIXME: remove when fallback is unnecessary *)
+  let old_toc_from_string s =
     match Yojson.Safe.from_string s with
     | `List xs -> List.map toc_of_json xs
     | _ -> raise (Invalid_argument "the toplevel json is not a list")
 
-  let module_path_from_path s =
+  (* FIXME: remove when fallback is unnecessary *)
+  let old_breadcrumbs s =
     let parse_item i =
       match String.split_on_char '-' i with
       | [ "index.html" ] | [ "" ] -> None
-      | [ module_name ] -> Some (`Module module_name)
-      | [ "module"; "type"; module_name ] -> Some (`ModuleType module_name)
+      | [ module_name ] ->
+          Some { kind = Module; name = module_name; href = "#" }
+      | [ "module"; "type"; module_name ] ->
+          Some { kind = ModuleType; name = module_name; href = "#" }
       | [ "argument"; arg_number; arg_name ] -> (
-          try Some (`Parameter (int_of_string arg_number, arg_name))
+          try
+            Some
+              {
+                kind = Parameter (int_of_string arg_number);
+                name = arg_name;
+                href = "#";
+              }
           with Failure _ -> None)
-      | [ "class"; class_name ] -> Some (`Class class_name)
-      | [ "class"; "type"; class_name ] -> Some (`ClassType class_name)
+      | [ "class"; class_name ] ->
+          Some { kind = Class; name = class_name; href = "#" }
+      | [ "class"; "type"; class_name ] ->
+          Some { kind = ClassType; name = class_name; href = "#" }
       | _ -> None
     in
     String.split_on_char '/' s |> List.filter_map parse_item
+
+  (* FIXME: remove when fallback is unnecessary *)
+  let old_doc ~path ~module_map ~toc_content content =
+    let toc =
+      if toc_content != "" then (
+        try old_toc_from_string toc_content
+        with Yojson.Json_error err ->
+          Logs.err (fun m -> m "Invalid toc: %s" err);
+          [])
+      else []
+    in
+    {
+      module_map;
+      uses_katex = false;
+      toc;
+      breadcrumbs = old_breadcrumbs path;
+      content;
+    }
 end
 
 module Module_map = Module_map
 
-let package_path ~kind name version =
+(* FIXME: remove when fallback is no longer necessary *)
+let package_url ~kind name version =
+  match kind with
+  | `Package ->
+      "https://docs-data.ocaml.org/current/" ^ "p/" ^ name ^ "/" ^ version ^ "/"
+      (* "http://127.0.0.1:8000/" ^ "p/" ^ name ^ "/" ^ version ^ "/" *)
+  | `Universe s ->
+      "https://docs-data.ocaml.org/current/" ^ "u/" ^ s ^ "/" ^ name ^ "/"
+      ^ version ^ "/"
+(* "http://127.0.0.1:8000/" ^ "u/" ^ s ^ "/" ^ name ^ "/" ^ version ^ "/" *)
+
+(* FIXME: rename to package_path when fallback is no longer necessary *)
+let old_package_url ~kind name version =
   match kind with
   | `Package -> Config.documentation_url ^ "p/" ^ name ^ "/" ^ version ^ "/"
   | `Universe s ->
       Config.documentation_url ^ "u/" ^ s ^ "/" ^ name ^ "/" ^ version ^ "/"
-
-let documentation_path ~kind name version =
-  match kind with
-  | `Package ->
-      Config.documentation_url ^ "p/" ^ name ^ "/" ^ version ^ "/doc" ^ "/"
-  | `Universe s ->
-      Config.documentation_url ^ "u/" ^ s ^ "/" ^ name ^ "/" ^ version ^ "/doc"
-      ^ "/"
 
 let http_get url =
   let open Lwt.Syntax in
@@ -274,31 +366,66 @@ let http_get url =
       let+ () = Cohttp_lwt.Body.drain_body body in
       Error (`Msg "Failed to fetch the documentation page")
 
-let documentation_page ~kind t path =
+let fetch_module_map_from_url ~package_url =
   let open Lwt.Syntax in
-  let root =
-    documentation_path ~kind (Name.to_string t.name)
-      (Version.to_string t.version)
+  let url = package_url ^ "package.json" in
+  let+ content = http_get url in
+  match content with
+  | Ok v ->
+      let json = Yojson.Safe.from_string v in
+      Module_map.of_yojson json
+  | Error _ ->
+      Logs.info (fun m -> m "Failed to fetch module map at %s" url);
+      { Module_map.libraries = Module_map.String_map.empty }
+
+(* FIXME: remove fallback when it's no longer needed *)
+let old_documentation_page ~kind t path =
+  let open Lwt.Syntax in
+  let old_package_url =
+    old_package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
   in
-  let module_path = Documentation.module_path_from_path path in
-  let path = root ^ path in
-  let* content = http_get path in
+  let url = old_package_url ^ "doc/" ^ path in
+  let* content = http_get url in
   match content with
   | Ok content ->
-      let+ toc =
-        let toc_path = Filename.remove_extension path ^ ".toc.json" in
-        let+ toc_content = http_get toc_path in
-        match toc_content with
-        | Ok toc_content -> (
-            try Documentation.toc_from_string toc_content
-            with Invalid_argument err ->
-              Logs.err (fun m -> m "Invalid toc: %s" err);
-              [])
-        | Error _ -> []
+      let toc_url = Filename.remove_extension url ^ ".toc.json" in
+      let* toc_content =
+        let+ toc_response = http_get toc_url in
+        match toc_response with Ok toc_content -> toc_content | Error _ -> ""
       in
-      Logs.info (fun m -> m "Found documentation page for %s" path);
-      Some Documentation.{ content; toc; module_path }
-  | Error _ -> Lwt.return None
+      let* module_map =
+        fetch_module_map_from_url ~package_url:old_package_url
+      in
+      Logs.info (fun m -> m "Found OLD documentation page at %s" url);
+      Lwt.return
+        (Some (Documentation.old_doc ~path ~module_map ~toc_content content))
+  | Error _ ->
+      Logs.info (fun m -> m "Failed to fetch OLD documentation page at %s" url);
+      Lwt.return None
+
+let documentation_page ~kind t path =
+  let open Lwt.Syntax in
+  let package_url =
+    package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
+  in
+  let url = package_url ^ "doc/" ^ path ^ ".json" in
+  let* content = http_get url in
+  match content with
+  | Ok content ->
+      let* module_map = fetch_module_map_from_url ~package_url in
+      let* maybe_doc =
+        try
+          Lwt.return (Some (Documentation.doc_from_string ~module_map content))
+        with Invalid_argument err ->
+          Logs.err (fun m -> m "Invalid documentation page: %s" err);
+          let+ maybe_old_doc = old_documentation_page ~kind t path in
+          maybe_old_doc
+      in
+      Logs.info (fun m -> m "Found documentation page for %s" url);
+      Lwt.return maybe_doc
+  | Error _ ->
+      Logs.info (fun m -> m "Failed to fetch new documentation page for %s" url);
+      old_documentation_page ~kind t path
 
 let maybe_file ~kind t filename =
   let open Lwt.Syntax in
@@ -331,28 +458,15 @@ let changes_filename ~kind t =
 
 let documentation_status ~kind t =
   let open Lwt.Syntax in
-  let root =
-    package_path ~kind (Name.to_string t.name) (Version.to_string t.version)
+  let package_url =
+    package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
   in
-  let path = root ^ "status.json" in
-  let+ content = http_get path in
+  let url = package_url ^ "status.json" in
+  let+ content = http_get url in
   match content with
   | Ok "\"Built\"" -> `Success
   | Ok "\"Failed\"" -> `Failure
   | _ -> `Unknown
-
-let module_map ~kind t =
-  let open Lwt.Syntax in
-  let root =
-    package_path ~kind (Name.to_string t.name) (Version.to_string t.version)
-  in
-  let path = root ^ "package.json" in
-  let+ content = http_get path in
-  match content with
-  | Ok v ->
-      let json = Yojson.Safe.from_string v in
-      Module_map.of_yojson json
-  | Error _ -> { Module_map.libraries = Module_map.String_map.empty }
 
 let doc_exists t name version =
   let package = get_package t name version in

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -225,7 +225,7 @@ module Documentation = struct
   type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
 
   type t = {
-    old: bool; (* FALLBACK REMOVE *)
+    old : bool; (* FALLBACK REMOVE *)
     module_map : Module_map.t;
     uses_katex : bool;
     toc : toc list;

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -80,6 +80,7 @@ module Documentation : sig
   type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
 
   type t = {
+    old: bool;
     module_map : Module_map.t;
     uses_katex : bool;
     toc : toc list;

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -80,7 +80,7 @@ module Documentation : sig
   type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
 
   type t = {
-    old: bool;
+    old : bool;
     module_map : Module_map.t;
     uses_katex : bool;
     toc : toc list;

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -67,14 +67,25 @@ end
 module Documentation : sig
   type toc = { title : string; href : string; children : toc list }
 
-  type item =
-    [ `Module of string
-    | `ModuleType of string
-    | `Parameter of int * string
-    | `Class of string
-    | `ClassType of string ]
+  type breadcrumb_kind =
+    | Page
+    | LeafPage
+    | Module
+    | ModuleType
+    | Parameter of int
+    | Class
+    | ClassType
+    | File
 
-  type t = { toc : toc list; module_path : item list; content : string }
+  type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
+
+  type t = {
+    module_map : Module_map.t;
+    uses_katex : bool;
+    toc : toc list;
+    breadcrumbs : breadcrumb list;
+    content : string;
+  }
 end
 
 module Module_map = Module_map
@@ -115,9 +126,6 @@ val documentation_status :
   t ->
   [ `Success | `Failure | `Unknown ] Lwt.t
 (** Get the build status of the documentation of a package *)
-
-val module_map :
-  kind:[< `Package | `Universe of string ] -> t -> Module_map.t Lwt.t
 
 val documentation_page :
   kind:[< `Package | `Universe of string ] ->

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -121,10 +121,10 @@ val changes_filename :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Get the changelog file name of a package *)
 
+type documentation_status = Success | Failure | Unknown
+
 val documentation_status :
-  kind:[< `Package | `Universe of string ] ->
-  t ->
-  [ `Success | `Failure | `Unknown ] Lwt.t
+  kind:[< `Package | `Universe of string ] -> t -> documentation_status Lwt.t
 (** Get the build status of the documentation of a package *)
 
 val documentation_page :

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -604,4 +604,4 @@ let package_doc t kind req =
           let package_meta = package_meta t package in
           Dream.html
             (Ocamlorg_frontend.package_documentation ~path ~title ~toc ~maptoc
-               ~content:doc.content package_meta))
+               ~old_doc:doc.old ~content:doc.content package_meta))

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -481,13 +481,9 @@ let package_doc t kind req =
             |> Option.value ~default:[]
           in
           let canonical_module =
-            doc.module_path
-            |> List.map (function
-                 | `Module s -> s
-                 | `ModuleType s -> s
-                 | `Parameter (_, s) -> s
-                 | `Class s -> s
-                 | `ClassType s -> s)
+            doc.breadcrumbs
+            |> List.map (fun (b : Ocamlorg_package.Documentation.breadcrumb) ->
+                   b.name)
             |> String.concat "."
           in
           let title =
@@ -527,15 +523,15 @@ let package_doc t kind req =
             in
             let kind =
               match kind with
-              | Module_map.Library -> Ocamlorg_frontend.Navmap.Library
               | Module_map.Page -> Ocamlorg_frontend.Navmap.Page
-              | Module_map.Module -> Ocamlorg_frontend.Navmap.Module
-              | Module_map.Leaf_page -> Ocamlorg_frontend.Navmap.Leaf_page
-              | Module_map.Module_type -> Ocamlorg_frontend.Navmap.Module_type
-              | Module_map.Parameter -> Ocamlorg_frontend.Navmap.Parameter
-              | Module_map.Class -> Ocamlorg_frontend.Navmap.Class
-              | Module_map.Class_type -> Ocamlorg_frontend.Navmap.Class_type
-              | Module_map.File -> Ocamlorg_frontend.Navmap.File
+              | Module -> Module
+              | Leaf_page -> Leaf_page
+              | Module_type -> Module_type
+              | Parameter _ -> Parameter
+              | OLDParameter -> OLDParameter
+              | Class -> Class
+              | Class_type -> Class_type
+              | File -> File
             in
             Ocamlorg_frontend.Navmap.{ title; href; kind; children }
           in
@@ -557,48 +553,47 @@ let package_doc t kind req =
                      { title; href; kind = Library; children })
           in
           let toc = toc_of_toc doc.toc in
-          let* map = Ocamlorg_package.module_map ~kind package in
           let (maptoc : Ocamlorg_frontend.Navmap.toc list) =
-            toc_of_map ~root map
+            toc_of_map ~root doc.module_map
           in
           let (path : Ocamlorg_frontend.Package_breadcrumbs.path) =
-            Ocamlorg_frontend.Package_breadcrumbs.Documentation
-              (if doc.module_path != [] then
-               let module_path_to_breadcrumb_path_item p =
-                 match p with
-                 | `Module s -> Ocamlorg_frontend.Package_breadcrumbs.Module s
-                 | `ModuleType s -> ModuleType s
-                 | `Parameter (i, s) -> Parameter (i, s)
-                 | `Class s -> Class s
-                 | `ClassType s -> ClassType s
-               in
-               let first_path_item = List.hd doc.module_path in
-               let first_path_item_title =
-                 match first_path_item with
-                 | `Module s | `ModuleType s | `Parameter (_, s) -> s
-                 | `Class s -> s
-                 | `ClassType s -> s
-               in
-               (* NOTE: if it's a standalone page, there is no library path
-                  item. TODO: update this when the docs pipeline provides
-                  breadcrumbs. *)
-               let library_path_item =
-                 List.find_opt
-                   (fun (toc : Ocamlorg_frontend.Navmap.toc) ->
-                     List.exists
-                       (fun (t : Ocamlorg_frontend.Navmap.toc) ->
-                         t.title = first_path_item_title)
-                       toc.children)
-                   maptoc
-               in
-               match library_path_item with
-               | Some item ->
-                   Library
-                     ( item.title,
-                       List.map module_path_to_breadcrumb_path_item
-                         doc.module_path )
-               | None -> Page first_path_item_title
-              else Index)
+            let breadcrumbs = doc.breadcrumbs in
+            if breadcrumbs != [] then
+              let first_path_item = List.hd breadcrumbs in
+              let doc_breadcrumb_to_library_path_item
+                  (p : Ocamlorg_package.Documentation.breadcrumb) =
+                match p.kind with
+                | Module -> Ocamlorg_frontend.Package_breadcrumbs.Module p.name
+                | ModuleType -> ModuleType p.name
+                | Parameter i -> Parameter (i, p.name)
+                | Class -> Class p.name
+                | ClassType -> ClassType p.name
+                | Page | LeafPage | File ->
+                    failwith
+                      "library paths do not contain Page, LeafPage or File"
+              in
+
+              match first_path_item.kind with
+              | Page | LeafPage | File ->
+                  Ocamlorg_frontend.Package_breadcrumbs.Documentation
+                    (Page first_path_item.name)
+              | Module | ModuleType | Parameter _ | Class | ClassType ->
+                  let library =
+                    List.find
+                      (fun (toc : Ocamlorg_frontend.Navmap.toc) ->
+                        List.exists
+                          (fun (t : Ocamlorg_frontend.Navmap.toc) ->
+                            t.title = first_path_item.name)
+                          toc.children)
+                      maptoc
+                  in
+
+                  Ocamlorg_frontend.Package_breadcrumbs.Documentation
+                    (Library
+                       ( library.title,
+                         List.map doc_breadcrumb_to_library_path_item
+                           breadcrumbs ))
+            else Ocamlorg_frontend.Package_breadcrumbs.Documentation Index
           in
           let package_meta = package_meta t package in
           Dream.html

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -435,8 +435,14 @@ let package_versioned t kind req =
             (url.Ocamlorg_package.Info.uri, url.Ocamlorg_package.Info.checksum))
           package_info.Ocamlorg_package.Info.url
       in
-      let* documentation_status =
+      let* package_documentation_status =
         Ocamlorg_package.documentation_status ~kind package
+      in
+      let documentation_status =
+        match package_documentation_status with
+        | Ocamlorg_package.Success -> Ocamlorg_frontend.Package_overview.Success
+        | Failure -> Failure
+        | Unknown -> Unknown
       in
       Dream.html
         (Ocamlorg_frontend.package_overview ~documentation_status ~readme

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -585,7 +585,7 @@ let package_doc t kind req =
                     (Page first_path_item.name)
               | Module | ModuleType | Parameter _ | Class | ClassType ->
                   let library =
-                    List.find
+                    List.find_opt
                       (fun (toc : Ocamlorg_frontend.Navmap.toc) ->
                         List.exists
                           (fun (t : Ocamlorg_frontend.Navmap.toc) ->
@@ -596,7 +596,9 @@ let package_doc t kind req =
 
                   Ocamlorg_frontend.Package_breadcrumbs.Documentation
                     (Library
-                       ( library.title,
+                       ( (match library with
+                         | Some l -> l.title
+                         | None -> "unknown"),
                          List.map doc_breadcrumb_to_library_path_item
                            breadcrumbs ))
             else Ocamlorg_frontend.Package_breadcrumbs.Documentation Index


### PR DESCRIPTION
Apply #878 again, but with two more commits added:

- 4bfb83d19f0401d6ec57793d0e7d4a1b41d37098 display to the user when we are displaying a fallback, so they know they're not seeing the most recent data.
- bf73248711439552d2f894f400bd411f1a1b142c if no library is found for a module, render it as 'unknown lib' (#878 would crash on that, instead). Example page: https://staging.ocaml.org/p/ocaml-base-compiler/4.14.1/doc/Asttypes/index.html

I also added these two commits to staging.

Merge at earliest in 30 minutes.