### PR TITLE
dune exec should point to the built executable

### DIFF
--- a/data/tutorials/getting-started/gs_00_up_and_running.md
+++ b/data/tutorials/getting-started/gs_00_up_and_running.md
@@ -419,7 +419,7 @@ When we change our program, we can type `dune build` again to make a new
 executable. To run the program, we can use:
 
 ```
-$ dune exec ./bin/main.exe
+$ dune exec ./_build/default/bin/main.exe
 Hello, World!
 ```
 


### PR DESCRIPTION
Minor fix to the getting started docs; It corrects the `dune exec` command, as the executable gets built into `./_build/default/bin` instead of `./bin` folder.