### PR TITLE
Refine package search results design, include docs link

### DIFF
--- a/src/ocamlorg_frontend/components/icons.eml
+++ b/src/ocamlorg_frontend/components/icons.eml
@@ -93,7 +93,7 @@ let document class_ =
 
 let documentation class_ =
   <svg xmlns="http://www.w3.org/2000/svg" class="<%s class_ %>" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
   </svg>
 
 let download class_ =

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -5,94 +5,110 @@ let render ~total ~search (packages : Package.package list) = Layout.render ~tit
 <div class="bg-white">
   <div class="py-10 lg:py-14">
     <div class="container-fluid">
-      <div class="flex flex-col lg:px-28">
-        <div class="max-w-prose space-y-6 mb-4">
-          <form action="/packages/search" method="GET">
-            <div class="flex items-center justify-center">
-              <input
-                type="search"
-                name="q" id="q2"
-                class="packages_search__search__input w-full focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1"
-                value="<%s search %>"
-                placeholder="Search OCaml Packages">
-              <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
-                <%s! Icons.magnifying_glass "w-6 h-6 text-white" %>
-              </button>
-            </div>
-          </form>
-
-          <div class="prose">
-            <h1 class="font-bold text-3xl mb-5 md:mb-0">
-              <% (match total with
-                | 0 -> %> No search results for "<%s search %>"
-              <% | 1 -> %> 1 search result for "<%s search %>"
-              <% | _ -> %> <%s string_of_int total ^ " search results for \"" ^ search ^ "\"" %>
-              <% ); %>
-            </h1>
-
-            <% if List.length packages = 0 then ( %>
-            <p>
-              We didn't find a match for "<%s search %>".
-            </p>
-            <p>
-              <strong>Search tips:</strong>
-            </p>
-            <ul>
-              <li>The search does not correct typos automatically (yet). Be sure to use correct spelling for keywords or package names.</li>
-              <li>Looking for a tutorial or guide, and not a package? Check out our <a href="<%s Url.learn %>">Learn area</a>.</li>
-              <li>Looking for the standard library API? It's <a href="<%s Url.api %>">here</a>.</li>
-            </ul>
-            </div>
-            <% ); %>
+      <div class="flex flex-col lg:px-28 gap-2 max-w-5xl">
+        <form action="/packages/search" method="GET">
+          <div class="flex items-center justify-center">
+            <input
+              type="search"
+              name="q" id="q2"
+              class="packages_search__search__input w-full focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 py-1"
+              value="<%s search %>"
+              placeholder="Search OCaml Packages">
+            <button aria-label="search" class="h-10 rounded-r-md bg-primary-600 text-white flex items-center justify-center px-4">
+              <%s! Icons.magnifying_glass "w-6 h-6 text-white" %>
+            </button>
           </div>
