### PR TITLE
Add section on debugging data races with TSan

### DIFF
--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -514,7 +514,7 @@ let () =
   Printf.printf "v is %i\n" (Atomic.get v)
 ```
 
-If we recompile and run our program with this change it now completes
+If we recompile and run our program with this change, it now completes
 without TSan warnings:
 ```
 $ dune build ./race.exe

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -405,13 +405,11 @@ report these.
 ### Installing a TSan Switch
 
 To install the TSan mode
-- First install the
-  [`libunwind`](https://github.com/libunwind/libunwind) dependency.
-  On macOS `libunwind` should already be installed by default.
-  On a Linux system with the `apt` package manager, installing
-  `libunwind` should be as simple as `sudo apt install libunwind-dev`.
-- Second create a TSan switch by running `opam switch create
-  5.0.0+tsan`.
+1. Install the [`libunwind`](https://github.com/libunwind/libunwind)
+   dependency. On macOS `libunwind` should already be installed by default.
+   On a Linux system with the `apt` package manager, installing
+   `libunwind` should be as simple as `sudo apt install libunwind-dev`.
+2. Create a TSan switch by running `opam switch create 5.0.0+tsan`.
 
 To confirm that the TSan switch is installed correctly, run `opam
 switch show` and confirm that it prints `5.0.0+tsan`.

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -397,7 +397,7 @@ Called from Dune__exe__Uncaught in file "uncaught.ml", line 8, characters 15-37
 
 ## Detecting a Data Race with Thread Sanitizer
 
-With the introduction of multicore parallelism in OCaml 5, comes the
+With the introduction of Multicore parallelism in OCaml 5, comes the
 risk of introducing data races among the involved `Domain`s. Luckily
 the Thread Sanitizer (TSan) mode for OCaml is helpful to catch and
 report these.

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -459,26 +459,26 @@ $ opam switch 5.0.0+tsan
 $ dune build ./race.exe
 $ dune exec ./race.exe
 ==================
-WARNING: ThreadSanitizer: data race (pid=1051032)
-  Write of size 8 at 0x7f48d8efe498 by thread T4 (mutexes: write M87):
-    #0 camlDune__exe__Race__fun_560 <null> (race.exe+0x4efb15)
-    #1 camlStdlib__Domain__body_696 <null> (race.exe+0x52b23c)
-    #2 caml_start_program <null> (race.exe+0x599feb)
-    #3 caml_callback_exn /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/callback.c:168:12 (race.exe+0x56bd84)
-    #4 caml_callback /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/callback.c:256:34 (race.exe+0x56c6d0)
-    #5 domain_thread_func /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/domain.c:1093:5 (race.exe+0x56f34e)
+WARNING: ThreadSanitizer: data race (pid=19414)
+  Write of size 8 at 0x7fb9d72fe498 by thread T4 (mutexes: write M87):
+    #0 camlDune__exe__Race__fun_560 /home/user/race/_build/default/race.ml:6 (race.exe+0x60c65)
+    #1 camlStdlib__Domain__body_696 /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/stdlib/domain.ml:202 (race.exe+0x9c38c)
+    #2 caml_start_program <null> (race.exe+0x110117)
+    #3 caml_callback_exn runtime/callback.c:168 (race.exe+0xe00fe)
+    #4 caml_callback runtime/callback.c:256 (race.exe+0xe0bb8)
+    #5 domain_thread_func runtime/domain.c:1093 (race.exe+0xe3e83)
 
-  Previous write of size 8 at 0x7f48d8efe498 by thread T1 (mutexes: write M83):
-    #0 camlDune__exe__Race__fun_556 <null> (race.exe+0x4efab5)
-    #1 camlStdlib__Domain__body_696 <null> (race.exe+0x52b23c)
-    #2 caml_start_program <null> (race.exe+0x599feb)
-    #3 caml_callback_exn /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/callback.c:168:12 (race.exe+0x56bd84)
-    #4 caml_callback /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/callback.c:256:34 (race.exe+0x56c6d0)
-    #5 domain_thread_func /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/domain.c:1093:5 (race.exe+0x56f34e)
+  Previous write of size 8 at 0x7fb9d72fe498 by thread T1 (mutexes: write M83):
+    #0 camlDune__exe__Race__fun_556 /home/user/race/_build/default/race.ml:5 (race.exe+0x60c05)
+    #1 camlStdlib__Domain__body_696 /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/stdlib/domain.ml:202 (race.exe+0x9c38c)
+    #2 caml_start_program <null> (race.exe+0x110117)
+    #3 caml_callback_exn runtime/callback.c:168 (race.exe+0xe00fe)
+    #4 caml_callback runtime/callback.c:256 (race.exe+0xe0bb8)
+    #5 domain_thread_func runtime/domain.c:1093 (race.exe+0xe3e83)
 
-  Mutex M87 (0x00000106ca88) created at:
-    #0 pthread_mutex_init <null> (race.exe+0x46173d)
-    #1 caml_plat_mutex_init /home/user/.opam/5.0.0+tsan/.opam-switch/build/ocaml-variants.5.0.0+tsan/runtime/platform.c:54:8 (race.exe+0x58c4e5)
+  Mutex M87 (0x560c0b4fc438) created at:
+    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1295 (libtsan.so.2+0x50468)
+    #1 caml_plat_mutex_init runtime/platform.c:54 (race.exe+0x1022f8)
   [...]
 
 SUMMARY: ThreadSanitizer: data race (/tmp/race/race.exe+0x4efb15) in camlRace__fun_560
@@ -492,10 +492,10 @@ this required no change to our `dune` file.
 
 The TSan report warns of a data race between two uncoordinated writes
 happening in parallel and prints a back trace for both:
-- The first back trace reports a write at `/tmp/race/race.ml` in line
-  7 of `thread T4` and
+- The first back trace reports a write at `race.ml` in line
+  6 of `thread T4` and
 - the second back trace reports a previous write at
-  `/tmp/race/race.ml` in line 8 of `thread T1`
+  `race.ml` in line 5 of `thread T1`
 
 Looking again at our program, we realize that these two writes are in
 fact not coordinated. One possible fix is to replace our mutable

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -452,7 +452,7 @@ $ dune exec ./race.exe
 v.x is 11
 ```
 
-However if we compile and run the program with `dune` from the new
+However, if we compile and run the program with Dune from the new
 `5.0.0+tsan` switch TSan warns us of a data race:
 ```
 $ opam switch 5.0.0+tsan

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -414,6 +414,8 @@ To install the TSan mode
 To confirm that the TSan switch is installed correctly, run `opam
 switch show` and confirm that it prints `5.0.0+tsan`.
 
+Note: TSan is only supported on x86-64 architectures for now.
+
 ### Detecting a Data Race
 
 Now consider the following OCaml program written in the file `race.ml`:

--- a/data/tutorials/wf_01_debugging.md
+++ b/data/tutorials/wf_01_debugging.md
@@ -487,7 +487,7 @@ v.x is 11
 ThreadSanitizer: reported 1 warnings
 ```
 
-Note that since TSan instrumentation operates in a separate switch,
+Note that since TSan instrumentation operates in a separate switch;
 this required no change to our `dune` file.
 
 The TSan report warns of a data race between two uncoordinated writes


### PR DESCRIPTION
This PR adds an fourth section to the current debugging guide on using the new Thread Sanitizer mode to detect data races in multi-domain code.

We are currently experiencing issues with TSan back traces missing file names and line numbers, when compiled with older versions of GCC (and `clang` too) as illustrated by the included `<null>`s.
For this reason I am therefore marking the PR as 'draft'.
Once this issue has been settled, I'll remove the label and update the expected output to be `<null>`-free :grin: 

CC: @OlivierNicole @fabbing