### PR TITLE
Add watch.ocaml.org to community page

### DIFF
--- a/asset/img/community/peertube.svg
+++ b/asset/img/community/peertube.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m3 0v12l9-6zm0 12v12l9-6zm9-6v12l9-6z"/></svg>

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -36,6 +36,10 @@ Layout.render
           <div class="text-base font-semibold"><img src="/img/community/discourse.svg" alt="" class="h-8 w-8 mr-2 inline-block"> Discuss</div>
           <div class="font-normal text-xs mt-4">Discuss with the community, ask questions and share your work on OCaml.</div>
         </a>
+        <a href="https://watch.ocaml.org/" class="border-gray-200 border p-8 rounded-xl card-hover">
+          <div class="text-base font-semibold"><img src="/img/community/peertube.svg" alt="" class="h-8 w-8 mr-2 inline-block"> Watch</div>
+          <div class="font-normal text-xs mt-4">Watch community videos like past OCaml Workshop events.</div>
+        </a>
         <a href="https://github.com/ocaml/ocaml" class="border-gray-200 border p-8 rounded-xl card-hover">
           <div class="text-base font-semibold"><img src="/img/community/github.svg" alt="" class="h-8 w-8 mr-2 inline-block"> Github</div>
           <div class="font-normal text-xs mt-4">Open bug reports and feature requests on the OCaml compiler.</div>
@@ -86,7 +90,7 @@ Layout.render
               <h2 class="font-bold text-primary-600 mb-6" id="workshops" >Workshops</h2>
               <div class="text-lg text-white mb-16">Here are some of the workshops we have had up until now</div>
           </div>
-          <% (match upcoming_workshops with 
+          <% (match upcoming_workshops with
              | [] -> ()
              | _ -> %>
           <div class="text-center text-white text-xl font-bold">
@@ -135,7 +139,9 @@ Layout.render
 </div>
 <div class="bg-white py-0 pt-20 md:pt-10 lg:p-20 pb-10 md:pb-20">
   <div class="container-fluid">
-      <h2 class="font-bold">Meetups</h2>
+      <div class="text-center">
+        <h2 class="font-bold">Meetups</h2>
+      </div>
       <div class="grid lg:grid-cols-3 gap-8 lg:gap-12 mt-12">
           <% meetups |> List.iter (fun (meetup : Ood.Meetup.t) -> %>
           <a href="<%s meetup.url %>" class="border border-gray-200 p-8 rounded-xl transition-transform hover:scale-105">

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -41,7 +41,7 @@ Layout.render
           <div class="font-normal text-xs mt-4">Watch community videos like past OCaml Workshop events.</div>
         </a>
         <a href="https://github.com/ocaml/ocaml" class="border-gray-200 border p-8 rounded-xl card-hover">
-          <div class="text-base font-semibold"><img src="/img/community/github.svg" alt="" class="h-8 w-8 mr-2 inline-block"> Github</div>
+          <div class="text-base font-semibold"><img src="/img/community/github.svg" alt="" class="h-8 w-8 mr-2 inline-block"> GitHub</div>
           <div class="font-normal text-xs mt-4">Open bug reports and feature requests on the OCaml compiler.</div>
         </a>
         <a href="https://discord.gg/cCYQbqN" class="border-gray-200 border p-8 rounded-xl card-hover">


### PR DESCRIPTION
This PR adds watch.ocaml.org to the communities page along with the Peertube logo:

<img width="1362" alt="Screenshot 2023-02-28 at 18 11 49" src="https://user-images.githubusercontent.com/20166594/221943151-bdd263ee-96e7-4df8-a451-1e8bde84f2b6.png">

Happy for better suggestions on the descriptive text.

And also centres the `Meetup` title too:

<img width="1429" alt="Screenshot 2023-02-28 at 18 11 58" src="https://user-images.githubusercontent.com/20166594/221943121-5ede2098-8ada-416a-9088-470458708e7d.png">


cc\ @avsm 