### PR TITLE
refactor package urls, routes, and handlers

### DIFF
--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -15,8 +15,6 @@ let package_file ?version ?hash ~filepath name =
 let package_documentation ?hash ?version ?(page = "index.html") name =
   with_hash hash ^ "/" ^ name ^ "/" ^ with_version version ^ "/doc/" ^ page
 
-let package_redirect ?hash name = with_hash hash ^ "/" ^ name
-let package_docs_redirect name = "/p/" ^ name ^ "/doc"
 let community = "/community"
 let success_story v = "/success-stories/" ^ v
 let industrial_users = "/industrial-users"

--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -3,17 +3,20 @@ let packages = "/packages"
 let packages_search = "/packages/search"
 let packages_autocomplete_fragment = "/packages/autocomplete"
 let with_hash = Option.fold ~none:"/p" ~some:(( ^ ) "/u/")
-let package ?hash v = with_hash hash ^ "/" ^ v
-let package_docs v = "/p/" ^ v ^ "/doc"
 let with_version = Option.value ~default:"latest"
-let with_page p = if p = "" then p else "/" ^ p
+let with_page p = if p = "" then "" else "/" ^ p
 
-let package_with_version ?version ?hash ?(page = "") v =
-  with_hash hash ^ "/" ^ v ^ "/" ^ with_version version ^ with_page page
+let package_overview ?version ?hash name =
+  with_hash hash ^ "/" ^ name ^ "/" ^ with_version version
 
-let package_doc ?hash ?version ?(page = "index.html") v =
-  with_hash hash ^ "/" ^ v ^ "/" ^ with_version version ^ "/doc/" ^ page
+let package_file ?version ?hash ~filepath name =
+  with_hash hash ^ "/" ^ name ^ "/" ^ with_version version ^ "/" ^ filepath
 
+let package_documentation ?hash ?version ?(page = "index.html") name =
+  with_hash hash ^ "/" ^ name ^ "/" ^ with_version version ^ "/doc/" ^ page
+
+let package_redirect ?hash name = with_hash hash ^ "/" ^ name
+let package_docs_redirect name = "/p/" ^ name ^ "/doc"
 let community = "/community"
 let success_story v = "/success-stories/" ^ v
 let industrial_users = "/industrial-users"

--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -9,11 +9,11 @@ let with_page p = if p = "" then "" else "/" ^ p
 let package_overview ?version ?hash name =
   with_hash hash ^ "/" ^ name ^ "/" ^ with_version version
 
-let package_file ?version ?hash ~filepath name =
-  with_hash hash ^ "/" ^ name ^ "/" ^ with_version version ^ "/" ^ filepath
-
 let package_documentation ?hash ?version ?(page = "index.html") name =
   with_hash hash ^ "/" ^ name ^ "/" ^ with_version version ^ "/doc/" ^ page
