### PR TITLE
Fix Table of Contents Highlighting for Headings whose ID contains a Comma Character

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -48,7 +48,7 @@ let render (t : t) =
         console.log("computeSectionYPositions", toc_el)
 
         function get_y(href) {
-          let heading = document.querySelector(href);
+          let heading = document.querySelector("*[id='"+href.substring(1)+"']");
           return heading.getBoundingClientRect().top + window.scrollY - 60;
         }
 


### PR DESCRIPTION
Comma is a legal character that can be used in the `id` attribute in HTML5.

However, in `.querySelector()`, comma is interpreted in the CSS sense as a delimiter with an OR-semantics.

Now we use `*[id='...']` as selector to query the HTML DOM for the heading element that corresponds to the table-of-contents entry.

Example: https://ocaml.org/p/xapi-stdext-std/latest/doc/Xapi_stdext_std/Listext/List/index.html