### PR TITLE
stay on current page when using version switch in package docs

### DIFF
--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -47,15 +47,24 @@ type path =
 
 let render_package_and_version
 ~(package: Package.package)
+~path
+?page
+?hash
+()
 =
   let version = Package.url_version package in
+  let url ~(version : string option) =
+    match path with
+    | Overview _ -> Url.package_with_version package.name ?version
+    | Documentation _ -> Url.package_doc package.name ?version ?hash ?page
+  in
   let version_options v =
     <% if v = package.latest_version then ( %>
-    <option value="<%s Url.package_with_version package.name %>" <%s if package.version = Latest then "selected" else "" %>>
+    <option value="<%s url ~version:None %>" <%s if package.version = Latest then "selected" else "" %>>
       <%s "latest (" ^ package.latest_version ^ ")" %>
     </option>
     <% ); %>
-    <option value="<%s Url.package_with_version package.name ?version:(Some v) %>" <%s if package.version = Specific v then "selected" else "" %>>
+    <option value="<%s url ~version:(Some v) %>" <%s if package.version = Specific v then "selected" else "" %>>
       <%s v %>
     </option>
   in
@@ -94,11 +103,14 @@ let render_library_path_breadcrumbs
 let render_docs_path_breadcrumbs
 ~(package: Package.package)
 ~(path: docs_path) 
+?page
+?hash
+()
   =
   let version = Package.url_version package in
   <nav aria-label="breadcrumb" class="flex" id="htmx-breadcrumbs">
     <ul class="flex flex-wrap gap-x-2 text-base leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~package %>
+      <%s! render_package_and_version ~package ~path:(Documentation path) ?page ?hash () %>
       <li>
         <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version %>">Documentation</a>
       </li>
@@ -117,10 +129,11 @@ let render_docs_path_breadcrumbs
 let render_overview_breadcrumbs
 ~(package: Package.package)
 ~(page: string option)
+?hash
 =
   <nav aria-label="breadcrumbs" class="flex">
     <ul class="flex flex-wrap gap-x-2 leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~package %>
+      <%s! render_package_and_version ~package ~path:(Overview page) ?hash () %>
       <% (match page with | Some p -> %>
       <li><%s p %></li>
       <% | None -> ()); %>
@@ -130,8 +143,10 @@ let render_overview_breadcrumbs
 let render
 ~(package: Package.package)
 ~(path: path)
+?page
+?hash
 =
   match path with
-    | Overview page -> render_overview_breadcrumbs ~package ~page
-    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~package ~path:docs_path
+    | Overview page -> render_overview_breadcrumbs ~package ~page ?hash
+    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~package ~path:docs_path ?hash ?page
     

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -46,25 +46,24 @@ type path =
   | Documentation of (docs_path)
 
 let render_package_and_version
-~(package: Package.package)
 ~path
 ?page
 ?hash
-()
+(package: Package.package)
 =
   let version = Package.url_version package in
-  let url ~(version : string option) =
+  let url (version : string option) =
     match path with
     | Overview _ -> Url.package_with_version package.name ?version
     | Documentation _ -> Url.package_doc package.name ?version ?hash ?page
   in
   let version_options v =
     <% if v = package.latest_version then ( %>
-    <option value="<%s url ~version:None %>" <%s if package.version = Latest then "selected" else "" %>>
+    <option value="<%s url None %>" <%s if package.version = Latest then "selected" else "" %>>
       <%s "latest (" ^ package.latest_version ^ ")" %>
     </option>
     <% ); %>
-    <option value="<%s url ~version:(Some v) %>" <%s if package.version = Specific v then "selected" else "" %>>
+    <option value="<%s url (Some v) %>" <%s if package.version = Specific v then "selected" else "" %>>
       <%s v %>
     </option>
   in
@@ -101,16 +100,15 @@ let render_library_path_breadcrumbs
   </li>
 
 let render_docs_path_breadcrumbs
-~(package: Package.package)
-~(path: docs_path) 
+~(path: docs_path)
 ?page
 ?hash
-()
+(package: Package.package)
   =
   let version = Package.url_version package in
   <nav aria-label="breadcrumb" class="flex" id="htmx-breadcrumbs">
     <ul class="flex flex-wrap gap-x-2 text-base leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~package ~path:(Documentation path) ?page ?hash () %>
+      <%s! render_package_and_version ~path:(Documentation path) ?page ?hash package %>
       <li>
         <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version %>">Documentation</a>
       </li>
@@ -127,13 +125,13 @@ let render_docs_path_breadcrumbs
   </nav>
 
 let render_overview_breadcrumbs
-~(package: Package.package)
 ~(page: string option)
 ?hash
+(package: Package.package)
 =
   <nav aria-label="breadcrumbs" class="flex">
     <ul class="flex flex-wrap gap-x-2 leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~package ~path:(Overview page) ?hash () %>
+      <%s! render_package_and_version ~path:(Overview page) ?hash package %>
       <% (match page with | Some p -> %>
       <li><%s p %></li>
       <% | None -> ()); %>
