### PR TITLE
splice out development dependencies from dependencies

### DIFF
--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -18,6 +18,7 @@ let render
 ~content
 ~content_title
 ~dependencies
+~dev_dependencies
 ~rev_dependencies
 ~conflicts
 (package : Package.package) =
@@ -103,6 +104,13 @@ Package_layout.render
           <ol class="grid xl:grid-cols-2">
               <%s if List.length dependencies = 0 then "None" else "" %>
               <% dependencies |> List.iter (fun (name, cstr) -> %>
+              <%s! render_dependency ~name ~cstr ~version:None %>
+              <% ); %>
+          </ol>
+          <%s! render_section_heading ~title:(title_with_number "Development Dependencies" (List.length dev_dependencies)) %>
+          <ol class="grid xl:grid-cols-2">
+              <%s if List.length dev_dependencies = 0 then "None" else "" %>
+              <% dev_dependencies |> List.iter (fun (name, cstr) -> %>
               <%s! render_dependency ~name ~cstr ~version:None %>
               <% ); %>
           </ol>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -435,6 +435,11 @@ let package_overview t kind req =
     package_info.Ocamlorg_package.Info.dependencies
     |> List.map (fun (name, x) -> (Ocamlorg_package.Name.to_string name, x))
   in
+  let dev_dependencies, dependencies =
+    dependencies
+    |> List.partition (fun (_, x) ->
+           String.contains_s (Option.value ~default:"" x) "with-")
+  in
   let conflicts =
     package_info.Ocamlorg_package.Info.conflicts
     |> List.map (fun (name, x) -> (Ocamlorg_package.Name.to_string name, x))
@@ -442,8 +447,8 @@ let package_overview t kind req =
 
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content:""
-       ~content_title:None ~dependencies ~rev_dependencies ~conflicts
-       frontend_package)
+       ~content_title:None ~dependencies ~dev_dependencies ~rev_dependencies
+       ~conflicts frontend_package)
 
 let package_documentation t kind req =
   let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
@@ -582,6 +587,7 @@ let package_file t kind req =
 
   let rev_dependencies = [] in
   let dependencies = [] in
+  let dev_dependencies = [] in
   let conflicts = [] in
 
   let* content =
@@ -594,5 +600,5 @@ let package_file t kind req =
   let</>? content = content in
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content
-       ~content_title:(Some path) ~dependencies ~rev_dependencies ~conflicts
-       frontend_package)
+       ~content_title:(Some path) ~dependencies ~dev_dependencies
+       ~rev_dependencies ~conflicts frontend_package)

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -438,7 +438,8 @@ let package_overview t kind req =
   let dev_dependencies, dependencies =
     dependencies
     |> List.partition (fun (_, x) ->
-           String.contains_s (Option.value ~default:"" x) "with-")
+           let s = Option.value ~default:"" x in
+           String.contains_s s "with-" || String.contains_s s "dev")
   in
   let conflicts =
     package_info.Ocamlorg_package.Info.conflicts


### PR DESCRIPTION
* split dependencies in development dependencies (anything depending `with-test`, `with-doc`, etc) and regular dependencies

100% not sure if the logic of checking for a substring `"with-"` here is correct.

|before|after|
|-|-|
|![Screenshot 2023-03-22 at 18-06-55 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226983183-387abdcb-8f6e-4814-b406-183574d7d09f.png)|![Screenshot 2023-03-22 at 18-06-59 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/226983190-89c952f8-87f6-45aa-82f3-373d6046ebc4.png)|
