### PR TITLE
Playground: make gen_stdlib.sh POSIX-compatible

### DIFF
--- a/playground/gen_stdlib.sh
+++ b/playground/gen_stdlib.sh
@@ -8,7 +8,7 @@ copylibcmis()  (
   srcdir=$(opam var $1:lib)
   jsoo_listunits -o $tmpfile $2
   for i in $(cat $tmpfile); do
-    cp $srcdir/?${i:1}.cmi stdlib/ 
+    cp $srcdir/?${i#?}.cmi stdlib/ 
   done
   rm $tmpfile
 )


### PR DESCRIPTION
```
[Line 11:](javascript:setPosition(11, 8))
    cp $srcdir/?${i:1}.cmi stdlib/
                ^-- [SC3057](https://www.shellcheck.net/wiki/SC3057) (warning): In POSIX sh, string indexing is undefined.
```

`gen_stdlib.sh` was not POSIX-compatible as it was using string indexing only provided by `bash` or `ksh`. This made the playground build fail for me.