+
+let package_file ?version ?hash ~filepath name =
+  with_hash hash ^ "/" ^ name ^ "/" ^ with_version version ^ "/" ^ filepath
 
 let community = "/community"
 let success_story v = "/success-stories/" ^ v

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -108,7 +108,7 @@ let render
     <% (match maptoc with [] ->  %>
     <span class="block py-2 text-gray-700">Package contains no libraries</span>
     <% | _ -> %>
-      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name ?version %>">
+      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_documentation package.name ?version %>">
         package <%s package.name %>
       </a>
     <ul>

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -35,8 +35,8 @@ let render_package_and_version
   let version = Package.url_version package in
   let url (version : string option) =
     match path with
-    | Overview _ -> Url.package_with_version package.name ?version
-    | Documentation _ -> Url.package_doc package.name ?version ?hash ?page
+    | Overview _ -> Url.package_overview package.name ?version
+    | Documentation _ -> Url.package_documentation package.name ?version ?hash ?page
   in
   let version_options v =
     <% if v = package.latest_version then ( %>
@@ -50,7 +50,7 @@ let render_package_and_version
   in
   <li>
     <h1 class="inline text-base">
-      <a class="font-semibold underline" href="<%s Url.package_with_version package.name ?version %>"><%s package.name %></a>
+      <a class="font-semibold underline" href="<%s Url.package_overview package.name ?version %>"><%s package.name %></a>
     </h1>
   </li>
   <li>
@@ -101,7 +101,7 @@ let render_docs_path_breadcrumbs
     <ul class="flex flex-wrap gap-x-2 text-base leading-8 package-breadcrumbs">
       <%s! render_package_and_version ~path:(Documentation path) ?page ?hash package %>
       <li>
-        <a class="underline font-semibold" href="<%s! Url.package_doc package.name ?version %>">Documentation</a>
+        <a class="underline font-semibold" href="<%s! Url.package_documentation package.name ?version %>">Documentation</a>
       </li>
       <% (match path with
          | Index -> %>

--- a/src/ocamlorg_frontend/package.ml
+++ b/src/ocamlorg_frontend/package.ml
@@ -1,4 +1,5 @@
 type version = Latest | Specific of string
+type documentation_status = Success | Failure | Unknown
 
 type package = {
   name : string;
@@ -13,6 +14,14 @@ type package = {
   authors : Ood.Opam_user.t list;
   maintainers : Ood.Opam_user.t list;
   publication : float;
+  homepages : string list;
+  source : (string * string list) option;
+      (* TODO: these should be part of package.json coming from voodoo, but they
+         currently aren't
+
+         documentation_status : documentation_status; readme_filename : string
+         option; changes_filename : string option; license_filename : string
+         option;*)
 }
 
 let specific_version package =

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -44,7 +44,7 @@ Package_layout.render
 ~package
 ~path
 ?page
-~canonical:(Url.package_doc package.name ~version:(Package.specific_version package) ~page:(Url.package_doc ?version:(Some (Package.specific_version package)) package.name))
+~canonical:(Url.package_documentation package.name ~version:(Package.specific_version package) ~page:(Url.package_documentation ?version:(Some (Package.specific_version package)) package.name))
 ~styles:["css/main.css"; "css/doc.css"] @@
 <div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
   <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -19,7 +19,7 @@ Package_layout.render
         <p class="mt-1 text-base text-gray-500">We're sorry, for some reason we don't have the documentation for this package.</p>
       </div>
       <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
-        <a href="<%s Url.package_with_version package.name ?version %>"
+        <a href="<%s Url.package_overview package.name ?version %>"
           class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500">
           Go To Package Overview
         </a>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -1,8 +1,3 @@
-type documentation_status =
-  | Success
-  | Failure
-  | Unknown
-
 let side_box_link ~href ~title ~icon_html =
     <a href="<%s href %>" class="flex items-center py-2 px-4 hover:text-primary-600">
         <%s! icon_html %>
@@ -11,22 +6,24 @@ let side_box_link ~href ~title ~icon_html =
 
 let num_of_users_to_show = 4
 
+type sidebar_data = {
+  documentation_status : Package.documentation_status;
+  readme_filename : string option;
+  changes_filename : string option;
+  license_filename : string option;
+}
+
 let render
-~documentation_status
+~(sidebar_data: sidebar_data)
 ~content
 ~content_title
 ~dependencies
 ~rev_dependencies
 ~conflicts
-~homepages
-~source
-~readme_filename
-~changes_filename
-~license_filename
 (package : Package.package) =
 let render_dependency ~version ~name ~cstr =
   <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
-    <a href="<%s Url.package_with_version name ?version %>" class="text-primary-600 hover:underline">
+    <a href="<%s Url.package_overview name ?version %>" class="text-primary-600 hover:underline">
       <%s name %>
     </a>
     <% match cstr with None -> () | Some cstr -> %>
@@ -73,7 +70,7 @@ let specific_version = Package.specific_version package in
 Package_layout.render
 ~title:(Printf.sprintf "%s %s · OCaml Package" package.name (Package.render_version package))
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
-~canonical:(Url.package_with_version package.name ~version:specific_version)
+~canonical:(Url.package_overview package.name ~version:specific_version)
 ~package
 ~path:(Overview content_title) @@
 <div class="flex md:space-x-4 xl:space-x-12 flex-col md:flex-row justify-between">
@@ -163,33 +160,33 @@ Package_layout.render
             </div>
         </div>
         <div class="flex flex-col mt-8 text-body-400">
-            <% (match documentation_status with
+            <% (match sidebar_data.documentation_status with
             | Success -> %>
-            <a href="<%s Url.package_doc package.name ?version %>" class="px-4 h-10 items-center mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
+            <a href="<%s Url.package_documentation package.name ?version %>" class="px-4 h-10 items-center mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
               <%s! Icons.documentation "w-6 h-6 mr-2 inline-block" %>
               Documentation
             </a>
             <% | Unknown -> ( %>
-            <a href="<%s Url.package_doc package.name ?version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <a href="<%s Url.package_documentation package.name ?version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <%s! Icons.error "" %>
               Documentation status is unknown.
             </a><% )
             | Failure -> ( %>
-            <a href="<%s Url.package_doc package.name ?version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
+            <a href="<%s Url.package_documentation package.name ?version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
               <%s! Icons.error "" %>
               Documentation failed to build.
             </a><% ));%>
-            <% homepages |> List.iter (fun homepage -> %>
+            <% package.homepages |> List.iter (fun homepage -> %>
             <%s! side_box_link ~icon_html:(Icons.package_homepage "h-4 w-4 mr-2 inline-block") ~href:homepage ~title:(Utils.host_of_uri homepage) %>
             <% ); %>
-            <% (match readme_filename with Some readme_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(readme_filename ^ ".html")) ~title:"Readme" %>
+            <% (match sidebar_data.readme_filename with Some readme_filename -> %>
+            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_file package.name ?version ~filepath:(readme_filename ^ ".html")) ~title:"Readme" %>
             <% | _ -> ()); %>
-            <% (match changes_filename with Some changes_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(changes_filename ^ ".html")) ~title:"Changelog" %>
+            <% (match sidebar_data.changes_filename with Some changes_filename -> %>
+            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.package_file package.name ?version ~filepath:(changes_filename ^ ".html")) ~title:"Changelog" %>
             <% | _ -> ()); %>
-            <% (match license_filename with Some license_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_with_version package.name ?version ~page:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
+            <% (match sidebar_data.license_filename with Some license_filename -> %>
+            <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.package_file package.name ?version ~filepath:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
             <% | _ -> ()); %>
             <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name specific_version) ~title:"Edit opam file" %>
         </div>
@@ -200,7 +197,7 @@ Package_layout.render
         <h2 class="mt-8 font-semibold text-base text-body-400">Maintainers</h2>
         <%s! render_user_list package.maintainers %>
 
-        <% match source with
+        <% match package.source with
         | None -> ()
         | Some (uri, checksums) -> %>
         <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Sources</h2>

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -1,4 +1,4 @@
-let href_package pkg = Url.package_with_version pkg.name ?version:(Package.url_version pkg)
+let href_package pkg = Url.package_overview pkg.name ?version:(Package.url_version pkg)
 
 let render (stats : Package.packages_stats option) (featured_packages : Package.package list) =
 Layout.render

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -48,7 +48,7 @@ let render
         x-init="max=<%s string_of_int i %>"
         id="package-autocomplete-<%s string_of_int i %>-0"
         :aria-selected="row == <%s string_of_int i %> && col == 0"
-        href="<%s Url.package_with_version package.name %>"
+        href="<%s Url.package_overview package.name %>"
         :class='{ "bg-background-mid-blue text-white": row == <%s string_of_int i %> && col == 0, "text-primary-600": row != <%s string_of_int i %> || col != 0}'
         class="flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 inline-block"
       >
@@ -57,7 +57,7 @@ let render
       <a 
         id="package-autocomplete-<%s string_of_int i %>-1"
         :aria-selected="row == <%s string_of_int i %> && col == 1"
-        href="<%s Url.package_doc package.name %>"
+        href="<%s Url.package_documentation package.name %>"
         :class='{ "bg-background-mid-blue text-white": row == <%s string_of_int i %> && col == 1}'
         class="justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100">
         docs

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -52,7 +52,7 @@ let render ~total ~search (packages : Package.package list) = Layout.render ~tit
           <% packages |> List.iter (fun (package : Package.package) -> %>
           <li class="border-gray-200 border-t mt-4 pt-4 mb-2 space-y-2">
             <a
-              href="<%s Url.package_with_version package.name %>"
+              href="<%s Url.package_overview package.name %>"
               class="text-lg font-semibold text-primary-600 inline-block"
             >
               <%s package.name %>

--- a/src/ocamlorg_frontend/pages/releases.eml
+++ b/src/ocamlorg_frontend/pages/releases.eml
@@ -60,7 +60,7 @@ Layout.render
                                 <a href="<%s Url.release release.version %>" class="text-primary-600 font-medium block">
                                     Release Notes
                                 </a>
-                                <a href="<%s Url.package_with_version "ocaml" ~version:release.version %>" class="text-primary-600 font-medium block">
+                                <a href="<%s Url.package_overview "ocaml" ~version:release.version %>" class="text-primary-600 font-medium block">
                                     OCaml Package
                                 </a>
                                 <a href="<%s Url.manual_with_version release.version %>" class="text-primary-600 font-medium block">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -624,5 +624,5 @@ let package_file t kind req =
       | Some content ->
           Dream.html
             (Ocamlorg_frontend.package_overview ~sidebar_data ~content
-                ~content_title:(Some path) ~dependencies ~rev_dependencies
-                ~conflicts frontend_package))
+               ~content_title:(Some path) ~dependencies ~rev_dependencies
+               ~conflicts frontend_package))

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -263,66 +263,112 @@ let best_practices _req =
   Dream.html (Ocamlorg_frontend.best_practices ~tutorials Ood.Workflow.all)
 
 let problems _req = Dream.html (Ocamlorg_frontend.problems Ood.Problem.all)
+let installer req = Dream.redirect req Url.github_installer
 
 type package_kind = Package | Universe
 
-let package_of_info ~name ~version ?(on_latest_url = false) ~latest_version
-    ~versions info =
-  let rev_deps =
-    List.map
-      (fun (name, _, _versions) -> Ocamlorg_package.Name.to_string name)
-      info.Ocamlorg_package.Info.rev_deps
-  in
-  Ocamlorg_frontend.Package.
-    {
-      name = Ocamlorg_package.Name.to_string name;
-      version =
-        (if on_latest_url then Latest
-        else Specific (Ocamlorg_package.Version.to_string version));
-      versions;
-      latest_version =
-        Option.value ~default:"???"
-          (Option.map Ocamlorg_package.Version.to_string latest_version);
-      synopsis = info.Ocamlorg_package.Info.synopsis;
-      description =
-        info.Ocamlorg_package.Info.description |> Omd.of_string |> Omd.to_html;
-      tags = info.tags;
-      rev_deps;
-      authors = info.authors;
-      maintainers = info.maintainers;
-      license = info.license;
-      publication = info.publication;
-    }
+module PackageHelpers = struct
+  let package_info_to_frontend_package ~name ~version ?(on_latest_url = false)
+      ~latest_version ~versions info =
+    let rev_deps =
+      List.map
+        (fun (name, _, _versions) -> Ocamlorg_package.Name.to_string name)
+        info.Ocamlorg_package.Info.rev_deps
+    in
+    Ocamlorg_frontend.Package.
+      {
+        name = Ocamlorg_package.Name.to_string name;
+        version =
+          (if on_latest_url then Latest
+          else Specific (Ocamlorg_package.Version.to_string version));
+        versions;
+        latest_version =
+          Option.value ~default:"???"
+            (Option.map Ocamlorg_package.Version.to_string latest_version);
+        synopsis = info.Ocamlorg_package.Info.synopsis;
+        description =
+          info.Ocamlorg_package.Info.description |> Omd.of_string |> Omd.to_html;
+        tags = info.tags;
+        rev_deps;
+        authors = info.authors;
+        maintainers = info.maintainers;
+        license = info.license;
+        publication = info.publication;
+        homepages = info.Ocamlorg_package.Info.homepage;
+        source =
+          Option.map
+            (fun url ->
+              (url.Ocamlorg_package.Info.uri, url.Ocamlorg_package.Info.checksum))
+            info.Ocamlorg_package.Info.url;
+      }
 
-(** Query all the versions of a package. *)
-let package_versions state name =
-  Ocamlorg_package.get_package_versions state name
-  |> Option.value ~default:[]
-  |> List.sort (Fun.flip Ocamlorg_package.Version.compare)
-  |> List.map Ocamlorg_package.Version.to_string
+  (** Query all the versions of a package. *)
+  let package_versions state name =
+    Ocamlorg_package.get_package_versions state name
+    |> Option.value ~default:[]
+    |> List.sort (Fun.flip Ocamlorg_package.Version.compare)
+    |> List.map Ocamlorg_package.Version.to_string
 
-let package_meta ?on_latest_url state (package : Ocamlorg_package.t) :
-    Ocamlorg_frontend.Package.package =
-  let name = Ocamlorg_package.name package
-  and version = Ocamlorg_package.version package
-  and info = Ocamlorg_package.info package in
-  let versions = package_versions state name in
-  let latest_version =
-    Option.map
-      (fun (p : Ocamlorg_package.t) -> Ocamlorg_package.version p)
-      (Ocamlorg_package.get_package_latest state name)
-  in
-  package_of_info ~name ~version ?on_latest_url ~latest_version ~versions info
-
-let packages state _req =
-  let package { Ocamlorg_package.Packages_stats.name; version; info } =
+  let frontend_package ?on_latest_url state (package : Ocamlorg_package.t) :
+      Ocamlorg_frontend.Package.package =
+    let name = Ocamlorg_package.name package
+    and version = Ocamlorg_package.version package
+    and info = Ocamlorg_package.info package in
     let versions = package_versions state name in
     let latest_version =
       Option.map
         (fun (p : Ocamlorg_package.t) -> Ocamlorg_package.version p)
         (Ocamlorg_package.get_package_latest state name)
     in
-    package_of_info ~name ~version ~latest_version ~versions info
+    package_info_to_frontend_package ~name ~version ?on_latest_url
+      ~latest_version ~versions info
+
+  let to_package t name version =
+    let package =
+      if version = "latest" then Ocamlorg_package.get_package_latest t name
+      else
+        Ocamlorg_package.get_package t name
+          (Ocamlorg_package.Version.of_string version)
+    in
+    package
+    |> Option.map (fun package ->
+           ( package,
+             frontend_package t package ~on_latest_url:(version = "latest") ))
+
+  let package_sidebar_data ~kind package =
+    let open Lwt.Syntax in
+    let* readme_filename = Ocamlorg_package.readme_filename ~kind package in
+    let* changes_filename = Ocamlorg_package.changes_filename ~kind package in
+    let* license_filename = Ocamlorg_package.license_filename ~kind package in
+    let* package_documentation_status =
+      Ocamlorg_package.documentation_status ~kind package
+    in
+    let documentation_status =
+      match package_documentation_status with
+      | Ocamlorg_package.Success -> Ocamlorg_frontend.Package.Success
+      | Failure -> Failure
+      | Unknown -> Unknown
+    in
+    Lwt.return
+      Ocamlorg_frontend.Package_overview.
+        {
+          documentation_status;
+          readme_filename;
+          changes_filename;
+          license_filename;
+        }
+end
+
+let packages state _req =
+  let package { Ocamlorg_package.Packages_stats.name; version; info } =
+    let versions = PackageHelpers.package_versions state name in
+    let latest_version =
+      Option.map
+        (fun (p : Ocamlorg_package.t) -> Ocamlorg_package.version p)
+        (Ocamlorg_package.get_package_latest state name)
+    in
+    PackageHelpers.package_info_to_frontend_package ~name ~version
+      ~latest_version ~versions info
   in
   let package_pair (pkg, snd) = (package pkg, snd) in
   let stats =
@@ -347,7 +393,7 @@ let packages state _req =
   and featured_packages =
     (* TODO: Should be cached ? *)
     match Ocamlorg_package.featured_packages state with
-    | Some pkgs -> List.map (package_meta state) pkgs
+    | Some pkgs -> List.map (PackageHelpers.frontend_package state) pkgs
     | None -> []
   in
   Dream.html (Ocamlorg_frontend.packages stats featured_packages)
@@ -359,7 +405,7 @@ let packages_search t req =
         Ocamlorg_package.search_package ~sort_by_popularity:true t search
       in
       let total = List.length packages in
-      let results = List.map (package_meta t) packages in
+      let results = List.map (PackageHelpers.frontend_package t) packages in
       let search = Dream.from_percent_encoded search in
       Dream.html (Ocamlorg_frontend.packages_search ~total ~search results)
   | None -> Dream.redirect req Url.packages
@@ -370,7 +416,7 @@ let packages_autocomplete_fragment t req =
       let packages =
         Ocamlorg_package.search_package ~sort_by_popularity:true t search
       in
-      let results = List.map (package_meta t) packages in
+      let results = List.map (PackageHelpers.frontend_package t) packages in
       let top_5 = results |> List.take 5 in
       let search = Dream.from_percent_encoded search in
       Dream.html
@@ -378,47 +424,20 @@ let packages_autocomplete_fragment t req =
            ~total:(List.length results) top_5)
   | _ -> Dream.html ""
 
-let package _t req =
-  let package = Dream.param req "name" in
-  let target = Url.package_with_version package in
-  Dream.redirect req target
-
-(** Redirect any URL with suffix /p/PACKAGE/docs to the latest documentation for
-    PACKAGE. *)
-let package_docs _t req =
-  let package = Dream.param req "name" in
-  let target = Url.package_doc package in
-  Dream.redirect req target
-
-let to_package t name version =
-  let package =
-    if version = "latest" then Ocamlorg_package.get_package_latest t name
-    else
-      Ocamlorg_package.get_package t name
-        (Ocamlorg_package.Version.of_string version)
-  in
-  package
-  |> Option.map (fun package ->
-         (package, package_meta t package ~on_latest_url:(version = "latest")))
-
-let installer req = Dream.redirect req Url.github_installer
-
-let package_versioned t kind req =
+let package_overview t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
-  let page_from_url = try Some (Dream.param req "page") with _ -> None in
-  match to_package t name version_from_url with
+  match PackageHelpers.to_package t name version_from_url with
   | None -> not_found req
-  | Some (package, package_meta) -> (
+  | Some (package, frontend_package) ->
       let open Lwt.Syntax in
       let kind =
         match kind with
         | Package -> `Package
         | Universe -> `Universe (Dream.param req "hash")
       in
-      let* readme_filename = Ocamlorg_package.readme_filename ~kind package in
-      let* changes_filename = Ocamlorg_package.changes_filename ~kind package in
-      let* license_filename = Ocamlorg_package.license_filename ~kind package in
+      let* sidebar_data = PackageHelpers.package_sidebar_data ~kind package in
+
       let package_info = Ocamlorg_package.info package in
       let rev_dependencies =
         package_info.Ocamlorg_package.Info.rev_deps
@@ -435,48 +454,52 @@ let package_versioned t kind req =
         package_info.Ocamlorg_package.Info.conflicts
         |> List.map (fun (name, x) -> (Ocamlorg_package.Name.to_string name, x))
       in
-      let homepages = package_info.Ocamlorg_package.Info.homepage in
-      let source =
-        Option.map
-          (fun url ->
-            (url.Ocamlorg_package.Info.uri, url.Ocamlorg_package.Info.checksum))
-          package_info.Ocamlorg_package.Info.url
+
+      Dream.html
+        (Ocamlorg_frontend.package_overview ~sidebar_data ~content:""
+           ~content_title:None ~dependencies ~rev_dependencies ~conflicts
+           frontend_package)
+
+let package_file t kind req =
+  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let version_from_url = Dream.param req "version" in
+  match PackageHelpers.to_package t name version_from_url with
+  | None -> not_found req
+  | Some (package, frontend_package) -> (
+      let open Lwt.Syntax in
+      let kind =
+        match kind with
+        | Package -> `Package
+        | Universe -> `Universe (Dream.param req "hash")
       in
-      let* package_documentation_status =
-        Ocamlorg_package.documentation_status ~kind package
-      in
-      let documentation_status =
-        match package_documentation_status with
-        | Ocamlorg_package.Success -> Ocamlorg_frontend.Package_overview.Success
-        | Failure -> Failure
-        | Unknown -> Unknown
-      in
+      let path = (Dream.path [@ocaml.warning "-3"]) req |> String.concat "/" in
+      let* sidebar_data = PackageHelpers.package_sidebar_data ~kind package in
+
+      let rev_dependencies = [] in
+      let dependencies = [] in
+      let conflicts = [] in
 
       let* content =
-        match page_from_url with
-        | None -> Lwt.return (Some "")
-        | Some page ->
-            let* file = Ocamlorg_package.file ~kind package page in
-            Lwt.return
-              (match file with
-              | None -> None
-              | Some file_content -> Some file_content.content)
+        let* file = Ocamlorg_package.file ~kind package path in
+        Lwt.return
+          (match file with
+          | None -> None
+          | Some file_content -> Some file_content.content)
       in
       match content with
       | None -> Dream.html (Ocamlorg_frontend.not_found ())
       | Some content ->
           Dream.html
-            (Ocamlorg_frontend.package_overview ~documentation_status ~content
-               ~content_title:page_from_url ~dependencies ~rev_dependencies
-               ~conflicts ~homepages ~source ~readme_filename ~changes_filename
-               ~license_filename package_meta))
+            (Ocamlorg_frontend.package_overview ~sidebar_data ~content
+               ~content_title:(Some path) ~dependencies ~rev_dependencies
+               ~conflicts frontend_package))
 
-let package_doc t kind req =
+let package_documentation t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
-  match to_package t name version_from_url with
+  match PackageHelpers.to_package t name version_from_url with
   | None -> not_found req
-  | Some (package, package_meta) -> (
+  | Some (package, frontend_package) -> (
       let open Lwt.Syntax in
       let kind =
         match kind with
@@ -486,8 +509,8 @@ let package_doc t kind req =
       let path = (Dream.path [@ocaml.warning "-3"]) req |> String.concat "/" in
       let root =
         let hash = match kind with `Package -> None | `Universe u -> Some u in
-        Url.package_doc ?hash ~page:""
-          ?version:(Ocamlorg_frontend.Package.url_version package_meta)
+        Url.package_documentation ?hash ~page:""
+          ?version:(Ocamlorg_frontend.Package.url_version frontend_package)
           (Ocamlorg_package.Name.to_string name)
       in
       let* docs = Ocamlorg_package.documentation_page ~kind package path in
@@ -496,7 +519,7 @@ let package_doc t kind req =
           Dream.html
             (Ocamlorg_frontend.package_documentation_not_found ~page:path
                ~path:(Ocamlorg_frontend.Package_breadcrumbs.Documentation Index)
-               package_meta)
+               frontend_package)
       | Some doc ->
           let toc_of_toc (xs : Ocamlorg_package.Documentation.toc list) :
               Ocamlorg_frontend.Toc.t =
@@ -602,4 +625,14 @@ let package_doc t kind req =
           Dream.html
             (Ocamlorg_frontend.package_documentation ~page:(Some path)
                ~path:breadcrumb_path ~toc ~maptoc ~content:doc.content
-               package_meta))
+               frontend_package))
+
+let package_redirect _t req =
+  let package = Dream.param req "name" in
+  Dream.redirect req (Url.package_overview package)
+
+(** Redirect any URL with suffix /p/PACKAGE/docs to the latest documentation for
+    PACKAGE. *)
+let package_docs_redirect _t req =
+  let package = Dream.param req "name" in
+  Dream.redirect req (Url.package_documentation package)

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -460,40 +460,6 @@ let package_overview t kind req =
            ~content_title:None ~dependencies ~rev_dependencies ~conflicts
            frontend_package)
 
