### PR TITLE
Tab Component For Learn Area Redesign

### DIFF
--- a/src/ocamlorg_frontend/components/learn_sidebar.eml
+++ b/src/ocamlorg_frontend/components/learn_sidebar.eml
@@ -9,26 +9,27 @@ let render
   let tutorial_sidebar_links_by_category category =
     tutorials |> List.filter (fun (x : Data.Tutorial.t) -> x.category = category) |> List.map render_tutorial |> String.concat "\n"
   in
+  <div class="flex flex-col gap-10">
+    <%s! Learn_layout.sidebar_link_group "Getting Started"
+      (tutorial_sidebar_links_by_category "getting-started") %>
 
-  <%s! Learn_layout.sidebar_link_group "Getting Started"
-    (tutorial_sidebar_links_by_category "getting-started") %>
+    <%s! Learn_layout.sidebar_link_group "Language"
+      (tutorial_sidebar_links_by_category "language") %>
 
-  <%s! Learn_layout.sidebar_link_group "Language"
-    (tutorial_sidebar_links_by_category "language") %>
+    <%s! Learn_layout.sidebar_link_group "Data Structures"
+      (tutorial_sidebar_links_by_category "data-structures") %>
 
-  <%s! Learn_layout.sidebar_link_group "Data Structures"
-    (tutorial_sidebar_links_by_category "data-structures") %>
+    <%s! Learn_layout.sidebar_link_group "Runtime"
+      (tutorial_sidebar_links_by_category "runtime") %>
 
-  <%s! Learn_layout.sidebar_link_group "Runtime"
-    (tutorial_sidebar_links_by_category "runtime") %>
+    <%s! Learn_layout.sidebar_link_group "Tutorials"
+      (tutorial_sidebar_links_by_category "tutorials") %>
 
-  <%s! Learn_layout.sidebar_link_group "Tutorials"
-    (tutorial_sidebar_links_by_category "tutorials") %>
+    <%s! Learn_layout.sidebar_link_group "Guides"
+      (tutorial_sidebar_links_by_category "guides") %>
 
-  <%s! Learn_layout.sidebar_link_group "Guides"
-    (tutorial_sidebar_links_by_category "guides") %>
-
-  <%s! Learn_layout.sidebar_link_group "Resources"
-    (tutorial_sidebar_links_by_category "resources")
-    ~extra_html:((render_tutorial_link ~title:"Best Practices" ~slug:"best-practices")
-      ^ (render_tutorial_link ~title:"OCaml Platform" ~slug:"platform")) %>
+    <%s! Learn_layout.sidebar_link_group "Resources"
+      (tutorial_sidebar_links_by_category "resources")
+      ~extra_html:((render_tutorial_link ~title:"Best Practices" ~slug:"best-practices")
+        ^ (render_tutorial_link ~title:"OCaml Platform" ~slug:"platform")) %>
+  </div>

--- a/src/ocamlorg_frontend/components/learn_sidebar.eml
+++ b/src/ocamlorg_frontend/components/learn_sidebar.eml
@@ -9,7 +9,6 @@ let render
   let tutorial_sidebar_links_by_category category =
     tutorials |> List.filter (fun (x : Data.Tutorial.t) -> x.category = category) |> List.map render_tutorial |> String.concat "\n"
   in
