### PR TITLE
resolve synopsis vs description confusion between Ocamlorg_frontend and Ocamlorg_package

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -22,7 +22,7 @@ Layout.render
 
           <% if path == Overview then (%>
             <div class="text-body-400">
-              <%s package.description %>
+              <%s package.synopsis %>
             </div>
           <% ); %>
         </div>

--- a/src/ocamlorg_frontend/package.ml
+++ b/src/ocamlorg_frontend/package.ml
@@ -2,6 +2,7 @@ type version = Latest | Specific of string
 
 type package = {
   name : string;
+  synopsis : string;
   description : string;
   license : string;
   version : version;

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -43,7 +43,7 @@ let path_page = match str_path |> String.concat "/" with
                 | path -> Some (path ^ if String.contains path '.' then "" else "/index.html") in
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
-~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
+~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
 ~package
 ~path
 ~canonical:(Url.package_doc package.name ~version:(Package.specific_version package) ?page:path_page)

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -4,7 +4,7 @@ let render
 =
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
-~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
+~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
 ~package
 ~path
 ~styles:["/css/main.css"; "/css/doc.css"] @@

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -25,7 +25,7 @@ let version = Package.url_version package in
 let specific_version = Package.specific_version package in
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
-~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
+~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
 ~canonical:(Url.package_with_version package.name ~version:specific_version)
 ~package
 ~path:Overview @@

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -72,7 +72,7 @@ Layout.render
 % let render_featured_package pkg =
     <a href="<%s href_package pkg %>" class="bg-white card-hover rounded-md p-6 text-body-600 text-left">
       <p class="font-semibold mb-2"><%s pkg.name %></p>
-      <p class="mb-3 text-sm text-body-400"><%s pkg.description %></p>
+      <p class="mb-3 text-sm text-body-400"><%s pkg.synopsis %></p>
       <p class="text-sm text-body-400 flex space-x-2">
         <%s! Icons.tag "h-5 w-5 pr-1" %> <%s Package.render_version pkg %>
       </p>
@@ -93,7 +93,7 @@ Layout.render
     <a href="<%s href_package pkg %>"
         class="block bg-white border border-gray-200 rounded-xl py-6 px-7 text-body-600 text-left card-hover">
       <div class="font-semibold mb-2"><%s pkg.name %></div>
-      <div class="mb-3 text-sm text-body-400"><%s pkg.description %></div>
+      <div class="mb-3 text-sm text-body-400"><%s pkg.synopsis %></div>
 % render_extra_stats ();
     </a>
 % in

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -57,7 +57,7 @@ let render ~total ~search (packages : Package.package list) = Layout.render ~tit
             >
               <%s package.name %>
             </a>
-            <div><%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search package.description %></div>
+            <div><%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search package.synopsis %></div>
             <div class="flex flex-wrap">
               <% package.tags |> List.iter (fun (tag : string) -> %>
               <a

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -283,7 +283,8 @@ let package_of_info ~name ~version ?(on_latest_url = false) ~latest_version
       latest_version =
         Option.value ~default:"???"
           (Option.map Ocamlorg_package.Version.to_string latest_version);
-      description = info.Ocamlorg_package.Info.synopsis;
+      synopsis = info.Ocamlorg_package.Info.synopsis;
+      description = info.Ocamlorg_package.Info.description;
       tags = info.tags;
       rev_deps;
       authors = info.authors;


### PR DESCRIPTION
Overall, `OCamlorg_frontend.Package` needs to be refactored to be "what a package looks like to the templates". This patch only resolves the confusion between `synopsis` and `description`.