### PR TITLE
enable table of contents highlighting for tutorials

### DIFF
--- a/src/ocamlorg_data/ood.mli
+++ b/src/ocamlorg_data/ood.mli
@@ -189,6 +189,8 @@ module Tool : sig
 end
 
 module Tutorial : sig
+  type toc = { title : string; href : string; children : toc list }
+
   type t = {
     title : string;
     fpath : string;
@@ -197,7 +199,7 @@ module Tutorial : sig
     date : string;
     category : string;
     body_md : string;
-    toc_html : string;
+    toc : toc list;
     body_html : string;
   }
 

--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -19,7 +19,7 @@ let render (t : t) =
     <ol class="leading-6 text-sm border-l">
       <% t |> List.iter begin fun item -> %>
         <li>
-          <a href="<%s item.href %>" class="text-gray-900 py-1 px-2 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+          <a href="<%s item.href %>" class="text-gray-900 py-2 px-2 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
             :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
           >
             <%s! item.title %>
@@ -33,6 +33,19 @@ let render (t : t) =
                 >
                   <%s! item.title %>
                 </a>
+                <% match item.children with [] -> () | items -> %>
+                <ol>
+                  <% items |> List.iter begin fun item -> %>
+                  <li>
+                    <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-8 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+                      :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
+                    >
+                      <%s! item.title %>
+                    </a>
+                  </li>
+                  <% end; %>
+                </ol>
+                <% ; %>
               </li>
               <% end; %>
             </ol>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -1,8 +1,16 @@
+let rec tutorial_toc_to_toc (toc : Ood.Tutorial.toc) =
+  Toc.{
+    title = toc.title;
+    href = toc.href;
+    children = List.map tutorial_toc_to_toc toc.children
+  }
+
 let right_sidebar
 (tutorial : Ood.Tutorial.t)
 =
-  <div class="font-semibold text-gray-500 text-sm mb-4">ON THIS PAGE</div>
-  <div class="page-toc"><%s! tutorial.toc_html %></div>
+  <div>
+    <%s! Toc.render (List.map tutorial_toc_to_toc tutorial.toc) %>
+  </div>
 
 let render
 (tutorial : Ood.Tutorial.t)


### PR DESCRIPTION
* generates a structured table of contents from the Omd.doc in `tutorial.ml`
* renders the structured table of contents in `tutorial.eml` using `toc.eml`
* extends `toc.eml` to also render the third level of the toc hierarchy

|before|after|
|-|-|
|![Screenshot 2023-04-17 at 08-41-22 Learn OCaml](https://user-images.githubusercontent.com/6594573/232404662-c924ff4e-7165-41b8-ab49-88d4ac8f149e.png)|![Screenshot 2023-04-17 at 08-41-26 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/232404679-3af7b131-785b-47de-9aeb-05c7fd751481.png)|
