### PR TITLE
package.version is either a `Specific` version or `Latest` (mostly a refactor)

### DIFF
--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -104,15 +104,13 @@ let rec nested_render ~path (item : toc) =
 let render
 ~(package: Package_intf.package)
 ~path
-~is_latest_url
 (maptoc : t)
 =
-  let version = if is_latest_url then None else Some package.version in
   <div class="navmap pb-12">
     <% (match maptoc with [] ->  %>
     <span class="block py-2 text-gray-700">Package contains no libraries</span>
     <% | _ -> %>
-      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name ?version %>">
+      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name ?version:package.version %>">
         package <%s package.name %>
       </a>
     <ul>

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -102,15 +102,16 @@ let rec nested_render ~path (item : toc) =
 
 
 let render
-~(package: Package_intf.package)
+~(package: Package.package)
 ~path
 (maptoc : t)
 =
+  let version = Package.url_version package in
   <div class="navmap pb-12">
     <% (match maptoc with [] ->  %>
     <span class="block py-2 text-gray-700">Package contains no libraries</span>
     <% | _ -> %>
-      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name ?version:package.version %>">
+      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name ?version %>">
         package <%s package.name %>
       </a>
     <ul>

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -46,21 +46,22 @@ type path =
   | Documentation of (docs_path)
 
 let render_package_and_version
-~(package: Package_intf.package)
+~(package: Package.package)
 =
+  let version = Package.url_version package in
   let version_options v =
     <% if v = package.latest_version then ( %>
-    <option value="<%s Url.package_with_version package.name %>" <%s if package.version = None then "selected" else "" %>>
+    <option value="<%s Url.package_with_version package.name %>" <%s if package.version = Latest then "selected" else "" %>>
       <%s "latest (" ^ package.latest_version ^ ")" %>
     </option>
     <% ); %>
-    <option value="<%s Url.package_with_version package.name ?version:(Some v) %>" <%s if package.version = Some v then "selected" else "" %>>
+    <option value="<%s Url.package_with_version package.name ?version:(Some v) %>" <%s if package.version = Specific v then "selected" else "" %>>
       <%s v %>
     </option>
   in
   <li>
     <h1 class="inline text-base">
-      <a class="font-semibold underline" href="<%s Url.package_with_version package.name ?version:package.version %>"><%s package.name %></a>
+      <a class="font-semibold underline" href="<%s Url.package_with_version package.name ?version %>"><%s package.name %></a>
     </h1>
   </li>
   <li>
@@ -91,14 +92,15 @@ let render_library_path_breadcrumbs
   </li>
 
 let render_docs_path_breadcrumbs
-~(package: Package_intf.package)
+~(package: Package.package)
 ~(path: docs_path) 
   =
+  let version = Package.url_version package in
   <nav aria-label="breadcrumb" class="flex" id="htmx-breadcrumbs">
     <ul class="flex flex-wrap gap-x-2 text-base leading-8 package-breadcrumbs">
       <%s! render_package_and_version ~package %>
       <li>
-        <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version:package.version %>">Documentation</a>
+        <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version %>">Documentation</a>
       </li>
       <% (match path with
          | Index -> %>
@@ -113,7 +115,7 @@ let render_docs_path_breadcrumbs
   </nav>
 
 let render_overview_breadcrumbs
-~(package: Package_intf.package)
+~(package: Package.package)
 =
   <nav aria-label="breadcrumbs" class="flex">
     <ul class="flex flex-wrap gap-x-2 leading-8 package-breadcrumbs">
@@ -122,7 +124,7 @@ let render_overview_breadcrumbs
   </nav>
 
 let render
-~(package: Package_intf.package)
+~(package: Package.package)
 ~(path: path)
 =
   match path with

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -47,26 +47,27 @@ type path =
 
 let render_package_and_version
 ~(package: Package_intf.package)
-~is_latest_url
 =
-  let version = if is_latest_url then None else Some package.version in
+  let version_options v =
+    <% if v = package.latest_version then ( %>
+    <option value="<%s Url.package_with_version package.name %>" <%s if package.version = None then "selected" else "" %>>
+      <%s "latest (" ^ package.latest_version ^ ")" %>
+    </option>
+    <% ); %>
+    <option value="<%s Url.package_with_version package.name ?version:(Some v) %>" <%s if package.version = Some v then "selected" else "" %>>
+      <%s v %>
+    </option>
+  in
   <li>
     <h1 class="inline text-base">
-      <a class="font-semibold underline" href="<%s Url.package_with_version package.name ?version %>"><%s package.name %></a>
+      <a class="font-semibold underline" href="<%s Url.package_with_version package.name ?version:package.version %>"><%s package.name %></a>
     </h1>
   </li>
   <li>
     <select id="version" name="version" aria-label="version" onchange="location = this.value;"
       class="leading-8 appearance-none cursor-pointer py-0 rounded-md border border-gray-400 pr-8"
-      style="background-position: right 0.25rem center"> 
-      <option value="/p/<%s package.name %>/<%s "latest" %>">
-         <%s if is_latest_url then "latest (" ^ package.version ^ ")" else "latest" %>
-      </option>
-      <% package.versions |> List.iter begin fun item -> %>
-      <option value="/p/<%s package.name %>/<%s item %>"<%s if not is_latest_url && item = package.version then "selected" else "" %>>
-      <%s item %>
-      </option>
-      <% end; %>
+      style="background-position: right 0.25rem center">
+      <%s! package.versions |> List.map version_options |> String.concat "" %>
     </select>
   </li>
 
@@ -92,14 +93,12 @@ let render_library_path_breadcrumbs
 let render_docs_path_breadcrumbs
 ~(package: Package_intf.package)
 ~(path: docs_path) 
-~is_latest_url
   =
-  let version = if is_latest_url then None else Some package.version in
   <nav aria-label="breadcrumb" class="flex" id="htmx-breadcrumbs">
     <ul class="flex flex-wrap gap-x-2 text-base leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~package ~is_latest_url %>
+      <%s! render_package_and_version ~package %>
       <li>
-        <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version %>">Documentation</a>
+        <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version:package.version %>">Documentation</a>
       </li>
       <% (match path with
          | Index -> %>
@@ -115,19 +114,18 @@ let render_docs_path_breadcrumbs
 
 let render_overview_breadcrumbs
 ~(package: Package_intf.package)
-~is_latest_url
 =
   <nav aria-label="breadcrumbs" class="flex">
     <ul class="flex flex-wrap gap-x-2 leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~package ~is_latest_url %>
+      <%s! render_package_and_version ~package %>
     </ul>
   </nav>
 
 let render
 ~(package: Package_intf.package)
 ~(path: path)
-~is_latest_url =
+=
   match path with
-    | Overview -> render_overview_breadcrumbs ~package ~is_latest_url
-    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~package ~path:docs_path ~is_latest_url
+    | Overview -> render_overview_breadcrumbs ~package
+    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~package ~path:docs_path
     

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -4,7 +4,7 @@ let render
 ~title
 ~description
 ?canonical
-~(package : Package_intf.package)
+~(package : Package.package)
 inner =
 Layout.render
 ?styles

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -5,7 +5,6 @@ let render
 ~description
 ?canonical
 ~(package : Package_intf.package)
-~is_latest_url
 inner =
 Layout.render
 ?styles
@@ -19,7 +18,7 @@ Layout.render
     <div class="container-fluid wide">
       <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
         <div class="flex flex-col items-baseline mb-6">
-          <%s! Package_breadcrumbs.render ~package ~path ~is_latest_url %>
+          <%s! Package_breadcrumbs.render ~package ~path %>
 
           <% if path == Overview then (%>
             <div class="text-body-400">

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -2,7 +2,7 @@ module Package_breadcrumbs = Package_breadcrumbs
 module Package_overview = Package_overview
 module Navmap = Navmap
 module Toc = Toc
-include Package_intf
+module Package = Package
 
 let about = About.render
 let academic_users = Academic_users.render

--- a/src/ocamlorg_frontend/package.ml
+++ b/src/ocamlorg_frontend/package.ml
@@ -14,7 +14,7 @@ type package = {
   publication : float;
 }
 
-let exact_version package =
+let specific_version package =
   match package.version with
   | Latest -> package.latest_version
   | Specific v -> v

--- a/src/ocamlorg_frontend/package.ml
+++ b/src/ocamlorg_frontend/package.ml
@@ -1,12 +1,10 @@
-type version = Latest | Version of string
+type version = Latest | Specific of string
 
 type package = {
   name : string;
   description : string;
   license : string;
-  version : string option;
-      (* None = we are looking at the latest version of the package on a
-         /latest-URL, Some v = we are looking at version v *)
+  version : version;
   versions : string list;
   latest_version : string;
   tags : string list;
@@ -17,12 +15,17 @@ type package = {
 }
 
 let exact_version package =
-  match package.version with None -> package.latest_version | Some v -> v
-
-let render_package_version package =
   match package.version with
-  | None -> Fmt.str "%s (latest)" package.latest_version
-  | Some v -> v
+  | Latest -> package.latest_version
+  | Specific v -> v
+
+let render_version package =
+  match package.version with
+  | Latest -> Fmt.str "%s (latest)" package.latest_version
+  | Specific v -> v
+
+let url_version package =
+  match package.version with Latest -> None | Specific v -> Some v
 
 type packages_stats = {
   nb_packages : int;

--- a/src/ocamlorg_frontend/package_intf.ml
+++ b/src/ocamlorg_frontend/package_intf.ml
@@ -1,15 +1,28 @@
+type version = Latest | Version of string
+
 type package = {
   name : string;
   description : string;
   license : string;
-  version : string;
+  version : string option;
+      (* None = we are looking at the latest version of the package on a
+         /latest-URL, Some v = we are looking at version v *)
   versions : string list;
+  latest_version : string;
   tags : string list;
   rev_deps : string list;
   authors : Ood.Opam_user.t list;
   maintainers : Ood.Opam_user.t list;
   publication : float;
 }
+
+let exact_version package =
+  match package.version with None -> package.latest_version | Some v -> v
+
+let render_package_version package =
+  match package.version with
+  | None -> Fmt.str "%s (latest)" package.latest_version
+  | Some v -> v
 
 type packages_stats = {
   nb_packages : int;

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -46,7 +46,7 @@ Package_layout.render
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
 ~package
 ~path
-~canonical:(Url.package_doc package.name ~version:(Package.exact_version package) ?page:path_page)
+~canonical:(Url.package_doc package.name ~version:(Package.specific_version package) ?page:path_page)
 ~styles:["css/main.css"; "css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -2,7 +2,7 @@ let sidebar
 ~str_path
 ~toc
 ~maptoc
-(package : Package_intf.package)
+(package : Package.package)
 =
   <div class="flex flex-col font-normal text-body-400" id="htmx-sidebar">
     <% if (toc != []) then ( %>
@@ -22,7 +22,7 @@ let render
 ~toc
 ~maptoc
 ~content
-(package : Package_intf.package)
+(package : Package.package)
 =
 let str_path =
   match path with
@@ -42,11 +42,11 @@ let path_page = match str_path |> String.concat "/" with
                 | "" -> None
                 | path -> Some (path ^ if String.contains path '.' then "" else "/index.html") in
 Package_layout.render
-~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package_intf.render_package_version package))
-~description:(Printf.sprintf "%s %s: %s" package.name (Package_intf.render_package_version package) package.description)
+~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
+~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
 ~package
 ~path
-~canonical:(Url.package_doc package.name ~version:(Package_intf.exact_version package) ?page:path_page)
+~canonical:(Url.package_doc package.name ~version:(Package.exact_version package) ?page:path_page)
 ~styles:["css/main.css"; "css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -2,7 +2,6 @@ let sidebar
 ~str_path
 ~toc
 ~maptoc
-~is_latest_url
 (package : Package_intf.package)
 =
   <div class="flex flex-col font-normal text-body-400" id="htmx-sidebar">
@@ -12,7 +11,7 @@ let sidebar
     </div><% ); %>
     <div class="space-y-6 flex flex-col overflow-x:scroll">
       <div>
-      <%s! Navmap.render ~package ~path:str_path ~is_latest_url maptoc %>
+      <%s! Navmap.render ~package ~path:str_path maptoc %>
       </div>
     </div>
   </div>
@@ -23,7 +22,6 @@ let render
 ~toc
 ~maptoc
 ~content
-~is_latest_url
 (package : Package_intf.package)
 =
 let str_path =
@@ -44,12 +42,11 @@ let path_page = match str_path |> String.concat "/" with
                 | "" -> None
                 | path -> Some (path ^ if String.contains path '.' then "" else "/index.html") in
 Package_layout.render
-~is_latest_url
-~title:(if is_latest_url then (Printf.sprintf "%s %s · OCaml Package" package.name "latest") else (Printf.sprintf "%s %s · OCaml Package" package.name package.version))
-~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
+~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package_intf.render_package_version package))
+~description:(Printf.sprintf "%s %s: %s" package.name (Package_intf.render_package_version package) package.description)
 ~package
 ~path
-~canonical:(Url.package_doc package.name ~version:package.version ?page:path_page)
+~canonical:(Url.package_doc package.name ~version:(Package_intf.exact_version package) ?page:path_page)
 ~styles:["css/main.css"; "css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
@@ -66,7 +63,7 @@ Package_layout.render
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
       x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
       x-transition:leave-end="-translate-x-full">
-      <%s! sidebar ~str_path ~toc ~maptoc ~is_latest_url package %>
+      <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
     <div class="flex-1 z-0 z- min-w-0 lg:max-w-3xl lg:pt-6" id="htmx-content">
       <%s if old_doc then "Falling back to pre-odoc.2.2.0 documentation page..." else "" %>

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -1,13 +1,14 @@
 let render
 ~path
-~(package : Package_intf.package)
+~(package : Package.package)
 =
 Package_layout.render
-~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package_intf.render_package_version package))
-~description:(Printf.sprintf "%s %s: %s" package.name (Package_intf.render_package_version package) package.description)
+~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
+~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
 ~package
 ~path
 ~styles:["/css/main.css"; "/css/doc.css"] @@
+  let version = Package.url_version package in
   <div class="sm:flex max-w-max mx-auto">
     <p class="text-4xl font-extrabold text-orange-600 sm:text-5xl">404</p>
     <div class="sm:ml-6">
@@ -16,7 +17,7 @@ Package_layout.render
         <p class="mt-1 text-base text-gray-500">We're sorry, for some reason we don't have the documentation for this package.</p>
       </div>
       <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
-        <a href="<%s Url.package_with_version package.name ?version:package.version %>"
+        <a href="<%s Url.package_with_version package.name ?version %>"
           class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500">
           Go To Package Overview
         </a>

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -1,12 +1,10 @@
 let render
 ~path
-~is_latest_url
 ~(package : Package_intf.package)
 =
 Package_layout.render
-~is_latest_url
-~title:(if is_latest_url then (Printf.sprintf "%s %s · OCaml Package" package.name "latest") else (Printf.sprintf "%s %s · OCaml Package" package.name package.version))
-~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
+~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package_intf.render_package_version package))
+~description:(Printf.sprintf "%s %s: %s" package.name (Package_intf.render_package_version package) package.description)
 ~package
 ~path
 ~styles:["/css/main.css"; "/css/doc.css"] @@
@@ -18,7 +16,7 @@ Package_layout.render
         <p class="mt-1 text-base text-gray-500">We're sorry, for some reason we don't have the documentation for this package.</p>
       </div>
       <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
-        <a href="<%s Url.package_with_version package.name ~version:(if is_latest_url then "latest" else package.version) %>"
+        <a href="<%s Url.package_with_version package.name ?version:package.version %>"
           class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500">
           Go To Package Overview
         </a>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -22,11 +22,11 @@ let render
 ~license_filename
 (package : Package.package) =
 let version = Package.url_version package in
-let exact_version = Package.exact_version package in
+let specific_version = Package.specific_version package in
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
-~canonical:(Url.package_with_version package.name ~version:exact_version)
+~canonical:(Url.package_with_version package.name ~version:specific_version)
 ~package
 ~path:Overview @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row justify-between">
@@ -45,11 +45,11 @@ Package_layout.render
                 <div class="relative flex items-stretch flex-grow focus-within:z-10">
                     <input type="text"
                         class="focus:ring-orange-500 focus:border-orange-500 block w-full rounded-none rounded-l-md bg-gray-800 text-gray-100 text-sm font-mono subpixel-antialiased border-gray-700"
-                        value="opam install <%s package.name %>.<%s exact_version %>">
+                        value="opam install <%s package.name %>.<%s specific_version %>">
                 </div>
                 <div role="button" title="Copy to clipboard"
                     class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-700 text-sm font-medium rounded-r-md text-gray-100 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
-                    @click="$clipboard('opam install <%s package.name %>.<%s exact_version %>'); copied = true; setTimeout(() => copied = false, 2000)"
+                    @click="$clipboard('opam install <%s package.name %>.<%s specific_version %>'); copied = true; setTimeout(() => copied = false, 2000)"
                     :class="{ 'border-gray-700': !copied, 'text-gray-100': !copied, 'focus:ring-orange-500': !copied, 'focus:border-orange-500': !copied, 'border-green-600': copied, 'text-green-600': copied, 'focus:ring-green-500': copied, 'focus:border-green-500': copied }">
                     <div x-show="!copied" class="h-6 w-6">
                       <%s! Icons.copy_to_clipboard "h-6 w-6" %>
@@ -98,7 +98,7 @@ Package_layout.render
             <% (match license_filename with Some license_filename -> %>
             <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_doc package.name ?version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
             <% | _ -> ()); %>
-            <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name exact_version) ~title:"Edit opam file" %>
+            <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name specific_version) ~title:"Edit opam file" %>
         </div>
 
         <h2 class="mt-8 font-semibold text-base text-body-400">Published</h2>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -20,14 +20,13 @@ let render
 ~source
 ~changes_filename
 ~license_filename
-~is_latest_url
 (package : Package_intf.package) =
-let version = if is_latest_url then None else Some package.version in
+let version = package.version in
+let exact_version = Package_intf.exact_version package in
 Package_layout.render
-~is_latest_url
-~title:(if is_latest_url then (Printf.sprintf "%s %s · OCaml Package" package.name "latest") else (Printf.sprintf "%s %s · OCaml Package" package.name package.version))
-~description:(if is_latest_url then (Printf.sprintf "%s %s: %s" package.name "latest" package.description) else (Printf.sprintf "%s %s: %s" package.name package.version package.description))
-~canonical:(Url.package_with_version package.name ~version:package.version)
+~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package_intf.render_package_version package))
+~description:(Printf.sprintf "%s %s: %s" package.name (Package_intf.render_package_version package) package.description)
+~canonical:(Url.package_with_version package.name ~version:exact_version)
 ~package
 ~path:Overview @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row justify-between">
