### PR TITLE
Fix link to heading around UTop recommendation

### DIFF
--- a/data/tutorials/getting-started/gs_01_a_first_hour_with_ocaml.md
+++ b/data/tutorials/getting-started/gs_01_a_first_hour_with_ocaml.md
@@ -35,7 +35,7 @@ into the OCaml Playground.
 ## Running OCaml Programs
 ### Using an OCaml Toplevel (REPL)
 
-We recommend using UTop (see [here](/docs/up-and-running#using-the-ocaml-toplevel-with-utop)),
+We recommend using UTop (see [here](/docs/up-and-running#using-the-utop-repl-to-run-ocaml-code)),
 but alternatively, the basic OCaml toplevel (`ocaml` command) can also be used. For installation instructions,
 see [Up and Running](/docs/up-and-running#installing-ocaml).
 


### PR DESCRIPTION
The link here does not navigate to the right place.

https://github.com/ocaml/ocaml.org/assets/3462960/bdd9edd3-44e1-43a5-b656-15f39d62a946

This happened because the title was changed at https://github.com/ocaml/ocaml.org/commit/6e62d71f601f35119f05722ffc3934bd5170fd45 and this link was not updated to reflect that.

This commit fixes it.