### PR TITLE
Move breadcrumbs to above the main content area

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -275,14 +275,3 @@ span.icon-expand.open::before {
   content: " \25BE";
 }
 
-.breadcrumbs-tag {
-  padding-right: 0.75em;
-  padding-left: 0.75em;
-  font-family: Inter, sans-serif;
-  border-radius: 0.25em;
-  font-weight:bold;
-  box-sizing: border-box;
-  color:white;
-  display:inline-block;
-  margin-left:0.5em;
-}

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -12,15 +12,15 @@ type docs_path =
 
 let kind_tag (m : library_path_item) = match m with
   | Module _ ->
-    <span tabindex="0" aria-label="module" class="breadcrumbs-tag module-tag text-white">Module</span>
+    <span tabindex="0" aria-label="module" class="breadcrumbs-tag module-tag">Module</span>
   | ModuleType _ ->
-    <span tabindex="0" aria-label="module type" class="breadcrumbs-tag module-type-tag text-white">Module type</span>
+    <span tabindex="0" aria-label="module type" class="breadcrumbs-tag module-type-tag">Module type</span>
   | Parameter { number; _ } ->
-    <span tabindex="0" aria-label="<%s "Parameter #" ^ (Int.to_string number) %>" class="breadcrumbs-tag parameter-tag text-white"><%s "Parameter #" ^ (Int.to_string number) %></span>
+    <span tabindex="0" aria-label="<%s "Parameter #" ^ (Int.to_string number) %>" class="breadcrumbs-tag parameter-tag"><%s "Parameter #" ^ (Int.to_string number) %></span>
   | Class _ ->
-    <span tabindex="0" aria-label="class" class="breadcrumbs-tag class-tag text-white">Class</span>
+    <span tabindex="0" aria-label="class" class="breadcrumbs-tag class-tag">Class</span>
   | ClassType _ ->
-    <span tabindex="0" aria-label="class type" class="breadcrumbs-tag class-type-tag text-white">Class type</span>
+    <span tabindex="0" aria-label="class type" class="breadcrumbs-tag class-type-tag">Class type</span>
 
 type path =
   | Overview of string option
@@ -48,18 +48,14 @@ let render_package_and_version
       <%s v %>
     </option>
   in
-  <li>
-    <h1 class="inline text-base">
-      <a class="font-semibold underline" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a>
-    </h1>
-  </li>
-  <li>
+  <div class="flex gap-4">
+    <a class="font-semibold text-3xl" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a>
     <select id="version" name="version" aria-label="version" onchange="location = this.value;"
       class="leading-8 appearance-none cursor-pointer py-0 rounded-md border border-gray-400 pr-8"
       style="background-position: right 0.25rem center">
       <%s! package.versions |> List.map version_options |> String.concat "" %>
     </select>
-  </li>
+  </div>
 
 type breadcrumb = {
   name: string;
@@ -80,26 +76,23 @@ let render_library_path_breadcrumbs
     if i < List.length path - 1 then
       <a href="<%s! b.href %>" class="font-semibold underline text-gray-800"><%s b.name %></a>
     else
-      <a href="<%s! b.href %>" aria-current="page" class="text-gray-800"><%s b.name %></a>
+      <a href="<%s! b.href %>" aria-current="page" class="text-gray-800 mr-2"><%s b.name %></a>
   in
   <li>
     <span tabindex="0" class="text-gray-600"><%s library_name %> lib</span>
   </li>
-  <li class="inline-flex">
+  <li class="flex flex-wrap items-center">
     <%s! String.concat "<span>.</span>" (path |> List.map library_path_item_to_breadcrumb |> List.mapi render_breadcrumb); %>
     <%s! kind_tag (List.hd (List.rev path)) %>
   </li>
 
 let render_docs_path_breadcrumbs
 ~(path: docs_path)
-?page
-?hash
 (package: Package.package)
   =
   let version = Package.url_version package in
-  <nav aria-label="breadcrumb" class="flex" id="htmx-breadcrumbs">
-    <ul class="flex flex-wrap gap-x-2 text-base leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~path:(Documentation path) ?page ?hash package %>
+  <nav aria-label="breadcrumb" class="flex mb-6 border-b pb-6">
+    <ul class="flex flex-wrap gap-x-2 text-base leading-7 package-breadcrumbs">
       <li>
         <a class="underline font-semibold" href="<%s! Url.Package.documentation package.name ?version %>">Documentation</a>
       </li>
@@ -115,14 +108,12 @@ let render_docs_path_breadcrumbs
     </ul>
   </nav>
 
+
 let render_overview_breadcrumbs
-~(page: string option)
-?hash
-(package: Package.package)
+(page: string option)
 =
-  <nav aria-label="breadcrumbs" class="flex">
+  <nav aria-label="breadcrumbs" class="flex mb-6 border-b">
     <ul class="flex flex-wrap gap-x-2 leading-8 package-breadcrumbs">
-      <%s! render_package_and_version ~path:(Overview page) ?hash package %>
       <% (match page with | Some p -> %>
       <li><%s p %></li>
       <% | None -> ()); %>
@@ -131,8 +122,8 @@ let render_overview_breadcrumbs
 
 let render
 ~(path: path)
-?page
+(package: Package.package)
 =
   match path with
-    | Overview page -> render_overview_breadcrumbs ~page
-    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~path:docs_path ?page
+    | Overview page -> render_overview_breadcrumbs page
+    | Documentation (docs_path) -> render_docs_path_breadcrumbs ~path:docs_path package

--- a/src/ocamlorg_frontend/css/partials/package_breadcrumbs.css
+++ b/src/ocamlorg_frontend/css/partials/package_breadcrumbs.css
@@ -2,3 +2,7 @@
   @apply text-gray-400;
   content: "/";
 }
+
+.package-breadcrumbs .breadcrumbs-tag {
+  @apply text-sm px-3 py-0.5 rounded font-bold text-white inline-block;
+}

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -23,8 +23,8 @@ Layout.render
   <div class="pt-6">
     <div class="container-fluid wide">
       <div class="flex justify-between flex-col md:flex-row">
-        <div class="flex flex-col items-baseline">
-          <%s! Package_breadcrumbs.render ~path ?hash ?page package %>
+        <div class="flex flex-col items-baseline" id="htmx-breadcrumbs">
+          <%s! Package_breadcrumbs.render_package_and_version ~path ?hash ?page package %>
         </div>
       </div>
       <div x-data="{ sidebar: window.matchMedia('(min-width: 48em)').matches }" @resize.window="sidebar = window.matchMedia('(min-width: 48em)').matches" x-on:close-sidebar="sidebar=window.matchMedia('(min-width: 48em)').matches">

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -57,6 +57,7 @@ Package_layout.render
 ~left_sidebar_html:(sidebar ~str_path ~toc ~maptoc package)
 ~right_sidebar_html:(right_sidebar ~toc) @@
 <div id="htmx-content">
+  <%s! Package_breadcrumbs.render ~path package %>
   <div class="odoc prose prose-orange">
     <%s! content %>
   </div>


### PR DESCRIPTION
We move the breadcrumbs to above the main content area so that there's room for badges next to the package title.

|before|after|
|-|-|
|![Screenshot 2023-04-26 at 11-59-50 cmdliner 1 2 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/234541743-931c9a52-5d37-4797-8102-13dbf1f94aa8.png)|![Screenshot 2023-04-26 at 11-59-54 cmdliner 1 2 0 (latest) · OCaml Package](https://user-images.githubusercontent.com/6594573/234541752-1c1c5b59-5ae8-4399-b0d9-44bf35b6d6e2.png)|
