### PR TITLE
Keyboard controls on package search dropdown

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -43,24 +43,20 @@ let render
     <ul class="hidden lg:flex items-center space-x-4 xl:space-x-8">
       <li class="relative">
         <form
-          <%s! Search.package_autocomplete_form_attributes_for_keyboard_controls %>
+          <%s! Packages_autocomplete_fragment.form_attributes %>
           action="/packages/search" method="GET">
           <div class="header__search relative flex items-center justify-center">
             <input type="search" name="q" class="header__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80"
               autocomplete="off"
               placeholder="Search OCaml Packages"
-              <%s! Search.package_autocomplete_input_attributes_for_keyboard_controls %>
-              hx-get="/packages/autocomplete"
-              hx-params="q"
-              hx-trigger="keyup changed delay:500ms, search"
-              hx-target="#search-results"
-              hx-indicator=".htmx-indicator">
+              <%s! Packages_autocomplete_fragment.input_attributes ~target_sel:"#header-search-results" ~indicator_sel:"#header-search-indicator" %>
+              >
             <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
               <%s! Icons.magnifying_glass "w-6 h-6 text-white" %>
             </button>
             <div class="header__search__dropdown z-10 absolute rounded-b-md w-full top-0 mt-10 p-2 bg-white border border-primary-600">
-              <span class="htmx-indicator mx-2">Searching...</span>
-              <div id="search-results"></div>
+              <span id="header-search-indicator" class="mx-2">Searching...</span>
+              <div id="header-search-results"></div>
               <span class="pl-2 font-semibold">Or go to:</span>
               <a class="flex py-2 px-4 gap-4 hover:bg-primary-100 font-semibold hover:font-semibold text-primary-600" href="<%s Url.api %>">
                 Standard Library API

--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -42,11 +42,18 @@ let render
     </ul>
     <ul class="hidden lg:flex items-center space-x-4 xl:space-x-8">
       <li class="relative">
-        <form action="/packages/search" method="GET">
+        <form
+          x-data="{ row: null, col: 0, max: 0 }"
+          @submit="if (row !== null ) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }"
+          action="/packages/search" method="GET">
           <div class="header__search relative flex items-center justify-center">
             <input type="search" name="q" class="header__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80"
               autocomplete="off"
               placeholder="Search OCaml Packages"
+              @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
+              @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
+              @keyup.right="col = (col + 1)%2"
+              @keyup.left="col = (col + 1)%2"
               hx-get="/packages/autocomplete"
               hx-params="q"
               hx-trigger="keyup changed delay:500ms, search"

--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -43,17 +43,13 @@ let render
     <ul class="hidden lg:flex items-center space-x-4 xl:space-x-8">
       <li class="relative">
         <form
-          x-data="{ row: null, col: 0, max: 0 }"
-          @submit="if (row !== null ) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }"
+          <%s! Search.package_autocomplete_form_attributes_for_keyboard_controls %>
           action="/packages/search" method="GET">
           <div class="header__search relative flex items-center justify-center">
             <input type="search" name="q" class="header__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 lg:w-56 xl:w-80"
               autocomplete="off"
               placeholder="Search OCaml Packages"
-              @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
-              @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
-              @keyup.right="col = (col + 1)%2"
-              @keyup.left="col = (col + 1)%2"
+              <%s! Search.package_autocomplete_input_attributes_for_keyboard_controls %>
               hx-get="/packages/autocomplete"
               hx-params="q"
               hx-trigger="keyup changed delay:500ms, search"

--- a/src/ocamlorg_frontend/components/search.eml
+++ b/src/ocamlorg_frontend/components/search.eml
@@ -10,3 +10,15 @@ let highlight_search_terms
   let r = Str.global_replace (Str.regexp "[ \t]+") "\\|" search in
   let split = Str.full_split (Str.regexp_case_fold r) text in
   List.fold_left (fun a b -> a ^ render_item b) "" split
