### PR TITLE
display of dependencies, tags+description+published styles/placement

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -22,6 +22,24 @@ let render
 ~changes_filename
 ~license_filename
 (package : Package.package) =
+let render_dependency ~version ~name ~cstr =
+  <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
+    <a href="<%s Url.package_with_version name ?version %>" class="text-primary-600 hover:underline">
+      <%s name %>
+    </a>
+    <% match cstr with None -> () | Some cstr -> %>
+      <code class="text-gray-700 font-medium"><%s cstr %></code>
+    <% ; %>
+  </li>
+in
+let render_section_heading ~title =
+  <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
+    <h2 class="text-xl font-medium my-2"><%s title %></h2>
+  </div>
+in
+let title_with_number title number =
+  title ^ if number > 0 then " (" ^ string_of_int number ^ ")" else ""
+in
 let version = Package.url_version package in
 let specific_version = Package.specific_version package in
 Package_layout.render
@@ -30,12 +48,57 @@ Package_layout.render
 ~canonical:(Url.package_with_version package.name ~version:specific_version)
 ~package
 ~path:(Overview content_title) @@
-<div class="flex lg:space-x-4 xl:space-x-12 flex-col lg:flex-row justify-between">
-    <div class="flex-1 prose w-full xl:w-1/2 max-w-full">
-        <div class="p-3 bg-body-600 bg-opacity-5 rounded font-semibold mb-8"><%s! Option.value ~default:"Description" content_title %></div>
+<div class="flex md:space-x-4 xl:space-x-12 flex-col md:flex-row justify-between">
+    <div class="flex-1 w-full xl:w-1/2 max-w-full">
+      <div class="p-4 border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
+        <h2 class="mb-4 mt-0 text-xl font-semibold uppercase"><%s Option.value ~default:"Description" content_title %></h2>
         <%s! content %>
+      </div>
+      
+      
+      <div class="flex flex-wrap gap-3 mt-4">
+        <% (match package.tags with [] -> () | _ ->  %>
+          <h2 class="text-base font-semibold text-body-400">Tags</h2>
+          <% package.tags |> List.iter (fun tag -> %>
+          <a href="<%s Url.packages_search %>?q=tag%3A%22<%s Dream.to_percent_encoded tag %>%22"
+            class="hover:underline px-2 text-primary-700 border border-primary-600 font-medium bg-primary-100 rounded">
+            <%s tag %>
+          </a>
+          <% ); %>
+        <% ); %>
+        <div class="flex-grow"></div>
+        <h2 class="font-semibold text-base text-body-400">Published:
+          <span class="font-normal"><%s Utils.human_date_of_timestamp package.publication %></span>
+        </h2>
+      </div>
+
+      <div class="border-l-2 border-gray-200 px-4 space-y-6">
+        <div class="mx-[-2px]">
+          <%s! render_section_heading ~title:(title_with_number "Dependencies" (List.length dependencies)) %>
+          <ol class="grid xl:grid-cols-2">
+              <%s if List.length dependencies = 0 then "None" else "" %>
+              <% dependencies |> List.iter (fun (name, cstr) -> %>
+              <%s! render_dependency ~name ~cstr ~version:None %>
+              <% ); %>
+          </ol>
+          <%s! render_section_heading ~title:(title_with_number "Reverse Dependencies" (List.length rev_dependencies)) %>
+          <ol class="grid xl:grid-cols-2 max-h-96 overflow-auto">
+              <%s if List.length rev_dependencies = 0 then "None" else "" %>
+              <% rev_dependencies |> List.iter (fun (name, cstr, version) -> %>
+              <%s! render_dependency ~name ~cstr ~version:(Some version) %>
+              <% ); %>
+          </ol>
+          <%s! render_section_heading ~title:(title_with_number "Conflicts" (List.length conflicts)) %>
+          <ol class="grid xl:grid-cols-2 max-h-96 overflow-auto">
+              <%s if List.length conflicts = 0 then "None" else "" %>
+              <% conflicts |> List.iter (fun (name, cstr) -> %>
+              <%s! render_dependency ~name ~cstr ~version:None %>
+              <% ); %>
+          </ol>
+        </div>
+      </div>
     </div>
-    <div class="p-3 py-6 lg:p-8 border border-gray-200 text-sm rounded-xl lg:max-w-sm w-full max-w-full">
+    <div class="p-3 py-6 lg:p-8 border border-gray-200 text-sm rounded-xl md:w-60 lg:w-auto lg:max-w-sm w-full max-w-full">
         <h2 class="inline-flex items-center text-lg font-medium text-gray-900">
             <%s! Icons.command_line "mr-4 h-6 w-6 text-orange-600" %>
             Install
@@ -61,18 +124,6 @@ Package_layout.render
                 </div>
             </div>
         </div>
