### PR TITLE
Comment out credits on sequence tutorial

### DIFF
--- a/data/tutorials/ds_05_seq.md
+++ b/data/tutorials/ds_05_seq.md
@@ -315,6 +315,7 @@ OCaml 4.14. Beware books and documentation written before may still mention it.
 * [Streams](/problems#100)
 * [Diagonal](/problems#101)
 
+<!--
 ## Credits
 
 * Authors:
@@ -330,3 +331,4 @@ OCaml 4.14. Beware books and documentation written before may still mention it.
   * Guillaume Petiot [@gpetiot](https://github.com/gpetiot)
   * Xavier Van de Woestyne [@xvw](https://github.com/xvw)
   * Simon Cruanes [@c-cube](https://github.com/c-cube)
+-->


### PR DESCRIPTION
Reason for doing this: Over time, these acknowledgements sections will grow very large and create a lot of visual noise in the tutorial right at the point where we want people to see the contribute and discuss links.

However, I think we can keep the credits/acknowledgements in a comment.