### PR TITLE
Unify package overview and documentation layout

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -7,6 +7,9 @@ let render
 ?hash
 ?page
 ~(package : Package.package)
+~(documentation_status: Package.documentation_status)
+~left_sidebar_html
+~right_sidebar_html
 inner =
 Layout.render
 ?styles
@@ -19,12 +22,70 @@ Layout.render
   <div class="py-5 lg:py-6">
     <div class="container-fluid">
       <div class="flex justify-between flex-col md:flex-row">
-        <div class="flex flex-col items-baseline mb-6">
+        <div class="flex flex-col items-baseline">
           <%s! Package_breadcrumbs.render ~path ?hash ?page package %>
         </div>
       </div>
-      <div class="py-6">
-        <%s! inner %>
+      <div x-data="{ open: false, sidebar: window.innerWidth >= 768 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 768" x-on:close-sidebar="sidebar=window.innerWidth >= 768 && true">
+        <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed md:hidden right-10"
+        x-on:click="sidebar = ! sidebar">
+          <%s! Icons.sidebar_menu "h-8 w-8" %>
+          <span class="hidden md:flex font-semibold px-2">side menu</span>
+        </button>
+        <div class="fixed z-10 inset-0 bg-background-dark-blue/20 backdrop-blur-sm md:hidden"
+          :class='sidebar ? "" : "hidden"' aria-hidden="true" x-on:click="sidebar = ! sidebar">
+        </div>
+
+        <div class="flex gap-4 xl:gap-8 flex-col md:flex-row mt-6">
+          <ol class="flex w-full md:w-60 lg:w-72 flex-shrink-0">
+            <li class="flex flex-auto">
+              <a class="w-full h-10 flex justify-center rounded-l-lg p-1 items-center font-semibold border border-r-0 border-primary-700 <%s (match path with | Overview _ -> "bg-primary-700 text-white" | _ -> "text-primary-700")%>" href="<%s Url.Package.overview package.name ?version:(Package.url_version package) %>">About</a>
+            </li>
+              <% (match documentation_status with
+              | Success -> %>
+              <li class="flex flex-auto">
+                <a class="w-full h-10 flex justify-center rounded-r-lg p-1 items-center font-semibold border border-l-0  border-primary-700 <%s (match path with | Documentation _ -> "bg-primary-700 text-white" | _ -> "text-primary-700")%>" href="<%s Url.Package.documentation package.name ?version:(Package.url_version package) %>">Docs</a>
+              </li>
+              <% | Unknown -> ( %>
+              <li class="flex flex-auto">
+                <a title="Documentation status is unknown" class="w-full h-10 flex justify-center gap-2 rounded-r-lg p-1 items-center font-semibold border border-l-0 border-gray-400 <%s (match path with | Documentation _ -> "bg-primary-700 text-white" | _ -> "text-gray-500 bg-background-default")%>" href="<%s Url.Package.documentation package.name ?version:(Package.url_version package) %>"><%s! Icons.error "" %> No Docs</a>
+              </li>
+              <% )
+              | Failure -> ( %>
+              <li class="flex flex-auto">
+                <a title="Documentation failed to build!" class="w-full h-10 flex justify-center gap-2 rounded-r-lg p-1 items-center font-semibold border border-l-0  border-gray-400 <%s (match path with | Documentation _ -> "bg-primary-700 text-white" | _ -> "text-gray-500 bg-background-default")%>" href="<%s Url.Package.documentation package.name ?version:(Package.url_version package) %>"><%s! Icons.error "" %> No Docs</a>
+              </li>
+              <% ));%>
+            </li>
+          </ol>
+
+          <div title="Sorry, in-package search is not yet implemented, but this is where it's going to appear." class="flex w-full items-center">
+            <input disabled type="search" name="q" class="focus:border-gray-800 text-gray-800 bg-gray-300 border-gray-300 h-10 rounded-l-md appearance-none px-4 flex-grow"
+              autocomplete="off"
+              placeholder="Sorry, in-package search is not yet implemented, but this is where it's going to appear :-)">
+            <button disabled aria-label="search" class="h-10 rounded-r-md bg-gray-300 text-gray-800 flex items-center justify-center px-4">
+              <%s! Icons.magnifying_glass "w-6 h-6" %>
+            </button>
+          </div>
+        </div>
+
+        <div class="flex md:gap-4 xl:gap-8">
+          <div
+            class="p-10 z-20 bg-white flex-col fixed h-screen overflow-auto md:flex left-0 top-0 md:sticky w-80 md:w-60 lg:w-72 md:p-0 md:pt-6"
+            x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
+            x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
+            x-transition:leave-end="-translate-x-full">
+            <%s! left_sidebar_html %>
+          </div>
+          <div class="flex-1 z-0 z- min-w-0 pt-6">
+            <%s! inner %>
+          </div>
+          <% (if right_sidebar_html <> "" then %>
+          <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto">
+            <%s! right_sidebar_html %>
+          </div>
+          <% ); %>
+        </div>
       </div>
     </div>
   </div>

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -39,7 +39,7 @@ Layout.render
         <div class="flex gap-4 xl:gap-8 flex-col md:flex-row mt-6">
           <ol class="flex w-full md:w-60 lg:w-72 flex-shrink-0">
             <li class="flex flex-auto">
