### PR TITLE
Expose GraphQL api over /graphql

### DIFF
--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -94,7 +94,7 @@ let graphql_route t =
   Dream.scope ""
     [ Dream_encoding.compress ]
     [
-      Dream.any "/api" (Dream.graphql Lwt.return (Graphql.schema t));
+      Dream.any "/graphql" (Dream.graphql Lwt.return (Graphql.schema t));
       Dream.get "/graphiql" (Dream.graphiql "/api");
     ]
 

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -95,7 +95,7 @@ let graphql_route t =
     [ Dream_encoding.compress ]
     [
       Dream.any "/graphql" (Dream.graphql Lwt.return (Graphql.schema t));
-      Dream.get "/graphiql" (Dream.graphiql "/api");
+      Dream.get "/graphiql" (Dream.graphiql "/graphql");
     ]
 
 let router t =


### PR DESCRIPTION
`/api` is already used and redirects towards `https://v2.ocaml.org/api/`