### PR TITLE
Search Banner Component According to Learn Area Redesign

### DIFF
--- a/src/ocamlorg_frontend/components/learn_overview.eml
+++ b/src/ocamlorg_frontend/components/learn_overview.eml
@@ -1,0 +1,9 @@
+let search_banner =
+  <div class="w-full h-64 bg-teal-900 flex flex-col items-center pt-14">
+    <h2 class="text-center text-white font-normal">Looking For Something? </h2>
+    <%s! Forms.search_input
+        ~name:"q"
+        ~label:"Search inside the OCaml documentation"
+        ~button_attrs:{|type="submit"|}
+        "w-1/2 mt-6" %>
+  </div>

--- a/src/ocamlorg_frontend/components/learn_overview.eml
+++ b/src/ocamlorg_frontend/components/learn_overview.eml
@@ -5,5 +5,5 @@ let search_banner =
         ~name:"q"
         ~label:"Search inside the OCaml documentation"
         ~button_attrs:{|type="submit"|}
-        "w-1/2 mt-6" %>
+        "w-1/2 mt-6 focus-within:outline-none focus-within:border-none focus-within:ring-0" %>
   </div>

--- a/src/ocamlorg_frontend/dune
+++ b/src/ocamlorg_frontend/dune
@@ -263,4 +263,12 @@
     %{bin:dream_eml}
     %{dep:learn_sidebar.eml}
     --workspace
+    %{workspace_root})))
+ (rule
+  (target learn_overview.ml)
+  (action
+   (run
+    %{bin:dream_eml}
+    %{dep:learn_overview.eml}
+    --workspace
     %{workspace_root}))))

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -117,6 +117,4 @@ Learn_layout.render
       <%s! Icons.chevron_right "h-5 w-5" %>
     </a>
   </div>
-  <div>
-    <%s! Learn_overview.search_banner %>
-  </div>
+  

--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -117,3 +117,6 @@ Learn_layout.render
       <%s! Icons.chevron_right "h-5 w-5" %>
     </a>
   </div>
+  <div>
+    <%s! Learn_overview.search_banner %>
+  </div>

--- a/src/ocamlorg_frontend/pages/outreachy.eml
+++ b/src/ocamlorg_frontend/pages/outreachy.eml
@@ -10,7 +10,7 @@ Layout.render
         <p>This is a record of all past OCaml Community <a href="https://www.outreachy.org/" target="_blank">Outreachy</a> Internship Projects.</p>
     </div>
 </div>
-
+<%s! Learn_overview.search_banner %>
 <div class="py-12 bg-default dark:bg-dark-default">
     <div class="container-fluid">
         <% metadata |> List.iter (fun (rounds : Data.Outreachy.t) -> %>


### PR DESCRIPTION
Created the search banner according to the learn area redesign

Figma Design
<img width="1173" alt="Screenshot 2023-07-25 at 11 13 44" src="https://github.com/ocaml/ocaml.org/assets/75541866/9650b055-c091-498d-b2d6-f61e3314c54e">

Current outcome
<img width="1296" alt="Screenshot 2023-07-24 at 19 11 45" src="https://github.com/ocaml/ocaml.org/assets/75541866/98039148-911b-4bbf-bb81-8b724a974a21">

There's a slight color difference but that will be fixed when there's a definite color scheme for the redesign
