### PR TITLE
remove top banner, but keep structure intact for future use

### DIFF
--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -51,18 +51,11 @@ inner =
 
   <body class="light">
     <% if banner then ( %>
-    <div class="relative bg-red-800">
+    <div class="relative bg-background-dark-blue">
       <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
         <div class="pr-16 sm:px-16 sm:text-center">
           <p class="font-medium text-white">
-            <span class="md:hidden">OCaml 5.0 is available!</span>
-            <span class="hidden md:inline">OCaml 5.0 is available! This release of OCaml comes with support for shared-memory parallelism through domains and direct-style concurrency through effect handlers!</span>
-            <span class="block sm:ml-2 sm:inline-block">
-              <a href="<%s Url.news_post "ocaml-5.0" %>" class="font-bold text-white underline">
-                Try it now
-                <span aria-hidden="true"> &rarr;</span>
-              </a>
-            </span>
+          PLACE BANNER TEXT HERE
           </p>
         </div>
       </div>

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -52,12 +52,17 @@ inner =
   <body class="light">
     <% if banner then ( %>
     <div class="relative bg-background-dark-blue">
-      <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
-        <div class="pr-16 sm:px-16 sm:text-center">
-          <p class="font-medium text-white">
-          PLACE BANNER TEXT HERE
-          </p>
-        </div>
+      <div class="mx-auto py-3 px-6 sm:px-16 max-w-6xl sm:text-center">
+        <p class="font-medium text-white">
+          <span class="md:hidden">OCaml 5.0 is available!</span>
+          <span class="hidden md:inline">OCaml 5.0 is available! This release of OCaml comes with support for shared-memory parallelism through domains and direct-style concurrency through effect handlers!</span>
+          <span class="block sm:ml-2 sm:inline-block">
+            <a href="<%s Url.news_post "ocaml-5.0" %>" class="font-bold text-white underline">
+              Try it now
+              <span aria-hidden="true"> &rarr;</span>
+            </a>
+          </span>
+        </p>
       </div>
     </div>
     <% ); %>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -1,7 +1,6 @@
 let render () =
 Layout.render
 ~use_swiper:true
-~banner:true
 ~title:"Welcome to a World of OCaml"
 ~description:"OCaml is a general-purpose, industrial-strength programming language with an emphasis on expressiveness and safety."
 ~canonical:"" @@

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,7 +52,7 @@ module.exports = {
           default: "#FAF8F3",
           beige: "#FAF8F3",
           "mid-blue": "#0C3B8C", // background for cursor highlighting in keyboard navigable areas (e.g. package search dropdown)
-          "dark-blue": "#0e1531", // one of the colors from the blue patterned background used in various parts of the site
+          "dark-blue": "#14294b", // one of the colors from the blue patterned background used in various parts of the site
           "light-blue": "rgb(221, 232, 251)",
         },
         body: {


### PR DESCRIPTION
* change banner color to dark blue, so the next person adding a banner doesn't have to think about that
* adjust `dark-blue` color to better resemble the dark blue background sections
* hide banner, but keep code around for future use

I imagine in a few months or weeks someone will want to add a banner again.

|before|after| after with banner|
|-|-|-|
|![Screenshot 2023-03-22 at 17-53-20 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226979893-32d37398-a076-4b83-8fed-666b1e1e1833.png)|![Screenshot 2023-03-22 at 17-52-51 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226979921-966d5116-4309-4d95-9e9d-7ec758d4f06a.png)|![Screenshot 2023-03-22 at 17-53-24 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226979934-636215b0-5745-49f4-a4fa-0c589c2bc453.png)|
|![Screenshot 2023-03-22 at 17-53-30 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226980031-9f948dbc-6855-40ec-9be4-a02b331ff23c.png)|-|![Screenshot 2023-03-22 at 17-53-33 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226980069-c0c267f5-d754-42f2-9627-0ebb1c03de2d.png)|
|![Screenshot 2023-03-22 at 17-53-41 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226980113-854e5774-0c7a-4359-ada5-d5d758510bf1.png) alignment messed up|-|![Screenshot 2023-03-22 at 17-53-44 Welcome to a World of OCaml](https://user-images.githubusercontent.com/6594573/226980122-f2b4db00-fceb-4584-aa68-fcade3fed093.png)|
