### PR TITLE
Update to Timedesc 1.1.1 and restore human readable uptime string in dashboard

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -51,7 +51,7 @@
    (= "2.0.0~alpha3"))
   opam-format
   (timedesc
-   (>= 0.8.0))
+   (>= 1.1.1))
   yojson
   lwt
   tailwindcss
@@ -76,8 +76,6 @@
   ppx_deriving_yojson
   ppx_stable
   yojson
-  (timedesc
-   (>= 0.8.0))
   ; tools/ood-gen
   ppx_deriving_yaml
   ppx_show

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -53,7 +53,6 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_stable"
   "yojson"
-  "timedesc" {>= "0.8.0"}
   "ppx_deriving_yaml"
   "ppx_show"
   "ezjsonm"

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -34,7 +34,7 @@ depends: [
   "logs"
   "omd" {= "2.0.0~alpha3"}
   "opam-format"
-  "timedesc" {>= "0.8.0"}
+  "timedesc" {>= "1.1.1"}
   "yojson"
   "lwt"
   "tailwindcss"

--- a/src/dream_dashboard/info.ml
+++ b/src/dream_dashboard/info.ml
@@ -24,7 +24,7 @@ let uptime =
 let uptime_string () =
   let s = Int64.of_float (uptime ()) in
   let span = Timedesc.Span.make ~s () in
-  Timedesc.Span.to_string span
+  Timedesc.Span.For_human.to_string span
 
 type platform = Darwin | Freebsd | Linux | Openbsd | Sunos | Win32 | Android
 


### PR DESCRIPTION
This fixes #946 from Timedesc side properly, and should not crash the dashboard now.

I'll address the frictions in use of Timedesc in a later release, namely

```ocaml
let human_date s =
  let open Timedesc in
  try
    let date = Date.of_iso8601_exn s in
    let time = Time.make_exn ~hour:0 ~minute:0 ~second:0 () in
    let date_time =
      Zoneless.make date time |> Zoneless.to_zoned_exn ~tz:Time_zone.utc
    in
    Format.asprintf "%a" (pp ~format:"{day:0X} {mon:Xxx} {year}" ()) date_time
  with Timedesc.ISO8601_parse_exn msg ->
    Logs.err (fun m -> m "Could not parse date %s: %s" s msg);
    s
```
from `src/ocamlorg_frontend/utils.ml`