### PR TITLE
Improve Authors/Maintainers Display on Package Overview

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -9,6 +9,8 @@ let side_box_link ~href ~title ~icon_html =
         <%s title %>
     </a>
 
+let num_of_users_to_show = 4
+
 let render
 ~documentation_status
 ~content
@@ -35,6 +37,32 @@ in
 let render_section_heading ~title =
   <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
     <h2 class="text-xl font-medium my-2"><%s title %></h2>
+  </div>
+in
+let render_user_avatar ~x_show (user: Ood.Opam_user.t) =
+  <li class="flex justify-start" <%s! if x_show then "x-show='open'" else "" %>>
+    <a href="<%s Url.packages_search %>?q=author%3A%22<%s Dream.to_percent_encoded user.name %>%22" class="flex items-center gap-3">
+      <% (match user.avatar with | None -> %>
+      <div class="shrink-0 inline-flex items-center justify-center text-xl font-medium h-10 w-10 rounded-full bg-avatar-<%s string_of_int ((Hashtbl.hash user.name) mod 12 )%> text-white">
+      <%s String.uppercase_ascii (String.sub user.name 0 1); %>
+      </div>
+      <% | Some avatar -> %>
+      <img class="shrink-0 inline-flex h-10 w-10 rounded-full" src="<%s avatar %>" alt="">
+      <% ); %>
+      <div class="text-sm font-medium text-gray-900"><%s user.name %></div>
+    </a>
+  </li>
+in
+let render_user_list (users: Ood.Opam_user.t list) =
+  <div class="mt-3 text-sm text-gray-900" <%s! if List.length users > num_of_users_to_show then "x-data='{ open: false }'" else "" %>>
+    <ol class="space-y-3">
+      <% users |> List.iteri (fun i (user : Ood.Opam_user.t) -> %>
+      <%s! render_user_avatar ~x_show:(i > num_of_users_to_show - 1) user %>
+      <% ); %>
+    </ol>
+    <% if List.length users > num_of_users_to_show then (%>
+    <button class="text-primary-700 py-4" x-on:click="open = !open" x-text="open ? 'Hide <%s string_of_int (List.length users - num_of_users_to_show) %>...' : 'Show <%s string_of_int (List.length users - num_of_users_to_show) %> more...'"></button>
+    <% ) else (); %>
   </div>
 in
 let title_with_number title number =
@@ -167,40 +195,10 @@ Package_layout.render
         </div>
 
         <h2 class="mt-8 font-semibold text-base text-body-400">Authors</h2>
-        <div class="mt-3 text-sm text-gray-900">
-          <ul class="space-y-3">
-          <% package.authors |> List.iter (fun (author : Ood.Opam_user.t) -> %>
-          <li class="flex justify-start">
-            <a href="<%s Url.packages_search %>?q=author%3A%22<%s Dream.to_percent_encoded author.name %>%22" class="flex items-center space-x-3">
-              <% (match author.avatar with | None -> () | Some avatar -> %>
-              <div class="flex-shrink-0">
-                  <img class="h-10 w-10 rounded-full" src="<%s avatar %>" alt="">
-              </div>
-              <% ); %>
-              <div class="text-sm font-medium text-gray-900"><%s author.name %></div>
-            </a>
-          </li>
-          <% ); %>
-          </ul>
-        </div>
+        <%s! render_user_list package.authors %>
 
         <h2 class="mt-8 font-semibold text-base text-body-400">Maintainers</h2>
-        <div class="mt-3 text-sm text-gray-900">
-          <ul class="space-y-3">
-          <% package.maintainers |> List.iter (fun (author : Ood.Opam_user.t) -> %>
-          <li class="flex justify-start">
-            <a href="<%s Url.packages_search %>?q=author%3A%22<%s Dream.to_percent_encoded author.name %>%22" class="flex items-center space-x-3">
-              <% (match author.avatar with | None -> () | Some avatar -> %>
-              <div class="flex-shrink-0">
-              <img class="h-10 w-10 rounded-full" src="<%s avatar %>" alt="">
-              </div>
-              <% ); %>
-              <div class="text-sm font-medium text-gray-900"><%s author.name %></div>
-            </a>
-          </li>
-          <% ); %>
-          </ul>
-        </div>
+        <%s! render_user_list package.maintainers %>
 
         <% match source with
         | None -> ()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -80,6 +80,20 @@ module.exports = {
           12: "rgba(26, 32, 44, 0.12)",
           16: "rgba(26, 32, 44, 0.16)",
         },
+        avatar: {
+          0: "#bb452a",
+          1: "#a35829",
+          2: "#926229",
+          3: "#746e29",
+          4: "#367a28",
+          5: "#2a7a54",
+          6: "#2c786d",
+          7: "#2e7587",
+          8: "#336db7",
+          9: "#6855e3",
+          10: "#ad35bc",
+          11: "#c62d69"
+        }
       },
     },
   },
@@ -88,4 +102,18 @@ module.exports = {
     require("@tailwindcss/typography"),
     require("@tailwindcss/aspect-ratio"),
   ],
+  safelist: [
+    'bg-avatar-0',
+    'bg-avatar-1',
+    'bg-avatar-2',
+    'bg-avatar-3',
+    'bg-avatar-4',
+    'bg-avatar-5',
+    'bg-avatar-6',
+    'bg-avatar-7',
+    'bg-avatar-8',
+    'bg-avatar-9',
+    'bg-avatar-10',
+    'bg-avatar-11',
+  ]
 };


### PR DESCRIPTION
* give every author/maintainer a default avatar based on their first letter so that authors with and without images align nicely
* always show the first 4 authors/maintainers - the remaining ones collapse behind a "show more" button
* there are 12 proposed different avatar colors which are assigned based on a hash of the name (up for discussion, I just put some colors here @Clairevanden)

|before|after|
|-|-|
|![Screenshot 2023-03-22 at 11-00-14 advi 2 0 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226868388-5adae65e-1b20-47c6-844e-b1402bc48073.png)|![Screenshot 2023-03-22 at 11-00-19 advi 2 0 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226868402-1e09e49e-8247-4c82-9c97-f7922fcaccc6.png)|
