### PR TITLE
Update about.eml

### DIFF
--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -60,7 +60,7 @@ Layout.render
           </p>
           <ul>
             <li>
-              <strong><a href="https://dev.realworldocaml.org/garbage-collector.html">Generational garbage collection</a></strong> for automatic memory management, now a feature of almost every modern, high-level language.
+              <strong><a href="https://dev.realworldocaml.org/garbage-collector.html">Generational garbage collection</a></strong> for automatic memory management.
             </li>
             <li>
               <strong>First-class functions</strong> that can be passed around like ordinary values, as seen in

--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -81,13 +81,13 @@ Layout.render
               found in distributed, big-data frameworks like Hadoop.
             </li>
             <li>
-              <strong>Type inference</strong>, so you don’t need to annotate every single variable in your program with
-              its type. Instead, types are inferred based on how a value is used. Available in a limited form in C# with
+              <strong>Type inference</strong>, so you don’t need to annotate function parameters, return types, and variables. 
+              Instead, types are inferred based on how a value is used. Available in a limited form in C# with
               implicitly-typed local variables and in C++11 with its auto keyword.
             </li>
             <li>
               <strong>Algebraic data types</strong> and <strong>pattern matching</strong> to define and manipulate
-              complex data structures, available in Scala and F#.
+              complex data structures, also available in Scala and F#.
             </li>
           </ul>
           <p>
@@ -148,8 +148,8 @@ Layout.render
             The last two decades have seen OCaml attract a significant user base, and language improvements have been
             steadily added to support the growing commercial and academic codebases. By 2012, the OCaml 4.0 release had
             added Generalised Algebraic Data Types (GADTs) and first-class modules to increase the flexibility of the
-            language. Since then, OCaml has had a steady, yearly release cadence, and OCaml 5.0 with Multicore support is
-            scheduled for release in September 2022. There is also fast, native-code support for the latest CPU architectures, such as
+            language. Since then, OCaml has had a steady, yearly release cadence, and OCaml 5.0 with Multicore support 
+            did release in December 2022. There is also fast, native-code support for the latest CPU architectures, such as
             x86_64, ARM, RISC-V, and PowerPC, making OCaml a good choice for systems where resource usage,
             predictability, and performance all matter.
           </p>
@@ -198,7 +198,7 @@ Layout.render
               OCaml runs on a wide variety of platforms. There are both officially supported platforms as well as
               platforms supported by the community. For example, there are OCaml apps available on the Apple App Store,
               and it is possible to compile OCaml to JavaScript with Js_of_ocaml, which enables the creation of rich,
-              client-side applications. OCaml-Java also enables direct compilation of OCaml to Java bytecode.
+              client-side applications. OCaml-Wasm also enables direct compilation of OCaml to WebAssembly bytecode.
             </li>
           </ul>
           <p>

--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -60,8 +60,8 @@ Layout.render
           </p>
           <ul>
             <li>
-              <strong>Garbage collection (GC)</strong> for automatic memory management, now a feature of almost every
-              modern, high-level language, but here done in a <code><a href="https://ocamlpro.com/blog/2020_03_23_in_depth_look_at_best_fit_gc/">two tier, generational manner.</a></code> 
+              <strong><code><a href="https://dev.realworldocaml.org/garbage-collector.html">Generational</a></code> garbage collection </strong> for automatic memory management, now a feature of almost every
+              modern, high-level language, and here done in a <code><a href="https://ocamlpro.com/blog/2020_03_23_in_depth_look_at_best_fit_gc/">very performant style.</a></code> 
             </li>
             <li>
               <strong>First-class functions</strong> that can be passed around like ordinary values, as seen in

--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -61,7 +61,7 @@ Layout.render
           <ul>
             <li>
               <strong>Garbage collection (GC)</strong> for automatic memory management, now a feature of almost every
-              modern, high-level language.
+              modern, high-level language, but here done in a <code><a href="https://ocamlpro.com/blog/2020_03_23_in_depth_look_at_best_fit_gc/">two tier, generational manner.</a></code> 
             </li>
             <li>
               <strong>First-class functions</strong> that can be passed around like ordinary values, as seen in

--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -81,7 +81,7 @@ Layout.render
               found in distributed, big-data frameworks like Hadoop.
             </li>
             <li>
-              <strong>Type inference</strong>, so you don’t need to annotate function parameters, return types, and variables. 
+              <strong>Type inference</strong>, so you don’t need to annotate every function parameter, return type, and variable. 
               Instead, types are inferred based on how a value is used. Available in a limited form in C# with
               implicitly-typed local variables and in C++11 with its auto keyword.
             </li>

--- a/src/ocamlorg_frontend/pages/about.eml
+++ b/src/ocamlorg_frontend/pages/about.eml
@@ -60,8 +60,7 @@ Layout.render
           </p>
           <ul>
             <li>
-              <strong><code><a href="https://dev.realworldocaml.org/garbage-collector.html">Generational</a></code> garbage collection </strong> for automatic memory management, now a feature of almost every
-              modern, high-level language, and here done in a <code><a href="https://ocamlpro.com/blog/2020_03_23_in_depth_look_at_best_fit_gc/">very performant style.</a></code> 
+              <strong><a href="https://dev.realworldocaml.org/garbage-collector.html">Generational garbage collection</a></strong> for automatic memory management, now a feature of almost every modern, high-level language.
             </li>
             <li>
               <strong>First-class functions</strong> that can be passed around like ordinary values, as seen in


### PR DESCRIPTION
Really love this page overall. 

And I thought it is currently underselling OCaml in significant ways.  This PR changes a few minor things:

I rephrased the type inference part, since it did sound before like only the variables would be inferred. 

One thing that I removed, is the mention of the Java compiler.  That one has received no commit for over 1 1/2 years, and it is unlikely, that it is picked up by anybody, so I changed it to the “actually in active development” ocaml-wasm project.

I also changed a few other things, and like to discuss some potential changes to this site, here in the comments. 

Specifically, I think the GC section forgets about the generational nature of the GC, and what impact that has on performance. Garbage collection generally is seens as a performance hog, and I like to make clear, that this isnt the case here. 

You dont need to go to Rust, to get proper system level performance ;) 
I would like to point out the dual nature of our GC, and how efficient it is. 

