### PR TITLE
Fix missing sidebar on htmx navigation on learn area

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -43,7 +43,7 @@ let sidebar_icon_link_block
 
 let htmx_attributes href
 =
-  <% if String.get href 0 != '#' then ( %> hx-boost="true" hx-ext="multi-swap" hx-swap="multi:#htmx-head,#htmx-sidebar,#htmx-content,#htmx-right-sidebar" hx-push-url="true" <% ); %>
+  <% if String.get href 0 != '#' then ( %> hx-boost="true" hx-ext="multi-swap" hx-swap="outerHTML multi:#htmx-head,#htmx-sidebar,#htmx-content,#htmx-right-sidebar" hx-push-url="true" <% ); %>
 
 let sidebar_link
 ~title
@@ -111,13 +111,10 @@ inner_html
              id="htmx-content">
           <%s! inner_html %>
         </div>
-        <% (match right_sidebar_html with
-            | Some (html) -> %>
-          <div class="hidden xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto lg:pt-6 right-sidebar"
-               id="htmx-right-sidebar">
-            <%s! html %>
-          </div>
-        <% | None -> () ); %>
+        <div class="hidden <%s Option.fold right_sidebar_html ~none:"" ~some:(Fun.const "xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto lg:pt-6 right-sidebar") %>"
+            id="htmx-right-sidebar">
+          <%s! Option.value ~default:"" (right_sidebar_html) %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
In order to sometimes have a sidebar on the learn area, and sometimes not, HTMX needs to be used in `outerHTML` swap mode so that the target div gets replaced fully.

All pages need to render the div with id `htmx-right-sidebar` so that there's always a swap target for the right sidebar.

Currently: When you navigate to the learn area and then navigate to a tutorial, the table of contents doesn't appear :see_no_evil:. This patch fixes this problem.