### PR TITLE
fix for #960 (Mobile breakpoints happens in two steps in the problems page)

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -22,8 +22,8 @@ let render
 =
 <header 
   class="h-20 flex items-center dark:bg-[#171717]"
-  x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}"
-  @resize.window="sidebar = window.innerWidth > 1024">
+  x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}"
+  @resize.window="sidebar = window.innerWidth >= 1024">
   <nav class="container-fluid wide header flex justify-between items-center">
     <ul class="space space-x-5 xl:space-x-8 items-center flex text-body-400 font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
       <li style="width:132px">

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -88,7 +88,7 @@ inner_html
   ~description
   ~canonical
   ?active_top_nav_item @@
-  <div class="bg-white" x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024"  x-on:close-sidebar="sidebar=window.innerWidth > 1024 && true">
+  <div class="bg-white" x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024"  x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
     <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
       x-on:click="sidebar = ! sidebar">
       <%s! Icons.sidebar_menu "h-8 w-8" %>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -51,7 +51,7 @@ Package_layout.render
 ~path
 ~canonical:(Url.package_doc package.name ~version:package.version ?page:path_page)
 ~styles:["css/main.css"; "css/doc.css"] @@
-<div x-data="{ open: false, sidebar: window.innerWidth > 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth > 1024" x-on:close-sidebar="sidebar=window.innerWidth > 1024 && true">
+<div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
     x-on:click="sidebar = ! sidebar">
     <%s! Icons.sidebar_menu "h-8 w-8" %>


### PR DESCRIPTION
Thank you for reporting @YassineHaouzane!

The sidebar now collapses in line with the `min-width: 1024px` media query of the `lg` breakpoint.

Resolves #960.