### PR TITLE
Allow workflows to run locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-repositories: |
             pin: git+https://github.com/ocaml/opam-repository#9cf27a6683dc4e56ccf7e35c008198828bd5c267
+          opam-disable-sandboxing: true
 
       - name: Install system dependencies (Linux)
         run: sudo apt-get install libev-dev libonig-dev

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -13,11 +13,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Assume Yes Installing Deb Packages
+        run: |
+          echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf
+
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ocaml-base-compiler.4.14.1
           opam-repositories: |
             pin: git+https://github.com/ocaml/opam-repository#9cf27a6683dc4e56ccf7e35c008198828bd5c267
+          opam-disable-sandboxing: true
 
       - run: git rev-parse HEAD

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -15,7 +15,6 @@ jobs:
 
       - name: Install Missing System Dependencies
         run: |
-          echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf
           sudo apt-get update
           sudo apt-get install rsync
 

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -13,9 +13,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Assume Yes Installing Deb Packages
+      - name: Install Missing System Dependencies
         run: |
           echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf
+          sudo apt-get update
+          sudo apt-get install rsync
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Missing System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install rsync
+          sudo apt-get install -y rsync
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Assume Yes Installing Deb Packages
+        run: |
+          echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf
+
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
@@ -31,6 +35,7 @@ jobs:
           dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-repositories: |
             pin: git+https://github.com/ocaml/opam-repository#9cf27a6683dc4e56ccf7e35c008198828bd5c267
+          opam-disable-sandboxing: true
 
       - name: Install opam dependencies
         run: opam install --deps-only --with-test .

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Assume Yes Installing Deb Packages
-        run: |
-          echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf
-
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:

--- a/HACKING.md
+++ b/HACKING.md
@@ -10,7 +10,11 @@ Before starting to hack you need a properly configured development environment. 
 * OpenSSL: https://www.openssl.org/
 * GNU Multiple Precision: https://gmplib.org/
 
-The project [`Dockerfile`](./Dockerfile) contains up-to-date system configuration instructions, as used to ship into production. It is written for the Alpine Linux distribution but is meant to be adapted to other environments such as Ubuntu, macOS+Homebrew or others. The GitHub workflow file [`.github/workflows/ci.yml`](.github/workflows/ci.yml) also contains useful commands for Ubuntu and macOS. Since ocaml.org is mostly written in OCaml, a properly configured OCaml development environment is also required, but is not detailed here. Although Docker is used to ship, it is not a requirement to begin hacking. Currently, ocaml.org doesn't yet compile using OCaml 5, version 4.14 of the language is used.
+The project [`Dockerfile`](./Dockerfile) contains up-to-date system configuration instructions, as used to ship into production. It is written for the Alpine Linux distribution but is meant to be adapted to other environments such as Ubuntu, macOS+Homebrew or others. The GitHub workflow file [`.github/workflows/ci.yml`](.github/workflows/ci.yml) also contains useful commands for Ubuntu and macOS. Since ocaml.org is mostly written in OCaml, a properly configured OCaml development environment is also required, but is not detailed here. Although Docker is used to ship, it is not a requirement to begin hacking. Currently, ocaml.org doesn't yet compile using OCaml 5, version 4.14 of the language is used. It is possible to run workflow files in `.github/workflows` using the [nektos/act](https://github.com/nektos/act) tool. For instance, run the following command to run the CI checks run by GitHub on each pull request (where `ghghgh` is replace by an _ad-hoc_ GitHub token, see: https://github.com/nektos/act#github_token)
+```
+act -s GITHUB_TOKEN=ghghgh .github/workflows/ci.yml -j build
+```
+
 
 The `Makefile` contains many commands that can get you up and running, a typical workflow will be to clone the repository after forking it.
 


### PR DESCRIPTION
For instance, using nektos/act

* Disable sandboxing (we're already in a container)
* Don't wait for user confirmation when installing system packages
