### PR TITLE
README, LICENSE, CHANGELOG display on package overview

### DIFF
--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -6,9 +6,10 @@ let with_hash = Option.fold ~none:"/p" ~some:(( ^ ) "/u/")
 let package ?hash v = with_hash hash ^ "/" ^ v
 let package_docs v = "/p/" ^ v ^ "/doc"
 let with_version = Option.value ~default:"latest"
+let with_page p = if p == "" then p else "/" ^ p
 
-let package_with_version ?version ?hash v =
-  with_hash hash ^ "/" ^ v ^ "/" ^ with_version version
+let package_with_version ?version ?hash ?(page = "") v =
+  with_hash hash ^ "/" ^ v ^ "/" ^ with_version version ^ with_page page
 
 let package_doc ?hash ?version ?(page = "index.html") v =
   with_hash hash ^ "/" ^ v ^ "/" ^ with_version version ^ "/doc/" ^ page

--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -6,7 +6,7 @@ let with_hash = Option.fold ~none:"/p" ~some:(( ^ ) "/u/")
 let package ?hash v = with_hash hash ^ "/" ^ v
 let package_docs v = "/p/" ^ v ^ "/doc"
 let with_version = Option.value ~default:"latest"
-let with_page p = if p == "" then p else "/" ^ p
+let with_page p = if p = "" then p else "/" ^ p
 
 let package_with_version ?version ?hash ?(page = "") v =
   with_hash hash ^ "/" ^ v ^ "/" ^ with_version version ^ with_page page

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -42,7 +42,7 @@ let rec breadcrumbs_from_path (reversed_library_path: library_path_item list) pr
     { text = library_path_item_name x ; href = prefix ^ "index.html" } :: breadcrumbs_from_path xs new_prefix
 
 type path = 
-  | Overview
+  | Overview of string option
   | Documentation of (docs_path)
 
 let render_package_and_version
@@ -116,10 +116,14 @@ let render_docs_path_breadcrumbs
 
 let render_overview_breadcrumbs
 ~(package: Package.package)
+~(page: string option)
 =
   <nav aria-label="breadcrumbs" class="flex">
     <ul class="flex flex-wrap gap-x-2 leading-8 package-breadcrumbs">
       <%s! render_package_and_version ~package %>
+      <% (match page with | Some p -> %>
+      <li><%s p %></li>
+      <% | None -> ()); %>
     </ul>
   </nav>
 
@@ -128,6 +132,6 @@ let render
 ~(path: path)
 =
   match path with
-    | Overview -> render_overview_breadcrumbs ~package
+    | Overview page -> render_overview_breadcrumbs ~package ~page
     | Documentation (docs_path) -> render_docs_path_breadcrumbs ~package ~path:docs_path
     

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -20,11 +20,11 @@ Layout.render
         <div class="flex flex-col items-baseline mb-6">
           <%s! Package_breadcrumbs.render ~package ~path %>
 
-          <% if path == Overview then (%>
+          <% (match path with | Overview _ -> %>
             <div class="text-body-400">
               <%s package.description %>
             </div>
-          <% ); %>
+          <% | _ -> ()); %>
         </div>
       </div>
       <div class="py-6">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -26,7 +26,7 @@ let render
 =
 let str_path =
   match path with
