### PR TITLE
minor tweak padding of icons source code download

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -213,7 +213,7 @@ Package_layout.render
               <%s Filename.basename uri %>
             </span>
 
-            <div class="p-2 bg-primary-600 text-white rounded">
+            <div class="p-1 bg-primary-600 text-white rounded">
                 <%s! Icons.download "h-6 w-6" %>
             </div>
           </a>
@@ -225,11 +225,11 @@ Package_layout.render
 
             <button
               @click="$clipboard('<%s checksum %>'); copied = true; setTimeout(() => copied = false, 2000)"
-              x-show="!copied" title="copy checksum to clipboard" class="py-1 px-2 text-primary-600 rounded">
+              x-show="!copied" title="copy checksum to clipboard" class="p-1 text-primary-600 rounded">
                 <%s! Icons.copy "h-6 w-6" %>
             </button>
-            <button x-show="copied" title="checksum copied to clipboard" class="py-1 px-2 text-primary-600 rounded">
-                <%s! Icons.copied_to_clipboard "h-4 w-4" %>
+            <button x-show="copied" title="checksum copied to clipboard" class="p-1 text-primary-600 rounded">
+                <%s! Icons.copied_to_clipboard "h-6 w-6" %>
             </button>
           </div>
           <% end; %>


### PR DESCRIPTION
* success icon when copying was too small
* padding adjusted to better match Claire's UI

|before|after|
|-|-|
|![Screenshot 2023-03-21 at 15-24-16 brr 0 0 4 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226636755-241bb50c-d17d-45f7-9042-dae2591c7371.png)|![Screenshot 2023-03-21 at 15-24-35 brr 0 0 4 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226636764-77c2b49d-aa6d-4485-b560-8a82c4b24e8d.png)|
