### PR TITLE
Add code of conduct to README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).

--- a/README.md
+++ b/README.md
@@ -106,3 +106,8 @@ See our contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 - The vendored files are listed with their licenses in [`LICENSE-3RD-PARTY`](./LICENSE-3RD-PARTY)
 
 See our [`LICENSE`](./LICENSE) for the complete licenses.
+
+## Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md)
+and follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).

--- a/README.md
+++ b/README.md
@@ -109,5 +109,4 @@ See our [`LICENSE`](./LICENSE) for the complete licenses.
 
 ## Code of Conduct
 
-This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md)
-and follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+This project follows the [OCaml Code of Conduct](https://github.com/ocaml/ocaml.org/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This code of conduct lives in https://github.com/ocaml/code-of-conduct and has been discussed [in this thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

It has been adopted in the OCaml compiler and in several tools, and is already displayed at https://ocaml.org/policies/code-of-conduct. Now we're officially adopting it in the OCaml.org repo as well.