### PR TITLE
Update new Install and Stdlib API cards to have consistent rounded borders

### DIFF
--- a/src/ocamlorg_frontend/components/learn_components.eml
+++ b/src/ocamlorg_frontend/components/learn_components.eml
@@ -27,7 +27,7 @@ let command_line_icon class_ =
 let install_card 
 latest_version
 =
-  <a href="<%s Url.install %>" class="h-full bg-learn-area-light-blue p-6 flex flex-row gap-8 max-w-[400px] sm:w-[450px] md:w-auto md:max-w-[480px] xl:max-w-[500px]">
+  <a href="<%s Url.install %>" class="h-full rounded-xl bg-learn-area-light-blue p-6 flex flex-row gap-8 max-w-[400px] sm:w-[450px] md:w-auto md:max-w-[480px] xl:max-w-[500px]">
     <div class="hidden lg:flex">
       <%s! download_icon "w-24 h-24 mt-8 flex-shrink-0" %>
     </div>
@@ -47,7 +47,7 @@ latest_version
 
 let standard_lib_card 
 = 
-  <a href="<%s Url.api %>" class="h-full bg-learn-area-light-blue p-6 pr-8 flex flex-row gap-8 max-w-[400px] sm:w-[450px] md:w-auto md:max-w-[480px] xl:max-w-[500px]">
+  <a href="<%s Url.api %>" class="h-full rounded-xl bg-learn-area-light-blue p-6 pr-8 flex flex-row gap-8 max-w-[400px] sm:w-[450px] md:w-auto md:max-w-[480px] xl:max-w-[500px]">
     <div class="hidden lg:flex">
       <%s! command_line_icon "w-24 h-24 mt-8 flex-shrink-0" %>
     </div>


### PR DESCRIPTION
The new Install and Stdlib API cards that were introduced yesterday in #1441 at commit 5bdc2a8 look(ed) a bit off and "sharp" relative to the rest of the page. I updated their styles to include `rounded-xl` for visual consistency.

Before:
![image](https://github.com/ocaml/ocaml.org/assets/2755722/589d15ef-a3c2-4926-beb3-572db7ac0609)

After:
![image](https://github.com/ocaml/ocaml.org/assets/2755722/46b94db5-e3cb-40cf-96c8-86781e378ba2)
