### PR TITLE
Changelog: Flex-wrap and gap to make the tags wrap around

### DIFF
--- a/src/ocamlorg_frontend/pages/changelog.eml
+++ b/src/ocamlorg_frontend/pages/changelog.eml
@@ -50,7 +50,7 @@ Layout.render
               </h2>
               <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-gray-600"><%s item.date %></time>
               <% (match item.tags with [] -> () | _ ->  %>
-              <div class="mt-3 flex flex-row justify-start space-x-4">
+              <div class="mt-3 flex flex-row flex-wrap justify-start gap-4">
                 <% item.tags |> List.iter (fun tag -> %>
                 <a href="<%s Url.changelog %>?t=<%s tag %>" class="whitespace-nowrap rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"><%s tag %></a>
                 <% ); %>


### PR DESCRIPTION
Fixes https://github.com/ocaml/ocaml.org/issues/1356.

Before:
![Screenshot 2023-07-03 at 10-20-02 OCaml Changelog](https://github.com/ocaml/ocaml.org/assets/6594573/cc26b5da-f9db-4a32-a809-93db83d355be)
After:
![Screenshot 2023-07-03 at 10-20-49 OCaml Changelog](https://github.com/ocaml/ocaml.org/assets/6594573/1c5bd462-d04e-4e8b-9fd4-bec0d00435a9)

