### PR TITLE
Remove duplicate doc.css anchor target styles, adjust hover styles

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -20,44 +20,7 @@ div.odoc div.spec code {
   white-space: pre-wrap;
 }
 
-/* clickable anchors with targets and code highlighting of targeted specs */
-
-div.odoc h1,
-div.odoc h2,
-div.odoc h3,
-div.odoc h4,
-div.odoc h5,
-div.odoc h6 {
-  position:relative;
-}
-
-div.odoc h1 a.anchor,
-div.odoc h2 a.anchor,
-div.odoc h3 a.anchor,
-div.odoc h4 a.anchor,
-div.odoc h5 a.anchor,
-div.odoc h6 a.anchor {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top:0;
-  bottom:0;
-  opacity: 0;
-  text-decoration: none;
-  color: rgb(156 163 175);
-  box-shadow: none;
-}
-
-div.odoc h1 a.anchor::after,
-div.odoc h2 a.anchor::after,
-div.odoc h3 a.anchor::after,
-div.odoc h4 a.anchor::after,
-div.odoc h5 a.anchor::after,
-div.odoc h6 a.anchor::after {
-  content: "#";
-  margin-left: -1.2em;
-  padding: 0.4em;
-}
+/* clickable anchors and highlighting of targeted .spec elements */
 
 div.odoc .spec {
   position: relative;

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -127,13 +127,8 @@ body {
 }
 
 .prose :is(h1, h2, h3, h4, h5, h6)[id]:hover::before {
-  content: "#";
-  position: absolute;
-  color: rgb(90, 98, 111);
-  margin-left: -1.2em;
-  padding: 0.39em;
-  margin-top: -.37em;
-  font-weight: 500;
+  content: " ";
+  @apply absolute top-0 h-full border-l-4 border-gray-400 -ml-3;
 }
 
 .prose :is(h1, h2, h3, h4, h5, h6) > a.anchor {


### PR DESCRIPTION
Since `.prose` is applied to the odoc output in the package documentation section, hover styles for the anchor elements in the headings were applied twice since #628. This patch removes the anchor target styles in `doc.css`, so that only one set of anchor target styles is applied.

Patch also changes the style of the hover effect because the `#` symbol would, on small screens, and when there are no sufficient margins, be cut off.

|before|after|
|-|-|
|![Screenshot from 2023-03-27 12-34-26](https://user-images.githubusercontent.com/6594573/227918302-5af7765e-1272-4769-870c-18420f166d10.png)|![Screenshot from 2023-03-27 12-34-33](https://user-images.githubusercontent.com/6594573/227918308-95eb1113-1486-49ef-a0a3-5d36c8a2e99c.png)|
| `#` is cut off at the edge of the browser window. In package docs, two `#` are rendered on hover| hover effect now requires just a very small margin and is applied only via `.prose`|