### PR TITLE
Table of contents on package overview pages

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -10,26 +10,26 @@ let render (t : t) =
   <div>
     <% (match t with [] ->  %>
     <% | _ -> %>
-    <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
-    <ul class="leading-6 space-y-3 text-sm">
+    <div class="font-semibold text-gray-500 text-sm mb-4">On This Page</div>
+    <ol class="leading-6 space-y-3 text-sm">
       <% t |> List.iter begin fun item -> %>
         <li>
-          <a href="<%s item.href %>" class="font-semibold text-gray-900 py-1 md:p-0 block transition-colors hover:text-orange-600">
+          <a href="<%s item.href %>" class="font-normal text-gray-900 py-1 md:p-0 block transition-colors hover:text-orange-600">
             <%s! item.title %>
           </a>
             <% match item.children with [] -> () | items -> %>
-            <ul>
+            <ol>
               <% items |> List.iter begin fun item -> %>
-              <li class="ml-4">
-                <a href="<%s item.href %>" class="font-regular text-body-600 py-1 md:p-0 block transition-colors hover:text-orange-600">
+              <li class="ml-2">
+                <a href="<%s item.href %>" class="font-normal text-body-600 py-1 md:p-0 block transition-colors hover:text-orange-600">
                   <%s! item.title %>
                 </a>
               </li>
               <% end; %>
-            </ul>
+            </ol>
             <% ; %>
           <% end; %>
         </li>
-    </ul>
+    </ol>
     <% ); %>
   </div>

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -81,7 +81,7 @@ Layout.render
             <%s! inner %>
           </div>
           <% (if right_sidebar_html <> "" then %>
-          <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto">
+          <div class="hidden xl:flex top-0 sticky h-screen flex-col w-52 overflow-auto">
             <%s! right_sidebar_html %>
           </div>
           <% ); %>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -130,10 +130,18 @@ in
   </div>
   <% ; %>
 
+let right_sidebar
+~toc
+=
+  <div class="pt-6">
+    <%s! Toc.render toc %>
+  </div>
+
 let render
 ~(sidebar_data: sidebar_data)
 ~content
 ~content_title
+~toc
 ~dependencies
 ~dev_dependencies
 ~rev_dependencies
@@ -167,7 +175,7 @@ Package_layout.render
 ~documentation_status:sidebar_data.documentation_status
 ~path:(Overview content_title)
 ~left_sidebar_html:(sidebar ~sidebar_data ~specific_version ~version package)