-              <a class="w-full h-10 flex justify-center rounded-l-lg p-1 items-center font-semibold border border-r-0 border-primary-700 <%s (match path with | Overview _ -> "bg-primary-700 text-white" | _ -> "text-primary-700")%>" href="<%s Url.Package.overview package.name ?version:(Package.url_version package) %>">About</a>
+              <a class="w-full h-10 flex justify-center rounded-l-lg p-1 items-center font-semibold border border-r-0 border-primary-700 <%s (match path with | Overview _ -> "bg-primary-700 text-white" | _ -> "text-primary-700")%>" href="<%s Url.Package.overview package.name ?version:(Package.url_version package) %>">Overview</a>
             </li>
               <% (match documentation_status with
               | Success -> %>

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -16,6 +16,13 @@ let sidebar
     </div>
   </div>
 
+let right_sidebar
+~toc
+=
+  <div class="pt-6" id="htmx-right-sidebar">
+    <%s! Toc.render toc %>
+  </div>
+
 let render
 ~(path: Package_breadcrumbs.path)
 ~page
@@ -44,33 +51,14 @@ Package_layout.render
 ~package
 ~path
 ?page
+~documentation_status:Success
 ~canonical:(Url.Package.documentation package.name ~version:(Package.specific_version package) ~page:(Url.Package.documentation ?version:(Some (Package.specific_version package)) package.name))
-~styles:["css/main.css"; "css/doc.css"] @@
-<div x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024" x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
-  <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
-    x-on:click="sidebar = ! sidebar">
-    <%s! Icons.sidebar_menu "h-8 w-8" %>
-    <span class="hidden md:flex font-semibold px-2">side menu</span>
-  </button>
-  <div class="fixed z-10 inset-0 bg-background-dark-blue/20 backdrop-blur-sm lg:hidden"
-    :class='sidebar ? "" : "hidden"' aria-hidden="true" x-on:click="sidebar = ! sidebar">
-  </div>
-  <div class="flex flex-col lg:flex-row md:gap-12">
-    <div
-      class="p-10 z-20 bg-white flex-col fixed h-screen overflow-auto lg:pr-0 lg:flex left-0 top-0 lg:sticky w-72 lg:p-0 lg:pt-6"
-      x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
-      x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
-      x-transition:leave-end="-translate-x-full">
-      <%s! sidebar ~str_path ~toc ~maptoc package %>
-    </div>
-    <div class="flex-1 z-0 z- min-w-0 lg:max-w-3xl lg:pt-6" id="htmx-content">
-      <div class="odoc prose prose-orange">
-        <%s! content %>
-      </div>
-    </div>
-    <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto right-sidebar" id="htmx-right-sidebar">
-      <%s! Toc.render toc %>
-    </div>
+~styles:["css/main.css"; "css/doc.css"]
+~left_sidebar_html:(sidebar ~str_path ~toc ~maptoc package)
+~right_sidebar_html:(right_sidebar ~toc) @@
+<div id="htmx-content">
+  <div class="odoc prose prose-orange">
+    <%s! content %>
   </div>
 </div>
 <script>

--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -9,7 +9,10 @@ Package_layout.render
 ~package
 ~path
 ?page
-~styles:["/css/main.css"; "/css/doc.css"] @@
+~documentation_status:Success
+~styles:["/css/main.css"; "/css/doc.css"]
+~left_sidebar_html:""
+~right_sidebar_html:"" @@
   let version = Package.url_version package in
   <div class="sm:flex max-w-max mx-auto">
     <p class="text-4xl font-extrabold text-orange-600 sm:text-5xl">404</p>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -13,30 +13,12 @@ type sidebar_data = {
   license_filename : string option;
 }
 
-let render
+let sidebar
 ~(sidebar_data: sidebar_data)
-~content
-~content_title
-~dependencies
-~dev_dependencies
-~rev_dependencies
-~conflicts
-(package : Package.package) =
-let render_dependency ~version ~name ~cstr =
-  <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
-    <a href="<%s Url.Package.overview name ?version %>" class="text-primary-600 hover:underline">
-      <%s name %>
-    </a>
-    <% match cstr with None -> () | Some cstr -> %>
-      <code class="text-gray-700 font-medium"><%s cstr %></code>
-    <% ; %>
-  </li>
-in
-let render_section_heading ~title =
-  <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
-    <h2 class="text-xl font-medium my-2"><%s title %></h2>
-  </div>
-in
+~specific_version
+~version
+(package: Package.package)
+=
 let render_user_avatar ~x_show (user: Ood.Opam_user.t) =
   <li class="flex justify-start" <%s! if x_show then "x-show='open'" else "" %>>
     <a href="<%s Url.packages_search %>?q=author%3A%22<%s Dream.to_percent_encoded user.name %>%22" class="flex items-center gap-3">
@@ -63,6 +45,115 @@ let render_user_list (users: Ood.Opam_user.t list) =
     <% ) else (); %>
   </div>
 in
