### PR TITLE
Add tabindex='0' to make :focus-within work on Safari

### DIFF
--- a/src/ocamlorg_frontend/components/forms.eml
+++ b/src/ocamlorg_frontend/components/forms.eml
@@ -4,7 +4,7 @@ let search_input ?button_attrs ?input_attrs ?dropdown_html ~label ~name _class =
         <%s! html %>
     </div>
   in
-  <div class="dropdown-container flex items-center justify-center h-10 rounded-md focus-within:outline-primary-300 focus-within:outline focus-within:outline-2 <%s _class %>">
+  <div class="dropdown-container flex items-center justify-center h-10 rounded-md focus-within:outline-primary-300 focus-within:outline focus-within:outline-2 <%s _class %>" tabindex="0">
     <label for="<%s name %>" class="sr-only"><%s label %></label>
     <input
         type="search"


### PR DESCRIPTION
Resolves https://github.com/ocaml/ocaml.org/issues/1494.