### PR TITLE
Bump ahrefs job as it's still relevant

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -34,6 +34,7 @@ jobs:
     locations:
       - Remote
       - Singapore
+    publication_date: 2023-05-10
     company: Ahrefs
     company_logo: /logos/ahrefs.svg
   - title: OCaml Developer


### PR DESCRIPTION
We might need a policy / system for checking whether job listings are still active. There is value in letting companies highlight to people that their listing is still relevant.

For now, I propose that manually bumping every 3-6 months is fine.