### PR TITLE
OCaml 5.1.0 rc3 announce

### DIFF
--- a/data/changelog/ocaml/2023-09-06-ocaml-5.1.0.rc3.md
+++ b/data/changelog/ocaml/2023-09-06-ocaml-5.1.0.rc3.md
@@ -8,14 +8,14 @@ changelog: |
   - [#11284](https://github.com/ocaml/ocaml/issues/11284), +[#12525](https://github.com/ocaml/ocaml/issues/12525): Use compression of entries scheme when pruning mark stack.
    Can decrease memory usage for some workloads, otherwise should be
    unobservable.
-   (Tom Kelly, review by Sabine Schmaltz, Sadiq Jaffer and Damien Doligez)
+   (Tom Kelly, review by Sabine Schmaltz, Sadiq Jaffer, and Damien Doligez)
 
   - [#12486](https://github.com/ocaml/ocaml/issues/12486): Fix delivery of unhandled effect exceptions on s390x
   (Miod Vallat, report by Jan Midtgaard, review by Vincent Laviron and Xavier
   Leroy)
 ---
 
-Since last week, there were two significant bugs fixed in the OCaml 5.1.0 runtime (one overflow bug, and a stack corruption bug in the s390x port). Since those bug fixes are as small as they are subtle, they were deemed worthy of a release of a third release candidate for OCaml 5.1.0.
+Since last week, there were two significant bugs fixed in the OCaml 5.1.0 runtime (one overflow bug and a stack corruption bug in the s390x port). Since those bug fixes are as small as they are subtle, they were deemed worthy of a release of a third release candidate for OCaml 5.1.0.
 
 If there are no more surprises this week, the release of OCaml 5.1.0 shall happen next week.
 

--- a/data/changelog/ocaml/2023-09-06-ocaml-5.1.0.rc3.md
+++ b/data/changelog/ocaml/2023-09-06-ocaml-5.1.0.rc3.md
@@ -1,0 +1,55 @@
+---
+title: OCaml 5.1.0 - Third Release Candidate
+description: Third Release Candidate of OCaml 5.1.0
+date: "2023-09-06"
+tags: [ocaml, release]
+changelog: |
+  ## Last Second Bug Fixes
+  - [#11284](https://github.com/ocaml/ocaml/issues/11284), +[#12525](https://github.com/ocaml/ocaml/issues/12525): Use compression of entries scheme when pruning mark stack.
+   Can decrease memory usage for some workloads, otherwise should be
+   unobservable.
+   (Tom Kelly, review by Sabine Schmaltz, Sadiq Jaffer and Damien Doligez)
+
+  - [#12486](https://github.com/ocaml/ocaml/issues/12486): Fix delivery of unhandled effect exceptions on s390x
+  (Miod Vallat, report by Jan Midtgaard, review by Vincent Laviron and Xavier
+  Leroy)
+---
+
+Since last week, there were two significant bugs fixed in the OCaml 5.1.0 runtime (one overflow bug, and a stack corruption bug in the s390x port). Since those bug fixes are as small as they are subtle, they were deemed worthy of a release of a third release candidate for OCaml 5.1.0.
+
+If there are no more surprises this week, the release of OCaml 5.1.0 shall happen next week.
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+The full changelog for OCaml 5.1.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.1/Changes)
+
+A short summary of the two fixed bugs in this release candidate is also available below.
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1 and later:
+```bash
+opam update
+opam switch create 5.1.0~rc3
+```
+
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.0-rc3.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0~rc3.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.1.0~rc3+options <option_list>
+```
+where `<option_list>` is a comma-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.1.0~rc3+flambda+nffa ocaml-variants.5.1.0~rc3+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
There were two subtle bug fixes on the OCaml runtime last week. Since those are safe bug fixes, that may avoid horrendous debugging session downstream, a third (and hopefully last) release candidate will be published tomorrow.

This PR adds the changelog announce to `ocaml.org` with hopefully a little more time for reviewing this time.