-  <%s! Learn_layout.sidebar_icon_link_block ~current:Learn %>
 
   <%s! Learn_layout.sidebar_link_group "Getting Started"
     (tutorial_sidebar_links_by_category "getting-started") %>

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -75,7 +75,7 @@ body {
 
 .intro-section-simple {
   background: url("/img/innerbottombg.png") left bottom no-repeat, url("/img/innertopbg.png") right top no-repeat;
-  @apply pt-48 pb-24 -mt-20;
+  @apply pt-48 pb-24;
 }
 
 .intro-section-simple p {

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -1,45 +1,41 @@
 type active_icon_link =
-  | Learn
+  | Overview
+  | GetStarted
+  | Platform
+  | BestPractices
   | Exercises
+  | Books
+  
 
-let sidebar_icon_link_block
+let tabs
 ~current =
-  <div class="space-y-4">
-    <a href="<%s Url.learn %>" class="flex justify-start items-center">
-      <div class="bg-primary-600 text-white rounded w-8 h-8 flex items-center justify-center">
-        <%s! Icons.book "h-5 w-5" %>
-      </div>
-      <div class="ml-3 font-semibold <%s if current != Learn then "opacity-70" else "" %>">Learn OCaml</div>
+  let link ~href ~title ~current =
+    <a href="<%s href %>" class="justify-start px-4 py-2 items-center font-semibold border-2 border-b-4 border-transparent rounded <%s if current then "no-underline text-primary-700 border-b-primary-700" else "opacity-80" %>">
+      <%s title %>
     </a>
+  in
+    <div class="bg-tab-overview text-default">
+      <nav class="container-fluid wide flex flex-wrap justify-around">
+        <%s! link ~href:Url.learn ~title:"Overview" ~current:(current = Overview) %>
 
-    <a href="<%s Url.manual %>" class="flex justify-start items-center">
-      <div class="bg-green-600 text-white rounded w-8 h-8 flex items-center justify-center">
-        <%s! Icons.document "h-5 w-5" %>
-      </div>
-      <div class="ml-3 font-semibold opacity-70">Language Manual</div>
-    </a>
+        <%s! link ~href:Url.platform ~title:"Platform Tools" ~current:(current = Platform) %>
 
-    <a href="<%s Url.api %>" class="flex justify-start items-center">
-      <div class="bg-sky-600 text-white rounded w-8 h-8 flex items-center justify-center">
-        <%s! Icons.command_line "h-5 w-5" %>
-      </div>
-      <div class="ml-3 font-semibold opacity-70">Standard Library API</div>
-    </a>
+        <%s! link ~href:Url.best_practices ~title:"Best Practices" ~current:(current = BestPractices) %>
 
-    <a href="<%s Url.problems %>" class="flex justify-start items-center">
-      <div class="bg-indigo-600 text-white rounded w-8 h-8 flex items-center justify-center">
-        <%s! Icons.exclamation_circle "h-5 w-5" %>
-      </div>
-      <div class="ml-3 font-semibold <%s if current != Exercises then "opacity-70" else "" %>">Exercises</div>
-    </a>
+        <%s! link ~href:Url.problems ~title:"Exercises" ~current:(current = Exercises) %>
 
-    <a href="<%s Url.about %>" class="flex justify-start items-center">
-      <div class="bg-primary-600 font-bold text-white rounded w-8 h-8 flex items-center justify-center">
-        ?
-      </div>
-      <div class="ml-3 font-semibold opacity-70">Why OCaml?</div>
-    </a>
-  </div>
+        <%s! link ~href:Url.books ~title:"Books" ~current:(current = Books) %>
+
+        <a href="<%s Url.manual %>" class="flex gap-2 justify-start px-4 py-2 items-center font-semibold opacity-80">
+          <%s! Icons.arrow_top_right_on_square "w-6 h-6" %> Language Manual
+        </a>
+
+        <a href="<%s Url.api %>" class="flex gap-2 justify-start px-4 py-2 items-center font-semibold opacity-80">
+          <%s! Icons.arrow_top_right_on_square "w-6 h-6" %> Standard Library API
+        </a>
+      </nav>
+    </div>
+
 
 let htmx_attributes href
 =
@@ -64,7 +60,7 @@ let sidebar_link_group
 title
 link_html
 =
-  <div class="space-y-2 flex mt-10 flex-col">
+  <div class="space-y-2 flex flex-col">
     <div class="text-sm font-semibold flex px-3 py-2 uppercase"><%s title %></div>
     <%s! link_html %>
     <%s! extra_html %>
@@ -77,8 +73,9 @@ let render
 ~description
 ~canonical
 ?active_top_nav_item
-~(left_sidebar_html: string)
+~(left_sidebar_html: string option)
 ~(right_sidebar_html: string option)
+~current
 inner_html
 =
   Layout.render
@@ -89,7 +86,9 @@ inner_html
   ~canonical
   ~footer_html:(Fixed_footer.render ())
   ?active_top_nav_item @@
+  <%s! tabs ~current %>
   <div class="bg-default dark:bg-dark-default" x-data="{ sidebar: window.matchMedia('(min-width: 64em)').matches, showOnMobile: false}" @resize.window="sidebar = window.matchMedia('(min-width: 64em)').matches"  x-on:close-sidebar="sidebar=window.matchMedia('(min-width: 64em)').matches">
+  <% if left_sidebar_html != None then ( %>  
     <button :title='(sidebar? "close" : "open")+" sidebar"' class="flex items-center bg-primary-600 p-3 z-30 rounded-full text-white shadow-md bottom-20 fixed lg:hidden right-10"
       x-on:click="sidebar = ! sidebar">
       <%s! Icons.sidebar_menu "h-8 w-8" %>
@@ -97,15 +96,15 @@ inner_html
     </button>
     <div class="fixed z-10 inset-0 bg-contrast/20 backdrop-blur-sm lg:hidden"
       :class='sidebar ? "" : "hidden"' aria-hidden="true" x-on:click="sidebar = ! sidebar"></div>
-
+  <% ); %>
     <div class="container-fluid wide pt-10">
       <div class="flex flex-col lg:flex-row lg:gap-6 xl:gap-12">
         <div
-          class="p-6 z-20 bg-default dark:bg-dark-default flex-col fixed h-screen overflow-auto lg:px-0 lg:flex left-0 top-0 lg:sticky w-80 lg:w-72 lg:px-0 lg:pt-6 lg:pb-72"
+          class="z-20 bg-default dark:bg-dark-default flex-col fixed h-screen overflow-auto lg:flex left-0 top-0 lg:sticky <%s Option.fold ~none:"" ~some:(fun _ -> "p-6 lg:px-0 w-80 lg:w-72 lg:px-0 lg:pt-6 lg:pb-72") left_sidebar_html %>"
           x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
           x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
           x-transition:leave-end="-translate-x-full" id="htmx-sidebar">
-          <%s! left_sidebar_html %>
+          <%s! Option.value ~default:"" left_sidebar_html %>
         </div>
 
         <div class="flex-1 z-0 z- min-w-0 lg:pt-6 pb-12 lg:pb-[70vh] <%s! if right_sidebar_html != None then "lg:max-w-3xl" else "" %>"

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -10,11 +10,11 @@ type active_icon_link =
 let tabs
 ~current =
   let link ~href ~title ~current =
-    <a href="<%s href %>" class="justify-start px-4 py-2 items-center font-semibold border-2 border-b-4 border-transparent rounded <%s if current then "no-underline text-primary-700 border-b-primary-700" else "opacity-80" %>">
+    <a href="<%s href %>" class="justify-start px-4 py-2 text-default items-center font-semibold border-2 border-b-4 border-transparent rounded <%s if current then "no-underline text-primary-700 border-b-primary-700" else "opacity-80" %>">
       <%s title %>
     </a>
   in
-    <div class="bg-tab-overview text-default">
+    <div class="bg-learn-area-light-blue">
       <nav class="container-fluid wide flex flex-wrap justify-around">
         <%s! link ~href:Url.learn ~title:"Overview" ~current:(current = Overview) %>
 
@@ -26,11 +26,11 @@ let tabs
 
         <%s! link ~href:Url.books ~title:"Books" ~current:(current = Books) %>
 
-        <a href="<%s Url.manual %>" class="flex gap-2 justify-start px-4 py-2 items-center font-semibold opacity-80">
+        <a href="<%s Url.manual %>" class="flex gap-2 justify-start px-4 py-2 border-2 border-transparent rounded items-center font-semibold opacity-80">
           <%s! Icons.arrow_top_right_on_square "w-6 h-6" %> Language Manual
         </a>
 
-        <a href="<%s Url.api %>" class="flex gap-2 justify-start px-4 py-2 items-center font-semibold opacity-80">
+        <a href="<%s Url.api %>" class="flex gap-2 justify-start px-4 py-2 items-center font-semibold opacity-80 border-2 border-transparent">
           <%s! Icons.arrow_top_right_on_square "w-6 h-6" %> Standard Library API
         </a>
       </nav>

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -15,7 +15,7 @@ let tabs
     </a>
   in
     <div class="bg-learn-area-light-blue">
-      <nav class="container-fluid wide flex flex-wrap justify-around">
+      <nav class="container-fluid wide flex flex-wrap">
         <%s! link ~href:Url.learn ~title:"Overview" ~current:(current = Overview) %>
 
         <%s! link ~href:Url.platform ~title:"Platform Tools" ~current:(current = Platform) %>

--- a/src/ocamlorg_frontend/pages/best_practices.eml
+++ b/src/ocamlorg_frontend/pages/best_practices.eml
@@ -1,14 +1,14 @@
 let render
 (best_practices : Data.Workflow.t list)
-~tutorials
 =
 Learn_layout.render
 ~title:"OCaml Best Practices"
 ~description:"Some guides to commonly used tools in OCaml development workflows."
 ~canonical:Url.best_practices
 ~active_top_nav_item:Header.Learn
-~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some "best-practices") ~tutorials)
-~right_sidebar_html: None @@
+~left_sidebar_html:None
+~right_sidebar_html:None
+~current:BestPractices @@
     <h1 class="font-bold mb-8">OCaml Best Practices</h1>
     <div class="prose prose-orange max-w-full">
         <p>