+  <div class="text-base text-body-400 mb-6">
+    <%s package.synopsis %>
+  </div>
+
+  <h2 class="inline-flex items-center text-lg font-medium text-gray-900">
+      <%s! Icons.command_line "mr-4 h-6 w-6 text-orange-600" %>
+      Install
+  </h2>
+
+  <div class="max-w-md" x-data="{ copied: false }">
+      <div class="mt-1 flex rounded-md shadow-sm">
+          <div class="relative flex items-stretch flex-grow focus-within:z-10">
+              <input type="text"
+                  class="focus:ring-orange-500 focus:border-orange-500 block w-full rounded-none rounded-l-md bg-gray-800 text-gray-100 text-sm font-mono subpixel-antialiased border-gray-700"
+                  value="opam install <%s package.name %>.<%s specific_version %>">
+          </div>
+          <div role="button" title="Copy to clipboard"
+              class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-700 text-sm font-medium rounded-r-md text-gray-100 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
+              @click="$clipboard('opam install <%s package.name %>.<%s specific_version %>'); copied = true; setTimeout(() => copied = false, 2000)"
+              :class="{ 'border-gray-700': !copied, 'text-gray-100': !copied, 'focus:ring-orange-500': !copied, 'focus:border-orange-500': !copied, 'border-green-600': copied, 'text-green-600': copied, 'focus:ring-green-500': copied, 'focus:border-green-500': copied }">
+              <div x-show="!copied" class="h-6 w-6">
+                <%s! Icons.copy_to_clipboard "h-6 w-6" %>
+              </div>
+              <div x-show="copied" class="h-6 w-6">
+                <%s! Icons.copied_to_clipboard "h-6 w-6" %>
+              </div>
+          </div>
+      </div>
+  </div>
+  <div class="flex flex-col mt-8 text-body-400">
+      <% package.homepages |> List.iter (fun homepage -> %>
+      <%s! side_box_link ~icon_html:(Icons.package_homepage "h-4 w-4 mr-2 inline-block") ~href:homepage ~title:(Utils.host_of_uri homepage) %>
+      <% ); %>
+      <% (match sidebar_data.readme_filename with Some readme_filename -> %>
+      <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.Package.file package.name ?version ~filepath:(readme_filename ^ ".html")) ~title:"Readme" %>
+      <% | _ -> ()); %>
+      <% (match sidebar_data.changes_filename with Some changes_filename -> %>
+      <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.Package.file package.name ?version ~filepath:(changes_filename ^ ".html")) ~title:"Changelog" %>
+      <% | _ -> ()); %>
+      <% (match sidebar_data.license_filename with Some license_filename -> %>
+      <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.Package.file package.name ?version ~filepath:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
+      <% | _ -> ()); %>
+      <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name specific_version) ~title:"Edit opam file" %>
+  </div>
+
+  <h2 class="mt-8 font-semibold text-base text-body-400">Authors</h2>
+  <%s! render_user_list package.authors %>
+
+  <h2 class="mt-8 font-semibold text-base text-body-400">Maintainers</h2>
+  <%s! render_user_list package.maintainers %>
+
+  <% match package.source with
+  | None -> ()
+  | Some (uri, checksums) -> %>
+  <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Sources</h2>
+  <div class="flex flex-col space-y-2">
+    <a class="flex font-mono items-center gap-4 text-body-700 hover:text-primary-600 overflow-hidden rounded"
+        href="<%s uri %>">
+      <span class="flex-grow">
+        <%s Filename.basename uri %>
+      </span>
+
+      <div class="p-1 bg-primary-600 text-white rounded">
+          <%s! Icons.download "h-6 w-6" %>
+      </div>
+    </a>
+
+    <% checksums |> List.iter begin fun checksum -> %>
+    <div class="flex items-center gap-4 bg-primary-200 text-gray-700 rounded"
+      x-data="{ copied: false }">
+      <code class="px-4 text-ellipsis overflow-hidden min-w-0" aria-label="checksum"><%s String.trim checksum %></code>
+
+      <button
+        @click="$clipboard('<%s checksum %>'); copied = true; setTimeout(() => copied = false, 2000)"
+        x-show="!copied" title="copy checksum to clipboard" class="p-1 text-primary-600 rounded">
+          <%s! Icons.copy "h-6 w-6" %>
+      </button>
+      <button x-show="copied" title="checksum copied to clipboard" class="p-1 text-primary-600 rounded">
+          <%s! Icons.copied_to_clipboard "h-6 w-6" %>
+      </button>
+    </div>
+    <% end; %>
+  </div>
+  <% ; %>
+
+let render
+~(sidebar_data: sidebar_data)
+~content
+~content_title
+~dependencies
+~dev_dependencies
+~rev_dependencies
+~conflicts
+(package : Package.package) =
+let render_dependency ~version ~name ~cstr =
+  <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
+    <a href="<%s Url.Package.overview name ?version %>" class="text-primary-600 hover:underline">
+      <%s name %>
+    </a>
+    <% match cstr with None -> () | Some cstr -> %>
+      <code class="text-gray-700 font-medium"><%s cstr %></code>
+    <% ; %>
+  </li>
+in
+let render_section_heading ~title =
+  <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
+    <h2 class="text-xl font-medium my-2"><%s title %></h2>
+  </div>
+in
 let title_with_number title number =
   title ^ if number > 0 then " (" ^ string_of_int number ^ ")" else ""
 in
