### PR TITLE
Expose check.ci.ocaml.org in package overview

### DIFF
--- a/src/global/import.ml
+++ b/src/global/import.ml
@@ -61,7 +61,6 @@ module List = struct
     | hd :: tl -> hd :: take (n - 1) tl
 
   let rec drop i = function _ :: u when i > 0 -> drop (i - 1) u | u -> u
-  let hd_opt u = try Some (hd u) with Failure _ -> None
 end
 
 module Acc_biggest (Elt : sig
@@ -94,16 +93,6 @@ end = struct
     if rem = 0 then (0, List.tl elts) else (rem - 1, elts)
 
   let to_list (_, elts) = elts
-end
-
-module Option = struct
-  include Stdlib.Option
-
-  let filter p = function Some x when p x -> Some x | _ -> None
-
-  let update_with x =
-    let none = Some x in
-    fold ~none ~some:(fun prev -> filter (( <> ) prev) none)
 end
 
 module Result = struct

--- a/src/global/import.ml
+++ b/src/global/import.ml
@@ -61,6 +61,7 @@ module List = struct
     | hd :: tl -> hd :: take (n - 1) tl
 
   let rec drop i = function _ :: u when i > 0 -> drop (i - 1) u | u -> u
+  let hd_opt u = try Some (hd u) with Failure _ -> None
 end
 
 module Acc_biggest (Elt : sig
@@ -93,6 +94,16 @@ end = struct
     if rem = 0 then (0, List.tl elts) else (rem - 1, elts)
 
   let to_list (_, elts) = elts
+end
+
+module Option = struct
+  include Stdlib.Option
+
+  let filter p = function Some x when p x -> Some x | _ -> None
+
+  let update_with x =
+    let none = Some x in
+    fold ~none ~some:(fun prev -> filter (( <> ) prev) none)
 end
 
 module Result = struct

--- a/src/ocamlorg_frontend/components/icons.eml
+++ b/src/ocamlorg_frontend/components/icons.eml
@@ -275,8 +275,8 @@ let rss class_ =
   </svg>
 
 let shield_check class_ =
-  <svg xmlns="http://www.w3.org/2000/svg" class="<%s class_ %>" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+  <svg xmlns="http://www.w3.org/2000/svg" class="<%s class_ %>" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
   </svg>
 
 let sidebar_menu class_ =

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -28,6 +28,7 @@ type path =
 
 let render_package_and_version
 ~path
+~build_check
 ?page
 ?hash
 (package: Package.package)
@@ -55,6 +56,9 @@ let render_package_and_version
       style="background-position: right 0.25rem center">
       <%s! package.versions |> List.map version_options |> String.concat "" %>
     </select>
+    <% if build_check then (%>
+    <div class="flex flex-row ml-5 mt-2 text-green-700 font-medium"><%s! Icons.shield_check "h-6 w-6 mr-1" %>OCaml 5</div>
+    <% ); %>
   </div>
 
 type breadcrumb = {

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -12,6 +12,7 @@ let render
 ?canonical
 ?hash
 ?page
+?(build_check = false)
 ~(package : Package.package)
 ~(documentation_status: Package.documentation_status)
 ~(search_index_digest: string option)
@@ -34,7 +35,7 @@ Layout.render
     <div class="container-fluid wide">
       <div class="flex justify-between flex-col md:flex-row">
         <div class="flex flex-col items-baseline" id="htmx-breadcrumbs">
-          <%s! Package_breadcrumbs.render_package_and_version ~path ?hash ?page package %>
+          <%s! Package_breadcrumbs.render_package_and_version ~path ~build_check ?hash ?page package %>
         </div>
       </div>
       <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed md:hidden right-10"

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -103,7 +103,7 @@ Layout.render
         <div class="lg:flex-1 mt-10 lg:mt-0">
           <div class="text-body-400 text-base">
             <div class="h-12 w-12 text-white rounded-xl flex bg-gradient-to-br from-blue-400 to-blue-600">
-              <%s! Icons.shield_check "h-7 w-7 m-auto" %>
+              <%s! Icons.shield_check "h-7 w-7 m-auto stroke-2" %>
             </div>
             <h3>
               <div class="text-lg my-4 font-bold" style="color: #225b90">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -1,3 +1,5 @@
+open Ocamlorg.Import
+
 let side_box_link ~href ~title ~icon_html =
     <a href="<%s href %>" class="flex items-center py-2 px-4 hover:text-primary-600">
         <%s! icon_html %>
@@ -138,7 +140,9 @@ let render
 ~content_title
 ~toc
 ~(deps_and_conflicts: dependencies_and_conflicts list)
+~build_check
 (package : Package.package) =
+ignore build_check; (* TODO: add UI about this *)
 let render_dependency ~name ~cstr ~version =
   <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
     <a href="<%s Url.Package.overview name ?version %>" class="text-primary-600 hover:underline">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -188,18 +188,14 @@ Package_layout.render
 ~package
 ~documentation_status:sidebar_data.documentation_status
 ~path:(Overview content_title)
+~build_check
 ~left_sidebar_html:(sidebar ~sidebar_data ~specific_version ~version package)
 ~right_sidebar_html:(right_sidebar ~toc) @@
 <div class="flex md:gap-6 xl:gap-12 flex-col md:flex-row justify-between">
     <div class="flex-1 max-w-full">
       <% (match content_title with | None -> %>
       <div class="p-4 max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
-        <div class="flex flex-row">
-          <h2 id="description" class="mt-0 text-xl font-semibold uppercase">Description</h2>
-          <% if build_check then (%>
-          <div class="flex flex-row ml-5 px-2 text-green-700 font-medium bg-green-100 rounded"><%s! Icons.shield_check "h-6 w-6 mr-1 inline-block" %>OCaml 5 Ready</div>
-          <% ); %>
-        </div>
+        <h2 id="description" class="text-xl font-semibold uppercase">Description</h2>
         <div class="prose mt-4">
           <%s! package.description %>
         </div>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -142,7 +142,6 @@ let render
 ~(deps_and_conflicts: dependencies_and_conflicts list)
 ~build_check
 (package : Package.package) =
-ignore build_check; (* TODO: add UI about this *)
 let render_dependency ~name ~cstr ~version =
   <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
     <a href="<%s Url.Package.overview name ?version %>" class="text-primary-600 hover:underline">
@@ -195,8 +194,13 @@ Package_layout.render
     <div class="flex-1 max-w-full">
       <% (match content_title with | None -> %>
       <div class="p-4 max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
-        <h2 id="description" class="mb-4 mt-0 text-xl font-semibold uppercase">Description</h2>
-        <div class="prose">
+        <div class="flex flex-row">
+          <h2 id="description" class="mt-0 text-xl font-semibold uppercase">Description</h2>
+          <% if build_check then (%>
+          <div class="flex flex-row ml-5 px-2 text-green-700 font-medium bg-green-100 rounded"><%s! Icons.shield_check "h-6 w-6 mr-1 inline-block" %>OCaml 5 Ready</div>
+          <% ); %>
+        </div>
+        <div class="prose mt-4">
           <%s! package.description %>
         </div>
       </div>

--- a/src/ocamlorg_package/lib/check.ml
+++ b/src/ocamlorg_package/lib/check.ml
@@ -1,0 +1,44 @@
+open Ocamlorg.Import
+
+let error kind str =
+  Error (`Msg (Printf.sprintf "Unrecognized %s: %s" kind str))
+
+let ( let* ) = Result.bind
+let ( <@> ) f = Result.fold ~ok:Result.map ~error:(fun e _ -> Error e) f
+let ok_cons f x u = Ok List.cons <@> f x <@> u
+
+type status = string option
+
+module Json = struct
+  let error kind json =
+    Error
+      (`Msg
+        (Printf.sprintf "Unrecognized %s: %s" kind (Yojson.Safe.to_string json)))
+
+  let status_of_string = function
+    | "good" -> Ok None
+    | ("bad" | "internal-failure" | "not-available" | "partial") as s ->
+        Ok (Some s)
+    | str -> Error (`Msg (Printf.sprintf "Unrecognized status: %s" str))
+
+  let to_build = function
+    | `Assoc [ ("compiler", `String version); ("status", `String status) ] ->
+        let* status = status_of_string status in
+        Ok (version, status)
+    | json -> error "build" json
+
+  let to_release = function
+    | `Assoc [ ("name", `String release); ("statuses", `List builds) ] ->
+        let* builds = List.fold_right (ok_cons to_build) builds (Ok []) in
+        Ok (release, builds)
+    | json -> error "release" json
+
+  let to_repo = function
+    | `List releases ->
+        List.fold_left (Fun.flip (ok_cons to_release)) (Ok []) releases
+    | json -> error "repo" json
+
+  let of_string json =
+    let of_list u = u |> List.to_seq |> String.Map.of_seq in
+    json |> to_repo |> Result.map of_list
+end

--- a/src/ocamlorg_package/lib/check.ml
+++ b/src/ocamlorg_package/lib/check.ml
@@ -1,4 +1,4 @@
-open Ocamlorg.Import
+open Import
 
 let error kind str =
   Error (`Msg (Printf.sprintf "Unrecognized %s: %s" kind str))

--- a/src/ocamlorg_package/lib/config.ml
+++ b/src/ocamlorg_package/lib/config.ml
@@ -7,6 +7,10 @@ let documentation_url =
   Sys.getenv_opt "OCAMLORG_DOC_URL"
   |> Option.value ~default:"https://docs-data.ocaml.org/live/"
 
+let build_check_url =
+  Sys.getenv_opt "OCAMLORG_BUILD_STATUS_URL"
+  |> Option.value ~default:"https://check.ci.ocaml.org/api/v1/latest/packages"
+
 let default_cache_dir =
   match Sys.os_type with
   | "Unix" -> Fpath.(v (Sys.getenv "HOME") / ".cache" / "ocamlorg")

--- a/src/ocamlorg_package/lib/config.mli
+++ b/src/ocamlorg_package/lib/config.mli
@@ -4,3 +4,4 @@ val opam_polling : int
 val documentation_url : string
 val opam_repository_path : Fpath.t
 val package_state_path : Fpath.t
+val build_check_url : string

--- a/src/ocamlorg_package/lib/info.ml
+++ b/src/ocamlorg_package/lib/info.ml
@@ -2,7 +2,7 @@ type url = { uri : string; checksum : string list }
 
 (* This is used to invalidate the package state cache if the type [Info.t]
    changes. *)
-let version = "3"
+let version = "4"
 
 type t = {
   synopsis : string;

--- a/src/ocamlorg_package/lib/info.ml
+++ b/src/ocamlorg_package/lib/info.ml
@@ -187,13 +187,13 @@ let of_opamfiles
     in
     List.fold_left f OpamPackage.Set.empty names
   in
-  Logs.info (fun f -> f "Dependencies...");
+  Logs.info (fun f -> f "Opam repo: Dependencies...");
   let dependencies = get_dependency_set packages opams in
-  Logs.info (fun f -> f "Reverse dependencies...");
+  Logs.info (fun f -> f "Opam repo: Reverse dependencies...");
   let* rev_deps = rev_depends dependencies in
-  Logs.info (fun f -> f "Publication dates...");
+  Logs.info (fun f -> f "Opam repo: Publication dates...");
   let* timestamps = Opam_repository.create_package_to_timestamp () in
-  Logs.info (fun f -> f "Generate package info");
+  Logs.info (fun f -> f "Opam repo: Generate package info");
   Lwt_fold.package_name_map
     (fun name vmap acc ->
       let+ vs =

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -174,7 +174,6 @@ let http_get url =
       Error (`Msg "Failed to fetch the documentation page")
 
 let ( let>& ) opt some = Option.fold ~none:(Lwt.return false) ~some opt
-
 let if_fresher new_x old_x = if Some new_x = old_x then None else Some new_x
 
 let maybe_update_repo state =
@@ -190,7 +189,7 @@ let maybe_update_build_check state =
   let>& data = Result.to_option data in
   let digest = data |> String.to_bytes |> Digest.bytes in
   Logs.info (fun m -> m "Build check: Digest %s" (digest |> Digest.to_hex));
-  let>& digest = if_fresher digest state.build_check_digest  in
+  let>& digest = if_fresher digest state.build_check_digest in
   update_build_check state (data, digest)
 
 let threads state =

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -204,3 +204,11 @@ val search :
       package author
 
     A call to this function call Lazy.force on every package info. *)
+
+module Build : sig
+  type status = string option
+
+  val find : state -> t -> (string * status) list
+  (** Returns a list of compiler version and build check status pairs
+      corresponding to the package release. *)
+end

--- a/src/ocamlorg_package/lib/opam_repository.ml
+++ b/src/ocamlorg_package/lib/opam_repository.ml
@@ -61,6 +61,7 @@ let clone () =
           Fpath.to_string clone_path;
         |] )
   in
+  Logs.info (fun m -> m "git clone");
   last_commit ()
 
 let pull () =
@@ -68,6 +69,7 @@ let pull () =
   let* () =
     Process.exec (git_cmd [ "pull"; "-q"; "--ff-only"; "origin"; "master" ])
   in
+  Logs.info (fun m -> m "git pull");
   last_commit ()
 
 let fold_dir f acc directory =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -597,9 +597,10 @@ let package_overview t kind req =
                   children = [];
                 }))
   in
