### PR TITLE
Use getElementById instead of querySelector in TOC highlight

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -48,7 +48,7 @@ let render (t : t) =
         console.log("computeSectionYPositions", toc_el)
 
         function get_y(href) {
-          let heading = document.querySelector("*[id='"+href.substring(1)+"']");
+          let heading = document.getElementById(href.substring(1));
           return heading.getBoundingClientRect().top + window.scrollY - 60;
         }
 


### PR DESCRIPTION
The better solution when looking up elements by id is to just use `getElementId` because that is just never parsed according to CSS rules. :see_no_evil: 