-let package_file t kind req =
-  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
-  let version_from_url = Dream.param req "version" in
-  match Package_helper.of_name_version t name version_from_url with
-  | None -> not_found req
-  | Some (package, frontend_package) -> (
-      let open Lwt.Syntax in
-      let kind =
-        match kind with
-        | Package -> `Package
-        | Universe -> `Universe (Dream.param req "hash")
-      in
-      let path = (Dream.path [@ocaml.warning "-3"]) req |> String.concat "/" in
-      let* sidebar_data = Package_helper.package_sidebar_data ~kind package in
-
-      let rev_dependencies = [] in
-      let dependencies = [] in
-      let conflicts = [] in
-
-      let* content =
-        let* file = Ocamlorg_package.file ~kind package path in
-        Lwt.return
-          (match file with
-          | None -> None
-          | Some file_content -> Some file_content.content)
-      in
-      match content with
-      | None -> Dream.html (Ocamlorg_frontend.not_found ())
-      | Some content ->
-          Dream.html
-            (Ocamlorg_frontend.package_overview ~sidebar_data ~content
-               ~content_title:(Some path) ~dependencies ~rev_dependencies
-               ~conflicts frontend_package))
-
 let package_documentation t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
@@ -626,3 +592,37 @@ let package_documentation t kind req =
             (Ocamlorg_frontend.package_documentation ~page:(Some path)
                ~path:breadcrumb_path ~toc ~maptoc ~content:doc.content
                frontend_package))
