### PR TITLE
escape search string on package search results page

### DIFF
--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -11,7 +11,7 @@ let render ~total ~search (packages : Package.package list) = Layout.render ~tit
             ~name:"q"
             ~label:"Search OCaml packages"
             ~button_attrs:{|type="submit"|}
-            ~input_attrs:("value=\"" ^ search ^ "\"")
+            ~input_attrs:("value=\"" ^ Dream.html_escape search ^ "\"")
             ""
           %>
         </form>


### PR DESCRIPTION
Fixes https://github.com/ocaml/ocaml.org/issues/1325.