### PR TITLE
Search packages by module name

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -45,6 +45,7 @@ module Info : sig
     url : url option;
     publication : float;
     flags : OpamTypes.package_flag list;
+    module_name : string;
   }
 end
 

--- a/src/ocamlorg_web/test/graphql_test.ml
+++ b/src/ocamlorg_web/test/graphql_test.ml
@@ -27,6 +27,7 @@ let empty_info =
     url = None;
     publication = 0.;
     flags = [];
+    module_name = "";
   }
 
 let packages : Package.t list =


### PR DESCRIPTION
Closes #1238 

`~name` is passed to `make` because calling `name opam` to try to get the package name would raise an exception if the `name:` field is missing from the opam file (which is often the case).