### PR TITLE
problem difficulty symbols collapse at xl

### DIFF
--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -62,11 +62,11 @@ Learn_layout.render
     <% problems |> List.iter (fun (problem : Ood.Problem.t) -> %>
     <div x-data="{statement: true}" id="<%s" problem.number %>
       >
-      <div class="flex space-y-4 lg:space-y-0 flex-col lg:flex-row lg:justify-between">
-        <span aria-hidden="true" class="danger invisible lg:visible" title="<%s Ood.Problem.difficulty_to_string problem.difficulty ^ " difficulty" %>"><%s danger problem.difficulty %></span>
+      <div class="flex space-y-4 xl:space-y-0 flex-col xl:flex-row xl:justify-between">
+        <span aria-hidden="true" class="danger invisible xl:visible" title="<%s Ood.Problem.difficulty_to_string problem.difficulty ^ " difficulty" %>"><%s danger problem.difficulty %></span>
         <h4 class="font-bold text-body-600">
           <%s problem.title %>
-          <span aria-hidden="true" class="ml-2 visible lg:invisible" title="<%s Ood.Problem.difficulty_to_string problem.difficulty ^ " difficulty" %>"> <%s danger problem.difficulty %></span>
+          <span aria-hidden="true" class="ml-2 visible xl:invisible" title="<%s Ood.Problem.difficulty_to_string problem.difficulty ^ " difficulty" %>"> <%s danger problem.difficulty %></span>
         </h4>
         <div class="w-0 h-0 overflow-hidden"><%s Ood.Problem.difficulty_to_string problem.difficulty ^ " difficulty" %></div>
         <div class="flex bg-body-600 bg-opacity-5 rounded-md p-1 items-center">


### PR DESCRIPTION
On the `lg` screen, there isn't enough space in the margins, so we have to collapse the problem difficulty symbols and only have them be in the margin on the `xl` screen.