### PR TITLE
Announce for the second alpha of Ocaml 5.1.0

### DIFF
--- a/data/changelog/ocaml/2023-04-14-ocaml-5.1.alpha1.md
+++ b/data/changelog/ocaml/2023-04-14-ocaml-5.1.alpha1.md
@@ -43,8 +43,8 @@ opam switch create 5.1.0~alpha1 --repositories=default,beta=git+https://github.c
 
 The source code for the alpha is also available at these addresses:
 
-* [GitHub](https://github.com/ocaml/ocaml/archive/5.0.0-rc1.tar.gz)
-* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~rc1.tar.gz)
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.0-alpha1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~alpha1.tar.gz)
 
 ### Fine-Tuned Compiler Configuration
 

--- a/data/changelog/ocaml/2023-04-14-ocaml-5.1.alpha1.md
+++ b/data/changelog/ocaml/2023-04-14-ocaml-5.1.alpha1.md
@@ -20,7 +20,7 @@ collector and Windows support. Those fixes will be available before the beta.
 The full release is expected in July.
 
 If you are interested in the ongoing list of new features and bug fixes, the
-updated change log for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.0/Changes).
+updated change log for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.1/Changes).
 
 
 ---

--- a/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
+++ b/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
@@ -3,6 +3,68 @@ title: OCaml 5.1.0 - Second Alpha
 description: Second Alpha Release of OCaml 5.1.0
 date: "2023-06-01"
 tags: [ocaml, release]
