### PR TITLE
Bringup Opam repo pin to 15b381eeae

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-repositories: |
-            pin: git+https://github.com/ocaml/opam-repository#b457e9f3d6
+            pin: git+https://github.com/ocaml/opam-repository#15b381eeae
 
       - name: Install system dependencies (Linux)
         run: sudo apt-get install libev-dev libonig-dev

--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           ocaml-compiler: ocaml-base-compiler.4.14.1
           opam-repositories: |
-            pin: git+https://github.com/ocaml/opam-repository#b457e9f3d6
+            pin: git+https://github.com/ocaml/opam-repository#15b381eeae
 
       - run: git rev-parse HEAD

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -30,7 +30,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-repositories: |
-            pin: git+https://github.com/ocaml/opam-repository#b457e9f3d6
+            pin: git+https://github.com/ocaml/opam-repository#15b381eeae
 
       - name: Install opam dependencies
         run: opam install --deps-only --with-test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ocaml/opam:alpine-3.17-ocaml-4.14 as build
 RUN sudo apk update && sudo apk add --update libev-dev openssl-dev gmp-dev oniguruma-dev inotify-tools
 
 # Branch freeze was opam-repo HEAD at the time of commit
-RUN cd opam-repository && git checkout -b freeze b457e9f3d6 && opam update
+RUN cd opam-repository && git checkout -b freeze 15b381eeae && opam update
 
 WORKDIR /home/opam
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deps: create_switch ## Install development dependencies
 
 .PHONY: create_switch
 create_switch: ## Create switch and pinned opam repo
-	opam switch create . 4.14.1 --no-install --repos pin=git+https://github.com/ocaml/opam-repository#b457e9f3d6
+	opam switch create . 4.14.1 --no-install --repos pin=git+https://github.com/ocaml/opam-repository#15b381eeae
 
 .PHONY: switch
 switch: deps ## Create an opam switch and install development dependencies

--- a/src/dream_dashboard/ip_info.ml
+++ b/src/dream_dashboard/ip_info.ml
@@ -17,8 +17,7 @@ let digest ip =
   Digestif.SHA256.digest_string ip |> Digestif.SHA256.to_raw_string
 
 let query_dbip ip =
-  let open Lwt.Syntax in
-  let+ response =
+  let response =
     Hyper.get
       ~headers:
         [
@@ -47,12 +46,11 @@ let get ip =
 
      - Store the errors in the cache, so we don't query the same IP if the
      answer is an error. *)
-  let open Lwt.Syntax in
   let ip_digest = digest ip in
   match Hashtbl.find_opt cache ip_digest with
-  | Some x -> Lwt.return (Some x)
+  | Some x -> Some x
   | None -> (
-      let+ result = query_dbip ip in
+      let result = query_dbip ip in
       match result with
       | Ok x ->
           Hashtbl.add cache ip_digest x;

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -9,7 +9,7 @@ let () =
   Logs.set_level (Some Info)
 
 let run () =
-  Mirage_crypto_rng_lwt.initialize ();
+  Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna);
   let state = Ocamlorg_package.init () in
   Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
   @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.head


### PR DESCRIPTION
This includes the changes written by @sabine in https://github.com/ocaml/ocaml.org/pull/1030 rebased on changes which took place on main in the interim. Also add the pin hash in other relevant files.

Unfortunately, this is not yet sufficient to merge https://github.com/ocaml/ocaml.org/pull/1059 by @darrenldl because maximum version of timedesc is 1.1.0 in opam repo at 15b381eeae

- Bringup Opam repo hash to 15b381eeae
- advance opam-repository to 9cfac26185d76f082bfdbf6f92f8e1a5aacbc589