@@ -73,9 +164,12 @@ Package_layout.render
 ~description:(Printf.sprintf "%s %s: %s" package.name (Package.render_version package) package.synopsis)
 ~canonical:(Url.Package.overview package.name ~version:specific_version)
 ~package
-~path:(Overview content_title) @@
+~documentation_status:sidebar_data.documentation_status
+~path:(Overview content_title)
+~left_sidebar_html:(sidebar ~sidebar_data ~specific_version ~version package)
+~right_sidebar_html:"" @@
 <div class="flex md:gap-6 xl:gap-12 flex-col md:flex-row justify-between">
-    <div class="flex-1 w-full xl:w-1/2 max-w-full">
+    <div class="flex-1 max-w-full">
       <% (match content_title with | None -> %>
       <div class="p-4 prose max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
         <h2 class="mb-4 mt-0 text-xl font-semibold uppercase">Description</h2>
@@ -101,28 +195,28 @@ Package_layout.render
       <div class="border-l-2 border-gray-200 px-4 space-y-6">
         <div class="mx-[-2px]">
           <%s! render_section_heading ~title:(title_with_number "Dependencies" (List.length dependencies)) %>
-          <ol class="grid xl:grid-cols-2">
+          <ol class="grid lg:grid-cols-2">
               <%s if List.length dependencies = 0 then "None" else "" %>
               <% dependencies |> List.iter (fun (name, cstr) -> %>
               <%s! render_dependency ~name ~cstr ~version:None %>
               <% ); %>
           </ol>
           <%s! render_section_heading ~title:(title_with_number "Development Dependencies" (List.length dev_dependencies)) %>
-          <ol class="grid xl:grid-cols-2">
+          <ol class="grid lg:grid-cols-2">
               <%s if List.length dev_dependencies = 0 then "None" else "" %>
               <% dev_dependencies |> List.iter (fun (name, cstr) -> %>
               <%s! render_dependency ~name ~cstr ~version:None %>
               <% ); %>
           </ol>
           <%s! render_section_heading ~title:(title_with_number "Reverse Dependencies" (List.length rev_dependencies)) %>
-          <ol class="grid xl:grid-cols-2 max-h-96 overflow-auto">
+          <ol class="grid lg:grid-cols-2 max-h-96 overflow-auto">
               <%s if List.length rev_dependencies = 0 then "None" else "" %>
               <% rev_dependencies |> List.iter (fun (name, cstr, version) -> %>
               <%s! render_dependency ~name ~cstr ~version:(Some version) %>
               <% ); %>
           </ol>
           <%s! render_section_heading ~title:(title_with_number "Conflicts" (List.length conflicts)) %>
-          <ol class="grid xl:grid-cols-2 max-h-96 overflow-auto">
+          <ol class="grid lg:grid-cols-2 max-h-96 overflow-auto">
               <%s if List.length conflicts = 0 then "None" else "" %>
               <% conflicts |> List.iter (fun (name, cstr) -> %>
               <%s! render_dependency ~name ~cstr ~version:None %>
@@ -140,108 +234,6 @@ Package_layout.render
         </div>
       </div>
       <% ); %>
-    </div>
-    <div class="order-first text-sm md:w-60 lg:w-72">
-        <div class="text-base text-body-400 mb-6">
-          <%s package.synopsis %>
-        </div>
-
-        <h2 class="inline-flex items-center text-lg font-medium text-gray-900">
-            <%s! Icons.command_line "mr-4 h-6 w-6 text-orange-600" %>
-            Install
-        </h2>
-
-        <div class="max-w-md" x-data="{ copied: false }">
-            <div class="mt-1 flex rounded-md shadow-sm">
-                <div class="relative flex items-stretch flex-grow focus-within:z-10">
-                    <input type="text"
-                        class="focus:ring-orange-500 focus:border-orange-500 block w-full rounded-none rounded-l-md bg-gray-800 text-gray-100 text-sm font-mono subpixel-antialiased border-gray-700"
-                        value="opam install <%s package.name %>.<%s specific_version %>">
-                </div>
-                <div role="button" title="Copy to clipboard"
-                    class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-700 text-sm font-medium rounded-r-md text-gray-100 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500"
-                    @click="$clipboard('opam install <%s package.name %>.<%s specific_version %>'); copied = true; setTimeout(() => copied = false, 2000)"
-                    :class="{ 'border-gray-700': !copied, 'text-gray-100': !copied, 'focus:ring-orange-500': !copied, 'focus:border-orange-500': !copied, 'border-green-600': copied, 'text-green-600': copied, 'focus:ring-green-500': copied, 'focus:border-green-500': copied }">
-                    <div x-show="!copied" class="h-6 w-6">
-                      <%s! Icons.copy_to_clipboard "h-6 w-6" %>
-                    </div>
-                    <div x-show="copied" class="h-6 w-6">
-                      <%s! Icons.copied_to_clipboard "h-6 w-6" %>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="flex flex-col mt-8 text-body-400">
-            <% (match sidebar_data.documentation_status with
-            | Success -> %>
-            <a href="<%s Url.Package.documentation package.name ?version %>" class="px-4 h-10 items-center mb-2 rounded-md bg-primary-600 text-white flex font-bold hover:underline">
-              <%s! Icons.documentation "w-6 h-6 mr-2 inline-block" %>
-              Documentation
-            </a>
-            <% | Unknown -> ( %>
-            <a href="<%s Url.Package.documentation package.name ?version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
-              <%s! Icons.error "" %>
-              Documentation status is unknown.
-            </a><% )
-            | Failure -> ( %>
-            <a href="<%s Url.Package.documentation package.name ?version %>" class="p-4 mb-2 flex gap-x-2 bg-background-default text-gray-600 font-semibold text-base">
-              <%s! Icons.error "" %>
-              Documentation failed to build.
-            </a><% ));%>
-            <% package.homepages |> List.iter (fun homepage -> %>
-            <%s! side_box_link ~icon_html:(Icons.package_homepage "h-4 w-4 mr-2 inline-block") ~href:homepage ~title:(Utils.host_of_uri homepage) %>
-            <% ); %>
-            <% (match sidebar_data.readme_filename with Some readme_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.Package.file package.name ?version ~filepath:(readme_filename ^ ".html")) ~title:"Readme" %>
-            <% | _ -> ()); %>
-            <% (match sidebar_data.changes_filename with Some changes_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.changelog "h-4 w-4 mr-2 inline-block") ~href:(Url.Package.file package.name ?version ~filepath:(changes_filename ^ ".html")) ~title:"Changelog" %>
-            <% | _ -> ()); %>
-            <% (match sidebar_data.license_filename with Some license_filename -> %>
-            <%s! side_box_link ~icon_html:(Icons.license "h-4 w-4 mr-2 inline-block") ~href:(Url.Package.file package.name ?version ~filepath:(license_filename ^ ".html")) ~title:( package.license ^ " License") %>
-            <% | _ -> ()); %>
-            <%s! side_box_link ~icon_html:(Icons.edit "h-4 w-4 mr-2 inline-block") ~href:(Url.github_opam_file package.name specific_version) ~title:"Edit opam file" %>
-        </div>
-
-        <h2 class="mt-8 font-semibold text-base text-body-400">Authors</h2>
-        <%s! render_user_list package.authors %>
-
-        <h2 class="mt-8 font-semibold text-base text-body-400">Maintainers</h2>
-        <%s! render_user_list package.maintainers %>
-
-        <% match package.source with
-        | None -> ()
-        | Some (uri, checksums) -> %>
-        <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Sources</h2>
-        <div class="flex flex-col space-y-2">
-          <a class="flex font-mono items-center gap-4 text-body-700 hover:text-primary-600 overflow-hidden rounded"
-             href="<%s uri %>">
-            <span class="flex-grow">
-              <%s Filename.basename uri %>
-            </span>
-
-            <div class="p-1 bg-primary-600 text-white rounded">
-                <%s! Icons.download "h-6 w-6" %>
-            </div>
-          </a>
-
-          <% checksums |> List.iter begin fun checksum -> %>
-          <div class="flex items-center gap-4 bg-primary-200 text-gray-700 rounded"
-            x-data="{ copied: false }">
-            <code class="px-4 text-ellipsis overflow-hidden min-w-0" aria-label="checksum"><%s String.trim checksum %></code>
-
-            <button
-              @click="$clipboard('<%s checksum %>'); copied = true; setTimeout(() => copied = false, 2000)"
-              x-show="!copied" title="copy checksum to clipboard" class="p-1 text-primary-600 rounded">
-                <%s! Icons.copy "h-6 w-6" %>
-            </button>
-            <button x-show="copied" title="checksum copied to clipboard" class="p-1 text-primary-600 rounded">
-                <%s! Icons.copied_to_clipboard "h-6 w-6" %>
-            </button>
-          </div>
-          <% end; %>
-        </div>
-        <% ; %>
     </div>
 </div>
 <script>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -74,7 +74,7 @@ in
           </div>
       </div>
   </div>