+
+let package_file t kind req =
+  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let version_from_url = Dream.param req "version" in
+  match Package_helper.of_name_version t name version_from_url with
+  | None -> not_found req
+  | Some (package, frontend_package) -> (
+      let open Lwt.Syntax in
+      let kind =
+        match kind with
+        | Package -> `Package
+        | Universe -> `Universe (Dream.param req "hash")
+      in
+      let path = (Dream.path [@ocaml.warning "-3"]) req |> String.concat "/" in
+      let* sidebar_data = Package_helper.package_sidebar_data ~kind package in
+
+      let rev_dependencies = [] in
+      let dependencies = [] in
+      let conflicts = [] in
+
+      let* content =
+        let* file = Ocamlorg_package.file ~kind package path in
+        Lwt.return
+          (match file with
+          | None -> None
+          | Some file_content -> Some file_content.content)
+      in
+      match content with
+      | None -> Dream.html (Ocamlorg_frontend.not_found ())
+      | Some content ->
+          Dream.html
+            (Ocamlorg_frontend.package_overview ~sidebar_data ~content
+                ~content_title:(Some path) ~dependencies ~rev_dependencies
+                ~conflicts frontend_package))

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -626,13 +626,3 @@ let package_documentation t kind req =
             (Ocamlorg_frontend.package_documentation ~page:(Some path)
                ~path:breadcrumb_path ~toc ~maptoc ~content:doc.content
                frontend_package))
