### PR TITLE
Catch all exceptions in River.fetch and just log them

### DIFF
--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -28,9 +28,10 @@ let feeds () =
   sources.sources
   |> List.filter_map (fun source ->
          try Some (River.fetch source)
-         with River__Http.Timeout ->
+         with e ->
            print_endline
-             (Printf.sprintf "failed to scrape %s: timeout" source.name);
+             (Printf.sprintf "failed to scrape %s: %s" source.name
+                (Printexc.to_string e));
            None)
 
 let validate_entries entries =


### PR DESCRIPTION
https://github.com/ocaml/ocaml.org/pull/1118 was catching the wrong exception. Apparently, one cannot just copy the name presented in the stacktrace catch that. So let's just catch every exception in `River.fetch` and log it.