### PR TITLE
Yoshi: use {js| |js} string delimiters

### DIFF
--- a/tool/yoshi/lib/yoshi.ml
+++ b/tool/yoshi/lib/yoshi.ml
@@ -34,7 +34,7 @@ module Gen = struct
 
   let rec string_of_field_value value =
     match value with
-    | `String s -> Printf.sprintf "\"%s\"" s
+    | `String s -> Printf.sprintf "{js|%s|js}" s
     | `Int i -> string_of_int i
     | `Float f -> string_of_float f
     | `Bool b -> string_of_bool b


### PR DESCRIPTION
https://github.com/ocaml/ocaml.org/pull/1124 fails to build because some strings contain the `"` character.

Delimiting the strings generated by yoshi with `{js|` and `|js}` allows strings to contain the `"` character.