--- a/src/ocamlorg_frontend/pages/books.eml
+++ b/src/ocamlorg_frontend/pages/books.eml
@@ -32,11 +32,14 @@ let render_books books =
     </div>
 
 let render books =
-Layout.render
+Learn_layout.render
 ~title:"OCaml Books"
 ~description:"A selection of books to learn the OCaml programming language."
 ~canonical:Url.books
-~active_top_nav_item:Header.Learn @@
+~active_top_nav_item:Header.Learn 
+~left_sidebar_html:None
+~right_sidebar_html:None
+~current:Books @@
 <div class="intro-section-simple">
     <div class="container-fluid">
         <div class="text-center w-full lg:w-2/3 m-auto">

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -8,8 +8,9 @@ Learn_layout.render
 ~description:"Getting started with the OCaml programming language. Read the official tutorials, exercices, and language manual."
 ~canonical:Url.learn
 ~active_top_nav_item:Header.Learn
-~left_sidebar_html:(Learn_sidebar.render ~tutorials ~current_tutorial:None)
-~right_sidebar_html:None @@
+~left_sidebar_html:(Some(Learn_sidebar.render ~tutorials ~current_tutorial:None))
+~right_sidebar_html:None
+~current:Overview @@
   <h1 class="font-bold mb-8">Learn OCaml</h1>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 xl:gap-8 border-b border-gray-200 pb-10">
     <div class="relative flex-1 bg-gradient-to-br from-orange-300 to-orange-500 rounded-xl text-white md:max-h-96 overflow-hidden">

