### PR TITLE
Prevent changes in linebreak position on toc highlight

### DIFF
--- a/src/ocamlorg_frontend/components/toc.eml
+++ b/src/ocamlorg_frontend/components/toc.eml
@@ -19,8 +19,9 @@ let render (t : t) =
     <ol class="leading-6 text-sm border-l">
       <% t |> List.iter begin fun item -> %>
         <li>
-          <a href="<%s item.href %>" class="text-gray-900 py-1 pl-2 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+          <a href="<%s item.href %>" class="text-gray-900 py-1 pl-2 pr-1 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
             :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
+            :style='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "letter-spacing: -0.012em;" : ""'
           >
             <%s! item.title %>
           </a>
@@ -28,8 +29,9 @@ let render (t : t) =
             <ol>
               <% items |> List.iter begin fun item -> %>
               <li>
-                <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-5 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+                <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-5 pr-1 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
                   :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
+                  :style='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "letter-spacing: -0.012em;" : ""'
                 >
                   <%s! item.title %>
                 </a>
@@ -37,8 +39,9 @@ let render (t : t) =
                 <ol>
                   <% items |> List.iter begin fun item -> %>
                   <li>
-                    <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-8 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
+                    <a href="<%s item.href %>" class="text-body-600 py-1 md:py-0 pl-8 pr-1 block transition-colors border-l-4 border-t-2 border-b-2 border-r-2 border-transparent rounded"
                       :class='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "font-semibold border-l-primary-700 text-primary-700 bg-primary-200": "hover:text-primary-700"'
+                      :style='isWithin(scrollY, "<%s item.href %>", sectionYPositions) ? "letter-spacing: -0.012em;" : ""'
                     >
                       <%s! item.title %>
                     </a>


### PR DESCRIPTION
When the font is bold, the text takes up more width and linebreak can happen earlier.

We counteract that by reducing the letter spacing so that line break position stays the same between the highlighted entry and the non-highlighted entry.

There was also some padding lacking on the right side, which would look bad in the highlighted state when the text was too close to the edge.

|before|after|
|-|-|
|![Screenshot 2023-04-20 at 14-15-13 Learn OCaml](https://user-images.githubusercontent.com/6594573/233362999-1d6ad1b3-d87d-48fc-91ac-a4bccd788a8d.png)![Screenshot 2023-04-20 at 14-15-20 Learn OCaml](https://user-images.githubusercontent.com/6594573/233363010-bff6a4c7-b91f-496e-83a5-8c756623b18f.png)|![Screenshot 2023-04-20 at 14-45-35 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/233370077-01fa7de5-d3ad-4365-a3c5-925f583004fa.png)![Screenshot 2023-04-20 at 14-45-39 Get Up and Running With OCaml · OCaml Tutorials](https://user-images.githubusercontent.com/6594573/233370084-de8b7867-db96-4304-a4be-ee48b6a4ff22.png)|
