### PR TITLE
Rework "Blog" page to feature less than three posts

### DIFF
--- a/data/rss/janestreet/magic-trace-diagnosing-tricky-performance-issues-easily-with-intel-processor-trace.md
+++ b/data/rss/janestreet/magic-trace-diagnosing-tricky-performance-issues-easily-with-intel-processor-trace.md
@@ -7,7 +7,7 @@ description: Intel Processor Trace is a hardware technology that can record allp
 url: https://blog.janestreet.com/magic-trace/
 date: 2022-01-11T00:00:00-00:00
 preview_image: https://blog.janestreet.com/magic-trace/magic-trace-blog-image.jpg
-featured: true
+featured:
 ---
 
 <p>Intel Processor Trace is a hardware technology that can record all

--- a/data/rss/tarides/benchmarking-ocaml-projects-with-current-bench.md
+++ b/data/rss/tarides/benchmarking-ocaml-projects-with-current-bench.md
@@ -5,7 +5,7 @@ description: "Regular CI systems are optimised for workloads that do not require
 url: https://tarides.com/blog/2021-08-26-benchmarking-ocaml-projects-with-current-bench
 date: 2021-08-26T00:00:00-00:00
 preview_image: https://tarides.com/static/2bd2e5940bdb329b93e236f44dd37e01/dfe86/current-bench-camel.jpg
-featured: true
+featured:
 ---
 
 <p>Regular CI systems are optimised for workloads that do not require stable performance over time. This makes them unsuitable for running performance benchmarks.</p>

--- a/data/rss/tarides/mirageos-40-preview-live-presentation.md
+++ b/data/rss/tarides/mirageos-40-preview-live-presentation.md
@@ -5,7 +5,7 @@ description: "The official release of MirageOS 4.0 quickly approaches! Learn abo
 url: https://tarides.com/blog/2021-11-09-mirageos-4-0-preview-live-presentation
 date: 2021-11-09T00:00:00-00:00
 preview_image: https://tarides.com/static/619c072d0a24bc8e8421e02cdafca46e/0132d/projector.jpg
-featured: true
+featured:
 ---
 
 <p>The official release of MirageOS 4.0 quickly approaches! Learn about some general MirageOS concepts and get a

--- a/data/rss/tarides/the-journey-to-ocaml-multicore-bringing-big-ideas-to-life.md
+++ b/data/rss/tarides/the-journey-to-ocaml-multicore-bringing-big-ideas-to-life.md
@@ -5,7 +5,7 @@ description: "Continuing our blog series on Multicore OCaml, this blog provides 
 url: https://tarides.com/blog/2023-03-02-the-journey-to-ocaml-multicore-bringing-big-ideas-to-life
 date: 2023-03-02T00:00:00-00:00
 preview_image: https://tarides.com/static/caf16b04b6417354dc02755abfc245ca/2070e/jack-anstey-zS4lUqLEiNA-unsplash.jpg
-featured:
+featured: true
 ---
 
 <p>Continuing our blog series on <a href="https://tarides.com/blog/2022-12-19-ocaml-5-with-multicore-support-is-here">Multicore OCaml</a>, this blog provides an overview of the road to OCaml Multicore. If you want to know how you can use OCaml 5 in your own projects, please <a href="https://tarides.com/company">contact us</a> for more information. We also recommend watching KC Sivaramakrishnan's ICFP 22' talk <a href="https://www.youtube.com/watch?v=zJ4G0TKwzVc">Retrofitting Concurrency - Lessons from the Engine Room</a></p>

--- a/src/ocamlorg_frontend/pages/blog.eml
+++ b/src/ocamlorg_frontend/pages/blog.eml
@@ -6,45 +6,41 @@ Layout.render
 ~active_top_nav_item:Header.Blog @@
 <div class="bg-white py-10">
     <div class="container-fluid wide">
-        <div>
-            <h2 class="font-bold">Blog</h2>
-            <p class="text-lg text-body-400 mt-6">This is where you'll find the latest stories from the OCaml Community!</p>
-        </div>
+        <h1 class="sr-only">OCaml Blog</h1>
 
-        <div class="mt-10 grid grid-cols-1 md:grid-cols-3 gap-16">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-16">
             <div class="col-span-2">
