### PR TITLE
Use odoc's breadcrumb href in package_breadcrumbs template

### DIFF
--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -1,9 +1,9 @@
 type library_path_item =
-  | Module of string
-  | ModuleType of string
-  | Parameter of int * string
-  | Class of string
-  | ClassType of string
+  | Module of { name: string; href: string; }
+  | ModuleType of { name: string; href: string; }
+  | Parameter of { name: string; href: string; number: int; }
+  | Class of { name: string; href: string; }
+  | ClassType of { name: string; href: string; }
 
 type docs_path = 
   | Index
@@ -15,31 +15,12 @@ let kind_tag (m : library_path_item) = match m with
     <span tabindex="0" aria-label="module" class="breadcrumbs-tag module-tag text-white">Module</span>
   | ModuleType _ ->
     <span tabindex="0" aria-label="module type" class="breadcrumbs-tag module-type-tag text-white">Module type</span>
-  | Parameter (number, _) ->
+  | Parameter { number; _ } ->
     <span tabindex="0" aria-label="<%s "Parameter #" ^ (Int.to_string number) %>" class="breadcrumbs-tag parameter-tag text-white"><%s "Parameter #" ^ (Int.to_string number) %></span>
   | Class _ ->
     <span tabindex="0" aria-label="class" class="breadcrumbs-tag class-tag text-white">Class</span>
   | ClassType _ ->
     <span tabindex="0" aria-label="class type" class="breadcrumbs-tag class-type-tag text-white">Class type</span>
-
-let library_path_item_name (m: library_path_item) = match m with
-  | Module name
-  | ModuleType name
-  | Parameter (_, name) -> name
-  | Class name -> name
-  | ClassType name -> name
-
-type breadcrumb = {
-  text : string;
-  href : string;
-}
-
-let rec breadcrumbs_from_path (reversed_library_path: library_path_item list) prefix : ( breadcrumb list ) = match reversed_library_path with
-  | [] -> []
-  | x::[] -> [{ text = library_path_item_name x; href = prefix ^ "index.html"}]
-  | x::xs ->
-    let new_prefix = prefix ^ "../" in
-    { text = library_path_item_name x ; href = prefix ^ "index.html" } :: breadcrumbs_from_path xs new_prefix
 
 type path = 
   | Overview of string option
@@ -80,23 +61,33 @@ let render_package_and_version
     </select>
   </li>
 
+type breadcrumb = {
+  name: string;
+  href: string;
+}
+
+let library_path_item_to_breadcrumb = function
+  | Module x -> { name = x.name; href = x.href }
+  | ModuleType x -> { name = x.name; href = x.href }
+  | Class x -> { name = x.name; href = x.href }
+  | ClassType x -> { name = x.name; href = x.href }
+  | Parameter x -> { name = x.name; href = x.href }
+
 let render_library_path_breadcrumbs
 ~library_name
 ~(path: library_path_item list) =
-  let (reversed_library_path : library_path_item list) = List.rev (path) in
-  let breadcrumbs = breadcrumbs_from_path reversed_library_path "" in
   let render_breadcrumb i b =
     if i < List.length path - 1 then
-      <a href="<%s! b.href %>" class="font-semibold underline text-gray-800"><%s b.text %></a>
+      <a href="<%s! b.href %>" class="font-semibold underline text-gray-800"><%s b.name %></a>
     else 
-      <a href="<%s! b.href %>" aria-current="page" class="text-gray-800"><%s b.text %></a>
+      <a href="<%s! b.href %>" aria-current="page" class="text-gray-800"><%s b.name %></a>
   in
   <li>
     <span tabindex="0" class="text-gray-600"><%s library_name %> lib</span>
   </li>
   <li class="inline-flex">
-    <%s! String.concat "<span>.</span>" (breadcrumbs |> List.rev |> List.mapi render_breadcrumb); %>
-    <%s! kind_tag (List.hd reversed_library_path) %>
+    <%s! String.concat "<span>.</span>" (path |> List.map library_path_item_to_breadcrumb |> List.mapi render_breadcrumb); %>
+    <%s! kind_tag (List.hd (List.rev path)) %>
   </li>
 
 let render_docs_path_breadcrumbs

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -30,11 +30,11 @@ let str_path =
     | Documentation (docs_path) -> (match docs_path with
         | Package_breadcrumbs.Index -> []
         | Library (s, p) -> s :: List.map (function
-            | Package_breadcrumbs.Module s -> s
-            | ModuleType s -> s
-            | Parameter (number, s) -> Int.to_string number ^ "-" ^ s
-            | Class s -> s
-            | ClassType s -> s
+            | Package_breadcrumbs.Module { name ; _ } -> name
+            | ModuleType { name ; _ } -> name
+            | Parameter  { name ; _ } -> name
+            | Class { name ; _ } -> name
+            | ClassType { name ; _ } -> name
           ) p
         | Page s -> [""; s])
 in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -562,11 +562,14 @@ let package_doc t kind req =
               let doc_breadcrumb_to_library_path_item
                   (p : Ocamlorg_package.Documentation.breadcrumb) =
                 match p.kind with
-                | Module -> Ocamlorg_frontend.Package_breadcrumbs.Module p.name
-                | ModuleType -> ModuleType p.name
-                | Parameter i -> Parameter (i, p.name)
-                | Class -> Class p.name
-                | ClassType -> ClassType p.name
+                | Module ->
+                    Ocamlorg_frontend.Package_breadcrumbs.Module
+                      { name = p.name; href = p.href }
+                | ModuleType -> ModuleType { name = p.name; href = p.href }
+                | Parameter i ->
+                    Parameter { name = p.name; href = p.href; number = i }
+                | Class -> Class { name = p.name; href = p.href }
+                | ClassType -> ClassType { name = p.name; href = p.href }
                 | Page | LeafPage | File ->
                     failwith
                       "library paths do not contain Page, LeafPage or File"


### PR DESCRIPTION
Instead of rendering the breadcrumb hrefs from the path string, use the breadcrumb hrefs coming from odoc 2.2.0.

Happens to fix a bug with how the navmap recognizes arguments in breadcrumbs:

|before|after|
|-|-|
|![Screenshot 2023-03-21 at 19-19-51 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226705024-c0581e37-0d8e-4ab0-a8bb-ca1a869ce486.png)|![Screenshot 2023-03-21 at 19-20-02 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226705035-50c6982d-d889-4a08-b8f2-dd78635db4f8.png)|
