### PR TITLE
CI: Install libcurl4-openssl-dev in ubuntu-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
           opam-disable-sandboxing: true
 
       - name: Install system dependencies (Linux)
-        run: sudo apt-get install libev-dev libonig-dev libcurl4-gnutls-dev
+        run: sudo apt-get install libev-dev libonig-dev libcurl4-openssl-dev
         if: runner.os == 'Linux'
 
       - name: Install system dependencies (macOS)
-        run: brew install libev curl openssl@3 # Openssl is a workaround for https://github.com/ocaml/opam-repository/issues/19676
+        run: brew install libev openssl@3 # Openssl is a workaround for https://github.com/ocaml/opam-repository/issues/19676
         if: runner.os == 'macOS'
 
       - name: Install opam dependencies


### PR DESCRIPTION
Turns out the `curl-config` failure is related to these:
- https://github.com/actions/runner-images/issues/7958
- https://github.com/actions/runner-images/issues/7945

Explicitly installing curl on macOS shouldn't be necessary, while on `ubuntu-latest`, we have to install `libcurl4-openssl-dev`.