+
+
+let package_autocomplete_input_attributes_for_keyboard_controls = 
+  {js| @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
+       @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
+       @keyup.right="col = (col + 1)%2"
+       @keyup.left="col = (col + 1)%2"
+       :aria-activedescendant="row !== null ? 'package-autocomplete-'+row+'-'+col : null" |js}
+
+let package_autocomplete_form_attributes_for_keyboard_controls =
+  {js| x-data="{ row: null, col: 0, max: 0 }"
+       @submit="if (row !== null ) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }" |js}

--- a/src/ocamlorg_frontend/components/search.eml
+++ b/src/ocamlorg_frontend/components/search.eml
@@ -10,15 +10,3 @@ let highlight_search_terms
   let r = Str.global_replace (Str.regexp "[ \t]+") "\\|" search in
   let split = Str.full_split (Str.regexp_case_fold r) text in
   List.fold_left (fun a b -> a ^ render_item b) "" split
-
-
-let package_autocomplete_input_attributes_for_keyboard_controls = 
-  {js| @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
-       @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
-       @keyup.right="col = (col + 1)%2"
-       @keyup.left="col = (col + 1)%2"
-       :aria-activedescendant="row !== null ? 'package-autocomplete-'+row+'-'+col : null" |js}
-
-let package_autocomplete_form_attributes_for_keyboard_controls =
-  {js| x-data="{ row: null, col: 0, max: 0 }"
-       @submit="if (row !== null ) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }" |js}

--- a/src/ocamlorg_frontend/css/partials/search.css
+++ b/src/ocamlorg_frontend/css/partials/search.css
@@ -6,6 +6,17 @@
   box-shadow: none;
 }
 