-  <div class="flex flex-col mt-8 text-body-400">
+  <div class="flex flex-col mt-8 text-sm text-body-400">
       <% package.homepages |> List.iter (fun homepage -> %>
       <%s! side_box_link ~icon_html:(Icons.package_homepage "h-4 w-4 mr-2 inline-block") ~href:homepage ~title:(Utils.host_of_uri homepage) %>
       <% ); %>
@@ -100,7 +100,7 @@ in
   | None -> ()
   | Some (uri, checksums) -> %>
   <h2 class="font-semibold mt-8 mb-3 text-base text-body-400">Sources</h2>
-  <div class="flex flex-col space-y-2">
+  <div class="flex flex-col space-y-2 text-sm">
     <a class="flex font-mono items-center gap-4 text-body-700 hover:text-primary-600 overflow-hidden rounded"
         href="<%s uri %>">
       <span class="flex-grow">


### PR DESCRIPTION
Rearranges package overview and documentation such that:
* `package_layout.eml` defines the two sidebars and the content area
* there is a navigation element to switch between Overview (About) and Documentation (Docs)
* there is a placeholder element for the upcoming in-package search (to remind us how important this feature is and to show users that we have a plan where it goes)

Consequences:
* package overview page now has a collapsing sidebar with a button to slide it in on small screens
* package documentation now has a tablet (`md`) layout that shows the sidebar on-screen, instead of collapsed

