### PR TITLE
Improve accessibility package+search

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -22,7 +22,7 @@ let render
 =
 let search_dropdown () =
   <span id="header-search-indicator" class="mx-2 htmx-indicator">Searching...</span>
-  <div id="header-search-results"></div>
+  <div id="header-search-results" aria-live="polite"></div>
   <span class="pl-2 font-semibold">Or go to:</span>
   <a class="flex py-2 px-4 gap-4 hover:bg-primary-100 font-semibold hover:font-semibold text-primary-600" href="<%s Url.api %>">
     Standard Library API

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -49,7 +49,7 @@ let render_package_and_version
     </option>
   in
   <div class="flex gap-4">
-    <a class="font-semibold text-3xl" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a>
+    <h1 class="m-0 text-3xl"><span class="sr-only">package </span><a class="font-semibold text-3xl" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a></h1>
     <select id="version" name="version" aria-label="version" onchange="location = this.value;"
       class="leading-8 appearance-none cursor-pointer py-0 rounded-md border border-gray-400 pr-8"
       style="background-position: right 0.25rem center">

--- a/src/ocamlorg_frontend/css/partials/in_package_search.css
+++ b/src/ocamlorg_frontend/css/partials/in_package_search.css
@@ -1,3 +1,7 @@
+#in-package-search-results h2 {
+  @apply text-sm font-semibold px-4;
+}
+
 #in-package-search-results ol {
   @apply m-0 p-0 list-none text-sm;
 }

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -1,7 +1,7 @@
 let search_instructions_html () =
   <div class="prose text-sm">
-    <p>To focus the search input from anywhere on the page, press the 'S' key.</p>
-    <p>in-package search v0.1.0</p>
+    <p>You can search for identifiers within the package.</p>
+    <p>in-package search v0.2.0</p>
   </div>
 
 let render
@@ -46,7 +46,7 @@ Layout.render
         :class='sidebar ? "" : "hidden"' aria-hidden="true" x-on:click="sidebar = ! sidebar">
       </div>
 
-      <button title="search" class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-36 fixed md:hidden right-10"
+      <button title="search" class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-36 fixed right-10 md:hidden"
       x-on:click="document.getElementById('in-package-search-input').focus();">
         <%s! Icons.magnifying_glass "h-8 w-8" %>
         <span class="hidden md:flex font-semibold px-2">search</span>
@@ -101,7 +101,7 @@ Layout.render
             <%s! search_instructions_html () %>
           </div>
 
-          <div id="in-package-search-results" class="absolute top-12 right-0 left-0 bg-white z-20 w-full max-h-[60vh] overflow-y-auto border rounded-lg shadow-xl">
+          <div id="in-package-search-results" aria-live="polite" class="absolute top-12 right-0 left-0 bg-white z-20 w-full max-h-[60vh] overflow-y-auto border rounded-lg shadow-xl">
           </div>
         </div>
       </div>
@@ -230,6 +230,13 @@ Layout.render
 
           search_results.appendChild(list_item);
       });
+
+      if (results.length > 0 || q.trim() != "") {
+        let announce_results = document.createElement("h2");
+        announce_results.innerHTML = results.length + " results"
+        container.appendChild(announce_results);
+      }
+
       container.appendChild(search_results);
 
       search_results_position = null;
@@ -256,7 +263,7 @@ Layout.render
       document.body.appendChild(scriptTag);
 
       let container = document.getElementById("in-package-search-results");
-      container.innerHTML = `<div class="px-4 py-2">Loading...</div>`;
+      container.innerHTML = `<div class="px-4 py-2">Loading search index...</div>`;
 
       document.getElementById("in-package-search-input").removeEventListener("focus", user_interacts);
     }
@@ -311,15 +318,6 @@ Layout.render
     }
 
     document.getElementById("in-package-search-input").addEventListener("keydown", keydown);
-
-    document.addEventListener("keydown", (event) => {
-      if (event.key == "s") {
-        document.getElementById("in-package-search-input").focus();
-        document.getElementById("in-package-search-input").select();
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    })
   }
 </script>
 <% | _ -> () ); %>

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -28,7 +28,7 @@ Layout.render
 
                   <div>
                     <span id="packages-search-indicator" class="htmx-indicator">Searching...</span>
-                    <div id="packages-search-results"></div>
+                    <div id="packages-search-results" aria-live="polite"></div>
                   </div>
                 </form>
             </div>

--- a/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
+++ b/src/ocamlorg_frontend/pages/packages_autocomplete_fragment.eml
@@ -2,7 +2,7 @@
    and the search results HTML fragment (see function [render]). *)
 let form_attributes =
   {js| x-data="{ row: null, col: 0, max: 0, total: 0 }"
-       @submit="if (row === null && total <= 5) row = 0; if (row !== null) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }" |js}
+       @submit="if (row !== null) { window.location = document.getElementById('package-autocomplete-'+row+'-'+col).getAttribute('href'); $event.stopPropagation(); $event.preventDefault(); return false }" |js}
 
 (* When the user types, htmx fetches the fragment rendered by
    the function [render] below, and and inserts it into the


### PR DESCRIPTION
Thank you @shindere.

I found the `aria-live` attribute which announces when a certain part of the page changes. This should be suitable for announcing new search results. I am curious if this is helpful.

- adds missing `h1` on package overview
- removes 'S' keybinding on package documentation search - it was a nice experiment, but capturing key presses is too invasive
- announce number of search results on in-package search
- go to the package search results page when pressing enter in package search when no package has been selected