-        <% (match package.tags with [] -> () | _ ->  %>
-        <div class="mt-4">
-            <div class="flex mt-5 flex-wrap">
-                <% package.tags |> List.iter (fun tag -> %>
-                <a href="<%s Url.packages_search %>?q=tag%3A%22<%s Dream.to_percent_encoded tag %>%22"
-                    class="hover:underline px-2 py-1 text-body-400 font-medium bg-gray-100 rounded mr-3 mt-3">
-                    <%s tag %>
-                </a>
-                <% ); %>
-            </div>
-        </div>
-        <% ); %>
         <div class="flex flex-col mt-8 text-body-400">
             <% (match documentation_status with
             | Success -> %>
@@ -103,11 +154,6 @@ Package_layout.render
             <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
             <% | _ -> ()); %>
             <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name specific_version) ~title:"Edit opam file" %>
-        </div>
-
-        <h2 class="mt-8 font-semibold text-base text-body-400">Published</h2>
-        <div class="mt-3 text-sm text-gray-900">
-          <%s Utils.human_date_of_timestamp package.publication %>
         </div>
 
         <h2 class="mt-8 font-semibold text-base text-body-400">Authors</h2>
@@ -179,58 +225,6 @@ Package_layout.render
           <% end; %>
         </div>
         <% ; %>
-
-        <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Dependencies</h2>
-        <div class="flex flex-col space-y-3 max-h-96 overflow-auto">
-            <%s if List.length dependencies = 0 then "None" else "" %>
-            <% dependencies |> List.iter (fun (name, cstr) -> %>
-            <div class="flex items-center space-x-3">
-                <a href="<%s Url.package name %>" class="text-primary-600 hover:underline">
-                    <%s name %>
-                </a>
-                <% match cstr with None -> () | Some cstr -> %>
-                <span
-                    class="px-2 py-1 font-medium text-body-400 font-medium bg-gray-100 rounded">
-                    <code><%s cstr %></code>
-                </span>
-                <% ; %>
-            </div>
-            <% ); %>
-        </div>
-        <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Reverse Dependencies</h2>
-        <div class="flex flex-col space-y-3 max-h-96 overflow-auto">
-            <%s if List.length rev_dependencies = 0 then "None" else "" %>
-            <% rev_dependencies |> List.iter (fun (name, cstr, version) -> %>
-            <div class="flex items-center space-x-3">
-                <a href="<%s Url.package_with_version name ~version %>" class="text-primary-600 hover:underline">
-                    <%s name %>
-                </a>
-                <% match cstr with None -> () | Some cstr -> %>
-                <span
-                    class="px-2 py-1 font-medium text-body-400 font-medium bg-gray-100 rounded">
-                    <code><%s cstr %></code>
-                </span>
-                <% ; %>
-            </div>
-            <% ); %>
-        </div>
-        <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Conflicts</h2>
-        <div class="flex flex-col space-y-3 max-h-96 overflow-auto">
-            <%s if List.length conflicts = 0 then "None" else "" %>
-            <% conflicts |> List.iter (fun (name, cstr) -> %>
-            <div class="flex items-center space-x-3">
-                <a href="<%s Url.package name %>" class="text-primary-600 hover:underline">
-                    <%s name %>
-                </a>
-                <% match cstr with None -> () | Some cstr -> %>
-                <span
-                    class="px-2 py-1 font-medium text-body-400 font-medium bg-gray-100 rounded">
-                    <code><%s cstr %></code>
-                </span>
-                <% ; %>
-            </div>
-            <% ); %>
-        </div>
     </div>
 </div>
 <script>


### PR DESCRIPTION
* display dependencies in the main content area.
* adjust package description styles
* move tags and publication date to below the package description
* show sidebar already on md screen (before: stacked)

This is only a small step towards implementing the layouts and styles proposed by @Clairevanden, there is more to do (e.g. sidebar styles, main heading, layout overarching both docs and package overview).

|screen|before|after|
|-|-|-|
|sm|![Screenshot 2023-03-20 at 17-39-59 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226408650-db7a7360-1dea-4a11-93b7-51d2e71b7486.png)|![Screenshot 2023-03-20 at 17-40-02 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226408660-0650a413-5140-4ec6-a741-84f81cd669a5.png)|
|md|![Screenshot 2023-03-20 at 17-49-47 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226411246-0a9ea178-9cd7-428c-896f-17ce28a702f3.png)|![Screenshot 2023-03-20 at 17-49-51 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226411258-68b819da-c53e-422e-8d20-99860d5b4225.png)|
|lg|![Screenshot 2023-03-20 at 17-53-27 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226412078-e902b915-6050-4f71-b8b8-f9e5ffe3a12f.png)|![Screenshot 2023-03-20 at 17-53-30 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226412117-3c22fdec-0734-412e-94f9-ab0306c91b66.png)|
|xl|![Screenshot 2023-03-20 at 17-52-50 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226411912-4895982a-d38b-480e-aa3c-06011365df98.png)|![Screenshot 2023-03-20 at 17-52-53 cow 2 4 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226411939-a8c00867-5310-429f-931f-799a63f9e4c0.png)|
