### PR TITLE
Serve dashboard assets from file system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY --from=build /home/opam/package.state /var/package.state
 COPY --from=build /home/opam/opam-repository /var/opam-repository
 COPY --from=build /home/opam/_build/default/src/ocamlorg_web/bin/main.exe /bin/server
 COPY --from=build /home/opam/_build/default/asset _build/default/asset
+COPY --from=build /home/opam/_build/default/src/dream_dashboard/asset _build/default/src/dream_dashboard/asset
 COPY --from=build /home/opam/_build/default/data/media _build/default/data/media
 
 COPY playground/asset playground/asset

--- a/src/dream_dashboard/dream_dashboard.ml
+++ b/src/dream_dashboard/dream_dashboard.ml
@@ -73,7 +73,8 @@ module Router = struct
       [
         Dream.get "" (Handler.overview ~prefix);
         Dream.get "/analytics" (Handler.analytics ~prefix ~store);
-        Dream.get "/assets/**" (Dream.static "_build/default/src/dream_dashboard/asset");
+        Dream.get "/assets/**"
+          (Dream.static "_build/default/src/dream_dashboard/asset");
       ]
 end
 

--- a/src/dream_dashboard/dream_dashboard.ml
+++ b/src/dream_dashboard/dream_dashboard.ml
@@ -68,19 +68,12 @@ module Middleware = struct
 end
 
 module Router = struct
-  let loader _root path _request =
-    let open Lwt.Syntax in
-    let* maybe_asset = Ocamlorg_static.Asset.read path in
-    match maybe_asset with
-    | None -> Dream.empty `Not_Found
-    | Some asset -> Dream.respond asset
-
   let route ~prefix middlewares store =
     Dream.scope prefix middlewares
       [
         Dream.get "" (Handler.overview ~prefix);
         Dream.get "/analytics" (Handler.analytics ~prefix ~store);
-        Dream.get "/assets/**" (Dream.static ~loader "");
+        Dream.get "/assets/**" (Dream.static "_build/default/src/dream_dashboard/asset");
       ]
 end
 


### PR DESCRIPTION
In https://github.com/ocaml/ocaml.org/pull/958, I mistakenly tried to serve the dashboard assets via `Ocamlorg_static.Asset.read`. However, the dashboard's assets are separate.

This patch serves the dashboard assets from the `_build` folder using the default loader from `Dream.static`.