### PR TITLE
Add changelog entries for OCaml LSP releases

### DIFF
--- a/data/changelog/ocaml-lsp/2023-06-21-ocaml-lsp-1.16.1.md
+++ b/data/changelog/ocaml-lsp/2023-06-21-ocaml-lsp-1.16.1.md
@@ -1,0 +1,69 @@
+---
+title: Ocaml-lsp 1.16.1
+date: "2023-06-21"
+tags: [ocaml-lsp, platform, release]
+changelog: |
+  ## Features
+
+  - Add "Remove type annotation" code action. ([#1039](https://github.com/ocaml/ocaml-lsp/pull/1039))
+  - Support settings through `didChangeConfiguration` notification ([#1103](https://github.com/ocaml/ocaml-lsp/pull/1103))
+  - Add "Extract local" and "Extract function" code actions. ([#870](https://github.com/ocaml/ocaml-lsp/pull/870))
+  - Depend directly on `merlin-lib` 4.9 ([#1070](https://github.com/ocaml/ocaml-lsp/pull/1070))
+
+  ## Fixes
+
+  - Support building with OCaml 5.0 and 5.1 ([#1150](https://github.com/ocaml/ocaml-lsp/pull/1150))
+  - Disable code lens by default. The support can be re-enabled by explicitly
+    setting it in the configuration. ([#1134](https://github.com/ocaml/ocaml-lsp/pull/1134))
+  - Fix initilization of `ocamlformat-rpc` in some edge cases when ocamlformat is
+    initialized concurrently ([#1132](https://github.com/ocaml/ocaml-lsp/pull/1132))
+  - Kill unnecessary `$ dune ocaml-merlin` with SIGTERM rather than SIGKILL
+    ([#1124](https://github.com/ocaml/ocaml-lsp/pull/1124))
+  - Refactor comment parsing to use `odoc-parser` and `cmarkit` instead of
+    `octavius` and `omd` ([#1088](https://github.com/ocaml/ocaml-lsp/pull/1088))
+
+    This allows users who migrated to omd 2.X to install ocaml-lsp-server in the
+    same opam switch.
+
+    We also slightly improved markdown generation support and fixed a couple in
+    the generation of inline heading and module types.
+  - Allow opening documents that were already open. This is a workaround for
+    neovim's lsp client ([#1067](https://github.com/ocaml/ocaml-lsp/pull/1067))
+  - Disable type annotation for functions ([#1054](https://github.com/ocaml/ocaml-lsp/pull/1054))
+  - Respect codeActionLiteralSupport capability ([#1046](https://github.com/ocaml/ocaml-lsp/pull/1046))
+  - Fix a document syncing issue when utf-16 is the position encoding ([#1004](https://github.com/ocaml/ocaml-lsp/pull/1004))
+  - Disable "Type-annotate" action for code that is already annotated.
+    ([#1037](https://github.com/ocaml/ocaml-lsp/pull/1037), fixes
+    [#1036](https://github.com/ocaml/ocaml-lsp/issues/1036))
+  - Fix semantic highlighting of long identifiers when using preprocessors
+    ([#1049](https://github.com/ocaml/ocaml-lsp/pull/1049), fixes
+    [#1034](https://github.com/ocaml/ocaml-lsp/issues/1034))
+  - Fix the type of DocumentSelector in cram document registration ([#1068](https://github.com/ocaml/ocaml-lsp/pull/1068))
+  - Accept the `--clientProcessId` command line argument. ([#1074](https://github.com/ocaml/ocaml-lsp/pull/1074))
+  - Accept `--port` as a synonym for `--socket`. ([#1075](https://github.com/ocaml/ocaml-lsp/pull/1075))
+  - Fix connecting to dune rpc on Windows. ([#1080](https://github.com/ocaml/ocaml-lsp/pull/1080))
+---
+
+We're thrilled to announce the release of OCaml LSP 1.16.1! 🎉
+
+This release comes with new "Extract local" and "Extract function" code actions
+to easily refactor your code.
+
+We've also disabled code lenses by default following user feedback. You can
+follow the discussion
+[on GitHub](https://github.com/ocaml/ocaml-lsp/pull/1134).
+
+This release is also the first OCaml LSP release to use upstream Merlin. Among
+other things, this means that it is compatible with all the OCaml versions
+supported by Merlin: currently OCaml 4.14 and 5.0.0.
+
+We're also releasing numerous bug fixes, including:
+
+- A fix to the integration with Dune RPC on Windows, which, alongside Dune
+  3.9.0, makes OCaml LSP report Dune errors to the editors with Dune watch mode
+  enabled.
+- Minor improvements to the Odoc <-> Markdown conversion to return better
+  function documentation on the editor.
+
+And much more! Read the full changelog for a complete list of improvements and
+bug fixes.

--- a/data/changelog/ocaml-lsp/2023-06-23-ocaml-lsp-1.16.2.md
+++ b/data/changelog/ocaml-lsp/2023-06-23-ocaml-lsp-1.16.2.md
@@ -1,0 +1,10 @@
+---
+title: Ocaml-lsp 1.16.2
+date: "2023-06-23"
+tags: [ocaml-lsp, platform, release]
+changelog: |
+  ## Fixes
+  * Fix file permissions used when specifying output files of pp and ppx. ([ocaml-lsp#1153](https://github.com/ocaml/ocaml-lsp/pull/1153))
+---
+
+We've released OCaml LSP 1.16.2 with a fix that was introduced in 1.16.1 that prevented users from using preprocessor such as [CPPO](https://github.com/ocaml-community/cppo).


### PR DESCRIPTION
I noticed that we were missing changelog entries for the recent releases of OCaml LSP.

cc @rgrinberg @voodoos - would be great to have these for future releases if possible, with https://github.com/ocaml/ocaml.org/pull/1394, we'll now link to the OCaml Changelog entries from the newsletter.