### PR TITLE
Collapse reverse dependencies section with more than 100 items

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -10,7 +10,7 @@ let render (t : t) =
   <div
     x-data='toc'
     @scroll.window="scrollY = window.scrollY"
-    @resize.window.throttle="sectionYPositions = computeSectionYPositions($el)"
+    @resize.window="setTimeout(() => sectionYPositions = computeSectionYPositions($el), 10)"
     x-init="setTimeout(() => sectionYPositions = computeSectionYPositions($el), 10)"
     >
     <% (match t with [] ->  %>

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -140,6 +140,7 @@ type dependencies_and_conflicts = {
   title: string;
   slug: string;
   items: dependency_or_conflict list;
+  collapsible: bool;
 }
 
 let right_sidebar
@@ -166,9 +167,31 @@ let render_dependency ~name ~cstr ~version =
     <% ; %>
   </li>
 in
-let render_section_heading ~title ~id =
-  <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
-    <h2 id="<%s id %>" class="text-xl font-medium my-2"><%s title %></h2>
+let num_of_dependencies_to_show = 100 in
+let render_collapsible_dependencies section =
+  let is_collapsible = section.collapsible && List.length section.items > num_of_dependencies_to_show in
+  <div <%s! if is_collapsible then "x-data='{ open: false }'" else "" %>>
+    <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
+      <h2 id="<%s section.slug %>" class="text-xl font-medium my-2">
+        <% if is_collapsible then (%>
+        <button class="flex gap-2 items-center" x-on:click="open = !open; $dispatch('resize')"><%s section.title %>
+          <span title="expand" x-show="!open"><%s! Icons.chevron_right "h-5 w-5" %></span><span title="collapse" x-show="open"><%s! Icons.chevron_down "h-5 w-5" %></span>
+        </button>
+        <% ) else ( %>
+        <%s section.title %>
+        <% ); %>
+      </h2>
+    </div>
+    <% if List.length section.items = 0 then ( %> None <% ) else ( %>
+      <ol class="grid lg:grid-cols-2" <%s! if is_collapsible then "x-show='open'" else "" %>>
+        <% section.items |> List.iter (fun { name; cstr; version } -> %>
+        <%s! render_dependency ~name ~cstr ~version %>
+        <% ); %>
+      </ol>
+      <% if is_collapsible then (%>
+      <button class="text-primary-700 py-4" x-on:click="open = !open; $dispatch('resize')" x-show="open">Hide</button>
+      <% ) else (); %>
+    <% ); %>
   </div>
 in
 let version = Package.url_version package in
@@ -211,20 +234,16 @@ Package_layout.render
       <div class="border-l-2 border-gray-200 px-4 space-y-6">
         <div class="mx-[-2px]">
           <% deps_and_conflicts |> List.iter (fun section -> %>
-            <%s! render_section_heading ~title:section.title ~id:section.slug %>
-            <ol class="grid lg:grid-cols-2">
-              <%s if List.length section.items = 0 then "None" else "" %>
-              <% section.items |> List.iter (fun { name; cstr; version } -> %>
-              <%s! render_dependency ~name ~cstr ~version %>
-              <% ); %>
-            </ol>
+            <%s! render_collapsible_dependencies section %>
           <% ); %>
         </div>
       </div>
       <% | Some content_title -> %>
       <div class="border-l-2 border-gray-200 px-4 space-y-6">
         <div class="mx-[-2px]">
-          <%s! render_section_heading ~title:content_title ~id:"content" %>
+          <div class="border-l-4 px-4 -ml-4 mb-6 mt-12 border-transparent border-l-body-400 rounded border-t-2 border-b-2 border-r-2">
+            <h2 id="content" class="text-xl font-medium my-2"><%s content_title %></h2>
+          </div>
           <div class="prose max-w-full">
             <%s! content %>
           </div>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -483,22 +483,26 @@ let package_overview t kind req =
         title = title_with_number "Dependencies" (List.length dependencies);
         slug = "dependencies";
         items = dependencies;
+        collapsible = false;
       };
       {
         title =
           title_with_number "Dev Dependencies" (List.length dev_dependencies);
         slug = "development-dependencies";
         items = dev_dependencies;
+        collapsible = false;
       };
       {
         title = title_with_number "Used by" (List.length rev_dependencies);
         slug = "used-by";
         items = rev_dependencies;
+        collapsible = true;
       };
       {
         title = title_with_number "Conflicts" (List.length conflicts);
         slug = "conflicts";
         items = conflicts;
+        collapsible = false;
       };
     ]
   in


### PR DESCRIPTION
Some packages have hundreds or even thousands of reverse dependencies.

This patch makes the reverse dependencies section collapsible in case there are more than 100 items in it.

|before|after|
|-|-|
|![Screenshot 2023-04-14 at 17-08-19 dune 3 7 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/232082954-5eac9993-e271-40cb-aad8-6a3f82d24ab6.png)|![Screenshot 2023-04-14 at 17-08-23 dune 3 7 1 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/232082960-cd7a5452-5bf8-4f1f-9994-91a49ab27b76.png)|

The table-of-contents listens to the `resize` event in order to compute the positions of the section headings for highlighting. So, on expanding and collapsing of the collapsible section, we dispatch the `resize` event.