|page|before|after|
|-|-|-|
|docs xl| ![Screenshot 2023-03-27 at 15-30-33 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227952427-601aab12-73eb-49e0-87a4-6bb1b8f94b4c.png)|![Screenshot 2023-03-27 at 15-30-37 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227952441-45e30c35-4da1-42c2-a922-a019ef3be958.png)|
| docs lg |![Screenshot 2023-03-27 at 15-31-49 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227952781-b29696d0-12b1-42cc-9e82-4d8688b21da2.png)|![Screenshot 2023-03-27 at 15-31-56 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227952809-3c25b12d-3de0-4084-86b8-b70f3142aefb.png)|
| docs md | ![Screenshot 2023-03-27 at 15-32-38 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227953030-b2cbe825-9f87-4ead-9f45-a2a0a8c7f85e.png)|![Screenshot 2023-03-27 at 15-32-43 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227953054-7bfb9edc-ea0a-4fd0-a6a9-39455deefea9.png)|
| docs sm |![Screenshot 2023-03-27 at 15-33-34 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227953356-8ebecefe-d120-4234-a084-ea375cf0d111.png)|![Screenshot 2023-03-27 at 15-33-43 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227953375-d35bd033-30a8-4fd3-9509-ae2da096d64b.png)|
|-|-|-|
| overview xl |![Screenshot 2023-03-27 at 16-00-59 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227963402-788a4d74-0ca6-49c6-9934-189d9fc8e509.png)|![Screenshot 2023-03-27 at 16-01-05 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227963411-cde5bb26-4a76-4a8a-8fd1-6e39b3a7820f.png)|
| overview lg with docs fail | ![Screenshot 2023-03-27 at 16-06-42 ocaml-base-compiler 5 0 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227963628-3c1159f8-1bb0-4563-bba6-faadff7392b6.png)|![Screenshot 2023-03-27 at 16-06-45 ocaml-base-compiler 5 0 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227963642-c3210121-9a15-4713-8086-8649a5283811.png)|
| overview md |![Screenshot 2023-03-27 at 16-07-43 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227963901-c559b7c7-ac15-4c17-9d73-faa5c8b6c18b.png)|![Screenshot 2023-03-27 at 16-07-46 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227963920-2d6496a9-e3f9-400a-a28d-fc6f08b7cc66.png)|
|overview sm| ![Screenshot 2023-03-27 at 15-46-52 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227957599-c31a161d-6425-49e2-afc6-31a1b20d1efa.png)|![Screenshot 2023-03-27 at 15-46-57 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/227957610-08d12443-18cb-44eb-994d-6fce995a38cd.png)|


Note: on the `sm` version of package overview, the "install" sidebar slides in on menu button tap, that's why we can see the content area after this patch. ETA: Claire has prepared a dedicated layout for the `sm` screen, so not too much emphasis needs to be put on this one here.

Note: docs failure has a `title` tooltip:
![Screenshot from 2023-03-27 15-52-00](https://user-images.githubusercontent.com/6594573/227959415-838995ad-2d62-4177-a88b-f3c11fdad27a.png)
