### PR TITLE
Fix copy-to-clipboard styles

### DIFF
--- a/scripts/scan-tailwind-colors.sh
+++ b/scripts/scan-tailwind-colors.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DIR="src/ocamlorg_frontend"
+
+TMP_FILE="tmp.txt"
+
+# Write all matches to temporary file
+grep -r -o -h -E "text-\w+-[0-9]{2,3}|bg-\w+-[0-9]{2,3}" $DIR > $TMP_FILE
+
+# Filter unique matches and print them
+sort $TMP_FILE | uniq
+
+# Remove temporary file
+rm $TMP_FILE

--- a/scripts/scan-tailwind-colors.sh
+++ b/scripts/scan-tailwind-colors.sh
@@ -8,7 +8,7 @@ TMP_FILE="tmp.txt"
 grep -r -o -h -E "text-\w+-[0-9]{2,3}|bg-\w+-[0-9]{2,3}" $DIR > $TMP_FILE
 
 # Filter unique matches and print them
-sort $TMP_FILE | uniq
+sort -u $TMP_FILE
 
 # Remove temporary file
 rm $TMP_FILE

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,17 +45,12 @@ module.exports = {
         600: "#EE6A1A",
       },
 
-      gray: {
-        400: colors.gray["400"],
-      },
-      blue: {
-        500: colors.blue["500"],
-      }
+      ...colors
     },
     backgroundColor: {
       default: "white",
       "mild-contrast": "#FAF8F3",
-      "contrast": "#14294b", // one of the colors from the dark blue contrash patterned background used in various parts of the site
+      "contrast": "#14294b", // one of the colors from the dark blue contrast patterned background used in various parts of the site
 
       "search-keyboard-cursor": "#0C3B8C", // background for cursor highlighting in keyboard navigable areas (e.g. package search dropdown)
       "search-term-highlight": "rgb(221, 232, 251)",


### PR DESCRIPTION
Reducing the available text colors in https://github.com/ocaml/ocaml.org/pull/1350 to a smaller set broke the copy-to-clipboard widgets.

This patch allows all Tailwind default colors as text color in tailwind.config.js - for some reason, Tailwind doesn't check that all the colors that are used as text color are actually available. I would have expected Tailwind to fail on this.

To identify exactly which default Tailwind colors we're using, I added a simple bash script to the repository under `scripts/scan-tailwind-colors.sh`. This helps with aligning the colors we use in the templates with the colors used in Figma.