-
-let package_redirect _t req =
-  let package = Dream.param req "name" in
-  Dream.redirect req (Url.package_overview package)
-
-(** Redirect any URL with suffix /p/PACKAGE/docs to the latest documentation for
-    PACKAGE. *)
-let package_docs_redirect _t req =
-  let package = Dream.param req "name" in
-  Dream.redirect req (Url.package_documentation package)

--- a/src/ocamlorg_web/lib/redirection.ml
+++ b/src/ocamlorg_web/lib/redirection.ml
@@ -669,6 +669,14 @@ let make ?(permanent = false) t =
            Some (Dream.get origin (fun req -> Dream.redirect ~status req new_)))
        t)
 
+let package req =
+  let package = Dream.param req "name" in
+  Dream.redirect req (Url.package_overview package)
+
+let package_docs req =
+  let package = Dream.param req "name" in
+  Dream.redirect req (Url.package_documentation package)
+
 let t =
   Dream.scope "" []
     [
@@ -683,4 +691,7 @@ let t =
       make ~permanent:true [ ("/code-of-conduct", "/policies/code-of-conduct") ];
       make ~permanent:true [ ("/opportunities", "/jobs") ];
       make ~permanent:false [ (Url.workshops, Url.community ^ "#workshops") ];
+      Dream.get "/p/:name" package;
+      Dream.get "/u/:hash/p/:name" package;
+      Dream.get "/p/:name/doc" package_docs;
     ]

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -66,26 +66,19 @@ let package_route t =
         (Url.package_overview ~hash:":hash" ":name" ~version:":version")
         ((Handler.package_overview t) Handler.Universe);
       Dream.get