@@ -46,11 +45,11 @@ Package_layout.render
                 <div class="relative flex items-stretch flex-grow focus-within:z-10">
                     <input type="text"
                         class="focus:ring-orange-500 focus:border-orange-500 block w-full rounded-none rounded-l-md bg-gray-800 text-gray-100 text-sm font-mono subpixel-antialiased border-gray-700"
-                        value="opam install <%s package.name %>.<%s package.version %>">
+                        value="opam install <%s package.name %>.<%s exact_version %>">
                 </div>
                 <div role="button" title="Copy to clipboard"
                     class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-700 text-sm font-medium rounded-r-md text-gray-100 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
-                    @click="$clipboard('opam install <%s package.name %>.<%s package.version %>'); copied = true; setTimeout(() => copied = false, 2000)"
+                    @click="$clipboard('opam install <%s package.name %>.<%s exact_version %>'); copied = true; setTimeout(() => copied = false, 2000)"
                     :class="{ 'border-gray-700': !copied, 'text-gray-100': !copied, 'focus:ring-orange-500': !copied, 'focus:border-orange-500': !copied, 'border-green-600': copied, 'text-green-600': copied, 'focus:ring-green-500': copied, 'focus:border-green-500': copied }">
                     <div x-show="!copied" class="h-6 w-6">
                       <%s! Icons.copy_to_clipboard "h-6 w-6" %>
