### PR TITLE
Add ocaml.org Hand-picked RSS feed

### DIFF
--- a/data/planet/backendbanter/001-elegance-in-ocaml-with-tj-devries.md
+++ b/data/planet/backendbanter/001-elegance-in-ocaml-with-tj-devries.md
@@ -1,0 +1,8 @@
+---
+title: Elegance in OCaml with TJ DeVries
+description: Lane and TJ DeVries chat about OCaml and why functional programming can result in more elegant and readable code. TJ is a core maintainer of NeoVim and explains how contributing to open source has had a huge positive impact on his coding career.
+url: https://www.backendbanter.fm/episodes/001-elegance-in-ocaml-with-tj-devries
+date: 2023-05-15T21:04:13-06:00
+preview_image: https://images.transistor.fm/file/transistor/images/show/41642/medium_1684191586-artwork.jpg
+featured:
+---

--- a/data/planet/meta/build-faster-with-buck2.md
+++ b/data/planet/meta/build-faster-with-buck2.md
@@ -1,0 +1,8 @@
+---
+title: 'Build faster with Buck2: Our open source build system'
+description: Buck2, Meta’s open source large-scale build system, is now publicly available via the Buck2 website and the Buck2 GitHub repository.
+url: https://engineering.fb.com/2023/04/06/open-source/buck2-open-source-large-scale-build-system/
+date: 2023-04-06T00:00:00-00:00
+preview_image: https://engineering.fb.com/wp-content/uploads/2023/03/Buck2-Hero.jpg
+featured:
+---

--- a/data/planet/sancho/learning-ocaml.md
+++ b/data/planet/sancho/learning-ocaml.md
@@ -1,0 +1,8 @@
+---
+title: Learning OCaml in 2023
+description: Software engineer into ReasonML and OCaml. Working on styled-ppx and UI stuff at Ahrefs. Co-host at emelle.tv
+url: https://sancho.dev/blog/learning-ocaml
+date: 2022-12-31T00:00:00-00:00
+preview_image: https://api.metaimg.net/v1/render?design=profile&avatar=https://avatars.githubusercontent.com/u/3763599?v=4&name=David+Sancho&handler=%40davesnx&description=Software+engineer.+Currently+working+at+Ahrefs+remotely+on+UI+stuff+and+building+styled-ppx.+Previously+%40draftbit+%40Typeform.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++Co-host+at+https%3A%2F%2Femelle.tv&backgroundColor=191919&textColor=ced0d2
+featured:
+---

--- a/data/planet/sancho/server-side-rendering-react-in-ocaml.md
+++ b/data/planet/sancho/server-side-rendering-react-in-ocaml.md
@@ -1,0 +1,8 @@
+---
+title: Server-side rendering React in OCaml
+description: Software engineer into ReasonML and OCaml. Working on styled-ppx and UI stuff at Ahrefs. Co-host at emelle.tv
+url: https://sancho.dev/blog/server-side-rendering-react-in-ocaml
+date: 2023-04-05T00:00:00-00:00
+preview_image: https://api.metaimg.net/v1/render?design=profile&avatar=https://avatars.githubusercontent.com/u/3763599?v=4&name=David+Sancho&handler=%40davesnx&description=Software+engineer.+Currently+working+at+Ahrefs+remotely+on+UI+stuff+and+building+styled-ppx.+Previously+%40draftbit+%40Typeform.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++Co-host+at+https%3A%2F%2Femelle.tv&backgroundColor=191919&textColor=ced0d2
+featured:
+---

--- a/data/planet/stackoverflow/for-those-who-just-dont-git-it.md
+++ b/data/planet/stackoverflow/for-those-who-just-dont-git-it.md
@@ -1,0 +1,8 @@
+---
+title: For those who just don’t Git it
+description: Pierre-Étienne Meunier, creator and lead developer of open-source version control system Pijul, joins the home team to talk about version control, functional programming, and why OCaml is a source of French national pride.
+url: https://stackoverflow.blog/2023/05/23/for-those-who-just-dont-git-it-ep-573
+date: 2023-05-23T21:04:40-00:00
+preview_image: https://149351115.v2.pressablecdn.com/wp-content/uploads/2022/03/blog-podcast-relaunch-1.png
+featured:
+---


### PR DESCRIPTION
DO NOT MERGE

This is a preliminary and hacky attempt at addressing issue #1203.

We have a manually created, edited and committed `asset/ocamlorg-handpicked-feed.xml` file containing one entry per foreign feed entry. This is served as-is.

ocaml.org recursively becomes its own feed source, adding `https://ocaml.org/ocamlorg-handpicked-feed.xml` to `data/planet-sources.yml`

Updating is where it becomes ugly. 
1. Update `asset/ocamlorg-handpicked-feed.xml`
2. Push online
3. Scrape
4. Push online a second time

Going further:
* Patch river to make it able to fetch a source from a local file (this would remove duplicate push)
* Generate `asset/ocamlorg-handpicked-feed.xml` from a Yaml data file

Tests results:
- [X] `make scrape`
- [X] `make start`
- [X] Browsing

 
![Screenshot_2023-05-26_13-52-58](https://github.com/ocaml/ocaml.org/assets/1917592/e3efe8f6-7a63-4000-9d7c-ce4652b090db)
