### PR TITLE
Remove the delay from the navbar autocomplete

### DIFF
--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -18,7 +18,7 @@ let input_attributes ~target_sel ~indicator_sel =
 
         hx-get="/packages/autocomplete"
         hx-params="q"
-        hx-trigger="keyup changed delay:500ms, search"
+        hx-trigger="keyup changed, search"
         hx-target="|js} ^ target_sel ^ {js|"
         hx-indicator="|js} ^ indicator_sel ^ {js|"
         |js}


### PR DESCRIPTION
It is probably unnecessary to have the delay here since we don't have a lot of packages, so the search should be fast enough, even when the server computes the result every time someone requests it. If we see negative performance effects, we can revert. But if not, this will make the search much more useful.