### PR TITLE
Fix Dashboard by using Timedesc.Span.to_string instead of Timedesc.Span.For_human.to_string

### DIFF
--- a/src/dream_dashboard/info.ml
+++ b/src/dream_dashboard/info.ml
@@ -24,7 +24,7 @@ let uptime =
 let uptime_string () =
   let s = Int64.of_float (uptime ()) in
   let span = Timedesc.Span.make ~s () in
-  Timedesc.Span.For_human.to_string span
+  Timedesc.Span.to_string span
 
 type platform = Darwin | Freebsd | Linux | Openbsd | Sunos | Win32 | Android
 


### PR DESCRIPTION
Resolves #946.