@@ -99,7 +98,7 @@ Package_layout.render
             <% (match license_filename with Some license_filename -> %>
             <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_doc package.name ?version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
             <% | _ -> ()); %>
-            <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name package.version) ~title:"Edit opam file" %>
+            <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name exact_version) ~title:"Edit opam file" %>
         </div>
 
         <h2 class="mt-8 font-semibold text-base text-body-400">Published</h2>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -20,12 +20,12 @@ let render
 ~source
 ~changes_filename
 ~license_filename
-(package : Package_intf.package) =
-let version = package.version in
-let exact_version = Package_intf.exact_version package in
+(package : Package.package) =
+let version = Package.url_version package in
+let exact_version = Package.exact_version package in
 Package_layout.render
-~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package_intf.render_package_version package))
-~description:(Printf.sprintf "%s %s: %s" package.name (Package_intf.render_package_version package) package.description)
+~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
+~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
 ~canonical:(Url.package_with_version package.name ~version:exact_version)
 ~package
 ~path:Overview @@

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -1,6 +1,6 @@
 open Package_intf
 
-let href_package pkg = Url.package_with_version pkg.name ~version:pkg.version
+let href_package pkg = Url.package_with_version pkg.name ?version:pkg.version
 
 let render (stats : packages_stats option) (featured_packages : package list) =
 Layout.render
