### PR TITLE
Include @gmevel proof-reading of Seq tutorial

### DIFF
--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -89,11 +89,11 @@ loop without any output:
 ```ocaml
 # Seq.iter ignore (ints 0);;
 ```
-In both cases, the key point is: it doesn't leak memory. These examples are
-running in constant space, it is effectively nothing more than an infinite loop,
-which can be confirmed by monitoring the space consumption of the program, and
-by noticing that it spins forever without crashing. Whereas a version of this
-with a list `let rec ints n = n :: ints (n + 1)` would allocate a list of length
+The key point is: it doesn't leak memory. This example is running in constant
+space, it is effectively nothing more than an infinite loop, which can be
+confirmed by monitoring the space consumption of the program, and by noticing
+that it spins forever without crashing. Whereas a version of this with a list
+`let rec ints n = n :: ints (n + 1)` would allocate a list of length
 proportional to the running time, and thus would crash by running out of memory
 pretty quickly.
 

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -162,13 +162,14 @@ For instance, here is the list of 100 first prime numbers:
  239; 241; 251; 257; 263; 269; 271; 277; 281; 283; 293; 307; 311; 313; 317;
  331; 337; 347; 349; 353; 359; 367; 373; 379; 383; 389; 397; 401; 409; 419;
  421; 431; 433; 439; 443; 449; 457; 461; 463; 467; 479; 487; 491; 499; 503;
- 509; 521; 523]
+ 509; 521; 523; 541]
 ```
 
 The function `trial_div` is recursive in OCaml and common sense. It is defined
 using the `rec` keyword and calls itself. However, some call that kind of
-function [corecursive](https://en.wikipedia.org/wiki/Corecursion). This word
-is used to emphasise that, although it may not terminate, it can indefinitely produce valid output.
+function [corecursive](https://en.wikipedia.org/wiki/Corecursion). This word is
+used to emphasise that, although it may not terminate, it can indefinitely
+produce valid output.
 
 ## Unfolding Sequences
 
@@ -225,24 +226,14 @@ Using this function:
 ```ocaml
 let input_line_opt chan =
   try Some (input_line chan, chan)
-  with End_of_file -> close_in chan; None
+  with End_of_file -> None
 ```
 It is possible to read a file using `Seq.unfold`:
 ```ocaml
-"README.md" |> open_in |> Seq.unfold input_line_opt |> Seq.iter print_endline
+let cin = open_in "README.md" in
+cin |> Seq.unfold input_line_opt |> Seq.iter print_endline;
+close_in cin
 ```
-
-Although this can be an appealing style, bear in mind that it does not prevent
-taking care of open files. While the code above is fine, this one no longer is:
-```ocaml
-"README.md" |> open_in |> Seq.unfold input_line_opt |> Seq.take 10 |> Seq.iter print_endline
-```
-Here, `close_in` will never be called over the input channel opened on
-`README.md`.
-
-<!--
-True but arguably the mistake is that input_line_opt should not close its input. That’s wonky style. I’m not sure why we would demonstrate it in a beginner’s tutorial.
--->
 
 <!--
 Suggestion: perhaps it would be enlightening to illustrate the use of Seq.unfold by re-implementing the already seen function primes? Perhaps in an exercise rather than in the main text of the tutorial.
@@ -284,7 +275,7 @@ The `Seq` module contains this definition:
 val cons : 'a -> 'a Seq.t -> 'a Seq.t
 ```
 
-Although `Seq.cons x seq` and `Seq.Cons x seq` are the same, `Seq.cons` is a function and `Seq.Cons` is a variant's constructor, which is not the same in OCaml. This can lead to subtle bugs. This section illustrates this.
+Although `Seq.cons x seq` and `Seq.Cons (x, seq)` are the same, `Seq.cons` is a function and `Seq.Cons` is a variant's constructor, which is not the same in OCaml. This can lead to subtle bugs. This section illustrates this.
 <!--
 No need to introduce another mathematical sequence, we can re-use earlier examples (better for pedagogy):
 ```

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -192,9 +192,9 @@ essentially the same. Observe that there is no `fold_right` function. Since
 OCaml 4.11, there is something which isn't (yet) available on other types:
 `unfold`. Here is how it is implemented:
 ```ocaml