-~right_sidebar_html:"" @@
+~right_sidebar_html:(right_sidebar ~toc) @@
 <div class="flex md:gap-6 xl:gap-12 flex-col md:flex-row justify-between">
     <div class="flex-1 max-w-full">
       <% (match content_title with | None -> %>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -130,6 +130,18 @@ in
   </div>
   <% ; %>
 
+type dependency_or_conflict = {
+  name: string;
+  cstr: string option;
+  version: string option;
+}
+
+type dependencies_and_conflicts = {
+  title: string;
+  slug: string;
+  items: dependency_or_conflict list;
+}
+
 let right_sidebar
 ~toc
 =
@@ -142,12 +154,9 @@ let render
 ~content
 ~content_title
 ~toc
-~dependencies
-~dev_dependencies
-~rev_dependencies
-~conflicts
+~(deps_and_conflicts: dependencies_and_conflicts list)
 (package : Package.package) =
-let render_dependency ~version ~name ~cstr =
+let render_dependency ~name ~cstr ~version =
   <li class="flex m-0 space-x-3 py-2 px-4 hover:bg-gray-100">
     <a href="<%s Url.Package.overview name ?version %>" class="text-primary-600 hover:underline">
       <%s name %>
@@ -161,9 +170,6 @@ let render_section_heading ~title ~id =
   <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
     <h2 id="<%s id %>" class="text-xl font-medium my-2"><%s title %></h2>
   </div>
-in
-let title_with_number title number =
-  title ^ if number > 0 then " (" ^ string_of_int number ^ ")" else ""
 in
 let version = Package.url_version package in
 let specific_version = Package.specific_version package in
@@ -204,34 +210,15 @@ Package_layout.render
 
       <div class="border-l-2 border-gray-200 px-4 space-y-6">
         <div class="mx-[-2px]">
-          <%s! render_section_heading ~title:(title_with_number "Dependencies" (List.length dependencies)) ~id:"dependencies" %>
-          <ol class="grid lg:grid-cols-2">
-              <%s if List.length dependencies = 0 then "None" else "" %>
-              <% dependencies |> List.iter (fun (name, cstr) -> %>
-              <%s! render_dependency ~name ~cstr ~version:None %>
+          <% deps_and_conflicts |> List.iter (fun section -> %>
+            <%s! render_section_heading ~title:section.title ~id:section.slug %>
+            <ol class="grid lg:grid-cols-2">
+              <%s if List.length section.items = 0 then "None" else "" %>
+              <% section.items |> List.iter (fun { name; cstr; version } -> %>
+              <%s! render_dependency ~name ~cstr ~version %>
               <% ); %>
-          </ol>
-          <%s! render_section_heading ~title:(title_with_number "Development Dependencies" (List.length dev_dependencies)) ~id:"dev_dependencies" %>
-          <ol class="grid lg:grid-cols-2">
-              <%s if List.length dev_dependencies = 0 then "None" else "" %>
-              <% dev_dependencies |> List.iter (fun (name, cstr) -> %>
-              <%s! render_dependency ~name ~cstr ~version:None %>
-              <% ); %>
-          </ol>
-          <%s! render_section_heading ~title:(title_with_number "Reverse Dependencies" (List.length rev_dependencies))  ~id:"rev_dependencies" %>
-          <ol class="grid lg:grid-cols-2 max-h-96 overflow-auto">
-              <%s if List.length rev_dependencies = 0 then "None" else "" %>
-              <% rev_dependencies |> List.iter (fun (name, cstr, version) -> %>
-              <%s! render_dependency ~name ~cstr ~version:(Some version) %>
-              <% ); %>
-          </ol>
-          <%s! render_section_heading ~title:(title_with_number "Conflicts" (List.length conflicts)) ~id:"conflicts" %>
-          <ol class="grid lg:grid-cols-2 max-h-96 overflow-auto">
-              <%s if List.length conflicts = 0 then "None" else "" %>
-              <% conflicts |> List.iter (fun (name, cstr) -> %>
-              <%s! render_dependency ~name ~cstr ~version:None %>
-              <% ); %>
-          </ol>
+            </ol>
+          <% ); %>
         </div>
       </div>
       <% | Some content_title -> %>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -157,9 +157,9 @@ let render_dependency ~version ~name ~cstr =
     <% ; %>
   </li>
 in
-let render_section_heading ~title =
+let render_section_heading ~title ~id =
   <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
-    <h2 class="text-xl font-medium my-2"><%s title %></h2>
+    <h2 id="<%s id %>" class="text-xl font-medium my-2"><%s title %></h2>
   </div>
 in
 let title_with_number title number =
@@ -179,9 +179,11 @@ Package_layout.render
 <div class="flex md:gap-6 xl:gap-12 flex-col md:flex-row justify-between">
     <div class="flex-1 max-w-full">
       <% (match content_title with | None -> %>
-      <div class="p-4 prose max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
-        <h2 class="mb-4 mt-0 text-xl font-semibold uppercase">Description</h2>
-        <%s! package.description %>
+      <div class="p-4 max-w-full border-2 border-l-4 border-gray-200 border-l-primary-700 rounded rounded-r-lg">
+        <h2 id="description" class="mb-4 mt-0 text-xl font-semibold uppercase">Description</h2>
+        <div class="prose">
+          <%s! package.description %>
+        </div>
       </div>
 
       <div class="flex flex-wrap gap-3 mt-4">
@@ -202,28 +204,28 @@ Package_layout.render
 
       <div class="border-l-2 border-gray-200 px-4 space-y-6">
         <div class="mx-[-2px]">
-          <%s! render_section_heading ~title:(title_with_number "Dependencies" (List.length dependencies)) %>
+          <%s! render_section_heading ~title:(title_with_number "Dependencies" (List.length dependencies)) ~id:"dependencies" %>
           <ol class="grid lg:grid-cols-2">
               <%s if List.length dependencies = 0 then "None" else "" %>
               <% dependencies |> List.iter (fun (name, cstr) -> %>
               <%s! render_dependency ~name ~cstr ~version:None %>
               <% ); %>
           </ol>
-          <%s! render_section_heading ~title:(title_with_number "Development Dependencies" (List.length dev_dependencies)) %>
+          <%s! render_section_heading ~title:(title_with_number "Development Dependencies" (List.length dev_dependencies)) ~id:"dev_dependencies" %>
           <ol class="grid lg:grid-cols-2">
               <%s if List.length dev_dependencies = 0 then "None" else "" %>
               <% dev_dependencies |> List.iter (fun (name, cstr) -> %>
               <%s! render_dependency ~name ~cstr ~version:None %>
               <% ); %>
           </ol>
-          <%s! render_section_heading ~title:(title_with_number "Reverse Dependencies" (List.length rev_dependencies)) %>
+          <%s! render_section_heading ~title:(title_with_number "Reverse Dependencies" (List.length rev_dependencies))  ~id:"rev_dependencies" %>
           <ol class="grid lg:grid-cols-2 max-h-96 overflow-auto">
               <%s if List.length rev_dependencies = 0 then "None" else "" %>
               <% rev_dependencies |> List.iter (fun (name, cstr, version) -> %>
               <%s! render_dependency ~name ~cstr ~version:(Some version) %>
               <% ); %>
           </ol>
-          <%s! render_section_heading ~title:(title_with_number "Conflicts" (List.length conflicts)) %>
+          <%s! render_section_heading ~title:(title_with_number "Conflicts" (List.length conflicts)) ~id:"conflicts" %>
           <ol class="grid lg:grid-cols-2 max-h-96 overflow-auto">
               <%s if List.length conflicts = 0 then "None" else "" %>
               <% conflicts |> List.iter (fun (name, cstr) -> %>
@@ -235,7 +237,7 @@ Package_layout.render
       <% | Some content_title -> %>
       <div class="border-l-2 border-gray-200 px-4 space-y-6">
         <div class="mx-[-2px]">
-          <%s! render_section_heading ~title:content_title %>
+          <%s! render_section_heading ~title:content_title ~id:"content" %>
           <div class="prose max-w-full">
             <%s! content %>
           </div>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -455,10 +455,18 @@ let package_overview t kind req =
     package_info.Ocamlorg_package.Info.conflicts
     |> List.map (fun (name, x) -> (Ocamlorg_package.Name.to_string name, x))
   in
+  let toc = [
+    Ocamlorg_frontend.Toc.{ title = "Description"; href = "#description"; children = []};
+    { title = "Dependencies"; href = "#dependencies"; children = []};
+    { title = "Development Dependencies"; href = "#dev_dependencies"; children = []};
+    { title = "Reverse Dependencies"; href = "#rev_dependencies"; children = []};
+    { title = "Conflicts"; href = "#conflicts"; children = []};
+  ]
+  in
 
   Dream.html
     (Ocamlorg_frontend.package_overview ~sidebar_data ~content:""
-       ~content_title:None ~toc:[] ~dependencies ~dev_dependencies ~rev_dependencies
+       ~content_title:None ~toc ~dependencies ~dev_dependencies ~rev_dependencies
        ~conflicts frontend_package)
 
 let package_documentation t kind req =


### PR DESCRIPTION
Patch adds a table of contents to the `xl` screen of package overview pages (reflecting the different sections in the main content area - to give a quick overview of number of dependencies and conflicts) and prepares the addition of table of contents to the package file pages README/CHANGELOG.



|before|after|
|-|-|
|![Screenshot 2023-03-28 at 13-54-15 caqti 1 9 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/228227956-ee682bcc-668d-4d73-b592-3e31a4aeeaa4.png)|![Screenshot 2023-03-28 at 13-54-19 caqti 1 9 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/228227964-0b88c869-1a5f-41db-84a9-55e3c4561930.png)|