--- a/src/ocamlorg_frontend/pages/platform.eml
+++ b/src/ocamlorg_frontend/pages/platform.eml
@@ -1,14 +1,24 @@
+let sidebar
+?active
+()
+=
+  <div class="flex flex-col gap-10">
+    <%s! Learn_layout.sidebar_link_group "Documentation" 
+      (Learn_layout.sidebar_link ~title:"opam" ~href:(Url.platform) ~current:(active = Some("opam")))
+       %>
+  </div>
+
 let render
 (tools : Data.Tool.t list)
-~tutorials
 =
 Learn_layout.render
 ~title:"OCaml Platform"
 ~description:"The OCaml Platform represents the best way for developers, both new and old, to write software in OCaml."
 ~canonical:Url.platform
 ~active_top_nav_item:Header.Learn
-~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some "platform") ~tutorials)
-~right_sidebar_html:None @@
+~left_sidebar_html:(Some(sidebar ()))
+~right_sidebar_html:None
+~current:Platform @@
   <div class="prose prose-orange max-w-none">
     <h1>The OCaml Platform</h1>
     <p>

--- a/src/ocamlorg_frontend/pages/problems.eml
+++ b/src/ocamlorg_frontend/pages/problems.eml
@@ -11,7 +11,6 @@ let problem_sidebar_links_by_tag ?tag title =
     (Problem.filter_tag ?tag problems |> List.fold_left (fun a b -> a ^ render_problem_link b) "")
   %>
 in
