### PR TITLE
Highlighting current section in Table of Contents (package section)

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -7,21 +7,30 @@ children : toc list
 type t = toc list
 
 let render (t : t) =
-  <div>
+  <div
+    x-data='toc'
+    @scroll.window="scrollY = window.scrollY"
+    @resize.window.throttle="sectionYPositions = computeSectionYPositions($el)"
+    x-init="setTimeout(() => sectionYPositions = computeSectionYPositions($el), 10)"
+    >
     <% (match t with [] ->  %>
     <% | _ -> %>
     <div class="font-semibold text-gray-500 text-sm mb-4">On This Page</div>
-    <ol class="leading-6 space-y-3 text-sm">
+    <ol class="leading-6 text-sm border-l">
       <% t |> List.iter begin fun item -> %>
         <li>
-          <a href="<%s item.href %>" class="font-normal text-gray-900 py-1 md:p-0 block transition-colors hover:text-orange-600">
+          <a href="<%s item.href %>" class="text-gray-900 py-1 px-2 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+            :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
+          >
             <%s! item.title %>
           </a>
             <% match item.children with [] -> () | items -> %>
             <ol>
               <% items |> List.iter begin fun item -> %>
-              <li class="ml-2">
-                <a href="<%s item.href %>" class="font-normal text-body-600 py-1 md:p-0 block transition-colors hover:text-orange-600">
+              <li>
+                <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-4 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+                  :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
+                >
                   <%s! item.title %>
                 </a>
               </li>
@@ -33,3 +42,47 @@ let render (t : t) =
     </ol>
     <% ); %>
   </div>
+  <script>
+    document.addEventListener('alpine:init', () => {
+      function computeSectionYPositions(toc_el) {
+        console.log("computeSectionYPositions", toc_el)
+
+        function get_y(href) {
+          let heading = document.querySelector(href);
+          return heading.getBoundingClientRect().top + window.scrollY - 60;
+        }
+
+        let sections = {};
+
+        let els = toc_el.querySelectorAll("a");
+        let l = els.length;
+        for (let i=0; i<l; i++) {
+          let target_href = els[i].getAttribute("href");
+          let next_el_href = i < l-1 ? els[i+1].getAttribute("href") : null;
+
+          sections[target_href] = {
+            start: get_y(target_href),
+            end: next_el_href ? get_y(next_el_href) : null,
+          }
+        }
+
+        return sections;
+      }
+
+      function isWithin(scrollY, href, sectionYPositions) {
+        if (sectionYPositions == null) return false;
+        return scrollY > sectionYPositions[href].start
+          && (scrollY <= sectionYPositions[href].end || sectionYPositions[href].end == null)
+      }
+
+      Alpine.data('toc', () => (
+        {
+          scrollY: window.scrollY,
+          sectionYPositions: null,
+
+          isWithin,
+          computeSectionYPositions,
+        }
+      ))
+    })
+  </script>


### PR DESCRIPTION
Patch enhances styling of table of contents in the package section by highlighting the current section as you scroll the page.

|before|after|
|-|-|
|![Screenshot 2023-04-13 at 12-34-08 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/231733356-4ebb2bc4-a887-4372-ab08-1e7c186793dd.png)|![Screenshot 2023-04-13 at 12-34-11 irmin 3 6 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/231733363-9dc4d7f6-4ccb-4a2e-8cd3-db4e70b72ebe.png)|