+  let build_check = Ocamlorg_package.Build.find t package in
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content:""
-       ~search_index_digest ~content_title:None ~toc ~deps_and_conflicts
+       ~search_index_digest ~content_title:None ~toc ~deps_and_conflicts ~build_check
        frontend_package)
 
 let package_documentation t kind req =
@@ -742,11 +743,12 @@ let package_file t kind req =
   in
   let* maybe_doc = Ocamlorg_package.file ~kind package path in
   let</>? doc = maybe_doc in
+  let build_check = Ocamlorg_package.Build.find t package in
   let content = doc.content in
   let toc = Package_helper.frontend_toc doc.toc in
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content
-       ~search_index_digest ~content_title:(Some path) ~toc
+       ~search_index_digest ~content_title:(Some path) ~toc ~build_check
        ~deps_and_conflicts:[] frontend_package)
 
 let package_search_index t kind req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -462,6 +462,7 @@ let is_author_match name pattern =
 let packages_search t req =
   match Dream.query req "q" with
   | Some search ->
+      Logs.info (fun m -> m "%s" search);
       let packages =
         Ocamlorg_package.search ~is_author_match ~sort_by_popularity:true t
           search

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -487,6 +487,11 @@ let packages_autocomplete_fragment t req =
            ~total:(List.length results) top_5)
   | _ -> Dream.html ""
 