@@ -76,7 +76,7 @@ Layout.render
       <p class="font-semibold mb-2"><%s pkg.name %></p>
       <p class="mb-3 text-sm text-body-400"><%s pkg.description %></p>
       <p class="text-sm text-body-400 flex space-x-2">
-        <%s! Icons.tag "h-5 w-5 pr-1" %> <%s pkg.version %>
+        <%s! Icons.tag "h-5 w-5 pr-1" %> <%s render_package_version pkg %>
       </p>
     </a>
 % in
@@ -132,7 +132,7 @@ Layout.render
 % let render_package_recently_updated pkg =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
-        <%s! Icons.refresh "h-5 w-5 pr-1" %> Version <%s pkg.version %>
+        <%s! Icons.refresh "h-5 w-5 pr-1" %> Version <%s render_package_version pkg %>
       </div>
 %   )
 % in

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -1,8 +1,6 @@
-open Package_intf
+let href_package pkg = Url.package_with_version pkg.name ?version:(Package.url_version pkg)
 
-let href_package pkg = Url.package_with_version pkg.name ?version:pkg.version
-
-let render (stats : packages_stats option) (featured_packages : package list) =
+let render (stats : Package.packages_stats option) (featured_packages : Package.package list) =
 Layout.render
 ~title:"OCaml Packages · Browse Community Packages"
 ~description:"Discover thousands of community packages and browse their documentation."
