### PR TITLE
Opam repository polling changes

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -170,7 +170,7 @@ let init ?(disable_polling = false) () =
   let state = try_load_state () in
   if Sys.file_exists (Fpath.to_string Config.opam_repository_path) then
     Lwt.async (fun () -> maybe_update state)
-  else Lwt.async (fun () -> Opam_repository.clone ());
+  else Lwt.async Opam_repository.clone;
   if disable_polling then ()
   else
     Lwt.async (fun () ->

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -170,8 +170,7 @@ let init ?(disable_polling = false) () =
   let state = try_load_state () in
   if Sys.file_exists (Fpath.to_string Config.opam_repository_path) then
     Lwt.async (fun () -> maybe_update state)
-  else
-    Lwt.async (fun () -> Opam_repository.clone ());
+  else Lwt.async (fun () -> Opam_repository.clone ());
   if disable_polling then ()
   else
     Lwt.async (fun () ->

--- a/src/ocamlorg_package/lib/opam_repository.ml
+++ b/src/ocamlorg_package/lib/opam_repository.ml
@@ -55,7 +55,7 @@ let clone () =
           |] )
   | _ -> Fmt.failwith "Error finding about this path: %a" Fpath.pp clone_path
 
-let pull () = Process.exec (git_cmd [ "pull"; "--ff-only"; "origin" ])
+let pull () = Process.exec (git_cmd [ "pull"; "-q"; "--ff-only"; "origin" ])
 
 let last_commit () =
   let open Lwt.Syntax in


### PR DESCRIPTION
- Remove "Already up-to-date." message emmited by git pull
- Move git clone repo from polling into init
- Start polling by sleeping
- Add poll/pull log
- Add package update log

Note: This will intended to prepare polling of check.ocamllabs.io in
maybe_update.
