### PR TITLE
wrapper div on the htmx sidebar to preserve scroll state with outerHTML mode

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -43,7 +43,7 @@ let sidebar_icon_link_block
 
 let htmx_attributes href
 =
-  <% if String.get href 0 != '#' then ( %> hx-boost="true" hx-ext="multi-swap" hx-swap="outerHTML multi:#htmx-head,#htmx-sidebar,#htmx-content,#htmx-right-sidebar" hx-push-url="true" <% ); %>
+  <% if String.get href 0 != '#' then ( %> hx-boost="true" hx-ext="multi-swap" hx-swap="multi:#htmx-head,#htmx-sidebar,#htmx-content,#htmx-right-sidebar" hx-push-url="true" <% ); %>
 
 let sidebar_link
 ~title
@@ -111,9 +111,10 @@ inner_html
              id="htmx-content">
           <%s! inner_html %>
         </div>
-        <div class="hidden <%s Option.fold right_sidebar_html ~none:"" ~some:(Fun.const "xl:flex top-0 sticky h-screen flex-col w-60 overflow-auto lg:pt-6 right-sidebar") %>"
-            id="htmx-right-sidebar">
-          <%s! Option.value ~default:"" (right_sidebar_html) %>
+        <div class="hidden xl:flex top-0 sticky h-screen overflow-auto lg:pt-6" id="htmx-right-sidebar">
+          <div class="<%s Option.fold ~none:"" ~some:(fun _ -> "flex-col w-60") right_sidebar_html %>">
+            <%s! Option.value ~default:"" right_sidebar_html %>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://github.com/ocaml/ocaml.org/pull/1021 fixed the lack of the right sidebar when navigating to a tutorial from the main "Learn" page, but it lead to resetting the scroll position on the left sidebar.

Here's a solution that remedies this, as well as a teachable moment on why the scroll position was lost:

`htmx`'s `outerHTML` mode replaces the scrollable target div, and it makes sense that this would reset the scroll position. My first idea was to use a child div which is swapped via the `outerHTML` mode of `htmx`. It turns out that, even when (1) the scrollable sidebar div contains another div, and (2) the contained div is swapped, this leads to (3) loss of scroll position. The reason for that appears to be that replacing content via `outerHTML` detaches the old content from the DOM before inserting the new content.

This patch takes a different approach:
* we go back to the default mode of `htmx`, which replaces `innerHTML` (we know scroll position is preserved when replacing `innerHTML`)
* the right sidebar htmx container is always rendered, but we do not specify a width - so that on pages without right sidebar content, the right sidebar shrinks to a width of zero as the main content area grows
* if the page in question has right sidebar content, we set the width of the sidebar