-let rec unfold f seq () = match f seq with
-  | None -> Nil
-  | Some (x, seq) -> Cons (x, unfold f seq)
+let rec unfold f x () = match f x with
+  | None -> Seq.Nil
+  | Some (x, seq) -> Seq.Cons (x, unfold f seq)
 ```
 And here is its type:
 ```ocaml
@@ -202,15 +202,20 @@ val unfold : ('a -> ('b * 'a) option) -> 'a -> 'b Seq.t = <fun>
 ```
 Unlike previously mentioned iterators, `Seq.unfold` does not have a sequence
 parameter, but a sequence result. `unfold` provides a general means to build
-sequences. For instance, `Seq.ints` can be implemented using `Seq.unfold` in a
+sequences. The result returned by `Seq.unfold f x` is the sequence built by accumulating the results of successive calls to `f` until it returns `None`. This is:
+```
+(fst p₀, fst p₁, fst p₂, fst p₃, fst p₄, ...)
+```
+where `Some p₀ = f x` and `Some pₙ₊₁ = f (snd pₙ)`.
+
+For instance, `Seq.ints` can be implemented using `Seq.unfold` in a
 fairly compact way:
 ```ocaml
 # let ints = Seq.unfold (fun n -> Some (n, n + 1));;
 val ints : int -> int Seq.t = <fun>
 ```
-<!--
-About Seq.unfold: perhaps the word accumulator should appear in explaining this function?
--->
+
+
 As a fun fact, one should observe `map` over sequences can be implemented using
 `Seq.unfold`. Here is how to write it:
 ```ocaml

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -24,7 +24,7 @@ reducing memory consumption from linear to constant space
 Still in the intro: for people familiar with Python, I believe it would be very useful to mention Python’s generators: OCaml sequences are similar to Python generators. The main difference is that each element of a Python generator is consumed only once and never seen again, while an element in an OCaml sequence can be queried several times, but is re-computed each time (more expressive but opportunity for bugs). Also, OCaml does not have all the convenient syntax that Python has (there is no yield in OCaml [at least, until algebraic effects land in OCaml 5!]). The contrast between list and Seq.t in OCaml is the same as between range and xrange in old Python 2 (or [i for i in range(100)] versus range(100) in Python 3).
 -->
 
-One way to look at a value of type `'a Seq.t` is to consider it as a list, with
+One way to look at a value of type `'a Seq.t` is to consider it as a list, but it contains
 a twist when it's not empty: its tail is frozen. To understand this analogy,
 consider how sequences are defined in the standard library:
 ```ocaml

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -85,15 +85,17 @@ has the same behaviour as `List.iter`. Writing this:
 ```
 in an OCaml toplevel means “print integers forever,” and you have to press
 `Ctrl-C` to interrupt the execution. The following code is the same infinite
-loop without any putput:
+loop without any output:
 ```ocaml
 # Seq.iter ignore (ints 0);;
 ```
-But the key point is: this doesn't leak memory.
-
-<!--
-This remark deserves to be expanded a bit. This example runs in constant space, it is effectively nothing more than an infinite loop, which can be confirmed by monitoring the space consumption of the program, and by noticing that it spins forever without crashing. Whereas a version of this with a list (let rec ints n = n :: ints (n+1)) would allocate a list of length proportional to the running time, and thus would crash by running out of memory pretty quickly.
--->
+In both cases, the key point is: it doesn't leak memory. These examples are
+running in constant space, it is effectively nothing more than an infinite loop,
+which can be confirmed by monitoring the space consumption of the program, and
+by noticing that it spins forever without crashing. Whereas a version of this
+with a list `let rec ints n = n :: ints (n + 1)` would allocate a list of length
+proportional to the running time, and thus would crash by running out of memory
+pretty quickly.
 
 ## Example
 

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -397,4 +397,5 @@ OCaml 4.14. Beware books and documentation written before may still mention it.
   * Guillaume Petiot [@gpetiot](https://github.com/gpetiot)
   * Xavier Van de Woestyne [@xvw](https://github.com/xvw)
   * Simon Cruanes [@c-cube](https://github.com/c-cube)
+  * Glen Mével [gmevel](https://github.com/c-cube)
 -->

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -16,7 +16,7 @@ You should be comfortable with writing functions over lists and options.
 
 Sequences are very much like lists. However from a pragmatic perspective, one
 should imagine they may be infinite. That's the key intuition to understanding
-and using sequences. To achieve this, sequence elements are computed on demand,
+and using sequences. To achieve this, sequence elements are computed on demand
 and not stored in memory. Perhaps more frequently, sequences also allow for
 reducing memory consumption from linear to constant space
 
@@ -90,8 +90,8 @@ loop without any output:
 # Seq.iter ignore (ints 0);;
 ```
 The key point is: it doesn't leak memory. This example is running in constant
-space, it is effectively nothing more than an infinite loop, which can be
-confirmed by monitoring the space consumption of the program, and by noticing
+space. It is effectively nothing more than an infinite loop, which can be
+confirmed by monitoring the space consumption of the program and by noticing
 that it spins forever without crashing. Whereas a version of this with a list
 `let rec ints n = n :: ints (n + 1)` would allocate a list of length
 proportional to the running time, and thus would crash by running out of memory
@@ -220,7 +220,7 @@ Here is a quick check:
 - : int list = [0; 1; 4; 9; 16; 25; 36; 49; 64; 81]
 ```
 The function `Seq.uncons` returns the head and tail of a sequence if it is not
-empty otherwise, it returns `None`.
+empty. Otherwise, it returns `None`.
 
 Using this function:
 ```ocaml
@@ -277,7 +277,7 @@ val cons : 'a -> 'a Seq.t -> 'a Seq.t
 
 Although `Seq.cons x seq` and `Seq.Cons (x, seq)` are the same, `Seq.cons` is a function and `Seq.Cons` is a variant's constructor, which is not the same in OCaml. This can lead to subtle bugs. This section illustrates this.
 <!--
-No need to introduce another mathematical sequence, we can re-use earlier examples (better for pedagogy):
+No need to introduce another mathematical sequence, we can reuse earlier examples (better for pedagogy):
 ```
 let rec ints n = Seq.cons n (ints (n+1))
 ```
@@ -288,7 +288,7 @@ sequence](https://en.wikipedia.org/wiki/Fibonacci_number):
 # let rec fibs m n = Seq.cons m (fibs n (n + m));;
 val fibs : int -> int -> int Seq.t = <fun>
 ```
-It actually isn't. It's a non-ending recursion which blows away the stack.
+It actually isn't. It's an unending recursion which blows away the stack.
 
 <!--
 At that point, Seq.cons has not been introduced yet, so the reader only knows fun () -> Seq.Cons … and would not have fallen into the trap of writing Seq.cons … instead. Besides, she may not understand this section at all because Seq.cons is not explained here. The progression of this section should be turned upside down.

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -14,7 +14,7 @@ You should be comfortable with writing functions over lists and options.
 
 ## Introduction
 
-Sequences are very much like lists. However from a pragmatic perspective, one
+Sequences are very much like lists. However, from a pragmatic perspective, one
 should imagine they may be infinite. That's the key intuition to understanding
 and using sequences. To achieve this, sequence elements are computed on demand
 and not stored in memory. Perhaps more frequently, sequences also allow for

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -142,20 +142,17 @@ The `Seq` module also has a function `Seq.filter`:
 ```
 It builds a sequence of elements satisfying a condition.
 
-Using `Seq.filter`, it is possible to make a straightforward implementation of
-the [Sieve of
-Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes). Here it is:
+Using `Seq.filter`, taking inspiration from the [trial division](https://en.wikipedia.org/wiki/Trial_division) algorithm, it is possible to define a function which seemingly generates the list of all primes numbers.
 ```ocaml
-let rec sieve seq () = match seq () with
-  | Seq.Cons (m, seq) -> Seq.Cons (m, sieve (Seq.filter (fun n -> n mod m > 0) seq))
+let rec trial_div seq () = match seq () with
+  | Seq.Cons (m, seq) -> Seq.Cons (m, trial_div (Seq.filter (fun n -> n mod m > 0) seq))
   | seq -> seq
-let primes = Seq.ints 2 |> sieve;;
-val sieve : int Seq.t -> int Seq.t = <fun>
+let primes = Seq.ints 2 |> trial_div;;
+val trial_div : int Seq.t -> int Seq.t = <fun>
 val primes : int Seq.t = <fun>
 ```
 
-This code can be used to generate lists of prime numbers. For instance, here is
-the list of 100 first prime numbers:
+For instance, here is the list of 100 first prime numbers:
 ```ocaml
 # primes |> Seq.take 100 |> List.of_seq;;
 - : int list =
@@ -168,16 +165,10 @@ the list of 100 first prime numbers:
  509; 521; 523]
 ```
 
-The function `sieve` is recursive in OCaml and common sense. It is defined using
-the `rec` keyword and calls itself. However, some call that kind of function
-[_corecursive_](https://en.wikipedia.org/wiki/Corecursion). This word is used to
-emphasise that, by design, it does not terminate. Strictly speaking, the sieve
-of Eratosthenes is not an algorithm either since it does not terminate. This
-implementation behaves the same.
-
-<!--
-Dubious. The sieve of Eratosthenes is commonly presented as acting on an array of numbers up to a given maximum number. It is an algorithm that terminates. The presented code is not a sieve of Eratosthenes (it is a trial division algorithm: every new number is tried for divisibility against all prime numbers found earlier; in a sieve algorithm, as soon as we find a prime, we preemptively remove its later multiples, and thus we avoid any useless divisibility test). This remark seems entirely unnecessary, cut it?
--->
+The function `trial_div` is recursive in OCaml and common sense. It is defined
+using the `rec` keyword and calls itself. However, some call that kind of
+function [corecursive](https://en.wikipedia.org/wiki/Corecursion). This word
+is used to emphasise that, although it may not terminate, it can indefinitely produce valid output.
 
 ## Unfolding Sequences
 

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -288,6 +288,12 @@ let primes =
 
 ## Sequences Are Functions
 
+The `Seq` module contains this definition:
+```ocaml
+val cons : 'a -> 'a Seq.t -> 'a Seq.t
+```
+
+Although `Seq.cons x seq` and `Seq.Cons x seq` are the same, `Seq.cons` is a function and `Seq.Cons` is a variant's constructor, which is not the same in OCaml. This can lead to subtle bugs. This section illustrates this.
 <!--
 No need to introduce another mathematical sequence, we can re-use earlier examples (better for pedagogy):
 ```

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -16,11 +16,9 @@ You should be comfortable with writing functions over lists and options.
 
 Sequences are very much like lists. However from a pragmatic perspective, one
 should imagine they may be infinite. That's the key intuition to understanding
-and using sequences.
-
-<!--
-IMHO, the key idea about sequences is that their elements are computed on-demand, and not stored in memory. I believe this is what should be highlighted in the very first (well, second) sentence of a tutorial. The fact that a sequence might be infinite is a corollary of this. Another corollary, perhaps more frequently used, is that sequences often allow to reduce memory consumption from linear to constant space.
--->
+and using sequences. To achieve this, sequence elements are computed on demand,
+and not stored in memory. Perhaps more frequently, sequences also allow for
+reducing memory consumption from linear to constant space
 
 <!--
 Still in the intro: for people familiar with Python, I believe it would be very useful to mention Python’s generators: OCaml sequences are similar to Python generators. The main difference is that each element of a Python generator is consumed only once and never seen again, while an element in an OCaml sequence can be queried several times, but is re-computed each time (more expressive but opportunity for bugs). Also, OCaml does not have all the convenient syntax that Python has (there is no yield in OCaml [at least, until algebraic effects land in OCaml 5!]). The contrast between list and Seq.t in OCaml is the same as between range and xrange in old Python 2 (or [i for i in range(100)] versus range(100) in Python 3).

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -390,5 +390,5 @@ OCaml 4.14. Beware books and documentation written before may still mention it.
   * Guillaume Petiot [@gpetiot](https://github.com/gpetiot)
   * Xavier Van de Woestyne [@xvw](https://github.com/xvw)
   * Simon Cruanes [@c-cube](https://github.com/c-cube)
-  * Glen Mével [gmevel](https://github.com/c-cube)
+  * Glen Mével [gmevel](https://github.com/gmevel)
 -->


### PR DESCRIPTION
Items from issue #1346 where either:
- Immediately included, when obvious
- Inlined as comment, when further discussion/rewriting is needed

After a couple of commits here are the remaining open items:

1. Comparison with Pythons generators
2. The real Eratosthenes sieve as an exercice
3. Example in section “Sequences Are Functions”
