### PR TITLE
Fix CSS of right sidebar to properly allow scrolling large TOCs

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -112,8 +112,8 @@ inner_html
              id="htmx-content">
           <%s! inner_html %>
         </div>
-        <div class="hidden xl:flex top-0 sticky h-screen overflow-auto lg:pt-6 lg:pb-72" id="htmx-right-sidebar">
-          <div class="<%s Option.fold ~none:"" ~some:(fun _ -> "flex-col w-60") right_sidebar_html %>">
+        <div class="hidden xl:block top-0 sticky h-screen overflow-auto lg:pt-6" id="htmx-right-sidebar">
+          <div class="<%s Option.fold ~none:"" ~some:(fun _ -> "w-60 lg:pb-72") right_sidebar_html %>">
             <%s! Option.value ~default:"" right_sidebar_html %>
           </div>
         </div>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -10,9 +10,7 @@ let rec tutorial_toc_to_toc (toc : Data.Tutorial.toc) =
 let right_sidebar
 (tutorial : Data.Tutorial.t)
 =
-  <div>
-    <%s! Toc.render (List.map tutorial_toc_to_toc tutorial.toc) %>
-  </div>
+  <%s! Toc.render (List.map tutorial_toc_to_toc tutorial.toc) %>
 
 let render
 (tutorial : Data.Tutorial.t)


### PR DESCRIPTION
The problem can be seen on https://ocaml.org/docs/error-handling#assertions.

This makes the sidebar grow so that the bottom padding of the scrollable sidebar is applied.