### PR TITLE
Reduce spacing in package documentation between .spec and .spec-doc

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -20,6 +20,10 @@ div.odoc div.spec code {
   white-space: pre-wrap;
 }
 
+div.odoc .spec-doc p {
+  margin-top: 0.5rem;
+}
+
 /* clickable anchors and highlighting of targeted .spec elements */
 
 div.odoc .spec {


### PR DESCRIPTION
Resolves https://github.com/ocaml/ocaml.org/issues/1506.