### PR TITLE
Howto stage PR

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -108,6 +108,38 @@ With the docker container running, you can visit the site at <http://localhost:8
 
 The docker images automatically build from the `live` and `staging` branches, and are then pushed to Docker Hub: https://hub.docker.com/r/ocurrent/v3.ocaml.org-server
 
+### Staging Pull Requests
+
+Staging is supposed to be as close as possible to the `main` branch, with a
+couple of PR added on top of it. To reduce the workload maintaining the
+`staging` branch is sync and with the correct PR added, some discipline is
+needed. The idea is to turn staged PR into single commits, which removes the need
+to use `git rebase`. Assuming a PR lies in branch `<pr-branch>` (e.g.
+`fix-issue-42`) and has number `<pr-num>` in GitHub (e.g. 43 in
+https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
+`ocaml/ocaml.org.git` at GitHub, here are the recipes that can be used:
+
+* Adding a PR to `staging`:
+  ```sh
+  $ git merge --squash foo-branch
+  $ git merge -m "Squash and merge PR #<pr-num> (<pr-branch>)"
+  $ git tag -a <pr-tag> -m "Stage PR #<pr-num>" HEAD
+  ```
+  Where `<pr-tag>` is the string `stage-<pr-num>` (e.g. `stage-43`):
+* Removing a PR from `staging`:
+  ```sh
+  $ git rebase --onto <pr-tag>^ <pr-tag>
+  $ git tag -d <pr-tag>
+  ```
+* Updating a PR in `staging` is just removing and adding
+* Sync `staging` with `main`
+  1. Pull `main`: checkout into `main` and `git pull origin main`
+  1. Checkout into `staging`
+  1. Remove staged PRs
+  1. `git reset --hard main`
+  1. Add staged PRs
+  1. `git push -f origin staging`
+
 ### Managing dependencies
 
 ocaml.org is using an Opam switch which is local and bound to a pinned commit in opam-repository. This is intended to protect the build from upstream regressions. The Opam repository is specified in three (3) places:

--- a/HACKING.md
+++ b/HACKING.md
@@ -110,35 +110,13 @@ The docker images automatically build from the `live` and `staging` branches, an
 
 ### Staging Pull Requests
 
-The `staging` branch is supposed to be as close as possible to the `main`
-branch, with a couple of PR added on top of it. To reduce the workload
-maintaining the `staging` branch in sync and with the correct PR added, some
-discipline is needed. The idea is to turn staged PR into single commits, which
-removes the need to use `git rebase`. Assuming a PR lies in branch `<pr-branch>`
-(e.g. `fix-issue-42`) and has number `<pr-num>` in GitHub (e.g. 43 in
-https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
-`ocaml/ocaml.org.git` at GitHub, here are the recipes that can be used:
+We [aim to keep the `staging` branch as close as possible to the `main`
+branch](doc/FOR_MAINTAINERS.md#how-we-maintain-the-staging-branch), with only a few PRs added on top of it.
 
-* Adding a PR to `staging`:
-  ```sh
-  $ git merge --squash <pr-branch>
-  $ git merge -m "Squash and merge PR #<pr-num> (<pr-branch>)"
-  $ git tag -a <pr-tag> -m "Stage PR #<pr-num>" HEAD
-  ```
-  Where `<pr-tag>` is the string `stage-<pr-num>` (e.g. `stage-43`):
-* Removing a PR from `staging`:
-  ```sh
-  $ git rebase --onto <pr-tag>^ <pr-tag>
-  $ git tag -d <pr-tag>
-  ```
-* Updating a PR in `staging` is just removing and adding
-* Sync `staging` with `main`
-  1. Pull `main`: checkout into `main` and `git pull origin main`
-  1. Checkout into `staging`
-  1. Remove staged PRs
-  1. `git reset --hard main`
-  1. Add staged PRs
-  1. `git push -f origin staging`
+The maintainers will add your pull request to `staging` if it is worthwhile
+to do so. For example, documentation PRs or new features where we need testing
+and feedback from the community will generally be live on `staging` for a while
+before they get merged.
 
 ### Managing dependencies
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -121,7 +121,7 @@ https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
 
 * Adding a PR to `staging`:
   ```sh
-  $ git merge --squash foo-branch
+  $ git merge --squash <pr-branch>
   $ git merge -m "Squash and merge PR #<pr-num> (<pr-branch>)"
   $ git tag -a <pr-tag> -m "Stage PR #<pr-num>" HEAD
   ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -110,12 +110,12 @@ The docker images automatically build from the `live` and `staging` branches, an
 
 ### Staging Pull Requests
 
-Staging is supposed to be as close as possible to the `main` branch, with a
-couple of PR added on top of it. To reduce the workload maintaining the
-`staging` branch is sync and with the correct PR added, some discipline is
-needed. The idea is to turn staged PR into single commits, which removes the need
-to use `git rebase`. Assuming a PR lies in branch `<pr-branch>` (e.g.
-`fix-issue-42`) and has number `<pr-num>` in GitHub (e.g. 43 in
+The `staging` branch is supposed to be as close as possible to the `main`
+branch, with a couple of PR added on top of it. To reduce the workload
+maintaining the `staging` branch in sync and with the correct PR added, some
+discipline is needed. The idea is to turn staged PR into single commits, which
+removes the need to use `git rebase`. Assuming a PR lies in branch `<pr-branch>`
+(e.g. `fix-issue-42`) and has number `<pr-num>` in GitHub (e.g. 43 in
 https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
 `ocaml/ocaml.org.git` at GitHub, here are the recipes that can be used:
 

--- a/doc/FOR_MAINTAINERS.md
+++ b/doc/FOR_MAINTAINERS.md
@@ -13,20 +13,36 @@ it is close to the main branch with only a few patches applied, some discipline 
 This way, looking at the commits on `staging` via `git log` or the GitHub UI, it is obvious where each commit is coming from and what its purpose is. Additionally, this ensures that rebasing on an updated
 `main` branch remains simple.
 
+## Add a PR to staging
+
 Example: Assuming a PR lies in branch `<pr-branch>`
 (e.g. `fix-issue-42`) and has number `<pr-num>` in GitHub (e.g. 43 in
 https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
 `ocaml/ocaml.org.git` at GitHub, here are the steps:
 
-1. Squash a PR:
+### Method 1: `git merge`
+
+1. Squash a PR directly onto staging:
   ```sh
+  $ git checkout staging
   $ git merge --squash <pr-branch>
   $ git merge -m "<title of PR on GitHub> #<pr-num>"
   ```
-  Alternatively, you can do
+
+2. Set the commit message to:
+  ```
+  <title of PR on GitHub> #<pr-num>
+
+  <message of last commit> <last commit id>
+  ```
+
+### Method 2: `git reset`
+
+An alternative method to get a squashed PR onto staging is this:
+1. On the PR branch: create a new branch from the PR branch and squash with `git reset`:
   ```sh
   $ git checkout -b <new-branch-name>
-  $ git reset main
+  $ git reset <commit id before the first commit of the patch>
   $ git commit
   ```
 
@@ -37,6 +53,12 @@ https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
   <message of last commit> <last commit id>
   ```
 
-To add a commit to `staging`, we can cherry-pick the commit with `git cherry-pick <commit id>`.
+3. Cherry-pick the commit to staging
+  ```sh
+  $ git checkout staging
+  $ git cherry-pick <commit id>
+  ```
 
-To remove a commit from `staging`, a simple method is to `git rebase -i main`. This gives you a list of commits that you can edit to remove a specific commit.
+## Remove a PR from staging
+
+To remove a commit from `staging`, a simple method is to `git rebase -i main`. This gives you a list of commits that you can edit to remove the commit.

--- a/doc/FOR_MAINTAINERS.md
+++ b/doc/FOR_MAINTAINERS.md
@@ -1,0 +1,42 @@
+# Information for maintainers
+
+# How we maintain the staging branch
+
+To reduce the workload maintaining the `staging` branch in a good shape where
+it is close to the main branch with only a few patches applied, some discipline is needed:
+
+1. We squash every patch into a single commit, and
+2. if the patch belongs to an open PR,
+  - we mention the PR number and title in the commit message, and
+  - we mention the commit id and message of the latest commit in that PR in the commit message body
+
+This way, looking at the commits on `staging` via `git log` or the GitHub UI, it is obvious where each commit is coming from and what its purpose is. Additionally, this ensures that rebasing on an updated
+`main` branch remains simple.
+
+Example: Assuming a PR lies in branch `<pr-branch>`
+(e.g. `fix-issue-42`) and has number `<pr-num>` in GitHub (e.g. 43 in
+https://https://github.com/ocaml/ocaml.org/pull/43), and `origin` is
+`ocaml/ocaml.org.git` at GitHub, here are the steps:
+
+1. Squash a PR:
+  ```sh
+  $ git merge --squash <pr-branch>
+  $ git merge -m "<title of PR on GitHub> #<pr-num>"
+  ```
+  Alternatively, you can do
+  ```sh
+  $ git checkout -b <new-branch-name>
+  $ git reset main
+  $ git commit
+  ```
+
+2. Set the commit message to:
+  ```
+  <title of PR on GitHub> #<pr-num>
+
+  <message of last commit> <last commit id>
+  ```
+
+To add a commit to `staging`, we can cherry-pick the commit with `git cherry-pick <commit id>`.
+
+To remove a commit from `staging`, a simple method is to `git rebase -i main`. This gives you a list of commits that you can edit to remove a specific commit.


### PR DESCRIPTION
This proposes a couple of recipes to stage PR in staging as squashed merges: a single commit per PR. This removes the need to use `git rebase`