### PR TITLE
Close <form> tag in changelog.eml

### DIFF
--- a/src/ocamlorg_frontend/pages/changelog.eml
+++ b/src/ocamlorg_frontend/pages/changelog.eml
@@ -30,6 +30,7 @@ Layout.render
           <option value="<%s item %>" <%s if current_tag = (Some item) then "selected" else "" %>><%s item %></option>
           <% ); %>
         </select>
+      </form>
     </div>
   </div>
 


### PR DESCRIPTION
The unclosed `form` tag in `changelog.eml` would prevent the main navbar from working properly on small screens, so I am adding the missing closing tag.