+        </form>
+
+        <div class="prose max-w-5xl">
+          <h1 class="font-bold text-2xl mb-5 md:mb-0">
+            <% (match total with
+              | 0 -> %> No search results for "<%s search %>"
+            <% | 1 -> %> 1 search result for "<%s search %>"
+            <% | _ -> %> <%s string_of_int total ^ " search results for \"" ^ search ^ "\"" %>
+            <% ); %>
+          </h1>
+
+          <% if List.length packages = 0 then ( %>
+          <p>
+            We didn't find a match for "<%s search %>".
+          </p>
+          <p>
+            <strong>Search tips:</strong>
+          </p>
+          <ul>
+            <li>The search does not correct typos automatically (yet). Be sure to use correct spelling for keywords or package names.</li>
+            <li>Looking for a tutorial or guide, and not a package? Check out our <a href="<%s Url.learn %>">Learn area</a>.</li>
+            <li>Looking for the standard library API? It's <a href="<%s Url.api %>">here</a>.</li>
+          </ul>
+          </div>
+          <% ); %>
         </div>
 
         <% if List.length packages > 0 then ( %>
-        <ol>
+        <ol class="flex flex-col">
           <% packages |> List.iter (fun (package : Package.package) -> %>
-          <li class="border-gray-200 border-t mt-4 pt-4 mb-2 space-y-2">
-            <a
-              href="<%s Url.Package.overview package.name %>"
-              class="text-lg font-semibold text-primary-600 inline-block"
-            >
-              <%s package.name %>
-            </a>
-            <div><%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search package.synopsis %></div>
-            <div class="flex flex-wrap">
-              <% package.tags |> List.iter (fun (tag : string) -> %>
+          <li class="border-gray-200 border-b py-3 space-y-2">
+            <div class="flex">
               <a
-                href="<%s Url.packages_search %>?q=tag%3A%22<%s Dream.to_percent_encoded tag %>%22"
-                class="px-2 py-1 text-body-400 font-medium bg-gray-100 rounded hover:underline mr-3 mb-2 mt-1 text-sm"
+                href="<%s Url.Package.overview package.name %>"
+                class="flex-grow text-lg font-semibold text-primary-700 inline-block"
               >
-                <%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search tag %>
+                <%s package.name %>
               </a>
-              <% ); %>
+              <div class="flex gap-4 justify-end items-center">
+              <a
+                href="<%s Url.Package.documentation package.name %>"
+                class="text-primary-700 flex gap-1 text-sm items-center"
+              >
+                <%s! Icons.documentation "h-5 w-5" %>
+                Documentation
+              </a>
+              </div>
             </div>
-            <div class="flex items-center space-y-1 md:space-y-0 text-body-600 text-sm flex-wrap justify-start">
-              <div class="flex items-center flex-wrap mr-4">
-                <% package.authors |> List.iter (fun (author : Ood.Opam_user.t) -> %>
+
+            <div class="text-sm flex flex-col gap-2">
+              <div><%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search package.synopsis %></div>
+              <% if List.length package.tags > 0 then ( %>
+              <div class="text-sm flex flex-wrap gap-1 text-body-500">
+                <% package.tags |> List.iter (fun (tag : string) -> %>
+                <a
+                  href="<%s Url.packages_search %>?q=tag%3A%22<%s Dream.to_percent_encoded tag %>%22"
+                  class="px-2 whitespace-nowrap py-0.5 text-primary-700 font-medium bg-primary-100 border border-primary-600 rounded hover:underline"
+                >
+                  <%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search tag %>
+                </a>
+                <% ); %>
+              </div>
+              <% ) else (); %>
+              <div class="flex items-center flex-wrap gap-x-3 text-sm text-body-500">
+                <% package.authors |> Ocamlorg.Import.List.take 5 |> List.iter (fun (author : Ood.Opam_user.t) -> %>
                 <a
                   href="<%s Url.packages_search %>?q=author%3A%22<%s Dream.to_percent_encoded author.name %>%22"
-                  class="text-sm hover:underline mr-3"
+                  class="hover:underline"
                 >
                   <%s! Search.highlight_search_terms ~class_:"bg-background-light-blue" ~search author.name %>
                 </a>
                 <% ); %>
+                <%s if List.length package.authors > 5 then " et al." else "" %>
               </div>
-              <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
-                <%s! Icons.hashtag "h-5 w-5"; %>
+            </div>
+            <div class="flex items-center gap-x-6 gap-y-2 text-body-500 text-sm flex-wrap justify-start">
+              <div class="flex items-center gap-1">
+                <%s! Icons.tag "h-5 w-5"; %>
                 <div><%s Package.render_version package %></div>
               </div>
-              <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
+              <div class="flex items-center gap-1">
                 <%s! Icons.license "h-5 w-5"; %>
-                <span class="text-sm hover:underline"> <%s package.license %> </span>
+                <span class="hover:underline"> <%s package.license %> </span>
               </div>
-              <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
+              <div class="flex items-center gap-1">
                 <%s! Icons.star "h-5 w-5"; %>
-                <div>Used by <%d List.length package.rev_deps %> other packages</div>
+                <span>Used by <%d List.length package.rev_deps %> other packages</span>
               </div>
-              <div class="flex items-center space-x-2 text-sm text-body-600 mr-4">
-                Last published <%s Utils.human_date_of_timestamp package.publication %>
+              <div class="flex items-center gap-1">
+                <%s! Icons.calendar "h-5 w-5"; %>
+                <span><%s Utils.human_date_of_timestamp package.publication %></span>
               </div>
             </div>
           </li>


### PR DESCRIPTION
Adjust the design of the search results to be more compact. For packages with more than 5 authors, list only the first five and "et al.".

Might want to compact the tags to a single line (expandable), or omit them (unless the search query matches), in the future. However, in contrast to the authors on some packages, the amount of tags seems to be still bearable so I refrain for now.

||before|after|
|-|-|-|
|xl|![Screenshot 2023-04-26 at 14-53-38 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/234581391-7af58c3f-6505-4343-9482-4fb4b665293f.png)|![Screenshot 2023-04-26 at 14-53-41 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/234581401-addc70ad-3829-48e2-9b20-4eddbecb8716.png)|
|xl|![Screenshot 2023-04-26 at 14-54-23 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/234581443-42390124-9f36-4f64-a46b-497af240e48d.png)|![Screenshot 2023-04-26 at 14-54-27 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/234581456-94294779-81e9-4e77-b88d-8b9ca49e0287.png)|
|sm|![Screenshot 2023-04-26 at 14-54-52 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/234581490-62cf263e-4172-4a67-bbf7-f4e7b0b4ff24.png)|![Screenshot 2023-04-26 at 14-54-58 OCaml Packages · Search Result](https://user-images.githubusercontent.com/6594573/234581500-2e51fa92-7cb0-4943-9e8a-19704d8169cf.png)|
