### PR TITLE
render README/CHANGELOG/LICENSE as .prose on their own pages

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -50,12 +50,12 @@ Package_layout.render
 ~path:(Overview content_title) @@
 <div class="flex md:space-x-4 xl:space-x-12 flex-col md:flex-row justify-between">
     <div class="flex-1 w-full xl:w-1/2 max-w-full">
-      <div class="p-4 border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
-        <h2 class="mb-4 mt-0 text-xl font-semibold uppercase"><%s Option.value ~default:"Description" content_title %></h2>
-        <%s! content %>
+      <% (match content_title with | None -> %>
+      <div class="p-4 prose max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
+        <h2 class="mb-4 mt-0 text-xl font-semibold uppercase">Description</h2>
+        <%s! package.description %>
       </div>
-      
-      
+
       <div class="flex flex-wrap gap-3 mt-4">
         <% (match package.tags with [] -> () | _ ->  %>
           <h2 class="text-base font-semibold text-body-400">Tags</h2>
@@ -97,6 +97,16 @@ Package_layout.render
           </ol>
         </div>
       </div>
+      <% | Some content_title -> %>
+      <div class="border-l-2 border-gray-200 px-4 space-y-6">
+        <div class="mx-[-2px]">
+          <%s! render_section_heading ~title:content_title %>
+          <div class="prose max-w-full">
+            <%s! content %>
+          </div>
+        </div>
+      </div>
+      <% ); %>
     </div>
     <div class="p-3 py-6 lg:p-8 border border-gray-200 text-sm rounded-xl md:w-60 lg:w-auto lg:max-w-sm w-full max-w-full">
         <h2 class="inline-flex items-center text-lg font-medium text-gray-900">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -284,7 +284,7 @@ let package_of_info ~name ~version ?(on_latest_url = false) ~latest_version
         Option.value ~default:"???"
           (Option.map Ocamlorg_package.Version.to_string latest_version);
       synopsis = info.Ocamlorg_package.Info.synopsis;
-      description = info.Ocamlorg_package.Info.description;
+      description = info.Ocamlorg_package.Info.description |> Omd.of_string |> Omd.to_html;
       tags = info.tags;
       rev_deps;
       authors = info.authors;
@@ -453,11 +453,7 @@ let package_versioned t kind req =
 
       let* content =
         match page_from_url with
-        | None ->
-            Lwt.return
-              (Some
-                 (package_info.Ocamlorg_package.Info.description
-                |> Omd.of_string |> Omd.to_html))
+        | None -> Lwt.return (Some "")
         | Some page ->
             let* file = Ocamlorg_package.file ~kind package page in
             Lwt.return

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -284,7 +284,8 @@ let package_of_info ~name ~version ?(on_latest_url = false) ~latest_version
         Option.value ~default:"???"
           (Option.map Ocamlorg_package.Version.to_string latest_version);
       synopsis = info.Ocamlorg_package.Info.synopsis;
-      description = info.Ocamlorg_package.Info.description |> Omd.of_string |> Omd.to_html;
+      description =
+        info.Ocamlorg_package.Info.description |> Omd.of_string |> Omd.to_html;
       tags = info.tags;
       rev_deps;
       authors = info.authors;


### PR DESCRIPTION
I was a bit rash with https://github.com/ocaml/ocaml.org/pull/987 and https://github.com/ocaml/ocaml.org/pull/985 together.

* Description box was lacking `.prose`
* README/CHANGELOG/LICENSE should not be displayed in the same box as description - this patch, for now, displays them as their own sub-page of package overview
* package.description in `Ocamlorg_frontend.Package` is now HTML

Overall all the handler code and templates around packages will need a cleanup, and I'll get there after docs-data is promoted to `live` and the fallback is removed.

|before|after|
|-|-|
|![Screenshot 2023-03-21 at 11-54-47 streaming 0 8 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226585880-13c2b3d0-425e-46a1-8958-ca70b12d02ea.png) forgot `.prose`|![Screenshot 2023-03-21 at 11-54-43 streaming 0 8 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226585891-4b319dae-cfaf-4a5f-9a44-4d698c30ed3e.png)|
