### PR TITLE
Simplify the building process for the playground

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -72,13 +72,7 @@ The OCaml playground is compiled separately from the rest of the server and the 
 
 You can build the playground from the root of the project, there is no need to move to the `./playground/` directory for the following commands.
 
-To regenerate the playground, you will need to set up an OCaml 5 switch:
-
-```
-make create_switch -C playground
-```
-
-You can then install the playground's dependencies:
+To regenerate the playground, you need to install the playground's dependencies first:
 
 ```
 make deps -C playground

--- a/HACKING.md
+++ b/HACKING.md
@@ -73,19 +73,19 @@ The OCaml playground is compiled separately from the rest of the server and the 
 To regenerate the playground, you will need to set up an OCaml 5 switch:
 
 ```
-opam switch create 5.0.0 5.0.0 --no-install
+make create_switch -C playground
 ```
 
-You can then go in the `playground/` directory and install the dependencies:
+You can then install the playground's dependencies:
 
 ```
-opam install . --deps-only
+make deps -C playground
 ```
 
 After the dependencies have been installed, simply build the project to re-generate the JavaScript assets:
 
 ```
-dune build --root .
+make playground
 ```
 
 Once the compilation is complete and successuful, the newly generated assets have to be git committed

--- a/HACKING.md
+++ b/HACKING.md
@@ -70,6 +70,8 @@ make test
 The OCaml playground is compiled separately from the rest of the server and the generated assets can be found in
 [`playground/asset/`](./playground/asset/).
 
+You can build the playground from the root of the project, there is no need to move to the `./playground/` directory for the following commands.
+
 To regenerate the playground, you will need to set up an OCaml 5 switch:
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ lock: ## Generate a lock file
 build: ## Build the project, including non installable libraries and executables
 	opam exec -- dune build --root .
 
+.PHONY: playground
+playground:
+	make build -C playground
+
 .PHONY: install
 install: all ## Install the packages on the system
 	opam exec -- dune install --root .

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -1,0 +1,11 @@
+.PHONY: create_switch
+create_switch: ## Create switch and pinned opam repo
+	opam switch create 5.0.0 5.0.0 --no-install
+
+.PHONY: deps
+deps: create_switch ## Install development dependencies
+	opam install . --deps-only
+
+.PHONY: build
+build:
+	opam exec --switch=5.0.0 -- dune build --root .

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -4,7 +4,7 @@ create_switch: ## Create switch and pinned opam repo
 
 .PHONY: deps
 deps: create_switch ## Install development dependencies
-	opam install . --deps-only
+	opam install . --deps-only --switch=5.0.0
 
 .PHONY: build
 build:

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -1,5 +1,5 @@
 COMPILER=5.0.0
-SWITCH=5.0.0
+SWITCH=playground
 
 .PHONY: create_switch
 create_switch: ## Create switch and pinned opam repo

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -1,11 +1,14 @@
+COMPILER=5.0.0
+SWITCH=5.0.0
+
 .PHONY: create_switch
 create_switch: ## Create switch and pinned opam repo
-	opam switch create 5.0.0 5.0.0 --no-install
+	opam switch create $(SWITCH) $(COMPILER) --no-install
 
 .PHONY: deps
 deps: create_switch ## Install development dependencies
-	opam install . --deps-only --switch=5.0.0
+	opam install . --deps-only --switch=$(SWITCH)
 
 .PHONY: build
 build:
-	opam exec --switch=5.0.0 -- dune build --root .
+	opam exec --switch=$(SWITCH) -- dune build --root .


### PR DESCRIPTION
Now the process is just:
```
make playground
make start
```
and we don't have to manually switch between 2 opam switches.