### PR TITLE
Use pinned opam repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ deps: ## Install development dependencies
 
 .PHONY: pin_repo
 pin_repo: ## Pin Opam repository
-	opam repository add ocamlorg git+https://github.com/ocaml/opam-repository#b457e9f3d6 --this-switch
-	opam repository remove default --this-switch
+	opam repository add set-url git+https://github.com/ocaml/opam-repository#b457e9f3d6 --this-switch
 
 .PHONY: create_switch
 create_switch:

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,19 @@ all:
 .PHONY: deps
 deps: ## Install development dependencies
 	opam install -y ocamlformat=0.24.1 ocaml-lsp-server
-	opam install --deps-only --with-test --with-doc -y .
+	opam install -y --deps-only --with-test --with-doc .
+
+.PHONY: pin_repo
+pin_repo: ## Pin Opam repository
+	opam repository add ocamlorg git+https://github.com/ocaml/opam-repository#b457e9f3d6 --this-switch
+	opam repository remove default --this-switch
 
 .PHONY: create_switch
 create_switch:
 	opam switch create . 4.14.0 --no-install
 
 .PHONY: switch
-switch: create_switch deps ## Create an opam switch and install development dependencies
+switch: create_switch pin_repo deps ## Create an opam switch and install development dependencies
 
 .PHONY: lock
 lock: ## Generate a lock file


### PR DESCRIPTION
Use a this-switch only opam repository pinned at the same commit hash as in the Dockerfile:

```
opam repository add ocamlorg git+https://github.com/ocaml/opam-repository#b457e9f3d6 --this-switch
```

Using a fresh clone on one side and the docker build container on the other here is the difference I observe between `opam list -i --columns=name,version"

```
                               > alcotest             1.6.0
                               > chrome-trace         3.6.1
                               > dune-rpc             3.6.1
                               > dyn                  3.6.1
                               > either               1.0.0
                               > fiber                3.6.1
                               > fix                  20220121
                               > mdx                  2.1.0
ocaml                4.14.1    | ocaml                4.14.0
ocaml-base-compiler  4.14.1    | ocaml-base-compiler  4.14.0
                               > ocaml-version        3.5.0
                               > ocamlc-loc           3.6.1
                               > ocamlformat          0.24.1
                               > ocamlformat-rpc-lib  0.24.1
                               > ocp-indent           1.8.1
                               > octavius             1.2.2
                               > odoc                 2.2.0
                               > odoc-parser          2.0.0
opam-depext          1.2.1-1   <
                               > ordering             3.6.1
                               > pp                   1.1.2
                               > ppx_yojson_conv_lib  v0.15.0
                               > spawn                v0.15.1
                               > stdune               3.6.1
                               > tyxml                4.5.0
                               > uucp                 15.0.0
                               > uuseg                15.0.0
                               > xdg                  3.6.1
```

Update:
* In this set-up, doing `opam update` is a noop.
* This is inspired by: https://github.com/ocaml/opam/issues/5274#issuecomment-1252678482