### PR TITLE
Docker build and push image container registry

### DIFF
--- a/.github/workflows/gh-push.yml
+++ b/.github/workflows/gh-push.yml
@@ -1,0 +1,25 @@
+name: Manual Docker Build and Push
+on:
+  workflow_dispatch:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./path/to/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.ref_slug }}
+          build-args: |
+            BRANCH=${{ github.event.inputs.branch || 'main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Yaml file was generated by  ChatGPT using the following prompt:

Write a yaml file which implements a github workflow action. The action is only triggered manually. The user must select a branch, default is main. It triggers build of the project Docker file. The built image is then push to github container registry using a GITHUB_TOKEN.

As of this commit, it hasn't been touched
