### PR TITLE
Add caption to playground share button

### DIFF
--- a/src/ocamlorg_frontend/pages/playground.eml
+++ b/src/ocamlorg_frontend/pages/playground.eml
@@ -41,12 +41,13 @@ let render
             <div
               class="bg-code-background shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)] p-4 absolute w-full bottom-0 z-10"
             >
-              <div class="flex w-full justify-end items-center px-4">
+              <div class="flex gap-7 w-full justify-end items-center px-4">
                 <button
                   id="share"
-                  class="mr-7 hover:bg-white hover:bg-opacity-10 active:bg-primary-100 active:text-primary-600 p-2 rounded-md text-gray-400"
+                  class="flex gap-2 hover:bg-white hover:bg-opacity-10 active:bg-primary-100 active:text-primary-600 p-2 rounded-md text-gray-400"
                 >
                   <%s! Icons.playground_share "h-6 w-6 stroke-current" %>
+                  Share
                 </button>
                 <button id="run" class="btn btn-md btn-secondary">
                   <span>Run</span>


### PR DESCRIPTION
It's not immediately obvious what the share button is for when there's no text on it. So now it says "Share".

|before|after|
|-|-|
|![Screenshot 2023-04-20 at 13-42-18 OCaml Playground](https://user-images.githubusercontent.com/6594573/233355987-3083376e-47d0-4a9e-9f68-7e7f874ec361.png)|![Screenshot 2023-04-20 at 13-42-21 OCaml Playground](https://user-images.githubusercontent.com/6594573/233355994-6eb8c3e0-bf4a-4939-aa9c-0cfd70b016ab.png)|
