### PR TITLE
Bring up Alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine-3.17-ocaml-4.14 as build
+FROM ocaml/opam:alpine-3.18-ocaml-4.14 as build
 
 # Install system dependencies
 RUN sudo apk update && sudo apk add --update libev-dev openssl-dev gmp-dev oniguruma-dev inotify-tools
@@ -22,7 +22,7 @@ ENV OCAMLORG_REPO_PATH opam-repository
 ENV OCAMLORG_PKG_STATE_PATH package.state
 RUN touch package.state && ./init-cache package.state
 
-FROM alpine:3.17 as run
+FROM alpine:3.18 as run
 
 RUN apk update && apk add --update libev gmp git
 


### PR DESCRIPTION
This needed to upgrade openssl to a version which is not vulnerable
to CVE-2023-2650 and CVE-2023-1255
