### PR TITLE
Use .not-prose for the .btn on install page, move .prose styles

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -108,6 +108,14 @@ body {
     background: rgba(39, 39, 39, 1);
 }
 
+:where(.prose a):not(:where([class~=not-prose] *)) {
+  @apply text-primary-600 no-underline;
+ }
+
+:where(.prose a:hover):not(:where([class~=not-prose] *)) {
+  @apply underline;
+ }
+
 .prose [id] {
   scroll-margin-top: 2rem;
 }

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -108,10 +108,6 @@ body {
     background: rgba(39, 39, 39, 1);
 }
 
-.prose a {
-  @apply text-primary-600 no-underline;
-}
-
 .prose [id] {
   scroll-margin-top: 2rem;
 }
@@ -145,10 +141,6 @@ body {
   top: 0;
   bottom: 0;
   opacity: 0;
-}
-
-.prose a:hover {
-  @apply underline;
 }
 
 .prose span.danger {

--- a/src/ocamlorg_frontend/pages/install.eml
+++ b/src/ocamlorg_frontend/pages/install.eml
@@ -89,7 +89,7 @@ Layout.render
 
           <p>Now you are ready to write some OCaml code!</p>
         </div>
-        <a class="btn mt-6 flex gap-2" href="<%s Url.tutorial "up-and-running" %>#first-steps-with-ocaml">First Steps with OCaml <%s! Icons.arrow_small_right "h-6 w-6" %></a>
+        <a class="btn mt-6 gap-2" href="<%s Url.tutorial "up-and-running" %>#first-steps-with-ocaml">First Steps with OCaml <%s! Icons.arrow_small_right "h-6 w-6" %></a>
 
         <div class="prose mt-6">
           <p>If the instructions on this page did not work for you, or you want to know more, you can find
@@ -115,9 +115,11 @@ Layout.render
                 provided in the <a href="<%s Url.ocaml_on_windows %>">"OCaml on Windows" guide</a>.
               </p>
 
-              <a class="btn hover:no-underline gap-2" href="https://github.com/diskuv/dkml-installer-ocaml/releases/download/v1.2.0/setup-diskuv-ocaml-windows_x86_64-1.2.0.exe">
-                <%s! Icons.download "h-6 w-6" %> Download DKML Installer
-              </a>
+              <div class="not-prose">
+                <a class="btn gap-2" href="https://github.com/diskuv/dkml-installer-ocaml/releases/download/v1.2.0/setup-diskuv-ocaml-windows_x86_64-1.2.0.exe">
+                  <%s! Icons.download "h-6 w-6" %> Download DKML Installer
+                </a>
+              </div>
 
               <p>
                 Before you run the installer: Make sure your Windows username does <b>not</b> contain a space character (e.g. for <code>C:\Users\Jane Smith</code>, OCaml will not install properly).
@@ -137,7 +139,7 @@ Layout.render
 
         <p>Now you are ready to write some OCaml code!</p>
       </div>
-      <a class="btn mt-6 flex gap-2" href="<%s Url.tutorial "up-and-running" %>#first-steps-with-ocaml">First Steps with OCaml <%s! Icons.arrow_small_right "h-6 w-6" %></a>
+      <a class="btn mt-6 gap-2" href="<%s Url.tutorial "up-and-running" %>#first-steps-with-ocaml">First Steps with OCaml <%s! Icons.arrow_small_right "h-6 w-6" %></a>
 
       <div class="prose mt-6">
         <p>If the instructions on this page did not work for you, or you want to know more, you can find

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,6 +33,13 @@ module.exports = {
             'h3 code': {
               fontSize: "1em",
             },
+            a: {
+              color: "#EE6A1A",
+              textDecoration: "none",
+              "&:hover": {
+                textDecoration: "underline",
+              }
+            }
           }]
         },
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,13 +33,6 @@ module.exports = {
             'h3 code': {
               fontSize: "1em",
             },
-            a: {
-              color: "#EE6A1A",
-              textDecoration: "none",
-              "&:hover": {
-                textDecoration: "underline",
-              }
-            }
           }]
         },
       },


### PR DESCRIPTION
https://discuss.ocaml.org/t/please-improve-my-draft-of-an-install-page-on-ocaml-org/11837/2:

![Screenshot 2023-06-13 at 11-12-55 Please Improve my Draft of an Install Page on OCaml org](https://github.com/ocaml/ocaml.org/assets/6594573/04d9a50a-175a-4fea-a19f-d57ab2b1b445)

1. we should use `not-prose` to disable prose styles when we want to use a component like `btn` inside a `prose` section.
2. `styles.css` had styles for `.prose a` which would, even when using `not-prose`, override the desired styles. Styles that extend `.prose` need to go in `tailwind.config.js` so that the `not-prose` class will work correctly.

ETA: Apparently, the `tailwind/typography` plugin produces a `.prose a` rule, instead of one that takes into account the `not-prose` class. 😢

Ok, then we just do it manually.
