### PR TITLE
Bringup ocaml to 4.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - ocaml-base-compiler.4.14.0
+          - ocaml-base-compiler.4.14.1
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - ocaml-base-compiler.4.14.0
+          - ocaml-base-compiler.4.14.1
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deps: create_switch ## Install development dependencies
 
 .PHONY: create_switch
 create_switch: ## Create switch and pinned opam repo
-	opam switch create . 4.14.0 --no-install --repos pin=git+https://github.com/ocaml/opam-repository#b457e9f3d6
+	opam switch create . 4.14.1 --no-install --repos pin=git+https://github.com/ocaml/opam-repository#b457e9f3d6
 
 .PHONY: switch
 switch: deps ## Create an opam switch and install development dependencies


### PR DESCRIPTION
Bringup existing switch using:
```
opam switch set-invariant ocaml-base-compiler.4.14.1
opam upgrade
```

There's no need to do `opam update`, the pinned opam-repo makes it a noop.

This will reduce the gap with Dockerfile build set-up.