### PR TITLE
Set link color on navbar search dropdown to be inherited from li element

### DIFF
--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -43,14 +43,14 @@ let render
 
   <ol class="flex flex-col" x-init="row = null; col = 0; total = <%s string_of_int total %>">
   <% packages |> List.iteri (fun i (package : Package.package) -> %>
-    <li class="flex flex-row">
+    <li class="flex flex-row text-primary-600">
       <a
         x-init="max=<%s string_of_int i %>"
         id="package-autocomplete-<%s string_of_int i %>-0"
         :aria-selected="row == <%s string_of_int i %> && col == 0"
         href="<%s Url.Package.overview package.name %>"
-        :class='{ "bg-background-mid-blue text-white": row == <%s string_of_int i %> && col == 0, "text-primary-600": row != <%s string_of_int i %> || col != 0}'
-        class="flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 inline-block"
+        :class='row == <%s string_of_int i %> && col == 0 ? "bg-background-mid-blue text-white": ""'
+        class="flex-grow px-2 py-2 leading-6 font-semibold hover:bg-primary-100 hover:text-primary-700 inline-block"
       >
         <%s! Search.highlight_search_terms ~class_:"bg-background-light-blue text-gray-800 font-normal" ~search package.name %>
       </a>
@@ -58,8 +58,8 @@ let render
         id="package-autocomplete-<%s string_of_int i %>-1"
         :aria-selected="row == <%s string_of_int i %> && col == 1"
         href="<%s Url.Package.documentation package.name %>"
-        :class='{ "bg-background-mid-blue text-white": row == <%s string_of_int i %> && col == 1}'
-        class="justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100">
+        :class='row == <%s string_of_int i %> && col == 1 ? "bg-background-mid-blue text-white": ""'
+        class="justify-self-end px-2 py-2 leading-6 font-semibold hover:bg-primary-100 hover:text-primary-700">
         docs
       </a>
     </li>


### PR DESCRIPTION
For some obscure reason, when triggering two searches one after another, css classes are not being added correctly by alpinejs (or by alpinejs in the context of htmx).

This patch applies a workaround that sets the text color in the surrounding `li` element to `text-primary-600`, so that the correct color is applied when no class is added.

Also adds missing hover style, and simplifies `:class` logic.