### PR TITLE
No crunching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN chmod -R 755 /var
 COPY --from=build /home/opam/package.state /var/package.state
 COPY --from=build /home/opam/opam-repository /var/opam-repository
 COPY --from=build /home/opam/_build/default/src/ocamlorg_web/bin/main.exe /bin/server
+COPY --from=build /home/opam/_build/default/asset _build/default/asset
+COPY --from=build /home/opam/_build/default/data/media _build/default/data/media
 
 COPY playground/asset playground/asset
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install: all ## Install the packages on the system
 
 .PHONY: start
 start: all ## Run the produced executable
-	opam exec -- dune exec src/ocamlorg_web/bin/main.exe
+	opam exec -- dune exec src/ocamlorg_web/bin/main.exe 
 
 .PHONY: test
 test: ## Run the unit tests

--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
   cohttp
   cohttp-lwt-unix
   bos
-  crunch
+  static-file-digest
   mirage-kv-mem
   (dream
    (>= 1.0.0~alpha3))

--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,6 @@
   cohttp
   cohttp-lwt-unix
   bos
-  static-file-digest
   mirage-kv-mem
   (dream
    (>= 1.0.0~alpha3))

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -23,7 +23,6 @@ depends: [
   "cohttp"
   "cohttp-lwt-unix"
   "bos"
-  "static-file-digest"
   "mirage-kv-mem"
   "dream" {>= "1.0.0~alpha3"}
   "dream-accept"

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -23,7 +23,7 @@ depends: [
   "cohttp"
   "cohttp-lwt-unix"
   "bos"
-  "crunch"
+  "static-file-digest"
   "mirage-kv-mem"
   "dream" {>= "1.0.0~alpha3"}
   "dream-accept"

--- a/src/dream_dashboard/dream_dashboard.ml
+++ b/src/dream_dashboard/dream_dashboard.ml
@@ -69,7 +69,9 @@ end
 
 module Router = struct
   let loader _root path _request =
-    match Asset.read path with
+    let open Lwt.Syntax in
+    let* maybe_asset = Ocamlorg_static.Asset.read path in
+    match maybe_asset with
     | None -> Dream.empty `Not_Found
     | Some asset -> Dream.respond asset
 

--- a/src/dream_dashboard/dune
+++ b/src/dream_dashboard/dune
@@ -3,6 +3,7 @@
  (public_name ocamlorg.dream-dashboard)
  (libraries
   ocamlorg.global
+  ocamlorg_static
   dream
   hyper
   yojson
@@ -15,16 +16,6 @@
   timedesc)
  (preprocess
   (pps ppx_deriving_yojson)))
-
-(rule
- (targets asset.ml)
- (deps
-  asset/main.css
-  (source_tree asset))
- (action
-  (with-stdout-to
-   %{null}
-   (run %{bin:ocaml-crunch} -m plain asset -o %{targets}))))
 
 (subdir
  asset/

--- a/src/ocamlorg_data/dune
+++ b/src/ocamlorg_data/dune
@@ -96,7 +96,8 @@
 (rule
  (target watch.ml)
  (deps
-  (:config %{workspace_root}/yoshi.yaml))
+  (:config %{workspace_root}/yoshi.yaml)
+  (:data %{workspace_root}/data/watch.yml))
  (action
   (run
    %{bin:yoshi}
@@ -104,7 +105,7 @@
    %{config}
    -o
    %{target}
-   %{workspace_root}/data/watch.yml)))
+   %{data})))
 
 (rule
  (target planet.ml)

--- a/src/ocamlorg_data/dune
+++ b/src/ocamlorg_data/dune
@@ -99,13 +99,7 @@
   (:config %{workspace_root}/yoshi.yaml)
   (:data %{workspace_root}/data/watch.yml))
  (action
-  (run
-   %{bin:yoshi}
-   -c
-   %{config}
-   -o
-   %{target}
-   %{data})))
+  (run %{bin:yoshi} -c %{config} -o %{target} %{data})))
 
 (rule
  (target planet.ml)

--- a/src/ocamlorg_static/dune
+++ b/src/ocamlorg_static/dune
@@ -1,29 +1,29 @@
 (library
  (name ocamlorg_static)
+ (public_name ocamlorg.static)
  (libraries fmt dream))
 
 (rule
- (target asset.ml)
+ (target asset_digests.ml)
  (deps
   %{workspace_root}/asset/css/main.css
   (source_tree %{workspace_root}/asset))
  (action
   (with-stdout-to
    %{null}
-   (run %{bin:ocaml-crunch} -m plain %{workspace_root}/asset -o %{target}))))
+   (run %{bin:static-file-digest} %{workspace_root}/asset/ -s -o %{target}))))
 
 (rule
- (target media.ml)
+ (target media_digests.ml)
  (deps
   (source_tree %{workspace_root}/data/media))
  (action
   (with-stdout-to
    %{null}
    (run
-    %{bin:ocaml-crunch}
-    -m
-    plain
-    %{workspace_root}/data/media
+    %{bin:static-file-digest}
+    %{workspace_root}/data/media/
+    -s
     -o
     %{target}))))
 

--- a/src/ocamlorg_static/dune
+++ b/src/ocamlorg_static/dune
@@ -6,26 +6,23 @@
 (rule
  (target asset_digests.ml)
  (deps
+  %{workspace_root}/tool/static-file-digest/main.exe
   %{workspace_root}/asset/css/main.css
   (source_tree %{workspace_root}/asset))
  (action
   (with-stdout-to
    %{null}
-   (run %{bin:static-file-digest} %{workspace_root}/asset/ -s -o %{target}))))
+   (run %{deps} %{workspace_root}/asset/ -s -o %{target}))))
 
 (rule
  (target media_digests.ml)
  (deps
+  %{workspace_root}/tool/static-file-digest/main.exe
   (source_tree %{workspace_root}/data/media))
  (action
   (with-stdout-to
    %{null}
-   (run
-    %{bin:static-file-digest}
-    %{workspace_root}/data/media/
-    -s
-    -o
-    %{target}))))
+   (run %{deps} %{workspace_root}/data/media/ -s -o %{target}))))
 
 (rule
  (target playground_digests.ml)

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -2,14 +2,14 @@ open Ocamlorg
 
 let asset_loader =
   Static.loader
-    ~read:(fun _root path -> Ocamlorg_static.Asset.read path |> Lwt.return)
+    ~read:(fun _root path -> Ocamlorg_static.Asset.read path)
     ~digest:(fun _root path ->
       Option.map Dream.to_base64url (Ocamlorg_static.Asset.digest path))
     ~not_cached:[ "robots.txt"; "/robots.txt" ]
 
 let media_loader =
   Static.loader
-    ~read:(fun _root path -> Ocamlorg_static.Media.read path |> Lwt.return)
+    ~read:(fun _root path -> Ocamlorg_static.Media.read path)
     ~digest:(fun _root path ->
       Option.map Dream.to_base64url @@ Ocamlorg_static.Media.digest path)
 
@@ -105,7 +105,11 @@ let router t =
       sitemap_routes;
       Dream.scope ""
         [ Dream_encoding.compress ]
-        [ Dream.get "/media/**" (Dream.static ~loader:media_loader "") ];
+        [
+          Dream.get
+            (Ocamlorg_static.Media.url_root ^ "/**")
+            (Dream.static ~loader:media_loader "");
+        ];
       Dream.scope ""
         [ Dream_encoding.compress ]
         [

--- a/tool/ood-gen/lib/data.ml
+++ b/tool/ood-gen/lib/data.ml
@@ -1,0 +1,20 @@
+let base_dir = Sys.getcwd () ^ "/../../../../data/"
+
+let read filename =
+  let ch = open_in (base_dir ^ filename) in
+  let s = really_input_string ch (in_channel_length ch) in
+  close_in ch;
+  Some s
+
+let file_list =
+  let rec loop result = function
+    | f :: fs when Sys.is_directory f ->
+        Sys.readdir f |> Array.to_list
+        |> List.map (Filename.concat f)
+        |> List.append fs |> loop result
+    | f :: fs -> loop (f :: result) fs
+    | [] -> result
+  in
+  let l = String.length base_dir in
+  loop [] [ base_dir ]
+  |> List.map (fun f -> String.sub f l (String.length f - l))

--- a/tool/ood-gen/lib/dune
+++ b/tool/ood-gen/lib/dune
@@ -19,12 +19,3 @@
   hilite)
  (preprocess
   (pps ppx_deriving_yaml ppx_stable ppx_show)))
-
-(rule
- (targets data.ml)
- (deps
-  (source_tree %{workspace_root}/data/))
- (action
-  (with-stdout-to
-   %{null}
-   (run %{bin:ocaml-crunch} -m plain %{workspace_root}/data -o %{targets}))))


### PR DESCRIPTION
Patch removes crunching of assets and data - compute static file digests for assets.

On my machine:
before:
```
$ time make
opam exec -- dune build --root .
Done in 382ms.
Done in 1421ms.
                                          
real	0m12,948s
user	0m40,899s
sys	0m7,429s
```

after:
```
$ time make
opam exec -- dune build --root .
Done in 344ms.
Done in 1286ms.
                                          
real	0m8,282s
user	0m28,940s
sys	0m6,731s
```