+#header-search-indicator,
+#packages-search-indicator {
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+#header-search-indicator.htmx-request ,
+#packages-search-indicator.htmx-request {
+  opacity: 1;
+}
+
 /* search dropdown */
 
 .header__search__dropdown{

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -16,17 +16,13 @@ Layout.render
             <div
                 class="flex justify-center flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-auto lg:w-auto mt-16">
                 <form
-                  x-data="{ row: null, col: 0, max: 0 }"
-                  @submit="if (row !== null ) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }"
+                  <%s! Search.package_autocomplete_form_attributes_for_keyboard_controls %>
                   action="/packages/search" method="GET" class="flex flex-col justify-center">
                   <div class="packages__search relative inline-flex mx-auto items-center justify-center">
                     <input type="search" name="q" class="packages__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 md:w-96 lg:w-[32rem] xl:w-[32rem]"
                       autocomplete="off"
                       placeholder="Search OCaml Packages"
-                      @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
-                      @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
-                      @keyup.right="col = (col + 1)%2"
-                      @keyup.left="col = (col + 1)%2"
+                      <%s! Search.package_autocomplete_input_attributes_for_keyboard_controls %>
                       hx-get="/packages/autocomplete"
                       hx-params="q"
                       hx-trigger="keyup changed delay:500ms, search"

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -16,24 +16,19 @@ Layout.render
             <div
                 class="flex justify-center flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-auto lg:w-auto mt-16">
                 <form
-                  <%s! Search.package_autocomplete_form_attributes_for_keyboard_controls %>
+                  <%s! Packages_autocomplete_fragment.form_attributes %>
                   action="/packages/search" method="GET" class="flex flex-col justify-center">
                   <div class="packages__search relative inline-flex mx-auto items-center justify-center">
                     <input type="search" name="q" class="packages__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 md:w-96 lg:w-[32rem] xl:w-[32rem]"
                       autocomplete="off"
                       placeholder="Search OCaml Packages"
-                      <%s! Search.package_autocomplete_input_attributes_for_keyboard_controls %>
-                      hx-get="/packages/autocomplete"
-                      hx-params="q"
-                      hx-trigger="keyup changed delay:500ms, search"
-                      hx-target="#packages-search-results"
-                      hx-indicator=".htmx-indicator">
+                      <%s! Packages_autocomplete_fragment.input_attributes ~target_sel:"#packages-search-results" ~indicator_sel:"#packages-search-indicator" %>>
                     <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
                       <%s! Icons.magnifying_glass "w-6 h-6 text-white" %>
                     </button>
                   </div>
                   <div>
-                    <span class="htmx-indicator">Searching...</span>
+                    <span id="packages-search-indicator">Searching...</span>
                     <div id="packages-search-results"></div>
                   </div>
                 </form>

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -15,11 +15,18 @@ Layout.render
             <p class="text-center">Explore thousands of open-source OCaml packages with their documentation.</p>
             <div
                 class="flex justify-center flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-auto lg:w-auto mt-16">
-                <form action="/packages/search" method="GET" class="flex flex-col justify-center">
+                <form
+                  x-data="{ row: null, col: 0, max: 0 }"
+                  @submit="if (row !== null ) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }"
+                  action="/packages/search" method="GET" class="flex flex-col justify-center">
                   <div class="packages__search relative inline-flex mx-auto items-center justify-center">
                     <input type="search" name="q" class="packages__search__input focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1 md:w-96 lg:w-[32rem] xl:w-[32rem]"
                       autocomplete="off"
                       placeholder="Search OCaml Packages"
+                      @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
+                      @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
+                      @keyup.right="col = (col + 1)%2"
+                      @keyup.left="col = (col + 1)%2"
                       hx-get="/packages/autocomplete"
                       hx-params="q"
                       hx-trigger="keyup changed delay:500ms, search"

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -1,12 +1,18 @@
 let render
 ~search
+~total
 (packages : Package_intf.package list)
 =
 <div class="mx-2 mb-2">
   <span class="font-semibold">Packages:</span>
-  <% if List.length packages = 0 then ( %>
+  <% if total = 0 then ( %>
   <p class="break-words">
     We didn't find a match for "<%s search %>".
+  </p>
+  <% ) else ( %>
+  <p class="break-words">
+    <%s (if total = List.length packages then "" else "Showing top " ^ string_of_int (List.length packages) ^ " out of ")
+    ^ string_of_int total ^ (if total = 1 then " search result" else " search results") %>:
   </p>
   <% ); %>
 

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -1,3 +1,41 @@
+(*
+  Package autocomplete works like this:
+  1. user types search terms into the search input
+  2. htmx fetches the fragment below (see function [render])
+     and inserts it into the HTMLElement selected by [target_sel].
+     While htmx's HTTP request is in progress, the HTMLElement
+     with selected by [indicator_sel] is shown.
+  3. user uses arrow keys to navigate the top 5 search results,
+     which present quick access to both the package overview page
+     and the documentation.
+
+  Note:
+  - when there are at most five search results, pressing the
+    Enter key in the input field sends you to the overview
+    page of the first search results
+ *)
+
+
+(* HTML <form> tag with these attributes wraps both the input element
+   and the search results HTML fragment (see function [render]). *)
+let form_attributes =
+  {js| x-data="{ row: null, col: 0, max: 0, total: 0 }"
+       @submit="if (row === null && total <= 5) row = 0; if (row !== null) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }" |js}
+
+let input_attributes ~target_sel ~indicator_sel =
+  {js|  @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
+        @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
+        @keyup.right="col = (col + 1)%2"
+        @keyup.left="col = (col + 1)%2"
+        :aria-activedescendant="row !== null ? 'package-autocomplete-'+row+'-'+col : null"
+
+        hx-get="/packages/autocomplete"
+        hx-params="q"
+        hx-trigger="keyup changed delay:500ms, search"
+        hx-target="|js} ^ target_sel ^ {js|"
+        hx-indicator="|js} ^ indicator_sel ^ {js|"
+        |js}
+
 let render
 ~search
 ~total
@@ -16,7 +54,7 @@ let render
   </p>
   <% ); %>
 
-  <ol class="flex flex-col" x-init="row = null; col = 0">
+  <ol class="flex flex-col" x-init="row = null; col = 0; total = <%s string_of_int total %>">
   <% packages |> List.iteri (fun i (package : Package_intf.package) -> %>
     <li class="flex flex-row">
       <a

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -40,7 +40,7 @@ let render
     </li>
   <% ); %>
   </ol>
-  <% if List.length packages > 0 then ( %>
+  <% if total > 5 then ( %>
   <a class="font-semibold hover:bg-primary-100 px-2 py-2 flex text-right" href="<%s Url.packages_search %>?q=<%s Dream.to_percent_encoded search %>">see more...</a>
   <% ); %>
 </div>

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -1,27 +1,14 @@
-(*
-  Package autocomplete works like this:
-  1. user types search terms into the search input
-  2. htmx fetches the fragment below (see function [render])
-     and inserts it into the HTMLElement selected by [target_sel].
-     While htmx's HTTP request is in progress, the HTMLElement
-     with selected by [indicator_sel] is shown.
-  3. user uses arrow keys to navigate the top 5 search results,
-     which present quick access to both the package overview page
-     and the documentation.
-
-  Note:
-  - when there are at most five search results, pressing the
-    Enter key in the input field sends you to the overview
-    page of the first search results
- *)
-
-
 (* HTML <form> tag with these attributes wraps both the input element
    and the search results HTML fragment (see function [render]). *)
 let form_attributes =
   {js| x-data="{ row: null, col: 0, max: 0, total: 0 }"
        @submit="if (row === null && total <= 5) row = 0; if (row !== null) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }" |js}
 
+(* When the user types, htmx fetches the fragment rendered by
+   the function [render] below, and and inserts it into the
+   HTMLElement selected by [target_sel].
+   While htmx's HTTP request is in progress, the HTMLElement
+   with selected by [indicator_sel] is shown. *)
 let input_attributes ~target_sel ~indicator_sel =
   {js|  @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
         @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -62,8 +62,8 @@ let render
         id="package-autocomplete-<%s string_of_int i %>-0"
         :aria-selected="row == <%s string_of_int i %> && col == 0"
         href="<%s Url.package_with_version package.name %>"
-        :class='{ "border-primary-600": row == <%s string_of_int i %> && col == 0}'
-        class="border flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 text-primary-600 inline-block"
+        :class='{ "bg-background-mid-blue text-white": row == <%s string_of_int i %> && col == 0, "text-primary-600": row != <%s string_of_int i %> || col != 0}'
+        class="flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 inline-block"
       >
         <%s! Search.highlight_search_terms ~class_:"bg-background-light-blue text-gray-800 font-normal" ~search package.name %>
       </a>
@@ -71,8 +71,8 @@ let render
         id="package-autocomplete-<%s string_of_int i %>-1"
         :aria-selected="row == <%s string_of_int i %> && col == 1"
         href="<%s Url.package_doc package.name %>"
-        :class='{ "border-primary-600": row == <%s string_of_int i %> && col == 1}'
-        class="border justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100">
+        :class='{ "bg-background-mid-blue text-white": row == <%s string_of_int i %> && col == 1}'
+        class="justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100">
         docs
       </a>
     </li>

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -10,16 +10,25 @@ let render
   </p>
   <% ); %>
 
-  <ol class="flex flex-col">
-  <% packages |> List.iter (fun (package : Package_intf.package) -> %>
+  <ol class="flex flex-col" x-init="row = null; col = 0">
+  <% packages |> List.iteri (fun i (package : Package_intf.package) -> %>
     <li class="flex flex-row">
       <a
+        x-init="max=<%s string_of_int i %>"
+        id="package-autocomplete-<%s string_of_int i %>-0"
+        :aria-selected="row == <%s string_of_int i %> && col == 0"
         href="<%s Url.package_with_version package.name %>"
-        class="flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 text-primary-600 inline-block"
+        :class='{ "border-primary-600": row == <%s string_of_int i %> && col == 0}'
+        class="border flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 text-primary-600 inline-block"
       >
         <%s! Search.highlight_search_terms ~class_:"bg-background-light-blue text-gray-800 font-normal" ~search package.name %>
       </a>
-      <a class="justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100" href="<%s Url.package_doc package.name %>">
+      <a 
+        id="package-autocomplete-<%s string_of_int i %>-1"
+        :aria-selected="row == <%s string_of_int i %> && col == 1"
+        href="<%s Url.package_doc package.name %>"
+        :class='{ "border-primary-600": row == <%s string_of_int i %> && col == 1}'
+        class="border justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100">
         docs
       </a>
     </li>

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -12,8 +12,8 @@ let form_attributes =
 let input_attributes ~target_sel ~indicator_sel =
   {js|  @keyup.down="if (row === null) { row = 0; col = 0; } else { row +=1; if (row > max) { row = max } }"
         @keyup.up="if (row !== null) { row -=1; if (row < 0) { row = null } }"
-        @keyup.right="col = (col + 1)%2"
-        @keyup.left="col = (col + 1)%2"
+        @keyup.right="if (col < 1) col++"
+        @keyup.left="if (col >= 1) col--"
         :aria-activedescendant="row !== null ? 'package-autocomplete-'+row+'-'+col : null"
 
         hx-get="/packages/autocomplete"

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -356,7 +356,8 @@ let packages_autocomplete_fragment t req =
       let top_5 = results |> List.take 5 in
       let search = Dream.from_percent_encoded search in
       Dream.html
-        (Ocamlorg_frontend.packages_autocomplete_fragment ~search ~total:(List.length results) top_5)
+        (Ocamlorg_frontend.packages_autocomplete_fragment ~search
+           ~total:(List.length results) top_5)
   | _ -> Dream.html ""
 
 let package _t req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -352,10 +352,11 @@ let packages_autocomplete_fragment t req =
       let packages =
         Ocamlorg_package.search_package ~sort_by_popularity:true t search
       in
-      let results = List.map (package_meta t) packages |> List.take 5 in
+      let results = List.map (package_meta t) packages in
+      let top_5 = results |> List.take 5 in
       let search = Dream.from_percent_encoded search in
       Dream.html
-        (Ocamlorg_frontend.packages_autocomplete_fragment ~search results)
+        (Ocamlorg_frontend.packages_autocomplete_fragment ~search ~total:(List.length results) top_5)
   | _ -> Dream.html ""
 
 let package _t req =

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,7 @@ module.exports = {
         background: {
           default: "#FAF8F3",
           beige: "#FAF8F3",
+          "mid-blue": "#0C3B8C", // background for cursor highlighting in keyboard navigable areas (e.g. package search dropdown)
           "dark-blue": "#0e1531", // one of the colors from the blue patterned background used in various parts of the site
           "light-blue": "rgb(221, 232, 251)",
         },


### PR DESCRIPTION
Patch adds keyboard controls to the package search dropdowns.

When there are more than 5 search results, pressing the enter key in the dropdown sends you to the full list of results. When there are 5 or less search results, pressing the enter key in the dropdown sends you to the first search result.

Resolves #944.

What this patch does not do:
- doesn't keyboard-navigate to Standard Library API link (could be added, though, but this here is pretty much the simplest implementation, so I'd like to have this as a reference point in the repo for adding keyboard-navigation to elements) - we will refine when there's enough feedback as this is going to be probably the most used control on the site
- css styles are not final. Claire prepared a really nice UI that a later patch should apply


|before|after|
|-|-|
|![Screenshot from 2023-03-14 12-58-24](https://user-images.githubusercontent.com/6594573/224994223-d7398b88-8eb4-401d-8c8f-ec686f41f6ce.png)|![Screenshot from 2023-03-14 12-58-20](https://user-images.githubusercontent.com/6594573/224994250-5da7af8b-2a9b-4c03-a7f9-4b7f682203bf.png)|