-                <div>
-                    <div class="text-lg font-semibold border-b border-current text-primary-600 pb-3">Featured</div>
-                    <div class="grid grid-cols-1 lg:grid-cols-3 py-12 gap-12 border-b border-gray-200">
-                        <% featured |> List.iter (fun (item : Ood.Rss.t) -> %>
-                        <div>
-                            <a href="<%s item.url %>"><img class="w-full" src="<%s Option.get item.preview_image %>" alt=""></a>
-                            <div class="space-y-3 mt-6 flex flex-col">
-                                <div class="space-y-2">
-                                    <a href="<%s item.url %>"
-                                        class="block text-lg font-semibold hover:text-primary-600">
-                                        <%s item.title %>
-                                    </a>
-                                </div>
-                                <a href="<%s item.url %>" class="text-body-400">
-                                    <%s Option.value ~default:"" item.description %>
-                                </a>
-                                <div class="text-body-400 flex space-x-2.5 text-sm">
-                                    <%s Utils.human_time item.date %>
-                                </div>
-                            </div>
-                        </div>
-                        <% ); %>
-                    </div>
-                </div>
+                <h2 class="text-lg mt-0 font-semibold border-b border-current text-primary-600 pb-3">OCaml Community Blog</h2>
+
                 <div class="mt-12 space-y-12">
+                    <% featured |> List.iter (fun (item : Ood.Rss.t) -> %>
+                    <div>
+                      <div class="font-semibold text-gray-400">FEATURED</div>
+                      <div class="flex flex-col-reverse lg:flex-row lg:gap-12">
+                          <div class="space-y-3 mt-6 lg:mt-0 flex flex-col flex-1">
+                              <a href="<%s item.url %>"
+                                  class="block text-xl font-semibold hover:text-primary-600"><%s item.title %></a>
+                              <a href="<%s item.url %>" class="text-body-400">
+                                  <%s Option.value ~default:"" item.description %>
+                              </a>
+                              <div class="text-body-400 flex space-x-2.5 text-sm">
+                                  <div><%s Utils.human_time item.date %></div>
+                              </div>
+                          </div>
+                          <% (match item.preview_image with | None -> () | Some image -> %>
+                          <div class="flex-none w-64">
+                              <a href="<%s item.url %>"><img class="w-full" src="<%s image %>" alt=""></a>
+                          </div>
+                          <% ); %>
+                      </div>
+                    </div>
+                    <% ); %>
+
                     <% rss |> List.iter (fun (item : Ood.Rss.t) -> %>
-                    <div class="flex flex-col-reverse lg:flex-row lg:space-x-12">
+                    <div class="flex flex-col-reverse lg:flex-row lg:gap-12">
                         <div class="space-y-3 mt-6 lg:mt-0 flex flex-col flex-1">
-                            <div class="space-y-2">
-                                <a href="<%s item.url %>"
-                                    class="block text-xl font-semibold hover:text-primary-600"><%s item.title %></a>
-                            </div>
+                            <a href="<%s item.url %>"
+                                class="block text-xl font-semibold hover:text-primary-600"><%s item.title %></a>
                             <a href="<%s item.url %>" class="text-body-400">
                                 <%s Option.value ~default:"" item.description %>
                             </a>
@@ -64,17 +60,14 @@ Layout.render
                 </div>
             </div>
             <div class="lg:pl-16 space-y-12">
-
-                <div class="text-lg font-semibold border-b border-body-400 text-body-400 pb-3">News</div>
+                <h2 class="text-lg mt-0 font-semibold border-b border-current text-primary-600 pb-3">News</h2>
 
                 <% news |> List.iter (fun (item : Ood.News.t) -> %>
-                <div class="flex lg:space-x-12">
+                <div class="flex lg:gap-12">
                     <div class="space-y-3 flex flex-col flex-1">
-                        <div class="space-y-2">
-                            <a href="<%s Url.news_post item.slug %>" class="block font-semibold hover:text-primary-600">
-                                <%s item.title %>
-                            </a>
-                        </div>
+                        <a href="<%s Url.news_post item.slug %>" class="block font-semibold hover:text-primary-600">
+                            <%s item.title %>
+                        </a>
                         <a href="<%s Url.news_post item.slug %>" class="text-body-400 text-sm">
                             <%s item.description %>
                         </a>


### PR DESCRIPTION
* rearrange `blog.eml` page layout to have less boilerplate and clearer heading "OCaml Community Blog" to make it more obvious what's being shown here
* change featured post to "The Journey to OCaml Multicore: Bringing Big Ideas to Life"
* change featured section to not require three featured posts. Anything from 1-3 works fine.
* clean up HTML and styles a bit (use `h2` and `h1`, remove unnecessary wrapper `div`)
* old page had issues with alignment in the three-column layout

|before|after|
|-|-|
|![Screenshot 2023-04-11 at 11-33-28 OCaml Blog](https://user-images.githubusercontent.com/6594573/231118712-1a196ed9-245d-46c2-afd5-9e04a9f9a0a6.png)|![Screenshot 2023-04-11 at 11-34-48 OCaml Blog](https://user-images.githubusercontent.com/6594573/231119019-e88466c8-7abc-4874-b6b3-d294ea4b4466.png)|