### PR TITLE
Changelog entry for OCaml 5.1.0-beta1

### DIFF
--- a/data/changelog/ocaml/2023-07-04-ocaml-5.1.beta1.md
+++ b/data/changelog/ocaml/2023-07-04-ocaml-5.1.beta1.md
@@ -1,0 +1,71 @@
+---
+title: OCaml 5.1.0 - First Beta
+description: First Beta Release of OCaml 5.1.0
+date: "2023-07-04"
+tags: [ocaml, release]
+changelog: |
+  ### Runtime System Bugfix
+
+  - [#12037](https://github.com/ocaml/ocaml/issues/12037): Fix some data races by using volatile when necessary
+    (Fabrice Buoro and Olivier Nicole, review by Guillaume Munch-Maccagnoni,
+    Gabriel Scherer and Luc Maranget)
+
+  - [#12253](https://github.com/ocaml/ocaml/issues/12253), [#12342](https://github.com/ocaml/ocaml/issues/12342): Fix infinite loop in signal handling.
+    (Guillaume Munch-Maccagnoni, report by Thomas Leonard, review by
+     KC Sivaramakrishnan and Sadiq Jaffer)
+
+  ### Windows Bugfix
+
+  - [#12184](https://github.com/ocaml/ocaml/issues/12184), [#12320](https://github.com/ocaml/ocaml/issues/12320): Sys.rename Windows fixes on directory corner cases.
+    (Jan Midtgaard, review by Anil Madhavapeddy)
+
+---
+
+After two alpha releases, the release of OCaml 5.1.0 is drawing near.
+We have thus released a first beta version of OCaml 5.1.0 to help you update your softwares and libraries ahead of the release (see below for the installation instructions).
+Compared to the last alpha release, this beta contains two subtle internal runtime fixes, and one Windows fix.
+Overall, the opam ecosystem looks in a good shape for the first beta release.
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+Nearly all core development tools supports OCaml 5.1.0, and you can follow the last remaining wrinkles on the
+[opam readiness for 5.1.0 meta-issue](https://github.com/ocaml/opam-repository/issues/23669).
+
+Currently, the release is planned for the end of July or the beginning of August.
+
+If you are interested in full list of features and bug fixes of the new OCaml version, the
+updated change log for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.1/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1:
+
+```bash
+opam update
+opam switch create 5.1.0~beta1
+```
+
+The source code for the alpha is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.0-beta1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~beta1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.1.0~beta1+options <option_list>
+```
+
+where `option_list` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+
+```bash
+opam switch create 5.1.0~beta1+flambda+nffa ocaml-variants.5.1.0~beta1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.

--- a/data/changelog/ocaml/2023-07-04-ocaml-5.1.beta1.md
+++ b/data/changelog/ocaml/2023-07-04-ocaml-5.1.beta1.md
@@ -23,7 +23,7 @@ changelog: |
 
 After two alpha releases, the release of OCaml 5.1.0 is drawing near.
 We have thus released a first beta version of OCaml 5.1.0 to help you update your softwares and libraries ahead of the release (see below for the installation instructions).
-Compared to the last alpha release, this beta contains two subtle internal runtime fixes, and one Windows fix.
+Compared to the last alpha release, this beta contains two subtle internal runtime fixes and one Windows fix.
 Overall, the opam ecosystem looks in a good shape for the first beta release.
 
 If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).

--- a/data/changelog/ocaml/2023-07-04-ocaml-5.1.beta1.md
+++ b/data/changelog/ocaml/2023-07-04-ocaml-5.1.beta1.md
@@ -28,7 +28,7 @@ Overall, the opam ecosystem looks in a good shape for the first beta release.
 
 If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
 
-Nearly all core development tools supports OCaml 5.1.0, and you can follow the last remaining wrinkles on the
+Nearly all core development tools support OCaml 5.1.0, and you can follow the last remaining wrinkles on the
 [opam readiness for 5.1.0 meta-issue](https://github.com/ocaml/opam-repository/issues/23669).
 
 Currently, the release is planned for the end of July or the beginning of August.


### PR DESCRIPTION
This PR adds the changelog entry for the first beta release of OCaml 5.1.0. 