### PR TITLE
Changelog: OCaml 5.1.0 release candidate

### DIFF
--- a/data/changelog/ocaml/2023-08-01-ocaml-5.1.rc1.md
+++ b/data/changelog/ocaml/2023-08-01-ocaml-5.1.rc1.md
@@ -1,5 +1,5 @@
 ---
-title: OCaml 5.1.0 - First release candidate
+title: OCaml 5.1.0 - First Release Candidate
 description: First Release Candidate of OCaml 5.1.0
 date: "2023-08-01"
 tags: [ocaml, release]
@@ -8,12 +8,12 @@ changelog: |
   
   ### Bug Fix
   
-  - [#12445](https://github.com/ocaml/ocaml/issues/12445): missing GC root registrations in runtime/io.c
+  - [#12445](https://github.com/ocaml/ocaml/issues/12445): missing GC root registrations in `runtime/io.c`
     (Gabriel Scherer, review by Xavier Leroy and Jeremy Yallop)
   
   ### Configuration Fix (openBSD)
   
-  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option `-no-execute-only` to the linker for OpenBSD >= 7.3
     so that code sections remain readable, as needed for closure marshaling.
     (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
     Sébastien Hinderer)
@@ -21,8 +21,8 @@ changelog: |
   ### Tool Fix (ocamlmktop)
   
   * [#11745](https://github.com/ocaml/ocaml/issues/11745), [#12358](https://github.com/ocaml/ocaml/issues/12358): Debugger and toplevels: embed printer types rather than
-    reading their representations from topdirs.cmi at runtime.
-    This change also removes the ocamlmktop initialization module introduced
+    reading their representations from `topdirs.cmi` at runtime.
+    This change also removes the ocamlmktop initialisation module introduced
     in [#11382](https://github.com/ocaml/ocaml/issues/11382) which was no longer useful.
     This change breaks toplevel scripts relying on the visibility of `Topdirs`
     in the initial toplevel environment without loading `topfind`.
@@ -35,7 +35,7 @@ changelog: |
     ```
    as was already the case for the other modules in the toplevel interface
    library.
-   (Sébastien Hinderer, review by Florian Angeletti, Nicolás Ojeda Bär and
+   (Sébastien Hinderer, review by Florian Angeletti, Nicolás Ojeda Bär, and
    Gabriel Scherer)
   
   ### Documentation Changes
@@ -56,7 +56,7 @@ As a final step, we are publishing a release candidate to check that everything 
 
 If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
 
-Compared to the beta release, this release contains one safe runtime fix, and two configuration tweaks.
+Compared to the beta release, this release contains one safe runtime fix and two configuration tweaks.
 
 The full change log for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.1/Changes)
 A short summary of the changes since the beta release is also available below.

--- a/data/changelog/ocaml/2023-08-01-ocaml-5.1.rc1.md
+++ b/data/changelog/ocaml/2023-08-01-ocaml-5.1.rc1.md
@@ -1,0 +1,90 @@
+---
+title: OCaml 5.1.0 - First release candidate
+description: First Release Candidate of OCaml 5.1.0
+date: "2023-08-01"
+tags: [ocaml, release]
+changelog: |
+  ## Changes Since the Beta
+  
+  ### Bug Fix
+  
+  - [#12445](https://github.com/ocaml/ocaml/issues/12445): missing GC root registrations in runtime/io.c
+    (Gabriel Scherer, review by Xavier Leroy and Jeremy Yallop)
+  
+  ### Configuration Fix (openBSD)
+  
+  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+    so that code sections remain readable, as needed for closure marshaling.
+    (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+    Sébastien Hinderer)
+  
+  ### Tool Fix (ocamlmktop)
+  
+  * [#11745](https://github.com/ocaml/ocaml/issues/11745), [#12358](https://github.com/ocaml/ocaml/issues/12358): Debugger and toplevels: embed printer types rather than
+    reading their representations from topdirs.cmi at runtime.
+    This change also removes the ocamlmktop initialization module introduced
+    in [#11382](https://github.com/ocaml/ocaml/issues/11382) which was no longer useful.
+    This change breaks toplevel scripts relying on the visibility of `Topdirs`
+    in the initial toplevel environment without loading `topfind`.
+    Since the opam default `.ocamlinit` file loads `topfind`, it is expected
+    that only scripts run with `ocaml -noinit` are affected.
+    For those scripts, accessing `Topdirs` now requires the `compiler-libs`
+    directory to be added to the toplevel search path with
+    ```
+      #directory "+compiler-libs";;
+    ```
+   as was already the case for the other modules in the toplevel interface
+   library.
+   (Sébastien Hinderer, review by Florian Angeletti, Nicolás Ojeda Bär and
+   Gabriel Scherer)
+  
+  ### Documentation Changes
+  
+  
+  - [#12201](https://github.com/ocaml/ocaml/issues/12201): in the tutorial on modules, replace priority queue example by
+    a simpler example based on FIFO queues.
+    (Xavier Leroy, review by Anil Madhavapeddy and Nicolás Ojeda Bär).
+  
+  - [#12352](https://github.com/ocaml/ocaml/issues/12352): Fix a typo in the documentation of Arg.write_arg
+    (Christophe Raffalli, review by Florian Angeletti)
+
+---
+
+
+The release of OCaml 5.1.0 is imminent.
+As a final step, we are publishing a release candidate to check that everything is in order before the release in the upcoming week(s).
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+Compared to the beta release, this release contains one safe runtime fix, and two configuration tweaks.
+
+The full change log for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.1/Changes)
+A short summary of the changes since the beta release is also available below.
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1 and later:
+```bash
+opam update
+opam switch create 5.1.0~rc1
+```
+
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.0-rc1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.1.0~rc1+options <option_list>
+```
+where `<option_list>` is a comma-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.1.0~rc1+flambda+nffa ocaml-variants.5.1.0~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This PR adds an announce for the first release candidate of OCaml 5.1.0 on the changelog.
The opam packages have just be merged to the opam repository, so it is probably safe to merge this PR once edited.