### PR TITLE
move package overview sidebar to the left, remove borders

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -18,15 +18,9 @@ Layout.render
 <div class="bg-white">
   <div class="py-5 lg:py-6">
     <div class="container-fluid">
-      <div class="flex justify-between flex-col md:flex-row border-b border-gray-200">
+      <div class="flex justify-between flex-col md:flex-row">
         <div class="flex flex-col items-baseline mb-6">
           <%s! Package_breadcrumbs.render ~path ?hash ?page package %>
-
-          <% (match path with | Overview _ -> %>
-            <div class="text-body-400">
-              <%s package.synopsis %>
-            </div>
-          <% | _ -> ()); %>
         </div>
       </div>
       <div class="py-6">

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -73,7 +73,7 @@ Package_layout.render
 ~canonical:(Url.package_overview package.name ~version:specific_version)
 ~package
 ~path:(Overview content_title) @@
-<div class="flex md:space-x-4 xl:space-x-12 flex-col md:flex-row justify-between">
+<div class="flex md:gap-6 xl:gap-12 flex-col md:flex-row justify-between">
     <div class="flex-1 w-full xl:w-1/2 max-w-full">
       <% (match content_title with | None -> %>
       <div class="p-4 prose max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
@@ -133,7 +133,11 @@ Package_layout.render
       </div>
       <% ); %>
     </div>
-    <div class="p-3 py-6 lg:p-8 border border-gray-200 text-sm rounded-xl md:w-60 lg:w-auto lg:max-w-sm w-full max-w-full">
+    <div class="order-first text-sm md:w-60 lg:w-72">
+        <div class="text-base text-body-400 mb-6">
+          <%s package.synopsis %>
+        </div>
+
         <h2 class="inline-flex items-center text-lg font-medium text-gray-900">
             <%s! Icons.command_line "mr-4 h-6 w-6 text-orange-600" %>
             Install


### PR DESCRIPTION
* synopsis moves above "install" in preparation of unifying package documentation and package overview layout
* remove unnecessary borders
* move package overview sidebar to the left

|before|after|
|-|-|
|![Screenshot 2023-03-22 at 16-35-27 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226956820-a7c2dd8b-667f-48c0-a782-2ab3316dae1e.png)|![Screenshot 2023-03-22 at 16-35-30 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226956829-0ce89f9d-5ac3-4dee-bb82-71bc170db055.png)|
