### PR TITLE
Announce migration of Benchmarking Service

### DIFF
--- a/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
+++ b/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
@@ -1,5 +1,5 @@
 ---
-title: The Benchmarking Service moving to bench.ci.dev
+title: The Benchmarking Service Moving to bench.ci.dev
 date: "2023-07-24"
 tags: [infra]
 ---

--- a/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
+++ b/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
@@ -8,4 +8,4 @@ As part of our ongoing efforts to streamline our services, the Benchmarking Serv
 
 During the transition, we will make every effort to minimise any service disruptions, and our support team will be readily available to assist with any questions or concerns you may have. The new address is now active, and the old links remain valid.
 
-If you have any inquiries or require further information, please don't hesitate to reach out to the [Ocaml Infrastructure team](https://github.com/ocaml/infrastructure/issues).
+If you have any inquiries or require further information, please don't hesitate to reach out to the [OCaml Infrastructure team](https://github.com/ocaml/infrastructure/issues).

--- a/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
+++ b/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
@@ -6,6 +6,6 @@ tags: [infra]
 
 As part of our ongoing efforts to streamline our services, the Benchmarking Service will be migrating from [autumn.ocamllabs.io](https://autumn.ocamllabs.io) to [bench.ci.dev](https://bench.ci.dev). This move is a crucial step in our comprehensive plan to consolidate all CI and benchmarking services and retire the old OCaml Labs domains.
 
-During the transition, we will make every effort to minimize any service disruptions, and our support team will be readily available to assist with any questions or concerns you may have. The new address is now active, and the old links remain valid.
+During the transition, we will make every effort to minimise any service disruptions, and our support team will be readily available to assist with any questions or concerns you may have. The new address is now active, and the old links remain valid.
 
 If you have any inquiries or require further information, please don't hesitate to reach out to the [Ocaml Infrastructure team](https://github.com/ocaml/infrastructure/issues).

--- a/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
+++ b/data/changelog/infra/2023-07-24-moving-benchmarking-service.md
@@ -1,0 +1,11 @@
+---
+title: The Benchmarking Service moving to bench.ci.dev
+date: "2023-07-24"
+tags: [infra]
+---
+
+As part of our ongoing efforts to streamline our services, the Benchmarking Service will be migrating from [autumn.ocamllabs.io](https://autumn.ocamllabs.io) to [bench.ci.dev](https://bench.ci.dev). This move is a crucial step in our comprehensive plan to consolidate all CI and benchmarking services and retire the old OCaml Labs domains.
+
+During the transition, we will make every effort to minimize any service disruptions, and our support team will be readily available to assist with any questions or concerns you may have. The new address is now active, and the old links remain valid.
+
+If you have any inquiries or require further information, please don't hesitate to reach out to the [Ocaml Infrastructure team](https://github.com/ocaml/infrastructure/issues).


### PR DESCRIPTION
We're moving the Benchmarking Service (Autumn) to bench.ci.dev with the rest of the CI services.

cc: @shakthimaan @mtelvers 