-  <%s! Learn_layout.sidebar_icon_link_block ~current:Exercises %>
 
   <%s! problem_sidebar_links_by_tag ~tag:"list" "Lists" %>
   <%s! problem_sidebar_links_by_tag ~tag:"arithmetic" "Arithmetic" %>
@@ -40,8 +39,9 @@ Learn_layout.render
 ~description:"A list of exercises to work on your OCaml skills."
 ~canonical:Url.problems
 ~active_top_nav_item:Header.Learn
-~left_sidebar_html:(problems_sidebar ~problems)
-~right_sidebar_html:None @@
+~left_sidebar_html:(Some(problems_sidebar ~problems))
+~right_sidebar_html:None
+~current:Exercises @@
   <div class="prose prose-orange max-w-full">
     <h1 class="font-bold mb-8">Exercises</h1>
     <div class="prose prose-orange max-w-full mb-5">

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -22,8 +22,9 @@ Learn_layout.render
 ~description:tutorial.description
 ~canonical
 ~active_top_nav_item:Learn
-~left_sidebar_html:(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials)
-~right_sidebar_html:(Some(right_sidebar tutorial)) @@
+~left_sidebar_html:(Some(Learn_sidebar.render ~current_tutorial:(Some tutorial.slug) ~tutorials))
+~right_sidebar_html:(Some(right_sidebar tutorial))
+~current:Overview @@
   <div class="prose prose-orange max-w-full">
     <%s! tutorial.body_html %>
     <div class="pt-10 border-t border-slate-200 lg:grid lg:grid-cols-3 gap-4 text-slate-500">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -22,8 +22,7 @@ let learn _req =
 
 let platform _req =
   let tools = Data.Tool.all in
-  let tutorials = Data.Tutorial.all in
-  Dream.html (Ocamlorg_frontend.platform ~tutorials tools)
+  Dream.html (Ocamlorg_frontend.platform tools)
 
 let community _req =
   let workshops = Data.Workshop.all in
@@ -291,8 +290,7 @@ let tutorial req =
        tutorial)
 
 let best_practices _req =
-  let tutorials = Data.Tutorial.all in
-  Dream.html (Ocamlorg_frontend.best_practices ~tutorials Data.Workflow.all)
+  Dream.html (Ocamlorg_frontend.best_practices Data.Workflow.all)
 
 let problems req =
   let all_problems = Data.Problem.all in

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
 
       "search-keyboard-cursor": "#0C3B8C", // background for cursor highlighting in keyboard navigable areas (e.g. package search dropdown)
       "search-term-highlight": "rgb(221, 232, 251)",
+      "tab-overview": "rgba(211, 213, 249, 0.60)",
 
       transparent: "transparent",
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,7 +54,7 @@ module.exports = {
 
       "search-keyboard-cursor": "#0C3B8C", // background for cursor highlighting in keyboard navigable areas (e.g. package search dropdown)
       "search-term-highlight": "rgb(221, 232, 251)",
-      "tab-overview": "rgba(211, 213, 249, 0.60)",
+      "learn-area-light-blue": "rgba(211, 213, 249, 0.60)",
 
       transparent: "transparent",
 


### PR DESCRIPTION
Created a Tab Component To Learn Area Redesign.
<img width="1721" alt="Learn area tab component" src="https://github.com/ocaml/ocaml.org/assets/75541866/e612e8dc-1897-4a1d-b173-0b9074a0b1f9">
cc @sabine 