-        (Url.package_file ":name" ~version:":version" ~filepath:"**")
-        ((Handler.package_file t) Handler.Package);
-      Dream.get
-        (Url.package_file ~hash:":hash" ":name" ~version:":version"
-           ~filepath:"**")
-        ((Handler.package_file t) Handler.Package);
-      Dream.get
         (Url.package_documentation ":name" ~version:":version" ~page:"**")
         ((Handler.package_documentation t) Handler.Package);
       Dream.get
         (Url.package_documentation ~hash:":hash" ~page:"**" ":name"
            ~version:":version")
         ((Handler.package_documentation t) Handler.Universe);
-      Dream.get (Url.package_redirect ":name") (Handler.package_redirect t);
       Dream.get
-        (Url.package_redirect ~hash:":hash" ":name")
-        (Handler.package_redirect t);
+        (Url.package_file ":name" ~version:":version" ~filepath:"**")
+        ((Handler.package_file t) Handler.Package);
       Dream.get
-        (Url.package_docs_redirect ":name")
-        (Handler.package_docs_redirect t);
+        (Url.package_file ~hash:":hash" ":name" ~version:":version"
+           ~filepath:"**")
+        ((Handler.package_file t) Handler.Package);
     ]
 
 let graphql_route t =

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -59,25 +59,33 @@ let package_route t =
       Dream.get Url.packages_search (Handler.packages_search t);
       Dream.get Url.packages_autocomplete_fragment
         (Handler.packages_autocomplete_fragment t);