+let ocaml5_good (ocaml_version, status) =
+  match String.split_on_char '.' ocaml_version with
+  | major :: _ -> int_of_string major >= 5 && Option.is_none status
+  | _ -> false
+
 let package_overview t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
@@ -597,7 +602,7 @@ let package_overview t kind req =
                   children = [];
                 }))
   in
-  let build_check = Ocamlorg_package.Build.find t package in
+  let build_check = List.exists ocaml5_good (Ocamlorg_package.Build.find t package) in
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content:""
        ~search_index_digest ~content_title:None ~toc ~deps_and_conflicts ~build_check
@@ -743,7 +748,7 @@ let package_file t kind req =
   in
   let* maybe_doc = Ocamlorg_package.file ~kind package path in
   let</>? doc = maybe_doc in
-  let build_check = Ocamlorg_package.Build.find t package in
+  let build_check = List.exists ocaml5_good (Ocamlorg_package.Build.find t package) in
   let content = doc.content in
   let toc = Package_helper.frontend_toc doc.toc in
   Dream.html

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -602,11 +602,13 @@ let package_overview t kind req =
                   children = [];
                 }))
   in
-  let build_check = List.exists ocaml5_good (Ocamlorg_package.Build.find t package) in
+  let build_check =
+    List.exists ocaml5_good (Ocamlorg_package.Build.find t package)
+  in
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content:""
-       ~search_index_digest ~content_title:None ~toc ~deps_and_conflicts ~build_check
-       frontend_package)
+       ~search_index_digest ~content_title:None ~toc ~deps_and_conflicts
+       ~build_check frontend_package)
 
 let package_documentation t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
@@ -748,7 +750,9 @@ let package_file t kind req =
   in
   let* maybe_doc = Ocamlorg_package.file ~kind package path in
   let</>? doc = maybe_doc in
-  let build_check = List.exists ocaml5_good (Ocamlorg_package.Build.find t package) in
+  let build_check =
+    List.exists ocaml5_good (Ocamlorg_package.Build.find t package)
+  in
   let content = doc.content in
   let toc = Package_helper.frontend_toc doc.toc in
   Dream.html


### PR DESCRIPTION
This is a work in progress. The goal is to expose the opam package build results stored in check.ocamllabs.io in the corresponding package overview page

- [X] Display "OCaml 5 Ready" in package overview if build good
- [X] Process build result json
- [X] Store build statuses in state
- [X] Scrape json from check.ocamllabs.io
- [X] Expose package build check status in GraphQL API

To test, store the build statuses json in the cache dir:

```shell
wget https://check.ci.ocaml.org/api/v1/latest/packages -P ~/.cache/ocamlorg/
```

Corresponding Issue: https://github.com/ocaml/ocaml.org/issues/42