@@ -141,12 +139,9 @@ let render_overview_breadcrumbs
   </nav>
 
 let render
-~(package: Package.package)
 ~(path: path)
 ?page
-?hash
 =
   match path with
-    | Overview page -> render_overview_breadcrumbs ~package ~page ?hash
-    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~package ~path:docs_path ?hash ?page
-    
+    | Overview page -> render_overview_breadcrumbs ~page
+    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~path:docs_path ?page

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -4,6 +4,8 @@ let render
 ~title
 ~description
 ?canonical
+?hash
+?page
 ~(package : Package.package)
 inner =
 Layout.render
@@ -18,7 +20,7 @@ Layout.render
     <div class="container-fluid wide">
       <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
         <div class="flex flex-col items-baseline mb-6">
-          <%s! Package_breadcrumbs.render ~package ~path %>
+          <%s! Package_breadcrumbs.render ~package ~path ?hash ?page () %>
 
           <% (match path with | Overview _ -> %>
             <div class="text-body-400">

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -20,7 +20,7 @@ Layout.render
     <div class="container-fluid wide">
       <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
         <div class="flex flex-col items-baseline mb-6">
-          <%s! Package_breadcrumbs.render ~package ~path ?hash ?page () %>
+          <%s! Package_breadcrumbs.render ~path ?hash ?page package %>
 
           <% (match path with | Overview _ -> %>
             <div class="text-body-400">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -18,6 +18,7 @@ let sidebar
 
 let render
 ~old_doc (* FALLBACK REMOVE *)
+~page
 ~(path: Package_breadcrumbs.path)
 ~toc
 ~maptoc
@@ -38,15 +39,13 @@ let str_path =
           ) p
         | Page s -> [""; s])
 in
-let path_page = match str_path |> String.concat "/" with
-                | "" -> None
-                | path -> Some (path ^ if String.contains path '.' then "" else "/index.html") in
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
 ~package
 ~path
-~canonical:(Url.package_doc package.name ~version:(Package.specific_version package) ?page:path_page)
+?page
+~canonical:(Url.package_doc package.name ~version:(Package.specific_version package) ~page:(Url.package_doc ?version:(Some (Package.specific_version package)) package.name))
 ~styles:["css/main.css"; "css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -1,7 +1,7 @@
 let render
-~page
+?page
 ~path
-~(package : Package.package)
+(package : Package.package)
 =
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -1,4 +1,5 @@
 let render
+~page
 ~path
 ~(package : Package.package)
 =
@@ -7,6 +8,7 @@ Package_layout.render
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
 ~package
 ~path
+?page
 ~styles:["/css/main.css"; "/css/doc.css"] @@
   let version = Package.url_version package in
   <div class="sm:flex max-w-max mx-auto">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -497,7 +497,7 @@ let package_doc t kind req =
       match docs with
       | None ->
           Dream.html
-            (Ocamlorg_frontend.package_documentation_not_found
+            (Ocamlorg_frontend.package_documentation_not_found ~page:(Some path)
                ~path:(Ocamlorg_frontend.Package_breadcrumbs.Documentation Index)
                ~package:package_meta)
       | Some doc ->
@@ -559,7 +559,7 @@ let package_doc t kind req =
           let (maptoc : Ocamlorg_frontend.Navmap.toc list) =
             toc_of_map ~root module_map
           in
-          let (path : Ocamlorg_frontend.Package_breadcrumbs.path) =
+          let (breadcrumb_path : Ocamlorg_frontend.Package_breadcrumbs.path) =
             let breadcrumbs = doc.breadcrumbs in
             if breadcrumbs != [] then
               let first_path_item = List.hd breadcrumbs in
@@ -601,5 +601,6 @@ let package_doc t kind req =
             else Ocamlorg_frontend.Package_breadcrumbs.Documentation Index
           in
           Dream.html
-            (Ocamlorg_frontend.package_documentation ~path ~toc ~maptoc
-               ~old_doc:doc.old ~content:doc.content package_meta))
+            (Ocamlorg_frontend.package_documentation ~page:(Some path)
+               ~path:breadcrumb_path ~toc ~maptoc ~old_doc:doc.old
+               ~content:doc.content package_meta))

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -497,9 +497,9 @@ let package_doc t kind req =
       match docs with
       | None ->
           Dream.html
-            (Ocamlorg_frontend.package_documentation_not_found ~page:(Some path)
+            (Ocamlorg_frontend.package_documentation_not_found ~page:path
                ~path:(Ocamlorg_frontend.Package_breadcrumbs.Documentation Index)
-               ~package:package_meta)
+               package_meta)
       | Some doc ->
           let toc_of_toc (xs : Ocamlorg_package.Documentation.toc list) :
               Ocamlorg_frontend.Toc.t =


### PR DESCRIPTION
Resolves #138 by changing the version select such that it stays on the current package documentation URL when switching to another version of the package.