### PR TITLE
Reduce px-6 to px-4 on container-fluid for small screens

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -26,7 +26,13 @@ body {
 }
 
 .container-fluid {
-  @apply max-w-7xl w-full mx-auto px-6;
+  @apply max-w-7xl w-full mx-auto px-4;
+}
+
+@media (min-width: 40em) {
+  .container-fluid {
+    @apply px-6;
+  }
 }
 
 .container-fluid.wide {


### PR DESCRIPTION
I think people on phones would benefit from reduced padding of `container-fluid` (which wraps everything on the site).

|screen|before|after|
|-|-|-|
|md+ is unchanged|![Screenshot 2023-05-19 at 10-45-59 irmin 3 7 0 · OCaml Package](https://github.com/ocaml/ocaml.org/assets/6594573/277f70a5-d164-4707-89b2-db351a80e204)|![Screenshot 2023-05-19 at 10-46-03 irmin 3 7 0 · OCaml Package](https://github.com/ocaml/ocaml.org/assets/6594573/f621df4c-c7a7-49c1-b788-f9887981f60d)|
|sm|![Screenshot 2023-05-19 at 10-46-13 irmin 3 7 0 · OCaml Package](https://github.com/ocaml/ocaml.org/assets/6594573/15e343d7-ea7a-4a61-a255-e6aa51f354fb)|![Screenshot 2023-05-19 at 10-46-18 irmin 3 7 0 · OCaml Package](https://github.com/ocaml/ocaml.org/assets/6594573/f021ad90-e35f-4383-9733-fabd50dd2d77)|
|360px wide|![Screenshot 2023-05-19 at 10-52-06 irmin 3 7 0 · OCaml Package](https://github.com/ocaml/ocaml.org/assets/6594573/42e7850c-c17a-4e37-b761-2e7a4ba5b583)|![Screenshot 2023-05-19 at 10-52-11 irmin 3 7 0 · OCaml Package](https://github.com/ocaml/ocaml.org/assets/6594573/51a6458c-6268-4f8b-b083-9b4bfd84a767)|