-    | Overview -> []
+    | Overview _ -> []
     | Documentation (docs_path) -> (match docs_path with
         | Package_breadcrumbs.Index -> []
         | Library (s, p) -> s :: List.map (function

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -11,13 +11,14 @@ let side_box_link ~href ~title ~icon_html =
 
 let render
 ~documentation_status
-~readme
-~readme_title
+~content
+~content_title
 ~dependencies
 ~rev_dependencies
 ~conflicts
 ~homepages
 ~source
+~readme_filename
 ~changes_filename
 ~license_filename
 (package : Package.package) =
@@ -28,11 +29,11 @@ Package_layout.render
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.description)
 ~canonical:(Url.package_with_version package.name ~version:specific_version)
 ~package
-~path:Overview @@
+~path:(Overview content_title) @@
 <div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row justify-between">
     <div class="flex-1 prose w-full xl:w-1/2 max-w-full">
-        <div class="p-3 bg-body-600 bg-opacity-5 rounded font-semibold mb-8"><%s! readme_title %></div>
-        <%s! readme %>
+        <div class="p-3 bg-body-600 bg-opacity-5 rounded font-semibold mb-8"><%s! Option.value ~default:"Description" content_title %></div>
+        <%s! content %>
     </div>
     <div class="p-3 py-6 lg:p-8 border border-gray-200 text-sm rounded-xl lg:max-w-sm w-full max-w-full">
         <h2 class="inline-flex items-center text-lg font-medium text-gray-900">
@@ -92,11 +93,14 @@ Package_layout.render
             <% homepages |> List.iter (fun homepage -> %>
             <%s! side_box_link ~icon_html:(Icons.package_homepage "h-4 w-4 mr-2 inline-block") ~href:homepage ~title:(Utils.host_of_uri homepage) %>
             <% ); %>
+            <% (match readme_filename with Some readme_filename -> %>
+            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(readme_filename ^ ".html")) ~title:"Readme" %>
+            <% | _ -> ()); %>
             <% (match changes_filename with Some changes_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_doc package.name ?version ~page:(changes_filename ^ ".html")) ~title:"Changelog" %>
+            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(changes_filename ^ ".html")) ~title:"Changelog" %>
             <% | _ -> ()); %>
             <% (match license_filename with Some license_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_doc package.name ?version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
+            <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
             <% | _ -> ()); %>
             <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name specific_version) ~title:"Edit opam file" %>
         </div>

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -231,7 +231,6 @@ module Documentation = struct
 
   type t = {
     old : bool; (* FALLBACK REMOVE *)
-    module_map : Module_map.t;
     uses_katex : bool;
     toc : toc list;
     breadcrumbs : breadcrumb list;
@@ -256,7 +255,7 @@ module Documentation = struct
         { name; href; kind = breadcrumb_kind_from_string kind }
     | _ -> raise (Invalid_argument "malformed breadcrumb field")
 
-  let doc_from_string ~module_map s =
+  let doc_from_string s =
     match Yojson.Safe.from_string s with
     | `Assoc
         [
@@ -273,7 +272,6 @@ module Documentation = struct
         in
         {
           old = false;
-          module_map;
           uses_katex;
           breadcrumbs;
           toc = List.map toc_of_json json_toc;
@@ -314,7 +312,7 @@ module Documentation = struct
     String.split_on_char '/' s |> List.filter_map parse_item
 
   (* FIXME: remove when fallback is unnecessary *)
-  let old_doc ~path ~module_map ~toc_content content =
+  let old_doc ~path ~toc_content content =
     let toc =
       if toc_content != "" then (
         try old_toc_from_string toc_content
@@ -325,7 +323,6 @@ module Documentation = struct
     in
     {
       old = true;
-      module_map;
       uses_katex = false;
       toc;
       breadcrumbs = old_breadcrumbs path;
@@ -374,7 +371,10 @@ let http_get url =
       let+ () = Cohttp_lwt.Body.drain_body body in
       Error (`Msg "Failed to fetch the documentation page")
 
-let fetch_module_map_from_url ~package_url =
+let module_map ~kind t =
+  let package_url =
+    package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
+  in
   let open Lwt.Syntax in
   let url = package_url ^ "package.json" in
   let+ content = http_get url in
@@ -386,13 +386,9 @@ let fetch_module_map_from_url ~package_url =
       Logs.info (fun m -> m "Failed to fetch module map at %s" url);
       { Module_map.libraries = String.Map.empty }
 