@@ -76,7 +74,7 @@ Layout.render
       <p class="font-semibold mb-2"><%s pkg.name %></p>
       <p class="mb-3 text-sm text-body-400"><%s pkg.description %></p>
       <p class="text-sm text-body-400 flex space-x-2">
-        <%s! Icons.tag "h-5 w-5 pr-1" %> <%s render_package_version pkg %>
+        <%s! Icons.tag "h-5 w-5 pr-1" %> <%s Package.render_version pkg %>
       </p>
     </a>
 % in
@@ -132,7 +130,7 @@ Layout.render
 % let render_package_recently_updated pkg =
 %   render_package_stat pkg (fun () ->
       <div class="text-sm text-body-400 flex space-x-2">
-        <%s! Icons.refresh "h-5 w-5 pr-1" %> Version <%s render_package_version pkg %>
+        <%s! Icons.refresh "h-5 w-5 pr-1" %> Version <%s Package.render_version pkg %>
       </div>
 %   )
 % in

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -26,7 +26,7 @@ let input_attributes ~target_sel ~indicator_sel =
 let render
 ~search
 ~total
-(packages : Package_intf.package list)
+(packages : Package.package list)
 =
 <div class="mx-2 mb-2">
   <span class="font-semibold">Packages:</span>
@@ -42,7 +42,7 @@ let render
   <% ); %>
 
   <ol class="flex flex-col" x-init="row = null; col = 0; total = <%s string_of_int total %>">
