### PR TITLE
disable autocomplete on navbar search

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -44,7 +44,7 @@ let render
       <li class="relative">
         <form action="/packages/search" method="GET">
           <div class="header__search relative flex items-center justify-center">
-            <input type="search" name="q" class="header__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80" placeholder="Search OCaml Packages">
+            <input type="search" autocomplete="off" name="q" class="header__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80" placeholder="Search OCaml Packages">
             <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
               <%s! Icons.magnifying_glass "w-6 h-6 text-white" %>
             </button>


### PR DESCRIPTION
Browser autocomplete on search box in top navbar would overlap the Stdlib dropdown. So we disable it.

We should have a proper autocomplete on the search bar anyways.

<img width="467" alt="Screenshot 2023-02-21 at 09 12 06" src="https://user-images.githubusercontent.com/6594573/220287951-320af314-5f18-4f84-9eb7-a5ce5f061eb2.png">
