### PR TITLE
dune build @runtest -> dune runtest

### DIFF
--- a/data/tutorials/platform/bp_03_run_executables_and_tests.md
+++ b/data/tutorials/platform/bp_03_run_executables_and_tests.md
@@ -44,7 +44,7 @@ You can run it with `dune exec bin/main.exe` or `dune exec my-app`.
 
 > **TL;DR**
 > 
-> Add a `test` stanza in your `dune` file and run the tests with `dune runtest`.
+> Add a `test` stanza in your `dune` file and run the tests with `dune test`.
 
 Tests are created using Dune's `test` stanza. The `test` stanza is a simple convenience wrapper that will create an executable and add it to the list of tests of the `@runtest` target.
 

--- a/data/tutorials/platform/bp_03_run_executables_and_tests.md
+++ b/data/tutorials/platform/bp_03_run_executables_and_tests.md
@@ -62,7 +62,7 @@ with a module `dummy_test.ml`:
 let () = exit 1
 ```
 
-Running `dune runtest` will fail with the following output:
+Running `dune test` will fail with the following output:
 
 ```
   dummy_test alias src/ocamlorg_web/test/runtest (exit 1)
@@ -100,7 +100,7 @@ let () =
   Alcotest.run "Dummy" [ "Greeting", suite ]
 ```
 
-If we run `dune runtest` again, the test should be successful and output the following:
+If we run `dune test` again, the test should be successful and output the following:
 
 
 ```

--- a/data/tutorials/platform/bp_03_run_executables_and_tests.md
+++ b/data/tutorials/platform/bp_03_run_executables_and_tests.md
@@ -45,7 +45,7 @@ You can run it with `dune exec bin/main.exe` or `dune exec my-app`.
 
 > **TL;DR**
 > 
-> Add a `test` stanza in your `dune` file and run the tests with `dune build @runtest`.
+> Add a `test` stanza in your `dune` file and run the tests with `dune runtest`.
 
 Tests are created using Dune's `test` stanza. The `test` stanza is a simple convenience wrapper that will create an executable and add it to the list of tests of the `@runtest` target.
 
@@ -63,7 +63,7 @@ with a module `dummy_test.ml`:
 let () = exit 1
 ```
 
-Running `dune build @runtest` will fail with the following output:
+Running `dune runtest` will fail with the following output:
 
 ```
   dummy_test alias src/ocamlorg_web/test/runtest (exit 1)
@@ -101,7 +101,7 @@ let () =
   Alcotest.run "Dummy" [ "Greeting", suite ]
 ```
 
-If we run `dune build @runtest` again, the test should be successful and output the following:
+If we run `dune runtest` again, the test should be successful and output the following:
 
 
 ```

--- a/data/tutorials/platform/bp_03_run_executables_and_tests.md
+++ b/data/tutorials/platform/bp_03_run_executables_and_tests.md
@@ -42,7 +42,6 @@ You can run it with `dune exec bin/main.exe` or `dune exec my-app`.
 
 ## Running Tests
 
-
 > **TL;DR**
 > 
 > Add a `test` stanza in your `dune` file and run the tests with `dune runtest`.


### PR DESCRIPTION
This replaces `dune build @runtest` by `dune runtest` in the tutorial. This command is equivalent and the recommended short form to run tests.