-  <% packages |> List.iteri (fun i (package : Package_intf.package) -> %>
+  <% packages |> List.iteri (fun i (package : Package.package) -> %>
     <li class="flex flex-row">
       <a
         x-init="max=<%s string_of_int i %>"

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -81,7 +81,7 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
               </div>
               <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
                 <%s! Icons.hashtag "h-5 w-5"; %>
-                <div><%s package.version %></div>
+                <div><%s Package_intf.render_package_version package %></div>
               </div>
               <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
                 <%s! Icons.license "h-5 w-5"; %>

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -1,4 +1,4 @@
-let render ~total ~search (packages : Package_intf.package list) = Layout.render ~title:"OCaml Packages · Search Result"
+let render ~total ~search (packages : Package.package list) = Layout.render ~title:"OCaml Packages · Search Result"
 ~description:"Find the package you need to build your application in the thousands of available OCaml packages."
 ~canonical:(Url.packages_search ^ "?q=" ^ search)
 ~active_top_nav_item:Header.Packages @@
@@ -49,7 +49,7 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
 
         <% if List.length packages > 0 then ( %>
         <ol>
-          <% packages |> List.iter (fun (package : Package_intf.package) -> %>
+          <% packages |> List.iter (fun (package : Package.package) -> %>
           <li class="border-gray-200 border-t mt-4 pt-4 mb-2 space-y-2">
             <a
               href="<%s Url.package_with_version package.name %>"
@@ -81,7 +81,7 @@ let render ~total ~search (packages : Package_intf.package list) = Layout.render
               </div>
               <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
                 <%s! Icons.hashtag "h-5 w-5"; %>
-                <div><%s Package_intf.render_package_version package %></div>
+                <div><%s Package.render_version package %></div>
               </div>
               <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
                 <%s! Icons.license "h-5 w-5"; %>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -273,12 +273,12 @@ let package_of_info ~name ~version ?(on_latest_url = false) ~latest_version
       (fun (name, _, _versions) -> Ocamlorg_package.Name.to_string name)
       info.Ocamlorg_package.Info.rev_deps
   in
-  Ocamlorg_frontend.
+  Ocamlorg_frontend.Package.
     {
       name = Ocamlorg_package.Name.to_string name;
       version =
-        (if on_latest_url then None
-        else Some (Ocamlorg_package.Version.to_string version));
+        (if on_latest_url then Latest
+        else Specific (Ocamlorg_package.Version.to_string version));
       versions;
       latest_version =
         Option.value ~default:"???"
@@ -300,7 +300,7 @@ let package_versions state name =
   |> List.map Ocamlorg_package.Version.to_string
 
 let package_meta ?on_latest_url state (package : Ocamlorg_package.t) :
-    Ocamlorg_frontend.package =
+    Ocamlorg_frontend.Package.package =
   let name = Ocamlorg_package.name package
   and version = Ocamlorg_package.version package
   and info = Ocamlorg_package.info package in
@@ -334,7 +334,7 @@ let packages state _req =
          } as t) ->
         Some
           {
-            Ocamlorg_frontend.nb_packages;
+            Ocamlorg_frontend.Package.nb_packages;
             nb_update_week;
             nb_packages_month;
             newest_packages = List.map package_pair t.newest_packages;
@@ -475,7 +475,8 @@ let package_doc t kind req =
       let path = (Dream.path [@ocaml.warning "-3"]) req |> String.concat "/" in
       let root =
         let hash = match kind with `Package -> None | `Universe u -> Some u in
-        Url.package_doc ?hash ~page:"" ?version:package_meta.version
+        Url.package_doc ?hash ~page:""
+          ?version:(Ocamlorg_frontend.Package.url_version package_meta)
           (Ocamlorg_package.Name.to_string name)
       in
       let* docs = Ocamlorg_package.documentation_page ~kind package path in


### PR DESCRIPTION
This patch
* renames and refactors `Ocamlorg_frontend.Package_intf` to `Ocamlorg_frontend.Package`, which has a notion of whether we are viewing this package through a 'latest`-URL or a specific-version-URL and
* adds `latest_version` to `Ocamlorg_frontend.Package`, so that we can display the specific latest version in the version switcher dropdown
* renders "latest" entry in the version dropdown next to the specific latest version (I don't know a package that has an `avoid-version`-flagged newest version off the top of my head, but on such a package you would really see the difference in a pleasant way).

|before|after|
|-|-|
|![Screenshot from 2023-02-23 18-03-20](https://user-images.githubusercontent.com/6594573/220978181-450422ab-e376-458d-b48b-98f0e0ac0e71.png) latest version is displayed as "latest" only|![Screenshot from 2023-02-23 18-03-10](https://user-images.githubusercontent.com/6594573/220978191-caf7cc27-88f3-4471-837b-cfd233b4c059.png) latest version entry includes specific version and appears in front of specific latest version|
