### PR TITLE
advance opam-repository to March 30, commit id 9cfac26185d76f082bfdbf6f92f8e1a5aacbc589

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ocaml/opam:alpine-3.17-ocaml-4.14 as build
 RUN sudo apk update && sudo apk add --update libev-dev openssl-dev gmp-dev oniguruma-dev
 
 # freeze branch was opam-repo HEAD at the time of commit
-RUN cd ~/opam-repository && git checkout -b freeze b457e9f3d6 && opam update
+RUN cd ~/opam-repository && git fetch && git checkout -b freeze 9cfac26185d76f082bfdbf6f92f8e1a5aacbc589 && opam update
 
 WORKDIR /home/opam
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deps: ## Install development dependencies
 
 .PHONY: pin_repo
 pin_repo: ## Pin Opam repository
-	opam repository set-url default git+https://github.com/ocaml/opam-repository#b457e9f3d6 --this-switch
+	opam repository set-url default git+https://github.com/ocaml/opam-repository#9cfac26185d76f082bfdbf6f92f8e1a5aacbc589 --this-switch
 
 .PHONY: create_switch
 create_switch:

--- a/src/dream_dashboard/ip_info.ml
+++ b/src/dream_dashboard/ip_info.ml
@@ -17,8 +17,7 @@ let digest ip =
   Digestif.SHA256.digest_string ip |> Digestif.SHA256.to_raw_string
 
 let query_dbip ip =
-  let open Lwt.Syntax in
-  let+ response =
+  let response =
     Hyper.get
       ~headers:
         [
@@ -47,12 +46,11 @@ let get ip =
 
      - Store the errors in the cache, so we don't query the same IP if the
      answer is an error. *)
-  let open Lwt.Syntax in
   let ip_digest = digest ip in
   match Hashtbl.find_opt cache ip_digest with
-  | Some x -> Lwt.return (Some x)
+  | Some x -> Some x
   | None -> (
-      let+ result = query_dbip ip in
+      let result = query_dbip ip in
       match result with
       | Ok x ->
           Hashtbl.add cache ip_digest x;

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -9,7 +9,7 @@ let () =
   Logs.set_level (Some Info)
 
 let run () =
-  Mirage_crypto_rng_lwt.initialize ();
+  Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna);
   let state = Ocamlorg_package.init () in
   Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
   @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.head


### PR DESCRIPTION
Advance the opam-repository pin and resolve breaking changes in `hyper` and `mirage-crypto-rng-lwt` (see https://discuss.ocaml.org/t/mirage-crypto-rng-unix-initialize/11505/3).