### PR TITLE
use asset url to cache-bust

### DIFF
--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -4,7 +4,7 @@ let render () =
   <div class="mx-auto max-w-7xl px-6 py-16 lg:px-8">
     <div class="xl:grid xl:grid-cols-3 xl:gap-8">
       <div class="space-y-8">
-        <img class="h-8" src="/camelope-with-name.svg" alt="OCaml">
+        <img class="h-8" src="<%s Ocamlorg_static.Asset.url "camelope-with-name.svg" %>" alt="OCaml">
         <p class="text-base leading-6 text-gray-600">Innovation. Community. Security.</p>
         <div class="flex space-x-6">
           <a href="https://github.com/ocaml/ocaml" class="text-gray-400 hover:text-gray-500">

--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -28,8 +28,8 @@ let render
     <ul class="space space-x-5 xl:space-x-8 items-center flex text-body-400 font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
       <li style="width:132px">
         <a href="<%s Url.index %>" class="block pb-2">
-          <img src="/camelope-with-name.svg" width="132" alt="OCaml logo" class="dark:hidden">
-          <img src="/camelope-with-name-white.svg" width="132" alt="OCaml logo" class="hidden dark:inline">
+          <img src="<%s Ocamlorg_static.Asset.url "camelope-with-name.svg" %>" width="132" alt="OCaml logo" class="dark:hidden">
+          <img src="<%s Ocamlorg_static.Asset.url "camelope-with-name-white.svg" %>" width="132" alt="OCaml logo" class="hidden dark:inline">
         </a>
       </li>
     </ul>
@@ -88,7 +88,7 @@ let render
     x-transition:leave-end="translate-x-full">
     <ul class="text-body-400 p-6 space-y-6 font-semibold">
       <li class="flex justify-between items-center">
-        <a href="<%s Url.index %>"><img width="132" src="/camelope-with-name.svg" alt=""></a>
+        <a href="<%s Url.index %>"><img width="132" src="<%s Ocamlorg_static.Asset.url "camelope-with-name.svg" %>" alt=""></a>
 
         <div class="close lg:hidden h-12 w-12 hover:bg-primary-100 flex items-center justify-center rounded-full"
           x-on:click="open = false">

--- a/src/ocamlorg_frontend/pages/industrial_users.eml
+++ b/src/ocamlorg_frontend/pages/industrial_users.eml
@@ -31,7 +31,7 @@ the community and learn more about how they use OCaml."
                   </div>
                   <div class="flex items-center h-full justify-center" x-show="!isPlaying">
                       <div class="z-10 lg:space-y-16 space-y-5 mb-10 lg:mb-0">
-                          <img width="132" class="m-auto" src="/camelope-logo.svg" alt="OCaml logo">
+                          <img width="132" class="m-auto" src="<%s Ocamlorg_static.Asset.url "camelope-logo.svg" %>" alt="OCaml logo">
                           <h3 class="font-bold">25 Years of OCaml</h3>
                           <div>Presented by Xavier Leroy</div>
                       </div>

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -67,7 +67,7 @@ Learn_layout.render
       </div>
       <div class="flex h-full justify-center" x-show="!isPlaying">
         <div class="z-10 mb-10 lg:mb-0">
-          <img width="160" class="m-auto mt-10 md:mt-20" src="/camelope-with-name.svg" alt="OCaml logo">
+          <img width="160" class="m-auto mt-10 md:mt-20" src="<%s Ocamlorg_static.Asset.url "camelope-with-name.svg" %>" alt="OCaml logo">
           <div class="text-body-400 mt-2">OCaml Workshop 2020</div>
           <h3 class="font-bold mt-16">State of the OCaml Platform 2020</h3>
           <div class="mt-16 flex justify-center">


### PR DESCRIPTION
When assets change, browsers may still have them cached. To make sure changed assets reach our users, there's the cache-busting immutable URLs (based on file digest) provided via `Ocamlorg_static.Asset.url`. So let's use them.