### PR TITLE
make package layout non-wide

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -17,7 +17,7 @@ Layout.render
 ~active_top_nav_item:Header.Packages @@
 <div class="bg-white">
   <div class="py-5 lg:py-6">
-    <div class="container-fluid wide">
+    <div class="container-fluid">
       <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
         <div class="flex flex-col items-baseline mb-6">
           <%s! Package_breadcrumbs.render ~path ?hash ?page package %>


### PR DESCRIPTION
To make the width of the content area more predictably match guidelines for readability/line-length: Package layout is no longer "wide".

|before|after|
|-|-|
|![Screenshot 2023-03-22 at 15-56-24 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226945108-eb2997c4-0f83-4331-90a6-e72373b8551d.png)|![Screenshot 2023-03-22 at 15-56-27 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226945120-b625f622-05ee-4970-9274-39390ba9b6c9.png)|
|![Screenshot 2023-03-22 at 15-56-40 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226945155-652db2cb-2f70-4a9d-b9f2-6c41ede87430.png)|![Screenshot 2023-03-22 at 15-56-46 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226945171-9fbca2e3-15e4-49a8-aa46-f74b46725dbb.png)|
