### PR TITLE
Setup the default example of the playground in the handler

### DIFF
--- a/data/code_examples/default.ml
+++ b/data/code_examples/default.ml
@@ -1,7 +1,4 @@
-let print = {|let () = print_endline "Welcome to the OCaml Playground"|}
-
-let adts =
-  {|(* 
+(*
   Welcome to the official OCaml Playground!
 
   You don't need to install anything - just write your code
@@ -47,4 +44,3 @@ let () =
   parallel computation, take a look at
   https://v2.ocaml.org/releases/5.0/manual/parallelism.html#s:par_iterators
 *)
-|}

--- a/src/ocamlorg_data/data.ml
+++ b/src/ocamlorg_data/data.ml
@@ -160,3 +160,9 @@ module Page = struct
     let slug = Filename.basename path in
     List.find (fun x -> String.equal slug x.slug) all
 end
+
+module Code_example = struct
+  include Code_example
+
+  let get title = List.find (fun x -> String.equal x.title title) all
+end

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -390,3 +390,9 @@ module Page : sig
 
   val get : string -> t
 end
+
+module Code_example : sig
+  type t = { title : string; body : string }
+
+  val get : string -> t
+end

--- a/src/ocamlorg_data/dune
+++ b/src/ocamlorg_data/dune
@@ -161,3 +161,10 @@
   (with-stdout-to
    %{target}
    (run %{dep:../../tool/ood-gen/bin/gen.exe} page))))
+
+(rule
+ (target code_example.ml)
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{dep:../../tool/ood-gen/bin/gen.exe} code_example))))

--- a/src/ocamlorg_frontend/pages/playground.eml
+++ b/src/ocamlorg_frontend/pages/playground.eml
@@ -1,5 +1,4 @@
-let render
-() =
+let render ~default_code =
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -26,6 +25,7 @@ let render
     <script id="playground-script"
       data-merlin-url="<%s Ocamlorg_static.Playground.url "merlin.min.js" %>"
       data-worker-url="<%s Ocamlorg_static.Playground.url "worker.min.js" %>"
+      data-default-code="<%s default_code %>"
       src="<%s Ocamlorg_static.Playground.url "playground.min.js" %>" defer></script>
     <title>OCaml Playground</title>
   </head>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -227,7 +227,11 @@ let carbon_footprint = page Url.carbon_footprint
 let privacy_policy = page Url.privacy_policy
 let governance = page Url.governance
 let code_of_conduct = page Url.code_of_conduct
-let playground _req = Dream.html (Ocamlorg_frontend.playground ())
+
+let playground _req =
+  let default = Data.Code_example.get "default.ml" in
+  let default_code = default.body in
+  Dream.html (Ocamlorg_frontend.playground ~default_code)
 
 let papers req =
   let search_paper pattern t =

--- a/tool/ood-gen/bin/gen.ml
+++ b/tool/ood-gen/bin/gen.ml
@@ -23,6 +23,7 @@ let term_templates =
     ("opam_user", Ood_gen.Opam_user.template);
     ("workflows", Ood_gen.Workflow.template);
     ("pages", Ood_gen.Page.template);
+    ("code_examples", Ood_gen.Code_example.template);
   ]
 
 let cmds =

--- a/tool/ood-gen/lib/code_example.ml
+++ b/tool/ood-gen/lib/code_example.ml
@@ -1,0 +1,23 @@
+type t = { title : string; body : string }
+[@@deriving show { with_path = false }]
+
+let all () =
+  Utils.read_from_dir "code_examples/*.ml"
+  |> List.fold_left
+       (fun acc (path, body) ->
+         let title = Filename.basename path in
+         { title; body } :: acc)
+       []
+
+let template () =
+  Format.asprintf
+    {|
+type t =
+  { title : string
+  ; body : string
+  }
+
+let all = %a
+|}
+    (Fmt.brackets (Fmt.list pp ~sep:Fmt.semi))
+    (all ())


### PR DESCRIPTION
Suggested by @sabine 

It works, but we should probably pass the url of the file .ml instead of its contents to the playground template? It would probably make this feature less flexible (I think) when we inject exercise/tutorial code in the playground (see #1159), what do you think?