### PR TITLE
Fix Tutorial Contribution Link

### DIFF
--- a/src/dream_dashboard/dream_dashboard.ml
+++ b/src/dream_dashboard/dream_dashboard.ml
@@ -1,3 +1,5 @@
+open Ocamlorg
+
 module Store = struct
   module type S = sig
     val create_event : Event.t -> (unit, string) result Lwt.t

--- a/src/dream_dashboard/dune
+++ b/src/dream_dashboard/dune
@@ -26,18 +26,6 @@
    %{null}
    (run %{bin:ocaml-crunch} -m plain asset -o %{targets}))))
 
-(rule
- (targets commit.ml)
- (action
-  (with-stdout-to
-   %{targets}
-   (progn
-    (echo "let hash = \"")
-    (pipe-stdout
-     (run "git" "rev-parse" "HEAD")
-     (run "tr" "-d" "\n"))
-    (echo "\"\n")))))
-
 (subdir
  asset/
  (rule

--- a/src/global/dune
+++ b/src/global/dune
@@ -3,10 +3,10 @@
  (public_name ocamlorg.global))
 
 (rule
- (targets commit.ml)
+ (deps (universe))
  (action
   (with-stdout-to
-   %{targets}
+   commit.ml
    (progn
     (echo "let hash = \"")
     (pipe-stdout

--- a/src/global/dune
+++ b/src/global/dune
@@ -1,3 +1,15 @@
 (library
  (name ocamlorg)
  (public_name ocamlorg.global))
+
+(rule
+ (targets commit.ml)
+ (action
+  (with-stdout-to
+   %{targets}
+   (progn
+    (echo "let hash = \"")
+    (pipe-stdout
+     (run "git" "rev-parse" "HEAD")
+     (run "tr" "-d" "\n"))
+    (echo "\"\n")))))

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -1,3 +1,5 @@
+open Ocamlorg
+
 let rec tutorial_toc_to_toc (toc : Ood.Tutorial.toc) =
   Toc.{
     title = toc.title;
@@ -32,7 +34,7 @@ Learn_layout.render
         <p class="text-sm mt-0 mb-4 max-w-xs">All OCaml docs are open source. See something that's wrong or unclear? Submit a pull request.</p>
         <a
           class="inline-block relative py-1 px-4 font-medium no-underline align-middle bg-transparent rounded-md border border-solid appearance-none cursor-pointer select-none whitespace-no-wrap hover:no-underline"
-          href="https://github.com/ocaml/ocaml.org/blob/<%s Ocamlorg.Commit.hash %>/data/<%s tutorial.fpath %>"
+          href="https://github.com/ocaml/ocaml.org/blob/<%s Commit.hash %>/data/<%s tutorial.fpath %>"
         >
           <%s! Icons.github_pull_request "inline-block overflow-visible mr-0 align-text-bottom select-none" %>
           Contribute</a

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -32,7 +32,7 @@ Learn_layout.render
         <p class="text-sm mt-0 mb-4 max-w-xs">All OCaml docs are open source. See something that's wrong or unclear? Submit a pull request.</p>
         <a
           class="inline-block relative py-1 px-4 font-medium no-underline align-middle bg-transparent rounded-md border border-solid appearance-none cursor-pointer select-none whitespace-no-wrap hover:no-underline"
-          href="https://github.com/ocaml/ocaml.org/blob/main/data/<%s tutorial.fpath %>"
+          href="https://github.com/ocaml/ocaml.org/blob/<%s Ocamlorg.Commit.hash %>/data/<%s tutorial.fpath %>"
         >
           <%s! Icons.github_pull_request "inline-block overflow-visible mr-0 align-text-bottom select-none" %>
           Contribute</a


### PR DESCRIPTION
This allows the “contribute” link in tutorial to point to correct
gh blob from staging.ocaml.org

- Make git commit available globally
- Use git commit in tutorial contrib link
