### PR TITLE
Point to docs-data.ocaml.org/live

### DIFF
--- a/src/ocamlorg_package/lib/config.ml
+++ b/src/ocamlorg_package/lib/config.ml
@@ -5,7 +5,7 @@ let opam_polling =
 
 let documentation_url =
   Sys.getenv_opt "OCAMLORG_DOC_URL"
-  |> Option.value ~default:"https://docs-data.ocaml.org/current/"
+  |> Option.value ~default:"https://docs-data.ocaml.org/live/"
 
 let default_cache_dir =
   match Sys.os_type with


### PR DESCRIPTION
Follow-up to
- https://github.com/ocaml/ocaml.org/pull/1435

To be merged after docs-data `current` is promoted to `live`.