-(* FIXME: remove fallback when it's no longer needed *)
-let old_documentation_page ~kind t path =
+(* FIXME: remove fallback *)
+let old_odoc_page ~path ~url =
   let open Lwt.Syntax in
-  let old_package_url =
-    old_package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
-  in
-  let url = old_package_url ^ "doc/" ^ path in
   let* content = http_get url in
   match content with
   | Ok content ->
@@ -401,88 +397,55 @@ let old_documentation_page ~kind t path =
         let+ toc_response = http_get toc_url in
         match toc_response with Ok toc_content -> toc_content | Error _ -> ""
       in
-      let* module_map =
-        fetch_module_map_from_url ~package_url:old_package_url
-      in
       Logs.info (fun m -> m "Found OLD documentation page at %s" url);
-      Lwt.return
-        (Some (Documentation.old_doc ~path ~module_map ~toc_content content))
+      Lwt.return (Some (Documentation.old_doc ~path ~toc_content content))
   | Error _ ->
       Logs.info (fun m -> m "Failed to fetch OLD documentation page at %s" url);
       Lwt.return None
 
-let documentation_page ~kind t path =
+let odoc_page ~path ~url ~old_url =
   let open Lwt.Syntax in
-  let package_url =
-    package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
-  in
-  let url = package_url ^ "doc/" ^ path ^ ".json" in
   let* content = http_get url in
   match content with
   | Ok content ->
-      let* module_map = fetch_module_map_from_url ~package_url in
       let* maybe_doc =
-        try
-          Lwt.return (Some (Documentation.doc_from_string ~module_map content))
+        try Lwt.return (Some (Documentation.doc_from_string content))
         with Invalid_argument err ->
           Logs.err (fun m -> m "Invalid documentation page: %s" err);
-          let+ maybe_old_doc = old_documentation_page ~kind t path in
+          let+ maybe_old_doc = old_odoc_page ~path ~url:old_url in
           maybe_old_doc
       in
       Logs.info (fun m -> m "Found documentation page for %s" url);
       Lwt.return maybe_doc
   | Error _ ->
       Logs.info (fun m -> m "Failed to fetch new documentation page for %s" url);
-      old_documentation_page ~kind t path
+      old_odoc_page ~path ~url:old_url
 
-(* FIXME: remove fallback when it's no longer needed *)
-let old_file ~kind t path =
-  let open Lwt.Syntax in
+let documentation_page ~kind t path =
+  let package_url =
+    package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
+  in
+  let url = package_url ^ "doc/" ^ path ^ ".json" in
+  (* FIXME: remove fallback when it's no longer needed *)
   let old_package_url =
     old_package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
   in
-  let url = old_package_url ^ "doc/" ^ path in
-  let* content = http_get url in
-  match content with
-  | Ok content ->
-      let toc_url = Filename.remove_extension url ^ ".toc.json" in
-      let* toc_content =
-        let+ toc_response = http_get toc_url in
-        match toc_response with Ok toc_content -> toc_content | Error _ -> ""
-      in
-      let* module_map =
-        fetch_module_map_from_url ~package_url:old_package_url
-      in
-      Logs.info (fun m -> m "Found OLD file at %s" url);
-      Lwt.return
-        (Some (Documentation.old_doc ~path ~module_map ~toc_content content))
-  | Error _ ->
-      Logs.info (fun m -> m "Failed to fetch OLD file at %s" url);
-      Lwt.return None
+  (* FIXME: remove fallback when it's no longer needed *)
+  let old_url = old_package_url ^ "doc/" ^ path in
+  odoc_page ~path ~url ~old_url
 
 let file ~kind t path =
-  let open Lwt.Syntax in
   let package_url =
     package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
   in
   let url = package_url ^ path ^ ".json" in
-  let* content = http_get url in
-  match content with
-  | Ok content ->
-      let* module_map = fetch_module_map_from_url ~package_url in
-      let* maybe_doc =
-        try
-          Lwt.return (Some (Documentation.doc_from_string ~module_map content))
-        with Invalid_argument err ->
-          Logs.err (fun m -> m "Invalid file: %s" err);
-          let+ maybe_old_doc = old_file ~kind t path in
-          maybe_old_doc
-      in
-      Logs.info (fun m -> m "Found file for %s" url);
-      Lwt.return maybe_doc
-  | Error _ ->
-      Logs.info (fun m -> m "Failed to fetch new file for %s" url);
-      old_file ~kind t path
+  (* FIXME: remove fallback when it's no longer needed *)
+  let old_package_url =
+    old_package_url ~kind (Name.to_string t.name) (Version.to_string t.version)
+  in
+  (* FIXME: remove fallback when it's no longer needed *)
+  let old_url = old_package_url ^ "doc/" ^ path in
+  odoc_page ~path ~url ~old_url
 
 let maybe_file ~kind t filename =
   let open Lwt.Syntax in

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -111,9 +111,9 @@ val info : t -> Info.t
 val create : name:Name.t -> version:Version.t -> Info.t -> t
 (** This is added to enable demo test package to use Package.t with abstraction *)
 
-val readme_file :
+val readme_filename :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
-(** Get the readme of a package *)
+(** Get the readme file name of a package *)
 
 val license_filename :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
@@ -136,6 +136,14 @@ val documentation_page :
   Documentation.t option Lwt.t
 (** Get the rendered content of an HTML page for a package given its URL
     relative to the root page of the documentation. *)
+
+val file :
+  kind:[< `Package | `Universe of string ] ->
+  t ->
+  string ->
+  Documentation.t option Lwt.t
+(** Get the rendered content of an HTML page for a file accompanying a package
+    given its URL relative to the root of the package. *)
 
 val init : ?disable_polling:bool -> unit -> state
 (** [init ()] initialises the opam-repository state. By default

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -82,7 +82,6 @@ module Documentation : sig
 
   type t = {
     old : bool;
-    module_map : Module_map.t;
     uses_katex : bool;
     toc : toc list;
     breadcrumbs : breadcrumb list;
@@ -128,6 +127,10 @@ type documentation_status = Success | Failure | Unknown
 val documentation_status :
   kind:[< `Package | `Universe of string ] -> t -> documentation_status Lwt.t
 (** Get the build status of the documentation of a package *)
+
+val module_map :
+  kind:[< `Package | `Universe of string ] -> t -> Module_map.t Lwt.t
+(** Get the module map of a package *)
 
 val documentation_page :
   kind:[< `Package | `Universe of string ] ->

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -553,9 +553,10 @@ let package_doc t kind req =
                    Ocamlorg_frontend.Navmap.
                      { title; href; kind = Library; children })
           in
+          let* module_map = Ocamlorg_package.module_map ~kind package in
           let toc = toc_of_toc doc.toc in
           let (maptoc : Ocamlorg_frontend.Navmap.toc list) =
-            toc_of_map ~root doc.module_map
+            toc_of_map ~root module_map
           in
           let (path : Ocamlorg_frontend.Package_breadcrumbs.path) =
             let breadcrumbs = doc.breadcrumbs in

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -66,7 +66,11 @@ let package_route t =
         (Url.package_with_version ":name" ~version:":version")
         ((Handler.package_versioned t) Handler.Package);
       Dream.get
-        (Url.package_with_version ~hash:":hash" ":name" ~version:":version")
+        (Url.package_with_version ":name" ~version:":version" ~page:":page")
+        ((Handler.package_versioned t) Handler.Package);
+      Dream.get
+        (Url.package_with_version ~hash:":hash" ":name" ~version:":version"
+           ~page:"**")
         ((Handler.package_versioned t) Handler.Universe);
       Dream.get
         (Url.package_doc ":name" ~version:":version" ~page:"**")


### PR DESCRIPTION
* Accompanying files (README, LICENSE, CHANGELOG) render in the package overview layout
* Pick up README/LICENSE/CHANGELOG from their new location in the output of voodoo (these files now reside in root of package folder, instead of under `doc/`)
* README now shows up next to license and changelog in the sidebar

Further refinements according to package overview redesign will happen in subsequent patches.

This patch is a prerequisite to removing the fallback to pre-odoc-2.2.0 docs.

|after|
|-|
|![Screenshot 2023-03-20 at 11-34-36 streaming 0 8 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226315117-5e130d03-55cb-4da6-8056-dd7c3ce36914.png)|
|![Screenshot 2023-03-20 at 11-34-51 streaming 0 8 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226315128-a9f43c42-17d5-4fb3-b3e7-4bd96d251d35.png)|

