### PR TITLE
use em breakpoints instead of px breakpoints

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -22,8 +22,8 @@ let render
 =
 <header 
   class="h-20 flex items-center dark:bg-[#171717]"
-  x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}"
-  @resize.window="sidebar = window.innerWidth >= 1024">
+  x-data="{ open: false, sidebar: window.matchMedia('(min-width: 64em)') && true, showOnMobile: false}"
+  @resize.window="sidebar = window.matchMedia('(min-width: 64em)')">
   <nav class="container-fluid wide header flex justify-between items-center">
     <ul class="space space-x-5 xl:space-x-8 items-center flex text-body-400 font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
       <li style="width:132px">

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -30,7 +30,7 @@ body {
 }
 
 .container-fluid.wide {
-  max-width: 1440px;
+  @apply max-w-8xl
 }
 
 .bg-pattern {
@@ -152,7 +152,7 @@ body {
   width: 3em;
   margin-left: -2.9em;
   margin-top: 0;
-  font-size: 18px;
+  font-size: 1rem;
 }
 
 .sidebar a.active {

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -88,7 +88,7 @@ inner_html
   ~description
   ~canonical
   ?active_top_nav_item @@
-  <div class="bg-white" x-data="{ open: false, sidebar: window.innerWidth >= 1024 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 1024"  x-on:close-sidebar="sidebar=window.innerWidth >= 1024 && true">
+  <div class="bg-white" x-data="{ open: false, sidebar: window.matchMedia('(min-width: 64em)') && true, showOnMobile: false}" @resize.window="sidebar = window.matchMedia('(min-width: 64em)')"  x-on:close-sidebar="sidebar=window.matchMedia('(min-width: 64em)') && true">
     <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
       x-on:click="sidebar = ! sidebar">
       <%s! Icons.sidebar_menu "h-8 w-8" %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,12 @@ module.exports = {
   content: ["**/*.eml"],
   darkMode: 'class',
   theme: {
+    screens: {
+      'sm': '40em',
+      'md': '48em',
+      'lg': '64em',
+      'xl': '80em',
+    },
     extend: {
       typography: {
         DEFAULT: {


### PR DESCRIPTION
There are problems with font scaling vs breakpoints when the user sets a custom font size in their OS or browser settings.

Possible solutions are either to
1. use `em` breakpoints in the media queries. Consequence: there may be bugs in ancient browsers that do not properly support relative units in media queries.
2. to set a 16px base font size on the `html` element. Consequence: some browsers will not apply the custom font size setting, resulting in a smaller font size than the user intended. And, since everything scales with the base font size, there will be a lot of white space on the sides for people with wide screens.

This patch changes the breakpoints to use the `em` unit.

Should hopefully fix the problem encountered in https://github.com/ocaml/ocaml.org/issues/1022.

|setting|before|after|
|-|-|-|
|Firefox, scale to 50%, font-size 24|![Screenshot 2023-03-30 at 12-39-36 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228811875-70fb31be-e9b8-464f-9f0d-5e1eee3ff6c3.png)|![Screenshot 2023-03-30 at 12-39-41 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228811883-9b9b808c-f878-4ef5-aa3b-84c642efdc41.png)|
|Firefox, scale to 80%, font-size 24|![Screenshot 2023-03-30 at 12-40-51 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228811988-81617cac-bd19-48d0-9569-f91bfdde775d.png)|![Screenshot 2023-03-30 at 12-40-56 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228811965-b3904835-4b47-495b-ac5a-384d1dabd4d1.png)|
|Firefox, scale 80%, font-size 16|![Screenshot 2023-03-30 at 12-44-00 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228812336-87ea6b85-f027-425f-95f2-60168230d538.png)|![Screenshot 2023-03-30 at 12-44-04 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228812342-b4e6b3b8-255a-4dc1-b8d6-3ed6f6727574.png)|
|Firefox, scale 120%, font-size 16| ![Screenshot 2023-03-30 at 12-44-16 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228812447-d57844e4-08a3-4fa3-af13-d97a3d85aba0.png)|![Screenshot 2023-03-30 at 12-44-22 OCaml on Windows · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/228812454-da508f1e-f04f-4863-8f2d-3ab58667f350.png)|
|Chrome, scale 80%, font-size "Large"| ![Screenshot from 2023-03-30 13-06-48](https://user-images.githubusercontent.com/6594573/228817498-352c342e-fbf1-4d7e-a266-4fb5aa8c32e7.png)|![Screenshot from 2023-03-30 13-06-54](https://user-images.githubusercontent.com/6594573/228817509-070124a7-769f-4121-8737-147694a9fb2d.png)|
