### PR TITLE
Clean up all sidebar alpinejs logic

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -22,8 +22,7 @@ let render
 =
 <header
   class="h-20 flex items-center dark:bg-[#171717]"
-  x-data="{ open: false, sidebar: window.matchMedia('(min-width: 64em)') && true, showOnMobile: false}"
-  @resize.window="sidebar = window.matchMedia('(min-width: 64em)')">
+  x-data="{ open: false }">
   <nav class="container-fluid wide header flex justify-between items-center">
     <ul class="space space-x-5 xl:space-x-8 items-center flex text-body-400 font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
       <li style="width:132px">

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -88,7 +88,7 @@ inner_html
   ~description
   ~canonical
   ?active_top_nav_item @@
-  <div class="bg-white" x-data="{ open: false, sidebar: window.matchMedia('(min-width: 64em)') && true, showOnMobile: false}" @resize.window="sidebar = window.matchMedia('(min-width: 64em)')"  x-on:close-sidebar="sidebar=window.matchMedia('(min-width: 64em)') && true">
+  <div class="bg-white" x-data="{ sidebar: window.matchMedia('(min-width: 64em)').matches, showOnMobile: false}" @resize.window="sidebar = window.matchMedia('(min-width: 64em)').matches"  x-on:close-sidebar="sidebar=window.matchMedia('(min-width: 64em)').matches">
     <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
       x-on:click="sidebar = ! sidebar">
       <%s! Icons.sidebar_menu "h-8 w-8" %>

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -26,7 +26,7 @@ Layout.render
           <%s! Package_breadcrumbs.render ~path ?hash ?page package %>
         </div>
       </div>
-      <div x-data="{ open: false, sidebar: window.innerWidth >= 768 && true, showOnMobile: false}" @resize.window="sidebar = window.innerWidth >= 768" x-on:close-sidebar="sidebar=window.innerWidth >= 768 && true">
+      <div x-data="{ sidebar: window.matchMedia('(min-width: 48em)').matches }" @resize.window="sidebar = window.matchMedia('(min-width: 48em)').matches" x-on:close-sidebar="sidebar=window.matchMedia('(min-width: 48em)').matches">
         <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed md:hidden right-10"
         x-on:click="sidebar = ! sidebar">
           <%s! Icons.sidebar_menu "h-8 w-8" %>


### PR DESCRIPTION
* remove useless alpinejs data (`open` on learn layout and package docs, `showOnMobile` on header, learn layout and package docs, and `sidebar` on header)
* use `window.matchMedia().matches`