+changelog: |
+  + Runtime System
+    - [#11589](https://github.com/ocaml/ocaml/issues/11589), [#11903](https://github.com/ocaml/ocaml/issues/11903): Modify the GC pacing code to make sure the GC keeps
+   up with allocations in the presence of idle domains.
+   (Damien Doligez and Stephen Dolan, report by Florian Angeletti,
+   review by KC Sivaramakrishnan and Sadiq Jaffer)
+    - (*breaking change*) [#11865](https://github.com/ocaml/ocaml/issues/11865), [#11868](https://github.com/ocaml/ocaml/issues/11868), [#11876](https://github.com/ocaml/ocaml/issues/11876): Clarify that the operations of a custom
+  block must never access the OCaml runtime. The previous
+  documentation only mentioned the main illicit usages. In particular,
+  since OCaml 5.0, it is no longer safe to call
+  `caml_remove_global_root` or `caml_remove_generational_global_root`
+  from within the C finalizer of a custom block, or within the
+  finalization function passed to `caml_alloc_final`. As a workaround,
+  such a finalization operation can be registered with `Gc.finalize`
+  instead, which guarantees to run the finalizer at a safe point.
+  (Report by Timothy Bourke, discussion by Yotam Barnoy, Timothy
+  Bourke, Sadiq Jaffer, Xavier Leroy, Guillaume Munch-Maccagnoni, and
+  Gabriel Scherer)
+    - [#11827](https://github.com/ocaml/ocaml/issues/11827), +[#12249](https://github.com/ocaml/ocaml/issues/12249): Restore prefetching for GC marking
+  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
+    - [#12131](https://github.com/ocaml/ocaml/issues/12131): Simplify implementation of weak hash sets, fixing a
+  performance regression. (Nick Barnes, review by François Bobot,
+  Alain Frisch and Damien Doligez).
+    - [#12231](https://github.com/ocaml/ocaml/issues/12231): Support MinGW-w64 11.0 winpthreads library, where the macro
+  to set up to get flexdll working changed
+  (David Allsopp and Samuel Hym, light review by Xavier Leroy)
+  + Type System
+    - (*breaking change*) [#12189](https://github.com/ocaml/ocaml/issues/12189), [#12211](https://github.com/ocaml/ocaml/issues/12211): anonymous row variables in explicitly polymorphic type
+  annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
+  universally quantified (in other words, the example above is now read
+  as `'a 'r. ([< X of 'a ] as 'r) -> 'a`).
+  (Florian Angeletti and Gabriel Scherer, review by Jacques Garrigue)
+  +  Code Generation And Optimizations:
+     - [#11712](https://github.com/ocaml/ocaml/issues/11712), [#12258](https://github.com/ocaml/ocaml/issues/12258), [#12261](https://github.com/ocaml/ocaml/issues/12261): s390x / IBM Z multicore support:
+  OCaml & C stack separation; dynamic stack size checks; fiber and
+  effects support.
+  (Aleksei Nikiforov, with help from Vincent Laviron and Xavier Leroy,
+   additional suggestions by Luc Maranget,
+   review by the same and KC Sivaramakrishnan)
+  + Internal/compiler-libs Changes:
+    - [#12119](https://github.com/ocaml/ocaml/issues/12119), +[#12188](https://github.com/ocaml/ocaml/issues/12188), +[#12191](https://github.com/ocaml/ocaml/issues/12191): mirror type constraints on value binding in the
+  parsetree:
+  the constraint `typ` in `let pat : typ = exp` is now directly stored
+  in the value binding node in the parsetree.
+  (Florian Angeletti, review by  Richard Eisenberg)
+  + Bug Fixes
+    - [#11846](https://github.com/ocaml/ocaml/issues/11846): Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
+  Reserve the shadow store for the ABI in the c_stack_link struct instead of
+  explictly when calling C functions. This simultaneously reduces the number of
+  stack pointer manipulations and also fixes a bug when calling noalloc
+  functions where the shadow store was not being reserved.
+  (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
+   KC Sivaramakrishnan)
+    - [#12170](https://github.com/ocaml/ocaml/issues/12170): fix pthread_geaffinity_np configure check for android
+  (David Allsopp, review by Sébastien Hinderer)
+    - [#12252](https://github.com/ocaml/ocaml/issues/12252): Fix shared library build error on RISC-V.
+  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
+    - [#12255](https://github.com/ocaml/ocaml/issues/12255), [#12256](https://github.com/ocaml/ocaml/issues/12256): Handle large signal numbers correctly (Nick Barnes,
+   review by David Allsopp).
+    - [#12277](https://github.com/ocaml/ocaml/issues/12277): ARM64, fix a potential assembler error for very large functions by
+  emitting stack reallocation code before the body of the function.
+  (Xavier Leroy, review by KC Sivaramakrishnan)
 ---
 
 With the progress of the on-going stabilisation effort for OCaml 5.1.0,
@@ -66,88 +128,3 @@ opam switch create 5.1.0~alpha2+flambda+nffa ocaml-variants.5.1.0~alpha2+options
 ```
 
 All available options can be listed with `opam search ocaml-option`.
-
-
------------------------------------
-
-## Changes Compared To The First Alpha Release
-
-### Runtime System:
-
-- [#11589](https://github.com/ocaml/ocaml/issues/11589), [#11903](https://github.com/ocaml/ocaml/issues/11903): Modify the GC pacing code to make sure the GC keeps
-   up with allocations in the presence of idle domains.
-   (Damien Doligez and Stephen Dolan, report by Florian Angeletti,
-   review by KC Sivaramakrishnan and Sadiq Jaffer)
-
-* (*breaking change*) [#11865](https://github.com/ocaml/ocaml/issues/11865), [#11868](https://github.com/ocaml/ocaml/issues/11868), [#11876](https://github.com/ocaml/ocaml/issues/11876): Clarify that the operations of a custom
-  block must never access the OCaml runtime. The previous
-  documentation only mentioned the main illicit usages. In particular,
-  since OCaml 5.0, it is no longer safe to call
-  `caml_remove_global_root` or `caml_remove_generational_global_root`
-  from within the C finalizer of a custom block, or within the
-  finalization function passed to `caml_alloc_final`. As a workaround,
-  such a finalization operation can be registered with `Gc.finalize`
-  instead, which guarantees to run the finalizer at a safe point.
-  (Report by Timothy Bourke, discussion by Yotam Barnoy, Timothy
-  Bourke, Sadiq Jaffer, Xavier Leroy, Guillaume Munch-Maccagnoni, and
-  Gabriel Scherer)
-
-+ [#11827](https://github.com/ocaml/ocaml/issues/11827), +[#12249](https://github.com/ocaml/ocaml/issues/12249): Restore prefetching for GC marking
-  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
-
-- [#12131](https://github.com/ocaml/ocaml/issues/12131): Simplify implementation of weak hash sets, fixing a
-  performance regression. (Nick Barnes, review by François Bobot,
-  Alain Frisch and Damien Doligez).
-
-- [#12231](https://github.com/ocaml/ocaml/issues/12231): Support MinGW-w64 11.0 winpthreads library, where the macro
-  to set up to get flexdll working changed
-  (David Allsopp and Samuel Hym, light review by Xavier Leroy)
-
-
-### Type System:
-
-* (*breaking change*) [#12189](https://github.com/ocaml/ocaml/issues/12189), [#12211](https://github.com/ocaml/ocaml/issues/12211): anonymous row variables in explicitly polymorphic type
-  annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
-  universally quantified (in other words, the example above is now read
-  as `'a 'r. ([< X of 'a ] as 'r) -> 'a`).
-  (Florian Angeletti and Gabriel Scherer, review by Jacques Garrigue)
-
-### Code Generation And Optimizations:
-
-- [#11712](https://github.com/ocaml/ocaml/issues/11712), [#12258](https://github.com/ocaml/ocaml/issues/12258), [#12261](https://github.com/ocaml/ocaml/issues/12261): s390x / IBM Z multicore support:
-  OCaml & C stack separation; dynamic stack size checks; fiber and
-  effects support.
-  (Aleksei Nikiforov, with help from Vincent Laviron and Xavier Leroy,
-   additional suggestions by Luc Maranget,
-   review by the same and KC Sivaramakrishnan)
-
-### Internal/compiler-libs Changes:
-
-+ [#12119](https://github.com/ocaml/ocaml/issues/12119), +[#12188](https://github.com/ocaml/ocaml/issues/12188), +[#12191](https://github.com/ocaml/ocaml/issues/12191): mirror type constraints on value binding in the
-  parsetree:
-  the constraint `typ` in `let pat : typ = exp` is now directly stored
-  in the value binding node in the parsetree.
-  (Florian Angeletti, review by  Richard Eisenberg)
-
-### Bug Fixes
-
-- [#11846](https://github.com/ocaml/ocaml/issues/11846): Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
-  Reserve the shadow store for the ABI in the c_stack_link struct instead of
-  explictly when calling C functions. This simultaneously reduces the number of
-  stack pointer manipulations and also fixes a bug when calling noalloc
-  functions where the shadow store was not being reserved.
-  (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
-   KC Sivaramakrishnan)
-
-- [#12170](https://github.com/ocaml/ocaml/issues/12170): fix pthread_geaffinity_np configure check for android
-  (David Allsopp, review by Sébastien Hinderer)
-
-- [#12252](https://github.com/ocaml/ocaml/issues/12252): Fix shared library build error on RISC-V.
-  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
-
-- [#12255](https://github.com/ocaml/ocaml/issues/12255), [#12256](https://github.com/ocaml/ocaml/issues/12256): Handle large signal numbers correctly (Nick Barnes,
-   review by David Allsopp).
-
-- [#12277](https://github.com/ocaml/ocaml/issues/12277): ARM64, fix a potential assembler error for very large functions by
-  emitting stack reallocation code before the body of the function.
-  (Xavier Leroy, review by KC Sivaramakrishnan)

--- a/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
+++ b/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
@@ -4,67 +4,84 @@ description: Second Alpha Release of OCaml 5.1.0
 date: "2023-06-01"
 tags: [ocaml, release]
 changelog: |
-  + Runtime System
-    - [#11589](https://github.com/ocaml/ocaml/issues/11589), [#11903](https://github.com/ocaml/ocaml/issues/11903): Modify the GC pacing code to make sure the GC keeps
-   up with allocations in the presence of idle domains.
-   (Damien Doligez and Stephen Dolan, report by Florian Angeletti,
-   review by KC Sivaramakrishnan and Sadiq Jaffer)
-    - (*breaking change*) [#11865](https://github.com/ocaml/ocaml/issues/11865), [#11868](https://github.com/ocaml/ocaml/issues/11868), [#11876](https://github.com/ocaml/ocaml/issues/11876): Clarify that the operations of a custom
-  block must never access the OCaml runtime. The previous
-  documentation only mentioned the main illicit usages. In particular,
-  since OCaml 5.0, it is no longer safe to call
-  `caml_remove_global_root` or `caml_remove_generational_global_root`
-  from within the C finalizer of a custom block, or within the
-  finalization function passed to `caml_alloc_final`. As a workaround,
-  such a finalization operation can be registered with `Gc.finalize`
-  instead, which guarantees to run the finalizer at a safe point.
-  (Report by Timothy Bourke, discussion by Yotam Barnoy, Timothy
-  Bourke, Sadiq Jaffer, Xavier Leroy, Guillaume Munch-Maccagnoni, and
-  Gabriel Scherer)
-    - [#11827](https://github.com/ocaml/ocaml/issues/11827), +[#12249](https://github.com/ocaml/ocaml/issues/12249): Restore prefetching for GC marking
-  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
-    - [#12131](https://github.com/ocaml/ocaml/issues/12131): Simplify implementation of weak hash sets, fixing a
-  performance regression. (Nick Barnes, review by François Bobot,
-  Alain Frisch and Damien Doligez).
-    - [#12231](https://github.com/ocaml/ocaml/issues/12231): Support MinGW-w64 11.0 winpthreads library, where the macro
-  to set up to get flexdll working changed
-  (David Allsopp and Samuel Hym, light review by Xavier Leroy)
-  + Type System
-    - (*breaking change*) [#12189](https://github.com/ocaml/ocaml/issues/12189), [#12211](https://github.com/ocaml/ocaml/issues/12211): anonymous row variables in explicitly polymorphic type
-  annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
-  universally quantified (in other words, the example above is now read
-  as `'a 'r. ([< X of 'a ] as 'r) -> 'a`).
-  (Florian Angeletti and Gabriel Scherer, review by Jacques Garrigue)
-  +  Code Generation And Optimizations:
-     - [#11712](https://github.com/ocaml/ocaml/issues/11712), [#12258](https://github.com/ocaml/ocaml/issues/12258), [#12261](https://github.com/ocaml/ocaml/issues/12261): s390x / IBM Z multicore support:
-  OCaml & C stack separation; dynamic stack size checks; fiber and
-  effects support.
-  (Aleksei Nikiforov, with help from Vincent Laviron and Xavier Leroy,
-   additional suggestions by Luc Maranget,
-   review by the same and KC Sivaramakrishnan)
-  + Internal/compiler-libs Changes:
-    - [#12119](https://github.com/ocaml/ocaml/issues/12119), +[#12188](https://github.com/ocaml/ocaml/issues/12188), +[#12191](https://github.com/ocaml/ocaml/issues/12191): mirror type constraints on value binding in the
-  parsetree:
-  the constraint `typ` in `let pat : typ = exp` is now directly stored
-  in the value binding node in the parsetree.
-  (Florian Angeletti, review by  Richard Eisenberg)
-  + Bug Fixes
-    - [#11846](https://github.com/ocaml/ocaml/issues/11846): Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
-  Reserve the shadow store for the ABI in the c_stack_link struct instead of
-  explictly when calling C functions. This simultaneously reduces the number of
-  stack pointer manipulations and also fixes a bug when calling noalloc
-  functions where the shadow store was not being reserved.
-  (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
-   KC Sivaramakrishnan)
-    - [#12170](https://github.com/ocaml/ocaml/issues/12170): fix pthread_geaffinity_np configure check for android
-  (David Allsopp, review by Sébastien Hinderer)
-    - [#12252](https://github.com/ocaml/ocaml/issues/12252): Fix shared library build error on RISC-V.
-  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
-    - [#12255](https://github.com/ocaml/ocaml/issues/12255), [#12256](https://github.com/ocaml/ocaml/issues/12256): Handle large signal numbers correctly (Nick Barnes,
-   review by David Allsopp).
-    - [#12277](https://github.com/ocaml/ocaml/issues/12277): ARM64, fix a potential assembler error for very large functions by
-  emitting stack reallocation code before the body of the function.
-  (Xavier Leroy, review by KC Sivaramakrishnan)
+  ### Runtime System
+
+  - [#11589](https://github.com/ocaml/ocaml/issues/11589), [#11903](https://github.com/ocaml/ocaml/issues/11903): Modify the GC pacing code to make sure the GC keeps
+    up with allocations in the presence of idle domains.
+    (Damien Doligez and Stephen Dolan, report by Florian Angeletti,
+    review by KC Sivaramakrishnan and Sadiq Jaffer)
+
+  * (*breaking change*) [#11865](https://github.com/ocaml/ocaml/issues/11865), [#11868](https://github.com/ocaml/ocaml/issues/11868), [#11876](https://github.com/ocaml/ocaml/issues/11876): Clarify that the operations of a custom
+    block must never access the OCaml runtime. The previous
+    documentation only mentioned the main illicit usages. In particular,
+    since OCaml 5.0, it is no longer safe to call
+    `caml_remove_global_root` or `caml_remove_generational_global_root`
+    from within the C finalizer of a custom block, or within the
+    finalization function passed to `caml_alloc_final`. As a workaround,
+    such a finalization operation can be registered with `Gc.finalize`
+    instead, which guarantees to run the finalizer at a safe point.
+    (Report by Timothy Bourke, discussion by Yotam Barnoy, Timothy
+    Bourke, Sadiq Jaffer, Xavier Leroy, Guillaume Munch-Maccagnoni, and
+    Gabriel Scherer)
+
+  + [#11827](https://github.com/ocaml/ocaml/issues/11827), +[#12249](https://github.com/ocaml/ocaml/issues/12249): Restore prefetching for GC marking
+    (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
+
+  - [#12131](https://github.com/ocaml/ocaml/issues/12131): Simplify implementation of weak hash sets, fixing a
+    performance regression. (Nick Barnes, review by François Bobot,
+    Alain Frisch and Damien Doligez).
+
+  - [#12231](https://github.com/ocaml/ocaml/issues/12231): Support MinGW-w64 11.0 winpthreads library, where the macro
+    to set up to get flexdll working changed
+    (David Allsopp and Samuel Hym, light review by Xavier Leroy)
+
+  ### Type System
+
+  * (*breaking change*) [#12189](https://github.com/ocaml/ocaml/issues/12189), [#12211](https://github.com/ocaml/ocaml/issues/12211): anonymous row variables in explicitly polymorphic type
+    annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
+    universally quantified (in other words, the example above is now read
+    as `'a 'r. ([< X of 'a ] as 'r) -> 'a`).
+    (Florian Angeletti and Gabriel Scherer, review by Jacques Garrigue)
+
+  ### Code Generation And Optimizations
+
+  - [#11712](https://github.com/ocaml/ocaml/issues/11712), [#12258](https://github.com/ocaml/ocaml/issues/12258), [#12261](https://github.com/ocaml/ocaml/issues/12261): s390x / IBM Z multicore support:
+    OCaml & C stack separation; dynamic stack size checks; fiber and
+    effects support.
+    (Aleksei Nikiforov, with help from Vincent Laviron and Xavier Leroy,
+    additional suggestions by Luc Maranget,
+    review by the same and KC Sivaramakrishnan)
+
+  ### Internal/compiler-libs Changes
+
+  + [#12119](https://github.com/ocaml/ocaml/issues/12119), +[#12188](https://github.com/ocaml/ocaml/issues/12188), +[#12191](https://github.com/ocaml/ocaml/issues/12191): mirror type constraints on value binding in the
+    parsetree:
+    the constraint `typ` in `let pat : typ = exp` is now directly stored
+    in the value binding node in the parsetree.
+    (Florian Angeletti, review by  Richard Eisenberg)
+
+  ### Bug Fixes
+
+  - [#11846](https://github.com/ocaml/ocaml/issues/11846): Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
+    Reserve the shadow store for the ABI in the c_stack_link struct instead of
+    explictly when calling C functions. This simultaneously reduces the number of
+    stack pointer manipulations and also fixes a bug when calling noalloc
+    functions where the shadow store was not being reserved.
+    (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
+    KC Sivaramakrishnan)
+
+  - [#12170](https://github.com/ocaml/ocaml/issues/12170): fix pthread_geaffinity_np configure check for android
+    (David Allsopp, review by Sébastien Hinderer)
+
+  - [#12252](https://github.com/ocaml/ocaml/issues/12252): Fix shared library build error on RISC-V.
+    (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
+
+  - [#12255](https://github.com/ocaml/ocaml/issues/12255), [#12256](https://github.com/ocaml/ocaml/issues/12256): Handle large signal numbers correctly (Nick Barnes,
+    review by David Allsopp).
+
+  - [#12277](https://github.com/ocaml/ocaml/issues/12277): ARM64, fix a potential assembler error for very large functions by
+    emitting stack reallocation code before the body of the function.
+    (Xavier Leroy, review by KC Sivaramakrishnan)
 ---
 
 With the progress of the on-going stabilisation effort for OCaml 5.1.0,

--- a/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
+++ b/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
@@ -1,0 +1,153 @@
+---
+title: OCaml 5.1.0 - Second Alpha
+description: Second Alpha Release of OCaml 5.1.0
+date: "2023-06-01"
+tags: [ocaml, release]
+---
+
+With the progress of the on-going stabilisation effort for OCaml 5.1.0,
+I am happy to announce a second alpha release for OCaml 5.1.0.
+
+This second alpha release contains many noteworthy fixes:
+
+- a long-awaited GC fix
+- a Windows ABI fix
+
+as announced in the first alpha but also
+
+- a compiler-libs (parsetree) fix
+- a type system compatibility enhancement change
+- a restored backed for  s390x/IBM Z
+
+The full list of changes since the first alpha is available below.
+
+Once most major OCaml tools are updated to the last compiler-libs changes,
+we will switch to beta releases. Hopefully, this will happen in the upcoming
+weeks. The progresses on stabilising the ecosystem are tracked on the
+[opam readiness for 5.1.0 meta-issue](https://github.com/ocaml/opam-repository/issues/23669).
+
+Currently, the release is still planned around in July.
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+If you are interested in the ongoing list of new features and bug fixes, the
+updated change log for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.1/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1:
+
+```bash
+opam update
+opam switch create 5.1.0~alpha2
+```
+
+The source code for the alpha is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.0.0-rc1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.1.0~alpha2+options <option_list>
+```
+
+where `option_list` is a space separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
+
+```bash
+opam switch create 5.1.0~alpha2+flambda+nffa ocaml-variants.5.1.0~alpha2+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.
+
+
+-----------------------------------
+
+## Changes Compared To The First Alpha Release
+
+### Runtime System:
+
+- [#11589](https://github.com/ocaml/ocaml/issues/11589), [#11903](https://github.com/ocaml/ocaml/issues/11903): Modify the GC pacing code to make sure the GC keeps
+   up with allocations in the presence of idle domains.
+   (Damien Doligez and Stephen Dolan, report by Florian Angeletti,
+   review by KC Sivaramakrishnan and Sadiq Jaffer)
+
+* (*breaking change*) [#11865](https://github.com/ocaml/ocaml/issues/11865), [#11868](https://github.com/ocaml/ocaml/issues/11868), [#11876](https://github.com/ocaml/ocaml/issues/11876): Clarify that the operations of a custom
+  block must never access the OCaml runtime. The previous
+  documentation only mentioned the main illicit usages. In particular,
+  since OCaml 5.0, it is no longer safe to call
+  `caml_remove_global_root` or `caml_remove_generational_global_root`
+  from within the C finalizer of a custom block, or within the
+  finalization function passed to `caml_alloc_final`. As a workaround,
+  such a finalization operation can be registered with `Gc.finalize`
+  instead, which guarantees to run the finalizer at a safe point.
+  (Report by Timothy Bourke, discussion by Yotam Barnoy, Timothy
+  Bourke, Sadiq Jaffer, Xavier Leroy, Guillaume Munch-Maccagnoni, and
+  Gabriel Scherer)
+
++ [#11827](https://github.com/ocaml/ocaml/issues/11827), +[#12249](https://github.com/ocaml/ocaml/issues/12249): Restore prefetching for GC marking
+  (Fabrice Buoro and Stephen Dolan, review by Gabriel Scherer and Sadiq Jaffer)
+
+- [#12131](https://github.com/ocaml/ocaml/issues/12131): Simplify implementation of weak hash sets, fixing a
+  performance regression. (Nick Barnes, review by François Bobot,
+  Alain Frisch and Damien Doligez).
+
+- [#12231](https://github.com/ocaml/ocaml/issues/12231): Support MinGW-w64 11.0 winpthreads library, where the macro
+  to set up to get flexdll working changed
+  (David Allsopp and Samuel Hym, light review by Xavier Leroy)
+
+
+### Type System:
+
+* (*breaking change*) [#12189](https://github.com/ocaml/ocaml/issues/12189), [#12211](https://github.com/ocaml/ocaml/issues/12211): anonymous row variables in explicitly polymorphic type
+  annotation, e.g. `'a. [< X of 'a ] -> 'a`, are now implicitly
+  universally quantified (in other words, the example above is now read
+  as `'a 'r. ([< X of 'a ] as 'r) -> 'a`).
+  (Florian Angeletti and Gabriel Scherer, review by Jacques Garrigue)
+
+### Code Generation And Optimizations:
+
+- [#11712](https://github.com/ocaml/ocaml/issues/11712), [#12258](https://github.com/ocaml/ocaml/issues/12258), [#12261](https://github.com/ocaml/ocaml/issues/12261): s390x / IBM Z multicore support:
+  OCaml & C stack separation; dynamic stack size checks; fiber and
+  effects support.
+  (Aleksei Nikiforov, with help from Vincent Laviron and Xavier Leroy,
+   additional suggestions by Luc Maranget,
+   review by the same and KC Sivaramakrishnan)
+
+### Internal/compiler-libs Changes:
+
++ [#12119](https://github.com/ocaml/ocaml/issues/12119), +[#12188](https://github.com/ocaml/ocaml/issues/12188), +[#12191](https://github.com/ocaml/ocaml/issues/12191): mirror type constraints on value binding in the
+  parsetree:
+  the constraint `typ` in `let pat : typ = exp` is now directly stored
+  in the value binding node in the parsetree.
+  (Florian Angeletti, review by  Richard Eisenberg)
+
+### Bug Fixes
+
+- [#11846](https://github.com/ocaml/ocaml/issues/11846): Mark rbx as destroyed at C call for Win64 (mingw-w64 and Cygwin64).
+  Reserve the shadow store for the ABI in the c_stack_link struct instead of
+  explictly when calling C functions. This simultaneously reduces the number of
+  stack pointer manipulations and also fixes a bug when calling noalloc
+  functions where the shadow store was not being reserved.
+  (David Allsopp, report by Vesa Karvonen, review by Xavier Leroy and
+   KC Sivaramakrishnan)
+
+- [#12170](https://github.com/ocaml/ocaml/issues/12170): fix pthread_geaffinity_np configure check for android
+  (David Allsopp, review by Sébastien Hinderer)
+
+- [#12252](https://github.com/ocaml/ocaml/issues/12252): Fix shared library build error on RISC-V.
+  (Edwin Török, review by Nicolás Ojeda Bär and Xavier Leroy)
+
+- [#12255](https://github.com/ocaml/ocaml/issues/12255), [#12256](https://github.com/ocaml/ocaml/issues/12256): Handle large signal numbers correctly (Nick Barnes,
+   review by David Allsopp).
+
+- [#12277](https://github.com/ocaml/ocaml/issues/12277): ARM64, fix a potential assembler error for very large functions by
+  emitting stack reallocation code before the body of the function.
+  (Xavier Leroy, review by KC Sivaramakrishnan)

--- a/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
+++ b/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
@@ -126,8 +126,8 @@ opam switch create 5.1.0~alpha2
 
 The source code for the alpha is also available at these addresses:
 
-* [GitHub](https://github.com/ocaml/ocaml/archive/5.0.0-rc1.tar.gz)
-* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0~rc1.tar.gz)
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.0-alpha2.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~alpha2.tar.gz)
 
 ### Fine-Tuned Compiler Configuration
 

--- a/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
+++ b/data/changelog/ocaml/2023-06-01-ocaml-5.1.alpha2.md
@@ -84,7 +84,7 @@ changelog: |
     (Xavier Leroy, review by KC Sivaramakrishnan)
 ---
 
-With the progress of the on-going stabilisation effort for OCaml 5.1.0,
+With the progress of the ongoing stabilisation effort for OCaml 5.1.0,
 I am happy to announce a second alpha release for OCaml 5.1.0.
 
 This second alpha release contains many noteworthy fixes:
@@ -102,10 +102,10 @@ The full list of changes since the first alpha is available below.
 
 Once most major OCaml tools are updated to the last compiler-libs changes,
 we will switch to beta releases. Hopefully, this will happen in the upcoming
-weeks. The progresses on stabilising the ecosystem are tracked on the
+weeks. The progress on stabilising the ecosystem is tracked on the
 [opam readiness for 5.1.0 meta-issue](https://github.com/ocaml/opam-repository/issues/23669).
 
-Currently, the release is still planned around in July.
+Currently, the release is still planned for around July.
 
 If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
 
@@ -138,7 +138,7 @@ opam update
 opam switch create <switch_name> ocaml-variants.5.1.0~alpha2+options <option_list>
 ```
 
-where `option_list` is a space separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
+where `option_list` is a space-separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
 
 ```bash
 opam switch create 5.1.0~alpha2+flambda+nffa ocaml-variants.5.1.0~alpha2+options ocaml-option-flambda ocaml-option-no-flat-float-array


### PR DESCRIPTION
This PR adds the announce for the upcoming second alpha release of OCaml 5.1.0 in the ocaml.org format (and fixes a typo in the previous announce).

This PR is still a draft since the new release has not yet been published in opam, and taking in account the time needed for the release to reach opam, I planning to send the announce tomorrow (on June 2 CEST).