-      Dream.get (Url.package ":name") (Handler.package t);
-      Dream.get (Url.package_docs ":name") (Handler.package_docs t);
-      Dream.get (Url.package ~hash:":hash" ":name") (Handler.package t);
       Dream.get
-        (Url.package_with_version ":name" ~version:":version")
-        ((Handler.package_versioned t) Handler.Package);
+        (Url.package_overview ":name" ~version:":version")
+        ((Handler.package_overview t) Handler.Package);
       Dream.get
-        (Url.package_with_version ":name" ~version:":version" ~page:":page")
-        ((Handler.package_versioned t) Handler.Package);
+        (Url.package_overview ~hash:":hash" ":name" ~version:":version")
+        ((Handler.package_overview t) Handler.Universe);
       Dream.get
-        (Url.package_with_version ~hash:":hash" ":name" ~version:":version"
-           ~page:"**")
-        ((Handler.package_versioned t) Handler.Universe);
+        (Url.package_file ":name" ~version:":version" ~filepath:"**")
+        ((Handler.package_file t) Handler.Package);
       Dream.get
-        (Url.package_doc ":name" ~version:":version" ~page:"**")
-        ((Handler.package_doc t) Handler.Package);
+        (Url.package_file ~hash:":hash" ":name" ~version:":version"
+           ~filepath:"**")
+        ((Handler.package_file t) Handler.Package);
       Dream.get
