### PR TITLE
make get_package_latest' a bit more efficient

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -108,9 +108,9 @@ let get_package_latest' packages name =
          in
          let avoided, packages = Version.Map.partition avoid_version versions in
          let version, info =
-           Option.value
-             ~default:(Version.Map.max_binding avoided)
-             (Version.Map.max_binding_opt packages)
+           match Version.Map.max_binding_opt packages with
+           | None -> Version.Map.max_binding avoided
+           | Some (version, info) -> (version, info)
          in
          { version; info; name })
 

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -103,22 +103,16 @@ let save_state t =
 let get_package_latest' packages name =
   Name.Map.find_opt name packages
   |> Option.map (fun versions ->
-         let avoid_version (info : Info.t) =
+         let avoid_version _ (info : Info.t) =
            List.exists (( = ) OpamTypes.Pkgflag_AvoidVersion) info.flags
          in
-         let f version info =
-           if avoid_version info then None else Some { version; info; name }
+         let avoided, packages = Version.Map.partition avoid_version versions in
+         let version, info =
+           Option.value
+             ~default:(Version.Map.max_binding avoided)
+             (Version.Map.max_binding_opt packages)
          in
-         let packages = Version.Map.filter_map f versions in
-         let packages =
-           if Version.Map.is_empty packages then
-             Version.Map.mapi
-               (fun version info -> { version; info; name })
-               versions
-           else packages
-         in
-         let _version, package = Version.Map.max_binding packages in
-         package)
+         { version; info; name })
 
 let update ~commit t =
   let open Lwt.Syntax in


### PR DESCRIPTION
Patch only simplifies the code, no changes to the logic.

The logic for getting the latest version of a package is this:
- take the newest version that is not flagged with `avoid-version`, if it exists
- if it does not exist, take the newest version that is flagged with `avoid-version`

Packages always have at least one version.