### PR TITLE
better 404 page on package documentation

### DIFF
--- a/src/ocamlorg_frontend/dune
+++ b/src/ocamlorg_frontend/dune
@@ -150,6 +150,11 @@
   (action
    (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
  (rule
+  (targets package_documentation_not_found.ml)
+  (deps package_documentation_not_found.eml)
+  (action
+   (run %{bin:dream_eml} %{deps} --workspace %{workspace_root})))
+ (rule
   (targets playground.ml)
   (deps playground.eml)
   (action

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -3,7 +3,7 @@ let render
 ~(path: Package_breadcrumbs.path)
 ~title
 ~description
-~canonical
+?canonical
 ~(package : Package_intf.package)
 ~is_latest_url
 inner =

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -12,7 +12,7 @@ Layout.render
 ~show_get_started:false
 ~title
 ~description
-~canonical
+?canonical
 ~active_top_nav_item:Header.Packages @@
 <div class="bg-white">
   <div class="py-5 lg:py-6">

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -36,6 +36,9 @@ let package_overview ~documentation_status ~readme ~readme_title ~dependencies
 let package_documentation ~path ~toc ~maptoc ~content package =
   Package_documentation.render ~path ~toc ~maptoc ~content package
 
+let package_documentation_not_found ~is_latest_url ~path ~package =
+  Package_documentation_not_found.render ~is_latest_url ~path ~package
+
 let packages stats = Packages.render stats
 let packages_search ~total packages = Packages_search.render ~total packages
 

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -24,7 +24,7 @@ let render
 ~maptoc
 ~content
 ~is_latest_url
-(package : Package_intf.package) 
+(package : Package_intf.package)
 =
 let str_path =
   match path with
@@ -49,7 +49,7 @@ Package_layout.render
 ~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
 ~package
 ~path
-~canonical:(Url.package_doc package.name ~version:package.version ?page:path_page)
+~canonical:(Some (Url.package_doc package.name ~version:package.version ?page:path_page))
 ~styles:["/css/main.css"; "/css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024" x-on:close-sidebar="sidebar=window.innerWidth > 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -49,7 +49,7 @@ Package_layout.render
 ~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
 ~package
 ~path
-~canonical:(Some (Url.package_doc package.name ~version:package.version ?page:path_page))
+~canonical:(Url.package_doc package.name ~version:package.version ?page:path_page)
 ~styles:["/css/main.css"; "/css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024" x-on:close-sidebar="sidebar=window.innerWidth > 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -9,7 +9,6 @@ Package_layout.render
 ~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
 ~package
 ~path
-~canonical:None
 ~styles:["/css/main.css"; "/css/doc.css"] @@
   <div class="sm:flex max-w-max mx-auto">
     <p class="text-4xl font-extrabold text-orange-600 sm:text-5xl">404</p>

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -1,0 +1,32 @@
+let render
+~path
+~is_latest_url
+~(package : Package_intf.package)
+=
+Package_layout.render
+~is_latest_url
+~title:(if is_latest_url then (Printf.sprintf "%s %s · OCaml Package" package.name "latest") else (Printf.sprintf "%s %s · OCaml Package" package.name package.version))
+~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
+~package
+~path
+~canonical:None
+~styles:["/css/main.css"; "/css/doc.css"] @@
+  <div class="sm:flex max-w-max mx-auto">
+    <p class="text-4xl font-extrabold text-orange-600 sm:text-5xl">404</p>
+    <div class="sm:ml-6">
+      <div class="sm:border-l sm:border-gray-200 sm:pl-6">
+        <h1 class="text-4xl font-extrabold text-gray-900 tracking-tight sm:text-5xl">Page not found</h1>
+        <p class="mt-1 text-base text-gray-500">We're sorry, for some reason we don't have the documentation for this package.</p>
+      </div>
+      <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
+        <a href="<%s Url.package_with_version package.name ~version:(if is_latest_url then "latest" else package.version) %>"
+          class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500">
+          Go To Package Overview
+        </a>
+        <a href="https://github.com/ocaml/ocaml.org/issues"
+          class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-orange-700 bg-orange-100 hover:bg-orange-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500">
+          Open an Issue
+        </a>
+      </div>
+    </div>
+  </div>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -27,7 +27,7 @@ Package_layout.render
 ~is_latest_url
 ~title:(if is_latest_url then (Printf.sprintf "%s %s · OCaml Package" package.name "latest") else (Printf.sprintf "%s %s · OCaml Package" package.name package.version))
 ~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
-~canonical:(Url.package_with_version package.name ~version:package.version)
+~canonical:(Some (Url.package_with_version package.name ~version:package.version))
 ~package
 ~path:Overview @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row justify-between">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -27,7 +27,7 @@ Package_layout.render
 ~is_latest_url
 ~title:(if is_latest_url then (Printf.sprintf "%s %s · OCaml Package" package.name "latest") else (Printf.sprintf "%s %s · OCaml Package" package.name package.version))
 ~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
-~canonical:(Some (Url.package_with_version package.name ~version:package.version))
+~canonical:(Url.package_with_version package.name ~version:package.version)
 ~package
 ~path:Overview @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row justify-between">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -448,6 +448,7 @@ let package_doc t kind req =
       let open Lwt.Syntax in
       let is_latest_url = version_from_url = "latest" in
       let version = Ocamlorg_package.version package in
+      let package_meta = package_meta t package in
       let kind =
         match kind with
         | Package -> `Package
@@ -465,15 +466,12 @@ let package_doc t kind req =
       in
       let* docs = Ocamlorg_package.documentation_page ~kind package path in
       match docs with
-      | None -> not_found req
+      | None ->
+          Dream.html
+            (Ocamlorg_frontend.package_documentation_not_found ~is_latest_url
+              ~path:(Ocamlorg_frontend.Package_breadcrumbs.Documentation Index)
+              ~package:package_meta)
       | Some doc ->
-          let _description =
-            (Ocamlorg_package.info package).Ocamlorg_package.Info.description
-          in
-          let _versions =
-            Ocamlorg_package.get_package_versions t name
-            |> Option.value ~default:[]
-          in
           let toc_of_toc (xs : Ocamlorg_package.Documentation.toc list) :
               Ocamlorg_frontend.Toc.t =
             let rec aux acc = function
@@ -574,7 +572,6 @@ let package_doc t kind req =
                            breadcrumbs ))
             else Ocamlorg_frontend.Package_breadcrumbs.Documentation Index
           in
-          let package_meta = package_meta t package in
           Dream.html
             (Ocamlorg_frontend.package_documentation ~path ~toc ~maptoc
                ~is_latest_url ~old_doc:doc.old ~content:doc.content package_meta)

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -469,8 +469,8 @@ let package_doc t kind req =
       | None ->
           Dream.html
             (Ocamlorg_frontend.package_documentation_not_found ~is_latest_url
-              ~path:(Ocamlorg_frontend.Package_breadcrumbs.Documentation Index)
-              ~package:package_meta)
+               ~path:(Ocamlorg_frontend.Package_breadcrumbs.Documentation Index)
+               ~package:package_meta)
       | Some doc ->
           let toc_of_toc (xs : Ocamlorg_package.Documentation.toc list) :
               Ocamlorg_frontend.Toc.t =


### PR DESCRIPTION
Instead of showing the generic 404 page, show a specific 404 page on package Documentation when we found the package, but no documentation.

(We need this to give people who click on a 404 documentation link from the search results a softer landing and recovery to the package overview page.)

|before|after|
|-|-|
|![Screenshot 2023-02-21 at 18-28-30 Page Not Found](https://user-images.githubusercontent.com/6594573/220417549-c63f2194-db75-45a5-b969-7c0f22fc62b4.png)|![Screenshot 2023-02-21 at 18-28-18 ocaml-variants latest · OCaml Package](https://user-images.githubusercontent.com/6594573/220417565-dd7961fe-f458-4238-9ea4-1cd31a82d2b1.png)|