-        (Url.package_doc ~hash:":hash" ~page:"**" ":name" ~version:":version")
-        ((Handler.package_doc t) Handler.Universe);
+        (Url.package_documentation ":name" ~version:":version" ~page:"**")
+        ((Handler.package_documentation t) Handler.Package);
+      Dream.get
+        (Url.package_documentation ~hash:":hash" ~page:"**" ":name"
+           ~version:":version")
+        ((Handler.package_documentation t) Handler.Universe);
+      Dream.get (Url.package_redirect ":name") (Handler.package_redirect t);
+      Dream.get
+        (Url.package_redirect ~hash:":hash" ":name")
+        (Handler.package_redirect t);
+      Dream.get
+        (Url.package_docs_redirect ":name")
+        (Handler.package_docs_redirect t);
     ]
 
 let graphql_route t =


### PR DESCRIPTION
This patch
* renames package urls and handlers to better reflect their purpose and be more consistently named
* introduces dedicated url and handler for package files (README, CHANGELOG, LICENSE)
* moves all non-handler package-related functions into a module `PackageHelpers` to prevent confusion with handlers
* extends Ocamlorg_frontend.Package by `homepages` and `source`

Resolves https://github.com/ocaml/ocaml.org/issues/995.

There's more potential for tidying up / clarifying that this patch does not include, e.g.
1) sidebar state of `package_documentation` handler
2) extend voodoo to inspect for README, CHANGELOG, LICENSE and add info about these files to `package.json`
3) make voodoo emit `documentation_status` as part of `package.json`
4) after 2+3) make Ocamlorg_frontend.Package pick up this info from `package.json`