### PR TITLE
don't crash on packages that have avoid-version on all versions

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -110,6 +110,13 @@ let get_package_latest' packages name =
            if avoid_version info then None else Some { version; info; name }
          in
          let packages = Version.Map.filter_map f versions in
+         let packages =
+           if Version.Map.is_empty packages then
+             Version.Map.mapi
+               (fun version info -> { version; info; name })
+               versions
+           else packages
+         in
          let _version, package = Version.Map.max_binding packages in
          package)
 


### PR DESCRIPTION
I'm pretty sure there's a clever way to do this more efficiently. However, for now I just want packages that have all versions tagged `avoid-version` not crash the search. (Example: search for "base".)