### PR TITLE
Fix mdx blocks

### DIFF
--- a/data/tutorials/ds_05_seq.md
+++ b/data/tutorials/ds_05_seq.md
@@ -136,19 +136,17 @@ It builds a sequence of elements satisfying a condition.
 Using `Seq.filter`, it is possible to make a straightforward implementation of
 the [Sieve of
 Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes). Here it is:
-<!-- $MDX part-begin=sieve -->
 ```ocaml
 # let rec sieve seq () = match seq () with
   | Seq.Cons (m, seq) -> Seq.Cons (m, sieve (Seq.filter (fun n -> n mod m > 0) seq))
-  | seq -> seq
-let primes = Seq.ints 2 |> sieve;;
+  | seq -> seq;;
 val sieve : int Seq.t -> int Seq.t = <fun>
+# let primes = Seq.ints 2 |> sieve;;
 val primes : int Seq.t = <fun>
 ```
 
 This code can be used to generate lists of prime numbers. For instance, here is
 the list of 100 first prime numbers:
-<!-- $MDX part=sieve -->
 ```ocaml
 # primes |> Seq.take 100 |> List.of_seq;;
 - : int list =
@@ -160,7 +158,6 @@ the list of 100 first prime numbers:
  421; 431; 433; 439; 443; 449; 457; 461; 463; 467; 479; 487; 491; 499; 503;
  509; 521; 523; 541]
 ```
-<!-- $MDX part-end=sieve -->
 
 The function `sieve` is recursive in OCaml and common sense. It is defined using
 the `rec` keyword and calls itself. However, some call that kind of function

--- a/data/tutorials/lg_08_error_handling.md
+++ b/data/tutorials/lg_08_error_handling.md
@@ -169,6 +169,7 @@ unwise to catch this exception, particularly for beginners), this
 results in the program stopping and printing out the source file and
 line number where the error occurred. An example:
 
+<!-- $MDX skip -->
 ```ocaml
 # assert (Sys.os_type = "Win32");;
 Exception: Assert_failure ("//toplevel//", 1, 1).

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
 
 (generate_opam_files true)
 
-(using mdx 0.1)
+(using mdx 0.3)
 
 (package
  (name ocamlorg)


### PR DESCRIPTION
We need to upgrade the version of the mdx extension to use the mdx sranza:
```dune
(mdx
 (files *.md))
```

Also, the `part` label is used to select parts of an .ml file to inject them in md blocks, and that's not what is done here, so I removed them. See https://github.com/realworldocaml/mdx/tree/main/test/bin/mdx-test/expect/parts-begin-end for an example.
