### PR TITLE
remove fallback to old docs-data

### DIFF
--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -5,7 +5,6 @@ type kind =
   | Leaf_page
   | Module_type
   | Parameter
-  | OLDParameter (* DEPRECATED FALLBACK *)
   | Class
   | Class_type
   | File
@@ -25,7 +24,6 @@ let kind_title = function
   | Module -> "Module"
   | Module_type -> "Module type"
   | Parameter -> "Parameter"
-  | OLDParameter -> "Parameter" (* DEPRECATED FALLBACK *)
   | Class -> "Class"
   | Class_type -> "Class type"
   | _ -> "?"
@@ -39,7 +37,6 @@ let icon_style = function
   | Module -> "navmap-tag module-tag"
   | Module_type -> "navmap-tag module-type-tag"
   | Parameter -> "navmap-tag parameter-tag"
-  | OLDParameter -> "navmap-tag parameter-tag" (* DEPRECATED FALLBACK *)
   | Class -> "navmap-tag class-tag"
   | Class_type -> "navmap-tag class-type-tag"
   | _ -> "navmap-tag"

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -17,9 +17,8 @@ let sidebar
   </div>
 
 let render
-~old_doc (* FALLBACK REMOVE *)
-~page
 ~(path: Package_breadcrumbs.path)
+~page
 ~toc
 ~maptoc
 ~content
@@ -65,7 +64,6 @@ Package_layout.render
       <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
     <div class="flex-1 z-0 z- min-w-0 lg:max-w-3xl lg:pt-6" id="htmx-content">
-      <%s if old_doc then "Falling back to pre-odoc.2.2.0 documentation page..." else "" %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>

--- a/src/ocamlorg_package/lib/module_map.ml
+++ b/src/ocamlorg_package/lib/module_map.ml
@@ -6,7 +6,6 @@ type kind =
   | Leaf_page
   | Module_type
   | Parameter of int
-  | OLDParameter (* FALLBACK, DEPRECATED*)
   | Class
   | Class_type
   | File
@@ -14,7 +13,6 @@ type kind =
 let prefix_of_kind = function
   | Module_type -> "module-type-"
   | Parameter i -> "argument-" ^ Int.to_string i ^ "-"
-  | OLDParameter -> "argument-" (* FALLBACK, DEPRECATED*)
   | Class -> "class-"
   | Class_type -> "class-type-"
   | _ -> ""
@@ -61,10 +59,6 @@ let kind_of_yojson v =
   | "class" -> Class
   | "class-type" -> Class_type
   | "file" -> File
-  | "argument" ->
-      OLDParameter
-      (* TODO: DEPRECATED, REMOVE when we no longer need to fall back to the old
-         format*)
   | s when String.starts_with ~prefix:"argument-" s ->
       let i = List.hd (List.tl (String.split_on_char '-' s)) in
       Parameter (int_of_string i)

--- a/src/ocamlorg_package/lib/module_map.mli
+++ b/src/ocamlorg_package/lib/module_map.mli
@@ -13,7 +13,6 @@ type kind =
   | Leaf_page
   | Module_type
   | Parameter of int
-  | OLDParameter
   | Class
   | Class_type
   | File

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -450,6 +450,55 @@ let file ~kind t path =
   let old_url = old_package_url ^ "doc/" ^ path in
   odoc_page ~path ~url ~old_url
 
+(* FIXME: remove fallback when it's no longer needed *)
+let old_file ~kind t path =
+  let open Lwt.Syntax in
+  let old_package_url =
+    old_package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
+  in
+  let url = old_package_url ^ "doc/" ^ path in
+  let* content = http_get url in
+  match content with
+  | Ok content ->
+      let toc_url = Filename.remove_extension url ^ ".toc.json" in
+      let* toc_content =
+        let+ toc_response = http_get toc_url in
+        match toc_response with Ok toc_content -> toc_content | Error _ -> ""
+      in
+      let* module_map =
+        fetch_module_map_from_url ~package_url:old_package_url
+      in
+      Logs.info (fun m -> m "Found OLD file at %s" url);
+      Lwt.return
+        (Some (Documentation.old_doc ~path ~module_map ~toc_content content))
+  | Error _ ->
+      Logs.info (fun m -> m "Failed to fetch OLD file at %s" url);
+      Lwt.return None
+
+let file ~kind t path =
+  let open Lwt.Syntax in
+  let package_url =
+    package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
+  in
+  let url = package_url ^ path ^ ".json" in
+  let* content = http_get url in
+  match content with
+  | Ok content ->
+      let* module_map = fetch_module_map_from_url ~package_url in
+      let* maybe_doc =
+        try
+          Lwt.return (Some (Documentation.doc_from_string ~module_map content))
+        with Invalid_argument err ->
+          Logs.err (fun m -> m "Invalid file: %s" err);
+          let+ maybe_old_doc = old_file ~kind t path in
+          maybe_old_doc
+      in
+      Logs.info (fun m -> m "Found file for %s" url);
+      Lwt.return maybe_doc
+  | Error _ ->
+      Logs.info (fun m -> m "Failed to fetch new file for %s" url);
+      old_file ~kind t path
+
 let maybe_file ~kind t filename =
   let open Lwt.Syntax in
   let+ doc = file ~kind t filename in

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -81,7 +81,6 @@ module Documentation : sig
   type breadcrumb = { name : string; href : string; kind : breadcrumb_kind }
 
   type t = {
-    old : bool;
     uses_katex : bool;
     toc : toc list;
     breadcrumbs : breadcrumb list;

--- a/src/ocamlorg_package/test/module_map_test.ml
+++ b/src/ocamlorg_package/test/module_map_test.ml
@@ -18,7 +18,7 @@ let json =
                   {
                     "name": "1-X",
                     "submodules": [],
-                    "kind": "argument"
+                    "kind": "argument-1"
                   }
                 ],
                 "kind": "module"

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -528,7 +528,6 @@ let package_doc t kind req =
               | Leaf_page -> Leaf_page
               | Module_type -> Module_type
               | Parameter _ -> Parameter
-              | OLDParameter -> OLDParameter
               | Class -> Class
               | Class_type -> Class_type
               | File -> File
@@ -599,5 +598,5 @@ let package_doc t kind req =
           in
           Dream.html
             (Ocamlorg_frontend.package_documentation ~page:(Some path)
-               ~path:breadcrumb_path ~toc ~maptoc ~old_doc:doc.old
-               ~content:doc.content package_meta))
+               ~path:breadcrumb_path ~toc ~maptoc ~content:doc.content
+               package_meta))


### PR DESCRIPTION
Removes the fallback to old (pre-odoc-2.2.0) documentation.

Todo:
- [x] fix problem with placement of CHANGELOG, README, LICENSE (see https://github.com/ocaml/ocaml.org/pull/985)
- [x] promote package documentation to `live` folder