### PR TITLE
Opening PR to address clarity

### DIFF
--- a/data/tutorials/language/0it_03_if_statements_loops_and_recursion.md
+++ b/data/tutorials/language/0it_03_if_statements_loops_and_recursion.md
@@ -12,7 +12,7 @@ As in other OCaml.org documentation, the code examples will either be something 
 an example of code. Code snippets that begin with the CLI prompt `#`, end with `;;`, and have a 
 clear output can be tested in the OCaml toplevel (`ocaml` or `utop`) 
 or pasted into the OCaml playground. If the code doesn't start with `#` and end in `;;`, 
-it's an example of how to write the code. 
+it's an example of how to write the code.
 
 ## If Statements
 OCaml has an `if` statement with two variations:


### PR DESCRIPTION
The previous PR addressing syntax/formatting/grammar, etc. has been merged. Opened this new PR to address the questions, as it will take more effort/time.

Here some questions and results that differed from the doc:

1. Everything from li 79 - 101 doesn't make sense to me. It's not clear where to put the `range 11 10` to get a return of `[]`. I tried many different things based on the code li 67 - 71, but I either got a `val range : int -> int -> int list = <fun>` or I got an error. IRT li 100/101, `range 1 10` is clear to evaluate to below, but it's the first time `range 1 10` is mentioned. It seems a bit of a non sequitur. 
2. ~What are the arrows for in li 94-97? It appears that it might be different possible outputs, but it's not clear and I can't get any of them to work in various attempts. I get the error that it's applied too many arguments if I put it in as shown (without arrows). Since it doesn't start with `#` or end with `;;`, I suspect it's not suppose to run. Perhaps we can clarify this? (Unless of course it would be crystal clear to a programmer, even one new to OCaml).~
3. li 108, "back to `if` statements"--when did we leave them? If li 94 - 97 aren't alternate tests of the previous `if` statement code, it's not clear what they are for.
4. For li 143 -145, are those `f` = 12.34, etc., supposed to plug into the 131 - 141 code after the `f =  ` on li 133? If so, it doesn't work for me. If not, then perhaps we can clarify. Let's include a clear example of how to call `loop`. 
5. For the pp li 143 - 155, should the number after the = also be in monospace, like: `f = 12.34`, `i = 1`, etc.?
6. I'd like to see an example of li 147 - 149 in code with the expected output. Perhaps something should be in there as a clear example where the reader can clearly try these other numbers in that same format.
7. In li 165, there's a reference to "the authors" of the code, but throughout the rest of the document, the author (of the doc) uses first person singular (I do prefer,... in li 219, for example). Unless there is a byline for these documents, do you think we should have these in first person singular? To me it makes more sense to have first person plural (we/us) to perhaps indicate the OCaml community (?).
9. Again, in li 173-177, would the reader test this code by plugging in a number after the `f = `?
10. In li 462 - 466, I get the response `- : int = 1` instead of `3628800`.
11. `#load "unix.cma";;` on li 643 gives an Alert : `ocaml_deprecated_auto_include`. The output I get is: `val readdir_no_ex : Unix.dir_handle -> string option = <fun>` -- there is just `Unix.dir_handle` rather than just `dir_handle`. Same with li 657.
12. For the code 664-668, I get an error: `Error: Unbound constructor File`. 
13. For code 752-771, I get an error: `Unbound value opendir` and a Hint: Did you mean open_in?
14. For the output on li 931, I get `- : int = 100000`
15. Li 1050, I don't get the `Line 1, characters 1-8:` output, just the Error following
16. Similar in li 1112, I only get the Error, not the `Line 1...`
17. On li 1128, I get this output `val r : int ref = {contents = 100}`
18. For the expression on li 1144, I get this: `Error: Unbound value Array.create`. Same for code li 1149-1151 and 1153: `Error: Unbound value a`. I suspect I missed a step where those things were defined?
19. For the output on li 1214, I get: `270165 1061760 1453695 1856025`
20. I only get the `Error` on li 1230, not the `Line 4` on li 1229. Same for 1243/44, 1250/51.