### PR TITLE
Scraper: in case of River__Http.Timeout, skip the source

### DIFF
--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -25,7 +25,13 @@ let pp_meta ppf v =
 
 let feeds () =
   let sources = all_sources () in
-  List.map River.fetch sources.sources
+  sources.sources
+  |> List.filter_map (fun source ->
+         try Some (River.fetch source)
+         with River__Http.Timeout ->
+           print_endline
+             (Printf.sprintf "failed to scrape %s: timeout" source.name);
+           None)
 
 let validate_entries entries =
   let validate_author (author : Syndic.Atom.author) =


### PR DESCRIPTION
The scraper would crash when there's a timeout fetching a source's feed.

This patch catches the `River__Http.Timeout` exception to skip the unreachable source during scraping so that at least all the reachable sources will be scraped.
