### PR TITLE
Edit Contributing ReadMe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ This guide documents the best way to contribute to the project when adding thing
 - **Good First Issues**: if you are either new to the repository or still getting started with OCaml in general, issues marked as a `good first issue` are ideal.
 - **Suggesting Changes**: most of the site content is stored in the `data` directory as Markdown or YAML. To suggest a change or update this content, you can edit those files directly and rebuild the website, detailed in the [HACKING](./HACKING.md) guide. This will promote the content into their `.ml` counterparts. If you would like to suggest entirely new website content or code, please [open an issue](https://github.com/ocaml/ocaml.org/issues) to discuss it first.
 - **Implementing Pages**: most pages are implemented in `src/ocamlorg_frontend/pages` using the [.eml templating preprocessor](https://aantron.github.io/dream/#templates). This is mixture or OCaml and HTML.
-- **Translating Content or Pages**: for now we are focusing on getting OCaml.org ready for launch and will add more information about translation later.
 
 ## Reporting Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ When compiling, the feed entries will be downloaded, and Markdown files for each
 
 Please, make sure your feed only contains articles about OCaml.
 
-To contribute an original blog post (referred to as [News](https://ocaml.org/blog) on the site), you can add a new Markdown file in [`/data/planet/ocamlorg`](/data/planet/ocamlorg/). For instance: [`about-utop.md`](data/planet/ocamlorg/about-utop.md).
+To contribute an original blog post (under [OCaml Community Blog](https://ocaml.org/blog) on the site), you can add a new Markdown file in [`/data/planet/ocamlorg`](/data/planet/ocamlorg/). For instance: [`about-utop.md`](data/planet/ocamlorg/about-utop.md).
 
 If you want to republish an blog post you previously posted on Discuss, you can fetch it using the Discuss API:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,25 @@
-# How to contribute
+# How to Contribute
 
-Welcome to Ocaml.org's contributing guide.
+Welcome to OCaml.org's contributing guide.
 
 This guide documents the best way to contribute to the project. If you're looking for a guide on how to setup the project and submit a contribution, you can refer to our [HACKING](./HACKING.md) guide.
 
-Thank you for taking the time to read the contributing guide. Your help with Ocaml.org is extremely welcome. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/ocaml.org/issues/new).
+Thank you for taking the time to read the contributing guide. Your help with OCaml.org is extremely welcome. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/ocaml.org/issues/new).
 
 We are particularly motivated to support new contributors and people who are looking to learn and develop their skills.
 
 - **Good First Issues**: issues marked as a `good first issue` are ideal for people who are either new to the repository or still getting started with OCaml in general.
 - **Fixing or Suggesting Content**: most of the content for the site is stored in the `data` directory as markdown or yaml. To fix this content you can edit those files directly and rebuild the website. This will promote the content into their `.ml` counterparts. If you would like to suggest entirely new content please open an issue to discuss it first.
-- **Implementing pages**: most pages are implemented in `src/ocamlorg_frontend/pages` using the [.eml templating preprocessor](https://aantron.github.io/dream/#templates). This is mixture or OCaml and HTML.
+- **Implementing Pages**: most pages are implemented in `src/ocamlorg_frontend/pages` using the [.eml templating preprocessor](https://aantron.github.io/dream/#templates). This is mixture or OCaml and HTML.
 - **Translating content or pages**: for now we are focusing on getting OCaml.org ready for launch and will add more information about translation later.
 
-## Reporting bugs
+## Reporting Bugs
 
 We use GitHub issues to track all bugs and feature requests; feel free to open an issue over [here](https://github.com/ocaml/ocaml.org/issues/new) if you have found a bug or wish to see a feature implemented.
 
 Please include images and browser-specific information if the bug is related to some visual aspect of the site. This tends to make it easier to reproduce and fix.
 
-## Contributing content
+## Contributing Content
 
 Here's a list of the content that is community driven and how you can contribute to it:
 
@@ -32,14 +32,14 @@ Here's a list of the content that is community driven and how you can contribute
 - [The featured packages](#content-package)
 - [The OCaml Changelog](#content-package)
 
-### <a name="content-blog"></a> Add an RSS feed to the blog
+### <a name="content-blog"></a> Add an RSS Feed to the Blog
 
 > Contribute to the [OCaml Blog](https://ocaml.org/blog).
 
 The blog is composed of two type of content:
 
-- Community blog posts fetched from RSS feeds.
-- Original blog posts.
+- Community blog posts fetched from RSS feeds
+- Original blog posts
 
 If you write about OCaml and have an RSS or Atom feed, you can add your feed to [`data/planet-sources.yml`](data/planet-sources.yml).
 
@@ -49,7 +49,7 @@ Please, make sure your feed only contains articles about OCaml.
 
 To contribute an original blog post (refer to as News on the site), you can add a new markdown file in [`data/news/`](/data/news/). For instance: [`multicore-2021-12.md`](data/news/multicore/multicore-2021-12.md).
 
-If you want to re-publish an blog post you previously posted on Discuss, you can fetch it using Discuss API:
+If you want to republish an blog post you previously posted on Discuss, you can fetch it using Discuss API:
 
 ```
 curl https://discuss.ocaml.org/raw/<id> > data/news/<fname>.md
@@ -57,7 +57,7 @@ curl https://discuss.ocaml.org/raw/<id> > data/news/<fname>.md
 
 Where `<id>` is the ID of the Discuss post.
 
-### <a name="content-job"></a> Add an entry to the job board
+### <a name="content-job"></a> Add an Entry to the Job Board
 
 > Contribute to the [Job Board](https://ocaml.org/jobs).
 
@@ -69,7 +69,7 @@ Please make sure that the job involves mostly writing OCaml. Contributions to ad
 
 If you notice that a job opportunity is outdated (e.g. already fulfilled, or not opened anymore), PRs to remove it are welcome as well.
 
-### <a name="content-success-story"></a> Add a success story
+### <a name="content-success-story"></a> Add a Success Story
 
 > Contribute to the [Success Stories](https://ocaml.org/success-stories).
 
@@ -84,7 +84,7 @@ The success stories should be structured in the following way:
 
 You can read [Ahref's success story](https://ocaml.org/success-stories/peta-byte-scale-web-crawler) for an examplary success story.
 
-### <a name="content-user"></a> Add an academic or industrial user
+### <a name="content-user"></a> Add an Academic or Industrial User
 
 > Contribute to the [Academic Users](https://ocaml.org/academic-users) and [Industrial Users](https://ocaml.org/industrial-users).
 
@@ -92,19 +92,19 @@ You can add a new academic user by creating a new markdown file in [data/industr
 
 You can add a new industrial user by creating a new markdown file in [data/academic_institutions/](data/academic_institutions). For instance: [cornell.md](data/academic_institutions/en/cornell.md).
 
-### <a name="content-book"></a> Add a book
+### <a name="content-book"></a> Add a Book
 
 > Contribute to the [OCaml Books](https://ocaml.org/books).
 
 You can add a new OCaml book by creating a new markdown file in [data/books/](data/books/). For instance: [ocaml-from-the-very-beginning.md](data/industrial_users/en/ocaml-from-the-very-beginning.md).
 
-### <a name="content-event"></a> Add an event
+### <a name="content-event"></a> Add an Event
 
 > Contribute to the [Community Events](https://ocaml.org/community).
 
 You can add a new community event by creating a new markdown file in [data/meetups.yml](data/meetups.yml).
 
-### <a name="content-package"></a> Add a featured packages
+### <a name="content-package"></a> Add a Featured Package
 
 > Contribute to the [Featured Packages](https://ocaml.org/packages).
 
@@ -125,7 +125,7 @@ The announcement is proofread by the OCaml.org team, who will also suggest highl
 
 To contribute to a new release announcement or feature highlight, add a markdown file in `data/changelog/`.
 
-## Git and GitHub workflow
+## Git and GitHub Workflow
 
 The preferred workflow for contributing to a repository is to fork the main repository on GitHub, clone, and develop on a new branch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,31 @@
 # How to Contribute
-
-Welcome to OCaml.org's contributing guide.
+ 
+Welcome to OCaml.org's contributing guide. Thank you for taking the time to read it! Your help with OCaml.org is extremely welcome. We are particularly motivated to support new contributors and people who are looking to learn and develop their skills. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/ocaml.org/issues/new).
 
 This guide documents the best way to contribute to the project. If you're looking for a guide on how to setup the project and submit a contribution, you can refer to our [HACKING](./HACKING.md) guide.
 
-Thank you for taking the time to read the contributing guide. Your help with OCaml.org is extremely welcome. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/ocaml.org/issues/new).
-
-We are particularly motivated to support new contributors and people who are looking to learn and develop their skills.
-
-- **Good First Issues**: issues marked as a `good first issue` are ideal for people who are either new to the repository or still getting started with OCaml in general.
-- **Fixing or Suggesting Content**: most of the content for the site is stored in the `data` directory as markdown or yaml. To fix this content you can edit those files directly and rebuild the website. This will promote the content into their `.ml` counterparts. If you would like to suggest entirely new content please open an issue to discuss it first.
+- **Good First Issues**: if you are either new to the repository or still getting started with OCaml in general, issues marked as a `good first issue` are ideal.
+- **Fixing or Suggesting Content**: most of the site content is stored in the `data` directory as Markdown or YAML. To fix this content, you can edit those files directly and rebuild the website. This will promote the content into their `.ml` counterparts. If you would like to suggest entirely new content, please open an issue to discuss it first.
 - **Implementing Pages**: most pages are implemented in `src/ocamlorg_frontend/pages` using the [.eml templating preprocessor](https://aantron.github.io/dream/#templates). This is mixture or OCaml and HTML.
-- **Translating content or pages**: for now we are focusing on getting OCaml.org ready for launch and will add more information about translation later.
+- **Translating Content or Pages**: for now we are focusing on getting OCaml.org ready for launch and will add more information about translation later.
 
 ## Reporting Bugs
 
-We use GitHub issues to track all bugs and feature requests; feel free to open an issue over [here](https://github.com/ocaml/ocaml.org/issues/new) if you have found a bug or wish to see a feature implemented.
+We use GitHub issues to track all bugs and feature requests. Feel free to open an issue over [here](https://github.com/ocaml/ocaml.org/issues/new) if you have found a bug or wish to see a feature implemented.
 
 Please include images and browser-specific information if the bug is related to some visual aspect of the site. This tends to make it easier to reproduce and fix.
 
 ## Contributing Content
 
-Here's a list of the content that is community driven and how you can contribute to it:
+Here's a list of community-driven content and how you can contribute to it:
 
-- [The blog](#content-blog)
-- [The job board](#content-job)
-- [The success stories](#content-success-story)
-- [The academic and industrial users](#content-user)
-- [The OCaml books](#content-book)
-- [The community events](#content-event)
-- [The featured packages](#content-package)
+- [The Blog](#content-blog)
+- [Job Board](#content-job)
+- [Success Stories](#content-success-story)
+- [Academic and Industrial Users](#content-user)
+- [OCaml Books](#content-book)
+- [Community Events](#content-event)
+- [Featured Packages](#content-package)
 - [The OCaml Changelog](#content-package)
 
 ### <a name="content-blog"></a> Add an RSS Feed to the Blog
@@ -43,13 +39,13 @@ The blog is composed of two type of content:
 
 If you write about OCaml and have an RSS or Atom feed, you can add your feed to [`data/planet-sources.yml`](data/planet-sources.yml).
 
-When compiling, the entries of the feed will be downloaded and markdown files for each item of the feed will be created in [`data/rss`](data/rss/). For instance: [building-ahrefs-codebase-with-melange.md`](data/rss/ahrefs/building-ahrefs-codebase-with-melange.md).
+When compiling, the feed entries will be downloaded, and Markdown files for each item will be created in [`data/rss`](data/rss/). For instance: [building-ahrefs-codebase-with-melange.md`](data/rss/ahrefs/building-ahrefs-codebase-with-melange.md).
 
 Please, make sure your feed only contains articles about OCaml.
 
-To contribute an original blog post (refer to as News on the site), you can add a new markdown file in [`data/news/`](/data/news/). For instance: [`multicore-2021-12.md`](data/news/multicore/multicore-2021-12.md).
+To contribute an original blog post (referred to as [News](https://ocaml.org/blog) on the site), you can add a new Markdown file in [`data/news/`](/data/news/). For instance: [`multicore-2021-12.md`](data/news/multicore/multicore-2021-12.md).
 
-If you want to republish an blog post you previously posted on Discuss, you can fetch it using Discuss API:
+If you want to republish an blog post you previously posted on Discuss, you can fetch it using the Discuss API:
 
 ```
 curl https://discuss.ocaml.org/raw/<id> > data/news/<fname>.md
@@ -65,22 +61,22 @@ The job board displays OCaml job opportunities.
 
 To add a new entry to the job board, you can add it to [`data/jobs.yml`](data/jobs.yml).
 
-Please make sure that the job involves mostly writing OCaml. Contributions to add jobs unrelated to OCaml, or where OCaml is a negligible part of the job won't be accepted.
+Please make sure that the job involves mostly writing OCaml. Contributions to add jobs unrelated to OCaml, or where OCaml is a negligible part of the job, won't be accepted.
 
-If you notice that a job opportunity is outdated (e.g. already fulfilled, or not opened anymore), PRs to remove it are welcome as well.
+If you notice that a job opportunity is outdated (e.g., already fulfilled or not open anymore), PRs to remove it are welcome as well.
 
 ### <a name="content-success-story"></a> Add a Success Story
 
 > Contribute to the [Success Stories](https://ocaml.org/success-stories).
 
-You can contribute a new success story by adding a markdown file in [data/success_stories/](data/success_stories/). For instance: [janestreet.md](data/success_stories/en/janestreet.md).
+You can contribute a new success story by adding a Markdown file in [data/success_stories/](data/success_stories/). For instance: [janestreet.md](data/success_stories/en/janestreet.md).
 
 The success stories should be structured in the following way:
 
-- An overview of your company.
-- The challenge you faced and solved.
-- The solution you implemented, which should describe the role OCaml played in solving the challenge.
-- A post-mortem describing the results you had after implementing the solution.
+- An overview of your company
+- The challenge you faced and solved
+- The solution you implemented, which should describe the role OCaml played in solving the challenge
+- A post-mortem describing the results you had after implementing the solution
 
 You can read [Ahref's success story](https://ocaml.org/success-stories/peta-byte-scale-web-crawler) for an examplary success story.
 
@@ -88,42 +84,42 @@ You can read [Ahref's success story](https://ocaml.org/success-stories/peta-byte
 
 > Contribute to the [Academic Users](https://ocaml.org/academic-users) and [Industrial Users](https://ocaml.org/industrial-users).
 
-You can add a new academic user by creating a new markdown file in [data/industrial_users/](data/industrial_users/). For instance: [cryptosense.md](data/industrial_users/en/cryptosense.md).
+You can add a new academic user by creating a new Markdown file in [data/industrial_users/](data/industrial_users/). For instance: [cryptosense.md](data/industrial_users/en/cryptosense.md).
 
-You can add a new industrial user by creating a new markdown file in [data/academic_institutions/](data/academic_institutions). For instance: [cornell.md](data/academic_institutions/en/cornell.md).
+You can add a new industrial user by creating a new Markdown file in [data/academic_institutions/](data/academic_institutions). For instance: [cornell.md](data/academic_institutions/en/cornell.md).
 
 ### <a name="content-book"></a> Add a Book
 
 > Contribute to the [OCaml Books](https://ocaml.org/books).
 
-You can add a new OCaml book by creating a new markdown file in [data/books/](data/books/). For instance: [ocaml-from-the-very-beginning.md](data/industrial_users/en/ocaml-from-the-very-beginning.md).
+You can add a new OCaml book by creating a new Markdown file in [data/books/](data/books/). For instance: [ocaml-from-the-very-beginning.md](data/industrial_users/en/ocaml-from-the-very-beginning.md).
 
 ### <a name="content-event"></a> Add an Event
 
 > Contribute to the [Community Events](https://ocaml.org/community).
 
-You can add a new community event by creating a new markdown file in [data/meetups.yml](data/meetups.yml).
+You can add a new community event by creating a new Markdown file in [data/meetups.yml](data/meetups.yml).
 
 ### <a name="content-package"></a> Add a Featured Package
 
 > Contribute to the [Featured Packages](https://ocaml.org/packages).
 
-To update the list of Featured Packages in the Packages page, you can update [data/packages.yml](data/packages.yml)
+To update the list of Featured Packages on the Packages page, you can update [data/packages.yml](data/packages.yml)
 
 ### <a name="ocaml-changelog"></a> OCaml Changelog
 
 The [OCaml Changelog](https://ocaml.org/changelog) is a feed of the latest releases and feature highlights for official OCaml projects. As of today, it features the following projects:
 
-- [The OCaml compiler](https://github.com/ocaml/ocaml)
-- [The OCaml Platform tools](https://ocaml.org/docs/platform)
-- [Ppxlib](https://github.com/ocaml-ppx/ppxlib)
-- [OMP](https://github.com/ocaml-ppx/ocaml-migrate-parsetree) (that has been deprecated in favour of Ppxlib)
+- [The OCaml Compiler](https://github.com/ocaml/ocaml)
+- [OCaml Platform Tools](https://ocaml.org/docs/platform)
+- [`ppxlib'](https://github.com/ocaml-ppx/ppxlib)
+- [OMP](https://github.com/ocaml-ppx/ocaml-migrate-parsetree) (that has been deprecated in favour of `ppxlib`)
 
-Before a release of the above tools land on the opam-repository, the release manager of the project opens a Pull Request on OCaml.org with an announcement for the release.
+Before a release of the above tools land on the `opam-repository`, the release manager of the project opens a pull request (PR) on OCaml.org with an announcement for the release.
 
-The announcement is proofread by the OCaml.org team, who will also suggest highlighting features from the release.
+The announcement is proofread by the OCaml.org team, who will also suggest highlighting release features.
 
-To contribute to a new release announcement or feature highlight, add a markdown file in `data/changelog/`.
+To contribute to a new release announcement or feature highlight, add a Markdown file in `data/changelog/`.
 
 ## Git and GitHub Workflow
 
@@ -131,15 +127,15 @@ The preferred workflow for contributing to a repository is to fork the main repo
 
 If you aren't familiar with how to work with Github or would like to learn it, here is [a great tutorial](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).
 
-Feel free to use any approach while creating a pull request. Here are a few suggestions from the dev team:
+Feel free to use any approach while creating a PR. Here are a few suggestions from the dev team:
 
-- If you are not sure whether your changes will be accepted or want to discuss the method before delving into it, please create an issue and ask it.
-- Clone the repo locally (or continue editing directly in github if the change is small). Checkout
+- If you are not sure whether your changes will be accepted or want to discuss the method before delving into it, please create an issue and ask.
+- Clone the repo locally (or continue editing directly in GitHub if the change is small). Checkout
   out the branch that you created.
-- Create a draft pull request with a small initial commit. Here's how you can [create a draft pull request.](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
-- Continue developing, feel free to ask questions in the PR, if you run into obstacles or uncertainty as you make changes
-- Review your implementation according to the checks noted in the PR template
-- Once you feel your branch is ready, change the PR status to "ready to review"
-- Consult the tasks noted in the PR template
-- When merging, consider cleaning up the commit body
+- Create a draft PR with a small initial commit. Here's how you can [create a draft pull request.](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+- Continue developing and feel free to ask questions in the PR if you run into obstacles or uncertainty as you make changes
+- Review your implementation according to the checks noted in the PR template.
+- Once you feel your branch is ready, change the PR status to "ready to review."
+- Consult the tasks noted in the PR template.
+- When merging, consider cleaning up the commit body.
 - Close any issues that were addressed by this PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
  
 Welcome to OCaml.org's contributing guide. Thank you for taking the time to read it! Your help with OCaml.org is extremely welcome. We are particularly motivated to support new contributors and people who are looking to learn and develop their skills. If you get stuck, please don’t hesitate to [ask questions on discuss](https://discuss.ocaml.org/) or [raise an issue](https://github.com/ocaml/ocaml.org/issues/new).
 
-This guide documents the best way to contribute to the project. If you're looking for a guide on how to setup the project and submit a contribution, you can refer to our [HACKING](./HACKING.md) guide.
+This guide documents the best way to contribute to the project when adding things listed below in Contributing Content. If you're looking for a guide on how to setup the project and suggest a change to the code, you can refer to our [HACKING](./HACKING.md) guide, which will also give instructions on how to rebuild the website, if necessary, when making changes. 
 
 - **Good First Issues**: if you are either new to the repository or still getting started with OCaml in general, issues marked as a `good first issue` are ideal.
-- **Fixing or Suggesting Content**: most of the site content is stored in the `data` directory as Markdown or YAML. To fix this content, you can edit those files directly and rebuild the website. This will promote the content into their `.ml` counterparts. If you would like to suggest entirely new content, please open an issue to discuss it first.
+- **Suggesting Changes**: most of the site content is stored in the `data` directory as Markdown or YAML. To suggest a change or update this content, you can edit those files directly and rebuild the website, detailed in the [HACKING](./HACKING.md) guide. This will promote the content into their `.ml` counterparts. If you would like to suggest entirely new website content or code, please [open an issue](https://github.com/ocaml/ocaml.org/issues) to discuss it first.
 - **Implementing Pages**: most pages are implemented in `src/ocamlorg_frontend/pages` using the [.eml templating preprocessor](https://aantron.github.io/dream/#templates). This is mixture or OCaml and HTML.
 - **Translating Content or Pages**: for now we are focusing on getting OCaml.org ready for launch and will add more information about translation later.
 
@@ -17,7 +17,7 @@ Please include images and browser-specific information if the bug is related to 
 
 ## Contributing Content
 
-Here's a list of community-driven content and how you can contribute to it:
+We've provided a list of community-driven content below. When adding content to any of these sections, it's best to fork the repo, add your file, and open a pull request (PR). 
 
 - [The Blog](#content-blog)
 - [Job Board](#content-job)
@@ -27,6 +27,8 @@ Here's a list of community-driven content and how you can contribute to it:
 - [Community Events](#content-event)
 - [Featured Packages](#content-package)
 - [The OCaml Changelog](#content-package)
+
+The following sections give more details on how to contribute to each.
 
 ### <a name="content-blog"></a> Add an RSS Feed to the Blog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,6 @@ The [OCaml Changelog](https://ocaml.org/changelog) is a feed of the latest relea
 
 - [The OCaml Compiler](https://github.com/ocaml/ocaml)
 - [OCaml Platform Tools](https://ocaml.org/docs/platform)
-- [`ppxlib'](https://github.com/ocaml-ppx/ppxlib)
-- [OMP](https://github.com/ocaml-ppx/ocaml-migrate-parsetree) (that has been deprecated in favour of `ppxlib`)
 
 Before a release of the above tools land on the `opam-repository`, the release manager of the project opens a pull request (PR) on OCaml.org with an announcement for the release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ When compiling, the feed entries will be downloaded, and Markdown files for each
 
 Please, make sure your feed only contains articles about OCaml.
 
-To contribute an original blog post (referred to as [News](https://ocaml.org/blog) on the site), you can add a new Markdown file in [`data/news/`](/data/news/). For instance: [`multicore-2021-12.md`](data/news/multicore/multicore-2021-12.md).
+To contribute an original blog post (referred to as [News](https://ocaml.org/blog) on the site), you can add a new Markdown file in [`/data/planet/ocamlorg`](/data/planet/ocamlorg/). For instance: [`about-utop.md`](data/planet/ocamlorg/about-utop.md).
 
 If you want to republish an blog post you previously posted on Discuss, you can fetch it using the Discuss API:
 


### PR DESCRIPTION
Since we're going to start actively encouraging contributions, I reviewed/revised the CONTRIBUTING.md doc.  

I found these points confusing: 

- the line: "This guide documents the best way to contribute to the project. If you're looking for a guide on how to setup the project and submit a contribution, you can refer to our [HACKING](https://github.com/christinerose/ocaml.org/blob/edit_blog-ReadMe/HACKING.md) guide." The first sentence says this guide is for contributing to the project, and the second sentence also says how to submit a contribution to the project via the HACKING guide. Are these two different project? Perhaps we can clarify this.
- the line: "To fix this content, you can edit those files directly and rebuild the website." Is "fix" the best word here? Perhaps "suggest a change or update" ? -- this reads as if they can change the site directly without opening a PR. Is that correct?
- this line: "Translating Content or Pages: for now we are focusing on getting OCaml.org ready for launch and will add more information about translation later." -- Since we've already launched OCaml.org, should this be updated or removed?
- If OMP is deprecated, should it just be removed from the list of Changelog examples?