### PR TITLE
Add attribution to blog posts

### DIFF
--- a/src/ocamlorg_frontend/pages/blog_post.eml
+++ b/src/ocamlorg_frontend/pages/blog_post.eml
@@ -14,9 +14,14 @@ Layout.render
       </a>
     </div>
 
-    <div class="prose prose-orange mx-auto max-w-5xl">
-      <h1><%s planet.title %></h1>
+    <article class="prose prose-orange mx-auto max-w-5xl">
+      <header>
+        <h1><%s planet.title %></h1>
+        <% (match planet.authors with None -> () | Some authors -> %>
+        Authored by: <%- String.concat ", " authors %>
+        <% ); %>
+      </header>
       <%s! planet.body_html %>
-    </div>
+    </article>
   </div>
 </div>

--- a/src/ocamlorg_frontend/pages/blog_post.eml
+++ b/src/ocamlorg_frontend/pages/blog_post.eml
@@ -18,7 +18,7 @@ Layout.render
       <header>
         <h1><%s planet.title %></h1>
         <% (match planet.authors with None -> () | Some authors -> %>
-        Authored by: <%- String.concat ", " authors %>
+        <i>Authored by: <%s String.concat ", " authors %></i>
         <% ); %>
       </header>
       <%s! planet.body_html %>


### PR DESCRIPTION
This is low effort and doesn't consider what css *should* be used. I have not tested it. It should hopefully not be difficult for someone with insight into the website to remedy this PR.

Motivated by https://github.com/ocaml/ocaml.org/pull/1240