### PR TITLE
Move table-of-contents highlighting script so it runs early enough

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -19,7 +19,7 @@ let render (t : t) =
     <ol class="leading-6 text-sm border-l">
       <% t |> List.iter begin fun item -> %>
         <li>
-          <a href="<%s item.href %>" class="text-gray-900 py-2 px-2 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+          <a href="<%s item.href %>" class="text-gray-900 py-1 pl-2 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
             :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
           >
             <%s! item.title %>
@@ -28,7 +28,7 @@ let render (t : t) =
             <ol>
               <% items |> List.iter begin fun item -> %>
               <li>
-                <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-4 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+                <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-5 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
                   :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
                 >
                   <%s! item.title %>
@@ -55,11 +55,12 @@ let render (t : t) =
     </ol>
     <% ); %>
   </div>
+  
+let script =
   <script>
     document.addEventListener('alpine:init', () => {
-      function computeSectionYPositions(toc_el) {
-        console.log("computeSectionYPositions", toc_el)
 
+      function computeSectionYPositions(toc_el) {
         function get_y(href) {
           let heading = document.getElementById(href.substring(1));
           return heading.getBoundingClientRect().top + window.scrollY - 60;

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -144,3 +144,4 @@ inner_html
     });
   };
   </script>
+  <%s! Toc.script %>

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -91,3 +91,4 @@ Layout.render
     </div>
   </div>
 </div>
+<%s! Toc.script %>


### PR DESCRIPTION
Moving from the Learn page to a tutorial by htmx wouldn't load the table-of-contents highlighting script before alpinejs would try to run it. So we have to add the script explicitly on the layouts that use it.