### PR TITLE
Add some missing icfp talks

### DIFF
--- a/data/papers.yml
+++ b/data/papers.yml
@@ -1,5 +1,5 @@
 papers:
-  - title: Bounding Data Races in Space and Time
+  - title: "Bounding Data Races in Space and Time"
     publication: Programming Language Design and Implementation (PLDI)
     abstract: >
       We propose a new semantics for shared-memory parallel
@@ -25,7 +25,7 @@ papers:
       - description: "Download PDF"
         uri: http://kcsrk.info/papers/pldi18-memory.pdf
     featured: true
-  - title: Retrofitting Effect Handlers Onto OCaml
+  - title: "Retrofitting Effect Handlers Onto OCaml"
     publication: Programming Language Design and Implementation (PLDI)
     abstract: >
       Effect handlers have been gathering momentum as a mechanism for modular
@@ -93,7 +93,7 @@ papers:
      - description: "Download PDF"
        uri: https://doi.org/10.1145/3408978
     featured: false
-  - title: Formal Verification of a Concurrent Bounded Queue in a Weak Memory Model
+  - title: "Formal Verification of a Concurrent Bounded Queue in a Weak Memory Model"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       We use Cosmo, a modern concurrent separation logic, to formally specify
@@ -116,7 +116,7 @@ papers:
       - description: "Download PDF"
         uri: https://doi.org/10.1145/3473571
     featured: false
-  - title: A Separation Logic for Effect Handlers
+  - title: "A Separation Logic for Effect Handlers"
     publication: Principles of Programming Languages (POPL)
     abstract: >
       User-defined effects and effect handlers are advertised and advocated as a
@@ -151,7 +151,7 @@ papers:
       - description: "Download PDF"
         uri: https://doi.org/10.1145/3434314
     featured: false
-  - title: A Memory Model for Multicore OCaml
+  - title: "A Memory Model for Multicore OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       We propose a memory model for OCaml, broadly following the design of axiomatic
@@ -169,7 +169,7 @@ papers:
       - description: "Download PDF"
         uri: https://kcsrk.info/papers/memory_model_ocaml17.pdf
     featured: false
-  - title: Extending OCaml's `open`
+  - title: "Extending OCaml's `open`"
     publication: Open Publishing Association
     abstract: >
       We propose a harmonious extension of OCaml's `open` construct.
@@ -188,7 +188,7 @@ papers:
       - description: "Download PDF"
         uri: https://arxiv.org/pdf/1905.06543.pdf
     featured: true
-  - title: Eff Directly in OCaml
+  - title: "Eff Directly in OCaml"
     publication: Open Publishing Association
     abstract: >
       The language Eff is an OCaml-like language serving as a prototype implementation
@@ -214,7 +214,7 @@ papers:
       - description: "Download PDF"
         uri: https://arxiv.org/pdf/1812.11664.pdf
     featured: false
-  - title: A Syntactic Approach to Type Soundness
+  - title: "A Syntactic Approach to Type Soundness"
     publication: Information & Computation, 115(1):38−94
     abstract: >
       This paper describes the semantics and the type system of Core ML and
@@ -231,9 +231,8 @@ papers:
       - description: "Download PostScript"
         uri: https://www.cs.rice.edu/CS/PLT/Publications/Scheme/ic94-wf.ps.gz
     featured: false
-  - title: The Essence of ML Type Inference
-    publication: Benjamin C. Pierce, editor, Advanced Topics in Types and
-      Programming Languages, MIT Press
+  - title: "The Essence of ML Type Inference"
+    publication: Benjamin C. Pierce, editor, Advanced Topics in Types and Programming Languages, MIT Press
     abstract: >
       This book chapter gives an in-depth abstract of the Core ML type system,
       with an emphasis on type inference. The type inference algorithm is
@@ -251,7 +250,7 @@ papers:
       - description: "Download PostScript"
         uri: https://cristal.inria.fr/attapl/preversion.ps.gz
     featured: false
-  - title: Relaxing the Value Restriction
+  - title: "Relaxing the Value Restriction"
     publication: International Symposium on Functional and Logic Programming
     abstract: >
       This paper explains why it is sound to generalise certain type variables
@@ -270,7 +269,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/garrigue-value_restriction-fiwflp04.ps.gz
     featured: false
-  - title: Manifest Types, Modules, and Separate Compilation
+  - title: "Manifest Types, Modules, and Separate Compilation"
     publication: Principles of Programming Languages
     abstract: >
       This paper presents a variant of the Standard ML module system that
@@ -295,7 +294,7 @@ papers:
       - description: "Download DVI"
         uri: https://caml.inria.fr/pub/papers/xleroy-manifest_types-popl94.dvi.gz
     featured: false
-  - title: Applicative Functors and Fully Transparent Higher-Order Modules
+  - title: "Applicative Functors and Fully Transparent Higher-Order Modules"
     publication: Principles of Programming Languages
     abstract: >
       This work extends the above paper by introducing so-called applicative
@@ -317,7 +316,7 @@ papers:
       - description: "Download DVI"
         uri: https://caml.inria.fr/pub/papers/xleroy-applicative_functors-popl95.dvi.gz
     featured: false
-  - title: A Modular Module System
+  - title: "A Modular Module System"
     publication: Journal of Functional Programming, 10(3):269-303
     abstract: >
       This accessible paper describes a simplified implementation of the OCaml
@@ -339,7 +338,7 @@ papers:
       - description: "Download DVI"
         uri: https://caml.inria.fr/pub/papers/xleroy-modular_modules-jfp.dvi.gz
     featured: false
-  - title: A Proposal for Recursive Modules in Objective Caml
+  - title: "A Proposal for Recursive Modules in Objective Caml"
     publication: Unpublication
     abstract: >
       This note describes the experimental recursive modules introduced in OCaml
@@ -378,7 +377,7 @@ papers:
       - description: "Download DVI"
         uri: https://caml.inria.fr/pub/papers/remy_vouillon-objective_ml-tapos98.dvi.gz
     featured: false
-  - title: Extending ML with Semi-Explicit Higher-Order Polymorphism
+  - title: "Extending ML with Semi-Explicit Higher-Order Polymorphism"
     publication: Information & Computation, 155(1/2):134−169
     abstract: >
       This paper proposes a device for re-introducing first-class polymorphic
@@ -400,7 +399,7 @@ papers:
       - description: "Download DVI"
         uri: https://caml.inria.fr/pub/papers/garrigue_remy-poly-ic99.dvi.gz
     featured: false
-  - title: Programming with Polymorphic Variants
+  - title: "Programming with Polymorphic Variants"
     publication: ML Workshop
     abstract: >
       This paper briefly explains what polymorphic variants are about and how
@@ -418,7 +417,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.ps.gz
     featured: false
-  - title: Code Reuse Through Polymorphic Variants
+  - title: "Code Reuse Through Polymorphic Variants"
     publication: Workshop on Foundations of Software Engineering
     abstract: >
       This short paper explains how to design a modular, extensible interpreter
@@ -434,7 +433,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/garrigue-variant-reuse-2000.ps.gz
     featured: false
-  - title: Simple Type Inference for Structural Polymorphism
+  - title: "Simple Type Inference for Structural Polymorphism"
     publication: Workshop on Foundations of Object-Oriented Languages
     abstract: >
       This paper explains most of the typechecking machinery behind polymorphic
@@ -453,7 +452,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/garrigue-structural_poly-fool02.ps.gz
     featured: false
-  - title: Typing Deep Pattern-matching in Presence of Polymorphic Variants
+  - title: "Typing Deep Pattern-matching in Presence of Polymorphic Variants"
     publication: JSSST Workshop on Programming and Programming Languages
     abstract: >
       This paper provides more details about the technical machinery behind
@@ -472,7 +471,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/garrigue-deep-variants-2004.ps.gz
     featured: false
-  - title: Labeled and Optional Arguments for Objective Caml
+  - title: "Labeled and Optional Arguments for Objective Caml"
     publication: JSSST Workshop on Programming and Programming Languages
     abstract: >
       This paper offers a dynamic semantics, a static semantics, and a
@@ -491,7 +490,7 @@ papers:
       - description: "Download DVI"
         uri: https://caml.inria.fr/pub/papers/garrigue-labels-ppl01.dvi.gz
     featured: false
-  - title: Meta-Programming Tutorial with CamlP4
+  - title: "Meta-Programming Tutorial with CamlP4"
     publication: Commercial Users of Functional Programming
     abstract: Meta-programming tutorial with Camlp4
     authors:
@@ -504,7 +503,7 @@ papers:
       - description: "View Online"
         uri: https://github.com/jaked/cufp-metaprogramming-tutorial
     featured: false
-  - title: The ZINC Experiment, an Economical Implementation of the ML Language
+  - title: "The ZINC Experiment, an Economical Implementation of the ML Language"
     publication: Technical report 117, INRIA
     abstract: >
       This report contains a abstract of the ZINC compiler, which later evolved
@@ -524,7 +523,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/xleroy-zinc.ps.gz
     featured: false
-  - title: The Effectiveness of Type-based Unboxing
+  - title: "The Effectiveness of Type-based Unboxing"
     publication: Workshop on Types in Compilation
     abstract: >
       This paper surveys and compares several data representation strategies,
@@ -541,8 +540,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/xleroy-unboxing-tic97.ps.gz
     featured: false
-  - title: A Concurrent, Generational Garbage Collector for a Multithreaded
-      Implementation of ML
+  - title: "A Concurrent, Generational Garbage Collector for a Multithreaded Implementation of ML"
     publication: Principles of Programming Languages
     abstract: >
       Superseded by "Portable, Unobtrusive Garbage Collection for Multiprocessor
@@ -560,7 +558,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/doligez_xleroy-concurrent_gc-popl93.ps.gz
     featured: false
-  - title: Portable, Unobtrusive Garbage Collection for Multiprocessor Systems
+  - title: "Portable, Unobtrusive Garbage Collection for Multiprocessor Systems"
     publication: Principles of Programming Languages
     abstract: >
       This paper describes a concurrent version of the garbage collector found
@@ -578,8 +576,7 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/doligez_gonthier-gc-popl94.ps.gz
     featured: false
-  - title: Conception, Réalisation et Certification d'un Glaneur de Cellules
-      Concurrent
+  - title: "Conception, Réalisation et Certification d'un Glaneur de Cellules Concurrent"
     publication: Ph.D. thesis, Université Paris 7
     abstract: >
       All you ever wanted to know about the garbage collector found in Caml
@@ -597,9 +594,8 @@ papers:
       - description: "Download PostScript"
         uri: https://caml.inria.fr/pub/papers/doligez-these.ps.gz
     featured: false
-  - title: Optimizing Pattern Matching
-    publication: Proceedings of the sixth ACM SIGPLAN International Conference on
-      Functional Programming (ICFP)
+  - title: "Optimizing Pattern Matching"
+    publication: Proceedings of the sixth ACM SIGPLAN International Conference on Functional Programming (ICFP)
     abstract: >
       All you ever wanted to know about the garbage collector found in Caml
       Light and OCaml's runtime system.
@@ -614,9 +610,9 @@ papers:
       - description: "View Online"
         uri: https://dl.acm.org/citation.cfm?id=507641
     featured: false
-  - title: OCaml for the Masses
+  - title: "OCaml for the Masses"
     publication: ACM Queue
-    abstract: |
+    abstract: >
       Why the next language you learn should be functional.
     authors:
       - Yaron Minsky
@@ -627,7 +623,7 @@ papers:
       - description: "View Online"
         uri: https://queue.acm.org/detail.cfm?id=2038036
     featured: false
-  - title: Xen and the Art of OCaml
+  - title: "Xen and the Art of OCaml"
     publication: Commercial Users of Functional Programming (CUFP)
     abstract: >
       In this talk, we will firstly describe the architecture of XenServer and
@@ -648,7 +644,7 @@ papers:
       - description: "Download PDF"
         uri: https://cufp.org/archive/2008/slides/MadhavapeddyAnil.pdf
     featured: false
-  - title: Chemoinformatics and Structural Bioinformatics in OCaml
+  - title: "Chemoinformatics and Structural Bioinformatics in OCaml"
     publication: Journal of Cheminformatics
     abstract: >
       In this article, we share our experience in prototyping chemoinformatics
@@ -666,7 +662,7 @@ papers:
       - description: "View Online"
         uri: https://jcheminf.biomedcentral.com/articles/10.1186/s13321-019-0332-0
     featured: false
-  - title: A Declarative Syntax Definition for OCaml
+  - title: "A Declarative Syntax Definition for OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk we present our work on a syntax definition for the OCaml
@@ -691,7 +687,7 @@ papers:
       - description: "View Online"
         uri: https://eelcovisser.org/talks/2020/08/28/ocaml/
     featured: false
-  - title: A Simple State-Machine Framework for Property-Based Testing in OCaml
+  - title: "A Simple State-Machine Framework for Property-Based Testing in OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Since their inception state-machine frameworks have proven their worth by
@@ -712,7 +708,7 @@ papers:
       - description: "Download PDF"
         uri: https://janmidtgaard.dk/papers/Midtgaard%3AOCaml20.pdf
     featured: false
-  - title: AD-OCaml: Algorithmic Differentiation for OCaml
+  - title: "AD-OCaml: Algorithmic Differentiation for OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       AD-OCaml is a library framework for calculating mathematically exact
@@ -733,7 +729,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/12/AD-OCaml-Algorithmic-Differentiation-for-OCaml
     featured: false
-  - title: API Migration: Compare Transformed
+  - title: "API Migration: Compare Transformed"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk we describe our experience in using an automatic
@@ -758,7 +754,7 @@ papers:
       - description: "Download PDF"
         uri: https://www.cs.kent.ac.uk/people/staff/sjt/Pubs/OCaml_workshop2020.pdf
     featured: false
-  - title: Irmin v2
+  - title: "Irmin v2"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Irmin is an OCaml library for building distributed databases with the same
@@ -783,7 +779,7 @@ papers:
       - description: "View Online"
         uri: https://tarides.com/blog/2019-11-21-irmin-v2
     featured: false
-  - title: LexiFi Runtime Types
+  - title: "LexiFi Runtime Types"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       LexiFi maintains an OCaml compiler extension that enables introspection
@@ -806,7 +802,7 @@ papers:
       - description: "View Online"
         uri: https://www.lexifi.com/blog/ocaml/runtime-types/
     featured: false
-  - title: OCaml Under the Hood: SmartPy
+  - title: "OCaml Under the Hood: SmartPy"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       SmartPy is a complete system to develop smart-contracts for the Tezos
@@ -830,7 +826,7 @@ papers:
       - description: "Download PDF"
         uri: https://wr.mondet.org/paper/smartpy-ocaml-2020.pdf
     featured: false
-  - title: OCaml-CI: A Zero-Configuration CI
+  - title: "OCaml-CI: A Zero-Configuration CI"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       OCaml-CI is a CI service for OCaml projects. It uses metadata from the
@@ -854,7 +850,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/6/OCaml-CI-A-Zero-Configuration-CI
     featured: false
-  - title: Parallelising Your OCaml Code with Multicore OCaml
+  - title: "Parallelising Your OCaml Code with Multicore OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       With the availability of multicore variants of the recent OCaml versions
@@ -876,7 +872,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/5/Parallelising-your-OCaml-Code-with-Multicore-OCaml
     featured: false
-  - title: The ImpFS Filesystem
+  - title: "The ImpFS Filesystem"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       This proposal describes a presentation to be given at the OCaml’20
@@ -896,7 +892,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/8/The-ImpFS-filesystem
     featured: false
-  - title: The Final Pieces of the OCaml Documentation Puzzle
+  - title: "The Final Pieces of the OCaml Documentation Puzzle"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       `odoc` is the latest attempt at creating a documentation tool which handles
@@ -918,7 +914,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/4/The-final-pieces-of-the-OCaml-documentation-puzzle
     featured: false
-  - title: Types in Amber
+  - title: "Types in Amber"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Coda is a new cryptocurrency that uses zk-SNARKs to dramatically reduce
@@ -939,7 +935,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/3/Types-in-amber
     featured: false
-  - title: OCamlPro: Promoting OCaml Use in Industry
+  - title: "OCamlPro: Promoting OCaml Use in Industry"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       One year after the foundation of OCamlPro, Fabrice Le Fessant presents at
@@ -956,7 +952,7 @@ papers:
       - description: "View Online"
         uri: https://www.youtube.com/watch?v=DXr8Lr3z7wY&feature=plcp
     featured: false
-  - title: opam: An OCaml Package Manager
+  - title: "opam: An OCaml Package Manager"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Six months after the start of the development of the opam package
@@ -977,7 +973,7 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/8UasGCviGqTPzNYgLZyPt1
     featured: false
-  - title: Study of OCaml Programs' memory behavior
+  - title: "Study of OCaml Programs' memory behavior"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       A two-fold presentation covering both a study of OCaml programs' memory
@@ -999,8 +995,8 @@ papers:
         uri: https://watch.ocaml.org/w/3YiLW4PfeStDUdf29aPtDH
       - description: "Read Online"
         uri: https://inria.hal.science/hal-01095305v1
-        featured: false
-  - title: Improving OCaml High-Level Optimisations
+    featured: false
+  - title: "Improving OCaml High-Level Optimisations"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       I spend a lot of time hacking the OCaml compiler. Hence when I write some
@@ -1032,7 +1028,7 @@ papers:
       - description: "Download PDF"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf
     featured: false
-  - title: OCamlot: OCaml Online Testing
+  - title: "OCamlot: OCaml Online Testing"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       OCamlot provides a distributed, continuous testing service for opam
@@ -1057,7 +1053,7 @@ papers:
       - description: "Download PDF"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf
     featured: false
-  - title: Profiling the Memory Usage of OCaml Applications Without Changing Their Behavior
+  - title: "Profiling the Memory Usage of OCaml Applications Without Changing Their Behavior"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this paper, we present the current state of our work on profiling the
@@ -1069,16 +1065,16 @@ papers:
       - Michel Mauny
       - Fabrice Le Fessant
       - Thomas Gazagnaire
-    tags: 2013
+    tags:
       - ocaml-workshop
-    year:
+    year: 2013
     links:
       - description: "Download PDF Slides"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf
       - description: "Download PDF"
         uri: https://inria.hal.science/hal-01095305v1
-        featured: false
-  - title: The OCaml Platform v1.0
+    featured: false
+  - title: "The OCaml Platform v1.0"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       The OCaml Platform combines the OCaml compiler toolchain with a coherent
@@ -1111,7 +1107,7 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/37eaef0e-d826-4452-bf84-f04244a85ce9
     featured: false
-  - title: A Proposal for Non-Intrusive Namespaces in OCaml
+  - title: "A Proposal for Non-Intrusive Namespaces in OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       We present a work-in-progress about adding namespaces to OCaml. Inspired
@@ -1134,8 +1130,8 @@ papers:
         uri: https://watch.ocaml.org/w/ded6e8bb-aebd-4fd2-989f-3f0b2b8efaf3
       - description: "Read Online"
         uri: https://inria.hal.science/hal-01091173v1
-        featured: false
-  - title: Towards A Debugger for Native-Code OCaml
+    featured: false
+  - title: "Towards A Debugger for Native-Code OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk, we will present a starting project at OCamlPro, the
@@ -1156,8 +1152,8 @@ papers:
         uri: https://watch.ocaml.org/w/e1a22cf8-5522-4c05-a8d4-af445bc73556
       - description: "Read Online"
         uri: https://inria.hal.science/hal-01245840v1
-        featured: false
-  - title: Global Semantic Analysis on OCaml programs
+    featured: false
+  - title: "Global Semantic Analysis on OCaml programs"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       We present an ongoing project at OCamlPro, the development of a semantic
@@ -1177,7 +1173,7 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/e1a22cf8-5522-4c05-a8d4-af445bc73556
     featured: false
-  - title: Learn OCaml: An Online Learning Center for OCaml
+  - title: "Learn OCaml: An Online Learning Center for OCaml"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       We present Learn OCaml, a Web application that packs a set of learning
@@ -1204,8 +1200,8 @@ papers:
         uri: https://watch.ocaml.org/w/uWJvzik5LKSTkroghup5oJ
       - description: "Read Online"
         uri: https://inria.hal.science/hal-01352015v1
-        featured: false
-  - title: The State of the OCaml Platform: September 2016
+    featured: false
+  - title: "The State of the OCaml Platform: September 2016"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Louis Gesbert covers the current state of the OCaml Platform in September
@@ -1222,7 +1218,7 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/c386fc95-092e-4ea7-9317-91edf287fea6
     featured: false
-  - title: Digodoc and Docs
+  - title: "Digodoc and Docs"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk, we will introduce a new tool called digodoc, that builds a
@@ -1241,11 +1237,9 @@ papers:
     tags:
       - ocaml-workshop
     year: 2021
-    links:
-      - description: "N/A"
-        uri: N/A
+    links: []
     featured: false
-  - title: `opam-bin`: Binary Packages With opam
+  - title: "`opam-bin`: Binary Packages With opam"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk, we will present `opam-bin`, an opam plugin that builds binary
@@ -1262,7 +1256,7 @@ papers:
       - description: "Download PDF"
         uri: https://icfp21.sigplan.org/details/ocaml-2021-papers/5/Opam-bin-Binary-Packages-with-Opam
     featured: false
-  - title: Supporting a Decade of Opam
+  - title: "Supporting a Decade of Opam"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Opam 1.2 was released in 2014. It was four years before opam 2.0 succeeded
@@ -1289,7 +1283,7 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/1rWj4jYyaDkmMjdH4KNcv6
     featured: false
-  - title: Flambda 2 Types: An Abstract Domain for Atatic Analysis of Functional Programs
+  - title: "Flambda 2 Types: An Abstract Domain for Atatic Analysis of Functional Programs"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk, we will present an overview of the abstract domains that
@@ -1314,7 +1308,7 @@ papers:
       - description: "Read Online"
         uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/9/Flambda-2-Types-An-abstract-domain-for-static-analysis-of-functional-programs
     featured: false
-  - title: Efficient OCaml Compilation with Flambda 2
+  - title: "Efficient OCaml Compilation with Flambda 2"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Flambda 2 is an IR and optimisation pass for OCaml centred around
@@ -1333,7 +1327,7 @@ papers:
       - description: "Read Online"
         uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/8/Efficient-OCaml-compilation-with-Flambda-2
     featured: false
-  - title: Wasocaml: A Compiler From OCaml to WebAssembly
+  - title: "Wasocaml: A Compiler From OCaml to WebAssembly"
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this presentation, we will explore the compilation of

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -30,7 +30,7 @@ papers:
     abstract: >
       Effect handlers have been gathering momentum as a mechanism for modular
       programming with user-defined effects. Effect handlers allow for non-local
-      control flow mechanisms such as generators, async/await, lightweight threads
+      control flow mechanisms such as generators, async/await, lightweight threads,
       and coroutines to be composably expressed. We present a design and evaluate
       a full-fledged efficient implementation of effect handlers for OCaml, an
       industrial-strength multi-paradigm programming language. Our implementation
@@ -217,7 +217,7 @@ papers:
   - title: A Syntactic Approach to Type Soundness
     publication: Information & Computation, 115(1):38−94
     abstract: >
-      This paper describes the semantics and the type system of Core ML, and
+      This paper describes the semantics and the type system of Core ML and
       uses a simple syntactic technique to prove that well-typed programs cannot
       go wrong.
     authors:
@@ -358,7 +358,7 @@ papers:
         uri: https://caml.inria.fr/pub/papers/xleroy-recursive_modules-03.ps.gz
     featured: false
   - title: "Objective ML: An Effective Object-Oriented Extension to ML"
-    publication: Theory And Practice of Objects Systems, 4(1):27−50
+    publication: Theory and Practice of Objects Systems, 4(1):27−50
     abstract: >
       This paper provides theoretical foundations for OCaml's object-oriented
       layer, including dynamic and static semantics.
@@ -637,7 +637,7 @@ papers:
       algorithmic problems such as distributed failure planning. In addition, we
       will discuss the challenges imposed by using OCaml in a commercial
       environment, such as supporting product upgrades, enhancing
-      supportability and scaling the development team.
+      supportability, and scaling the development team.
     authors:
       - Anil Madhavapeddy
     tags:
@@ -720,7 +720,7 @@ papers:
       OCaml programs via algorithmic differentiation. Unlike similar
       frameworks, this includes programs with side effects, aliasing, and
       programs with nested derivative operators. The framework also offers
-      implicit parallelization of both user programs and their transformations.
+      implicit parallelisation of both user programs and their transformations.
       The presentation will provide a short introduction to the mathematical
       problem, the difficulties of implementing a solution, the design of the
       library, and a demonstration of its capabilities.
@@ -817,8 +817,8 @@ papers:
       is also the name of the OCaml library which provides an interpreter, a
       compiler to Michelson (the smart-contract language of Tezos), as well as
       a scenario “on-chain” interpreter. The IDE uses a mix of OCaml built with
-      js_of_ocaml and pure Javascript. The command line interface also builds
-      with js_of_ocaml to run on Node.js.
+      `js_of_ocaml` and pure Javascript. The command line interface also builds
+      with `js_of_ocaml` to run on Node.js.
     authors:
       - Sebastien Mondet
     tags:
@@ -834,7 +834,7 @@ papers:
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       OCaml-CI is a CI service for OCaml projects. It uses metadata from the
-      project’s Opam and Dune files to work out what to build, and uses caching
+      project’s opam and `dune` files to work out what to build, and it uses caching
       to make builds fast. It automatically tests projects against multiple
       OCaml versions and OS platforms. The CI has been deployed on around 50
       projects so far on GitHub, and many of them see response times an order of
@@ -882,7 +882,7 @@ papers:
       This proposal describes a presentation to be given at the OCaml’20
       workshop. The presentation will cover a new OCaml filesystem, ImpFS, and
       the related libraries. The filesystem makes use of a B-tree library
-      presented at OCaml’17, and a key-value store presented at ML’19. In
+      presented at OCaml’17 and a key-value store presented at ML’19. In
       addition, there are a number of other support libraries that may be of
       interest to the community. ImpFS represents a single point in the
       filesystem design space, but we hope that the libraries we have developed
@@ -944,7 +944,7 @@ papers:
     abstract: >
       One year after the foundation of OCamlPro, Fabrice Le Fessant presents at
       the OCaml Workshop a brief summary of the tasks undertaken in the span of
-      that fateful year. Cheat Sheets, opam package manager, and many more,
+      that fateful year. Cheat Sheets, opam package manager, and many more are
       the start of a long stream of contributions for the OCaml Distribution
       and Community at large.
     authors:
@@ -983,7 +983,7 @@ papers:
       A two-fold presentation covering both a study of OCaml programs' memory
       behaviour and the development of memory profiling tools that were
       on-going at OCamlPro at the time. These works aimed at decreasing memory
-      footprint, pinpoint and fix memory leaks, decrease the amount of time
+      footprint, pinpoint and fix memory leaks, and decrease the amount of time
       spent in memory management at runtime.
     authors:
       - Çagdas Bozman
@@ -1008,7 +1008,7 @@ papers:
       This is nice when I want to write performance sensitive code, but as I
       usually write code for which execution time doesn't matter much, this
       mainly tends to torture me. A small voice in my head is telling me "you
-      shouldn't write it like that, you known you could avoid this allocation".
+      shouldn't write it like that, you known you could avoid this allocation."
       And usually, following that indication would only tend to make the code
       less readable. But there is a solution to calm that voice\: making the
       compiler smarter than me. OCaml compilation mechanisms are quite
@@ -1062,7 +1062,7 @@ papers:
     abstract: >
       In this paper, we present the current state of our work on profiling the
       memory usage of OCaml programs. Our technique allows to observe track
-      types, allocation points and reachability paths of blocks, with no
+      types, allocation points, and reachability paths of blocks with no
       runtime cost, except for saving the observations.
     authors:
       - Çagdas Bozman
@@ -1082,16 +1082,16 @@ papers:
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       The OCaml Platform combines the OCaml compiler toolchain with a coherent
-      set of tools for build, documentation, testing and IDE integration. The
+      set of tools for build, documentation, testing, and IDE integration. The
       project is a collaborative effort across the OCaml community, tied
       together by the OCaml Labs group in Cambridge and with other major
       contributors listed above. The requirements of the Platform are being
-      guided by the industrial OCaml Consortium (primarily Jane Street, Citrix
+      guided by the industrial OCaml Consortium (primarily Jane Street, Citrix,
       and Lexifi). This talk follows up the OCaml 2013 talk that introduced the
       Platform. Since then, many tools have been released in parallel via the
       opam package manager, and this year’s talk will demonstrate the concrete
       workflow that ties them together (see Figure 2). We will first recap the
-      Platform ethos briefly, update on the opam package manager v1.2, and
+      Platform ethos briefly, update on the opam package manager v1.2 and
       conclude with the Platform workflow.
     authors:
       - Anil Madhavapeddy
@@ -1116,7 +1116,7 @@ papers:
     abstract: >
       We present a work-in-progress about adding namespaces to OCaml. Inspired
       by other languages such as Scala or C++, our aim is to design and
-      formalize a simple and non-intrusive namespace mechanism without
+      formalise a simple and non-intrusive namespace mechanism without
       complexifying the core language. Namespaces in our approach are a simple
       way to define libraries while avoiding name clashes. They are also meant
       to simplify the build process, clarifying and reducing (to zero whenever
@@ -1142,7 +1142,7 @@ papers:
       development of a debugging framework for OCaml native-code applications,
       based on the LLDB Debugger, a debugger built on top of the LLVM
       framework. We implemented a complete binding of LLDB C++ API for OCaml,
-      and then used it to build several tools, one " generic " debugger, and
+      and then used it to build several tools, one "generic" debugger, and
       two small utilities to monitor the memory behavior of OCaml
       applications.
     authors:
@@ -1182,11 +1182,11 @@ papers:
     abstract: >
       We present Learn OCaml, a Web application that packs a set of learning
       activities for people who want to learn OCaml. It includes an integrated
-      and reworked version of the venerable Try OCaml, and an exercise
+      and reworked version of the venerable Try OCaml and an exercise
       environment with automated grading derived from the one developed for the
       OCaml MOOC. It works entirely in the browser, the server being used for
-      storing static files and synchronizing between different devices. A
-      special effort has been made to make it usable on tablets, and even
+      storing static files and synchronising between different devices. A
+      special effort has been made to make it usable on tablets and even
       mobiles. A main public instance will be hosted at OCamlPro, but the
       project is open-source, and universities can host their own version on
       site. We will also provide a public repository for teachers to contribute
@@ -1226,12 +1226,12 @@ papers:
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk, we will introduce a new tool called digodoc, that builds a
-      graph of an opam switch, associating files, libraries and opam packages
+      graph of an opam switch, associating files, libraries, and opam packages
       into a cyclic graph of inclusions and dependencies. We will then explain
       how we used that tool to build a documentation website that displays the
       generated documentation of a large set of opam packages from the official
       opam repository. Thanks to digodoc, users can easily navigate between
-      module documentations, sources, packages and libraries. We think it is an
+      module documentations, sources, packages, and libraries. We think it is an
       interesting contribution to the OCaml ecosystem.
     authors:
       - Mohamed Hernouf
@@ -1266,15 +1266,15 @@ papers:
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Opam 1.2 was released in 2014. It was four years before opam 2.0 succeeded
-      it, and another three for opam 2.1. The release of opam 2.2 is imminent,
+      it, and another three for opam 2.1. The release of opam 2.2 is imminent
       and will have arrived just a year after its predecessor. This talk
       presents features added to opam 2.1 intended to make dealing with multiple
       versions of opam easier. We see how small additional metadata, both stored
-      in .opam “roots” and also added to opam’s command line provide opam’s
+      in `.opam` “roots” and also added to opam’s command line to provide opam’s
       developers with the chance to add new features more easily, with
       confidence that users will be able to upgrade safely. In presenting this,
       we’ll also trumpet some of what we think are the amazing new features of
-      opam 2.1 (and 2.2), and why we think you should keenly watch for new
+      opam 2.1 (and 2.2) and why we think you should keenly watch for new
       releases and upgrade immediately on release!
     authors:
       - David Allsopp
@@ -1346,8 +1346,8 @@ papers:
       transferring verified properties. Various techniques for representing
       values in memory are discussed, with a focus on OCaml’s approach. An
       extension called Wasm-GC is introduced, enabling the compilation of
-      garbage-collected languages to Wasm by incorporating features like int31
-      and garbage-collected structs. The paper presents Wasmocaml, a complete
+      garbage-collected languages to Wasm by incorporating features like `int31`
+      and garbage-collected structs. The paper presents Wasocaml, a complete
       OCaml compiler for Wasm-GC, and discusses benchmarks and future work in
       compiling garbage-collected languages to WebAssembly.
     authors:

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -939,3 +939,388 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/3/Types-in-amber
     featured: false
+  - title: OCamlPro: promoting OCaml use in industry
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      One year after the foundation of OCamlPro, Fabrice Le Fessant presents at
+      the OCaml Workshop a brief summary of the tasks undertaken in the span of
+      that fateful year. Cheat Sheets, OPAM package manager, and many more,
+      the start of a long stream of contributions for the OCaml Distribution
+      and Community at large.
+    authors:
+      - Fabrice le Fessant
+    tags:
+      - ocaml-workshop
+    year: 2012
+    links:
+      - description: "View Online"
+        uri: https://www.youtube.com/watch?v=DXr8Lr3z7wY&feature=plcp
+    featured: false
+  - title: OPAM: an OCaml Package Manager
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      Six months after the start of the development of the OPAM Package
+      Manager, Frederick Tuong, Fabrice Le Fessant and Thomas Gazagnaire
+      present for the first time what would in time become the official package
+      manager for the OCaml Distribution. Covering the current state of the
+      repository, and future prospects for the platform, this small piece of
+      media witholds a significant piece of history for OCaml.
+    authors:
+      - Frederic Tuong
+      - Fabrice le Fessant
+      - Thomas Gazagnaire
+    tags:
+      - ocaml-workshop
+      - opam
+    year: 2012
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/8UasGCviGqTPzNYgLZyPt1
+    featured: false
+  - title: Study of OCaml programs' memory behavior
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      A two-fold presentation covering both a study of OCaml programs' memory
+      behaviour and the development of memory profiling tools that were
+      on-going at OCamlPro at the time. These works aimed at decreasing memory
+      footprint, pinpoint and fix memory leaks, decrease the amount of time
+      spent in memory management at runtime.
+    authors:
+      - Çagdas Bozman
+      - Thomas Gazagnaire
+      - Fabrice Le Fessant
+      - Michel Mauny
+    tags:
+      - ocaml-workshop
+      - memory
+    year: 2012
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/3YiLW4PfeStDUdf29aPtDH
+      - description: "Read Online"
+        uri: https://inria.hal.science/hal-01095305v1
+        featured: false
+  - title: Improving OCaml high level optimisations
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+     TODO 
+    authors:
+      - Pierre Chambart
+    tags:
+      - ocaml-workshop
+      - optimisation
+    year: 2013
+    links:
+      - description: "Download PDF"
+        uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/optimizations.pdf
+      - description: "Download PDF"
+        uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf
+    featured: false
+  - title: Ocamlot: OCaml Online Testing
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - David Sheets
+      - Anil Madhavapeddy
+      - Amir Chaudhry
+      - Thomas Gazagnaire
+    tags:
+      - ocaml-workshop
+    year: 2013
+    links:
+      - description: "Download PDF"
+        uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf
+    featured: false
+  - title: Profiling the Memory Usage of OCaml Applications without Changing their Behavior
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - Çagdas Bozman
+      - Michel Mauny
+      - Fabrice Le Fessant
+      - Thomas Gazagnaire
+    tags: 2013
+      - ocaml-workshop
+    year:
+    links:
+      - description: "Download PDF"
+        uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf
+    featured: false
+  - title: The OCaml Platform v1.0
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      The OCaml Platform combines the OCaml compiler toolchain with a coherent
+      set of tools for build, documen- tation, testing and IDE integration. The
+      project is a collab- orative effort across the OCaml community, tied
+      together by the OCaml Labs group in Cambridge and with other major
+      contributors listed above. The requirements of the Platform are being
+      guided by the industrial OCaml Consortium (primarily Jane Street, Citrix
+      and Lexifi). This talk follows up the OCaml 2013 talk that introduced the
+      Platform. Since then, many tools have been released in parallel via the
+      OPAM package manager, and this year’s talk will demonstrate the concrete
+      workflow that ties them together (see Figure 2). We will first recap the
+      Platform ethos briefly, update on the OPAM package manager v1.2, and
+      conclude with the Platform workflow.
+    authors:
+      - Anil Madhavapeddy
+      - Amir Chaudhry
+      - Jeremie Diminio
+      - Thomas Gazagnaire
+      - Louis Gesbert
+      - Thomas Leonard
+      - David Sheets
+      - Mark Shinwell
+      - Leo White
+      - Jeremy Yallop
+    tags:
+      - ocaml-workshop
+    year: 2014
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/37eaef0e-d826-4452-bf84-f04244a85ce9
+    featured: false
+  - title: A Proposal for Non-Intrusive Namespaces in OCaml
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - Pierrick Couderc
+      - Fabrice Le Fessant
+      - Benjamin Canou
+      - Pierre Chambart
+    tags:
+      - ocaml-workshop
+    year: 2014
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/ded6e8bb-aebd-4fd2-989f-3f0b2b8efaf3
+      - description: "Read Online"
+        uri: https://inria.hal.science/hal-01091173v1
+        featured: false
+  - title: Towards A Debugger for Native-Code OCaml
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - Fabrice Le Fessant
+      - Pierre Chambart
+    tags:
+      - ocaml-workshop
+    year: 2015
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/e1a22cf8-5522-4c05-a8d4-af445bc73556
+      - description: "Read Online"
+        uri: https://inria.hal.science/hal-01245840v1
+        featured: false
+  - title: Global Semantic Analysis on OCaml programs
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - Thomas Blanc
+      - Pierre Chambart
+      - Michel Mauny
+      - Fabrice Le Fessant
+    tags:
+      - ocaml-workshop
+    year: 2015
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/e1a22cf8-5522-4c05-a8d4-af445bc73556
+    featured: false
+  - title: Learn OCaml: An Online Learning Center for OCaml
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      We present Learn OCaml, a Web application that packs a set of learning
+      activities for people who want to learn OCaml. It includes an integrated
+      and reworked version of the venerable Try OCaml, and an exercise
+      environment with automated grading derived from the one developed for the
+      OCaml MOOC. It works entirely in the browser, the server being used for
+      storing static files and synchronizing between different devices. A
+      special effort has been made to make it usable on tablets, and even
+      mobiles. A main public instance will be hosted at OCamlPro, but the
+      project is open-source, and universities can host their own version on
+      site. We will also provide a public repository for teachers to contribute
+      lessons and exercises.
+    authors:
+      - Benjamin Canou
+      - Grégoire Henry
+      - Çagdas Bozman
+      - Fabrice Le Fessant
+    tags:
+      - ocaml-workshop
+    year: 2016
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/uWJvzik5LKSTkroghup5oJ
+      - description: "Read Online"
+        uri: https://inria.hal.science/hal-01352015v1
+        featured: false
+  - title: The State of the OCaml Platform: September 2016
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - Louis Gesbert, on behalf of the OCaml Platform team
+    tags:
+      - ocaml-workshop
+    year: 2016
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/c386fc95-092e-4ea7-9317-91edf287fea6
+    featured: false
+  - title: Partial evaluation and metaprogramming
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      TODO
+    authors:
+      - Pierre Chambart
+    tags:
+      - ocaml-workshop
+    year: 2016
+    links:
+      - description: "N/A"
+        uri: N/A
+    featured: false
+  - title: Digodoc and Docs
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      In this talk, we will introduce a new tool called digodoc, that builds a
+      graph of an opam switch, associating files, libraries and opam packages
+      into a cyclic graph of inclusions and dependencies. We will then explain
+      how we used that tool to build a documentation website that displays the
+      generated documentation of a large set of opam packages from the official
+      opam repository. Thanks to digodoc, users can easily navigate between
+      module documentations, sources, packages and libraries. We think it is an
+      interesting contribution to the OCaml ecosystem.
+    authors:
+      - Mohamed Hernouf
+      - Fabrice Le Fessant
+      - Thomas Blanc
+      - Louis Gesbert
+    tags:
+      - ocaml-workshop
+    year: 2021
+    links:
+      - description: "N/A"
+        uri: N/A
+    featured: false
+  - title: Opam-bin: Binary Packages with Opam
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      In this talk, we will present opam-bin, an Opam plugin that builds Binary
+      Opam packages on the fly, to speed-up reinstallation of pack- ages.
+      opam-bin also creates Opam Repositories for these binary pack- ages, to
+      make them easy to share with other users. We will show how it works and
+      how to use it on a daily basis.
+    authors:
+      - Fabrice Le Fessant
+    tags:
+      - ocaml-workshop
+    year: 2021
+    links:
+      - description: "Download PDF"
+        uri: https://icfp21.sigplan.org/details/ocaml-2021-papers/5/Opam-bin-Binary-Packages-with-Opam
+    featured: false
+  - title: Supporting a Decade of Opam
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      OPAM 1.2 was released in 2014. It was four years before opam 2.0 succeeded
+      it, and another three for opam 2.1. The release of opam 2.2 is imminent,
+      and will have arrived just a year after its predecessor. This talk
+      presents features added to opam 2.1 intended to make dealing with multiple
+      versions of opam easier. We see how small additional metadata, both stored
+      in .opam “roots” and also added to opam’s command line provide opam’s
+      developers with the chance to add new features more easily, with
+      confidence that users will be able to upgrade safely. In presenting this,
+      we’ll also trumpet some of what we think are the amazing new features of
+      opam 2.1 (and 2.2), and why we think you should keenly watch for new
+      releases and upgrade immediately on release!
+    authors:
+      - David Allsopp
+      - Raja Boujbel
+      - Kate Deplaix
+      - Louis Gesbert
+    tags:
+      - ocaml-workshop
+      - opam
+    year: 2022
+    links:
+      - description: "View Online"
+        uri: https://watch.ocaml.org/w/1rWj4jYyaDkmMjdH4KNcv6
+    featured: false
+  - title: Flambda 2 Types: An abstract domain for static analysis of functional programs
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      In this talk, we will present an overview of the abstract domains that
+      drive the Flambda 2 optimizer for OCaml programs. Like most optimizing
+      compilers, Flambda 2 relies on static analysis to find optimization
+      opportunities. There are several different analyses that are actually
+      performed, here we will focus on a forward value analysis that we call
+      Flambda 2 Types. Despite its name, it fits quite well the definition of
+      an abstract domain (in the sense of abstract interpretation), and it is
+      through that angle that we will introduce it.
+    authors:
+      - Vincent Laviron
+      - Pierre Chambart
+      - Mark Shinwell
+    tags:
+      - ocaml-workshop
+      - Flambda 2
+    year: 2023
+    links:
+      - description: "View Online"
+        uri: https://www.youtube.com/live/M5M3f31pxns?si=9Gb8ivCqOjbF9tqB&t=28242
+      - description: "Read Online"
+        uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/9/Flambda-2-Types-An-abstract-domain-for-static-analysis-of-functional-programs
+    featured: false
+  - title: Efficient OCaml compilation with Flambda 2
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      Flambda 2 is an IR and optimisation pass for OCaml centred around
+      inlining. We discuss the engineering constraints that shaped it and the
+      overall structure that allows the compiler to be fast enough to handle
+      very large industrial code bases.
+    authors:
+      - Vincent Laviron
+      - Pierre Chambart
+      - Mark Shinwell
+    tags:
+      - ocaml-workshop
+      - Flambda 2
+    year: 2023
+    links:
+      - description: "Read Online"
+        uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/8/Efficient-OCaml-compilation-with-Flambda-2
+    featured: false
+  - title: Wasocaml: a compiler from OCaml to WebAssembly
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      In this presentation, we will explore the compilation of
+      garbage-collected languages, such as Java or OCaml, to
+      WebAssembly (Wasm). The limitations of JavaScript as the web’s default
+      language led to the development of Wasm, a secure and
+      predictable-performance modular language. However, compiling
+      garbage-collected languages to Wasm presents challenges, including the
+      need to compile or re-implement the runtime and difficulties in
+      transferring verified properties. Various techniques for representing
+      values in memory are discussed, with a focus on OCaml’s approach. An
+      extension called Wasm-GC is introduced, enabling the compilation of
+      garbage-collected languages to Wasm by incorporating features like int31
+      and garbage-collected structs. The paper presents Wasmocaml, a complete
+      OCaml compiler for Wasm-GC, and discusses benchmarks and future work in
+      compiling garbage-collected languages to WebAssembly.
+    authors:
+      - Léo Andrès
+      - Pierre Chambart
+    tags:
+      - ocaml-workshop
+      - wasm
+    year: 2023
+    links:
+      - description: "Read Online"
+        uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/13/Wasocaml-a-compiler-from-OCaml-to-WebAssembly
+    featured: false

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -1035,7 +1035,10 @@ papers:
   - title: Profiling the Memory Usage of OCaml Applications without Changing their Behavior
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      TODO
+      In this paper, we present the current state of our work on profiling the
+      memory usage of OCaml programs. Our technique allows to observe track
+      types, allocation points and reachability paths of blocks, with no
+      runtime cost, except for saving the observations.
     authors:
       - Çagdas Bozman
       - Michel Mauny
@@ -1045,15 +1048,17 @@ papers:
       - ocaml-workshop
     year:
     links:
-      - description: "Download PDF"
+      - description: "Download PDF Slides"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/bozman.pdf
-    featured: false
+      - description: "Download PDF"
+        uri: https://inria.hal.science/hal-01095305v1
+        featured: false
   - title: The OCaml Platform v1.0
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       The OCaml Platform combines the OCaml compiler toolchain with a coherent
-      set of tools for build, documen- tation, testing and IDE integration. The
-      project is a collab- orative effort across the OCaml community, tied
+      set of tools for build, documentation, testing and IDE integration. The
+      project is a collaborative effort across the OCaml community, tied
       together by the OCaml Labs group in Cambridge and with other major
       contributors listed above. The requirements of the Platform are being
       guided by the industrial OCaml Consortium (primarily Jane Street, Citrix
@@ -1084,7 +1089,13 @@ papers:
   - title: A Proposal for Non-Intrusive Namespaces in OCaml
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      TODO
+      We present a work-in-progress about adding namespaces to OCaml. Inspired
+      by other languages such as Scala or C++, our aim is to design and
+      formalize a simple and non-intrusive namespace mechanism without
+      complexifying the core language. Namespaces in our approach are a simple
+      way to define libraries while avoiding name clashes. They are also meant
+      to simplify the build process, clarifying and reducing (to zero whenever
+      possible) the responsibility of external tools. 
     authors:
       - Pierrick Couderc
       - Fabrice Le Fessant
@@ -1102,7 +1113,13 @@ papers:
   - title: Towards A Debugger for Native-Code OCaml
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      TODO
+      In this talk, we will present a starting project at OCamlPro, the
+      development of a debugging framework for OCaml native-code applications,
+      based on the LLDB Debugger, a debugger built on top of the LLVM
+      framework. We implemented a complete binding of LLDB C++ API for OCaml,
+      and then used it to build several tools, one " generic " debugger, and
+      two small utilities to monitor the memory behavior of OCaml
+      applications.
     authors:
       - Fabrice Le Fessant
       - Pierre Chambart
@@ -1118,7 +1135,11 @@ papers:
   - title: Global Semantic Analysis on OCaml programs
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      TODO
+      We present an ongoing project at OCamlPro, the development of a semantic
+      analyser of OCaml code based on abstract interpretation techniques. This
+      analysis relies on the presence of the whole program at compile time, it
+      should work on full actual programs and shows interesting promises in
+      terms of uncaught exceptions detection.
     authors:
       - Thomas Blanc
       - Pierre Chambart
@@ -1162,9 +1183,13 @@ papers:
   - title: The State of the OCaml Platform: September 2016
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      TODO
+      Louis Gesbert covers the current state of the OCaml Platform in September
+      2016. Introducing the game-changing integrations to opam 2.0, the roadmap,
+      and many more an aspects of the OCaml Platform as a whole like
+      `opam-publish`.
     authors:
       - Louis Gesbert, on behalf of the OCaml Platform team
+      - Anil Madhavapeddy
     tags:
       - ocaml-workshop
     year: 2016

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -78,7 +78,7 @@ papers:
       independent of this memory model. We illustrate this claim via a number of
       case studies: we verify several implementations of locks with respect to a
       classic, memory-model-independent specification. Thus, a coarse-grained
-      application that uses locks as the sole means of synchronization can be
+      application that uses locks as the sole means of synchronisation can be
       verified in the Concurrent-Separation-Logic fragment of Cosmo, without
       any knowledge of the weak memory model.
     authors:
@@ -254,7 +254,7 @@ papers:
   - title: Relaxing the Value Restriction
     publication: International Symposium on Functional and Logic Programming
     abstract: >
-      This paper explains why it is sound to generalize certain type variables
+      This paper explains why it is sound to generalise certain type variables
       at a `let` binding, even when the expression that is being `let`-bound is
       not a value. This relaxed version of Wright's classic “value restriction”
       was introduced in OCaml 3.07.
@@ -927,7 +927,7 @@ papers:
       OCaml source files. As the Coda software evolves, these formats for sent
       data may change. We wish to allow nodes running older versions of the
       software to communicate with newer versions. To achieve that, we identify
-      stable types that must not change over time, so that their serializations
+      stable types that must not change over time, so that their serialisations
       also do not change.
     authors:
       - Paul Steckler
@@ -1032,7 +1032,7 @@ papers:
       - description: "Download PDF"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/chambart.pdf
     featured: false
-  - title: Ocamlot: OCaml Online Testing
+  - title: OCamlot: OCaml Online Testing
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       OCamlot provides a distributed, continuous testing service for opam

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -944,7 +944,7 @@ papers:
     abstract: >
       One year after the foundation of OCamlPro, Fabrice Le Fessant presents at
       the OCaml Workshop a brief summary of the tasks undertaken in the span of
-      that fateful year. Cheat Sheets, OPAM package manager, and many more,
+      that fateful year. Cheat Sheets, opam package manager, and many more,
       the start of a long stream of contributions for the OCaml Distribution
       and Community at large.
     authors:
@@ -956,11 +956,11 @@ papers:
       - description: "View Online"
         uri: https://www.youtube.com/watch?v=DXr8Lr3z7wY&feature=plcp
     featured: false
-  - title: opam: an OCaml Package Manager
+  - title: opam: An OCaml Package Manager
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      Six months after the start of the development of the OPAM Package
-      Manager, Frederick Tuong, Fabrice Le Fessant and Thomas Gazagnaire
+      Six months after the start of the development of the opam package
+      manager, Frederick Tuong, Fabrice Le Fessant, and Thomas Gazagnaire
       present for the first time what would in time become the official package
       manager for the OCaml Distribution. Covering the current state of the
       repository, and future prospects for the platform, this small piece of
@@ -1035,9 +1035,9 @@ papers:
   - title: Ocamlot: OCaml Online Testing
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      OCamlot provides a distributed, continuous testing service for OPAM
+      OCamlot provides a distributed, continuous testing service for opam
       package quality and compatibility. Using signals from GitHub, OCamlot
-      ensures that, before being merged, patches submitted to the OPAM
+      ensures that, before being merged, patches submitted to the opam
       repository are thoroughly tested on the variety of supported
       configurations, architectures, and systems. The resulting improved build
       and metadata quality in turn speeds up development on other aspects of
@@ -1089,9 +1089,9 @@ papers:
       guided by the industrial OCaml Consortium (primarily Jane Street, Citrix
       and Lexifi). This talk follows up the OCaml 2013 talk that introduced the
       Platform. Since then, many tools have been released in parallel via the
-      OPAM package manager, and this year’s talk will demonstrate the concrete
+      opam package manager, and this year’s talk will demonstrate the concrete
       workflow that ties them together (see Figure 2). We will first recap the
-      Platform ethos briefly, update on the OPAM package manager v1.2, and
+      Platform ethos briefly, update on the opam package manager v1.2, and
       conclude with the Platform workflow.
     authors:
       - Anil Madhavapeddy

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -1,5 +1,5 @@
 papers:
-  - title: Bounding data races in space and time
+  - title: Bounding Data Races in Space and Time
     publication: Programming Language Design and Implementation (PLDI)
     abstract: >
       We propose a new semantics for shared-memory parallel
@@ -25,7 +25,7 @@ papers:
       - description: "Download PDF"
         uri: http://kcsrk.info/papers/pldi18-memory.pdf
     featured: true
-  - title: Retrofitting effect handlers onto OCaml
+  - title: Retrofitting Effect Handlers Onto OCaml
     publication: Programming Language Design and Implementation (PLDI)
     abstract: >
       Effect handlers have been gathering momentum as a mechanism for modular
@@ -93,7 +93,7 @@ papers:
      - description: "Download PDF"
        uri: https://doi.org/10.1145/3408978
     featured: false
-  - title: Formal verification of a concurrent bounded queue in a weak memory model
+  - title: Formal Verification of a Concurrent Bounded Queue in a Weak Memory Model
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       We use Cosmo, a modern concurrent separation logic, to formally specify
@@ -712,7 +712,7 @@ papers:
       - description: "Download PDF"
         uri: https://janmidtgaard.dk/papers/Midtgaard%3AOCaml20.pdf
     featured: false
-  - title: "AD-OCaml: Algorithmic Differentiation for OCaml"
+  - title: AD-OCaml: Algorithmic Differentiation for OCaml
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       AD-OCaml is a library framework for calculating mathematically exact
@@ -733,7 +733,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/12/AD-OCaml-Algorithmic-Differentiation-for-OCaml
     featured: false
-  - title: "API Migration: Compare Transformed"
+  - title: API Migration: Compare Transformed
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk we describe our experience in using an automatic
@@ -806,7 +806,7 @@ papers:
       - description: "View Online"
         uri: https://www.lexifi.com/blog/ocaml/runtime-types/
     featured: false
-  - title: "OCaml Under the Hood: SmartPy"
+  - title: OCaml Under the Hood: SmartPy
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       SmartPy is a complete system to develop smart-contracts for the Tezos
@@ -830,7 +830,7 @@ papers:
       - description: "Download PDF"
         uri: https://wr.mondet.org/paper/smartpy-ocaml-2020.pdf
     featured: false
-  - title: "OCaml-CI: A Zero-Configuration CI"
+  - title: OCaml-CI: A Zero-Configuration CI
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       OCaml-CI is a CI service for OCaml projects. It uses metadata from the
@@ -939,7 +939,7 @@ papers:
       - description: "View Online"
         uri: https://icfp20.sigplan.org/details/ocaml-2020-papers/3/Types-in-amber
     featured: false
-  - title: OCamlPro: promoting OCaml use in industry
+  - title: OCamlPro: Promoting OCaml Use in Industry
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       One year after the foundation of OCamlPro, Fabrice Le Fessant presents at
@@ -956,7 +956,7 @@ papers:
       - description: "View Online"
         uri: https://www.youtube.com/watch?v=DXr8Lr3z7wY&feature=plcp
     featured: false
-  - title: OPAM: an OCaml Package Manager
+  - title: opam: an OCaml Package Manager
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Six months after the start of the development of the OPAM Package
@@ -977,7 +977,7 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/8UasGCviGqTPzNYgLZyPt1
     featured: false
-  - title: Study of OCaml programs' memory behavior
+  - title: Study of OCaml Programs' memory behavior
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       A two-fold presentation covering both a study of OCaml programs' memory
@@ -1000,7 +1000,7 @@ papers:
       - description: "Read Online"
         uri: https://inria.hal.science/hal-01095305v1
         featured: false
-  - title: Improving OCaml high level optimisations
+  - title: Improving OCaml High-Level Optimisations
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       I spend a lot of time hacking the OCaml compiler. Hence when I write some
@@ -1057,7 +1057,7 @@ papers:
       - description: "Download PDF"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf
     featured: false
-  - title: Profiling the Memory Usage of OCaml Applications without Changing their Behavior
+  - title: Profiling the Memory Usage of OCaml Applications Without Changing Their Behavior
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this paper, we present the current state of our work on profiling the
@@ -1245,12 +1245,12 @@ papers:
       - description: "N/A"
         uri: N/A
     featured: false
-  - title: Opam-bin: Binary Packages with Opam
+  - title: `opam-bin`: Binary Packages With opam
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      In this talk, we will present opam-bin, an Opam plugin that builds Binary
-      Opam packages on the fly, to speed-up reinstallation of pack- ages.
-      opam-bin also creates Opam Repositories for these binary pack- ages, to
+      In this talk, we will present `opam-bin`, an opam plugin that builds binary
+      opam packages on the fly to speed-up reinstallation of packages.
+      `opam-bin` also creates opam repositories for these binary packages in order to
       make them easy to share with other users. We will show how it works and
       how to use it on a daily basis.
     authors:
@@ -1265,7 +1265,7 @@ papers:
   - title: Supporting a Decade of Opam
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      OPAM 1.2 was released in 2014. It was four years before opam 2.0 succeeded
+      Opam 1.2 was released in 2014. It was four years before opam 2.0 succeeded
       it, and another three for opam 2.1. The release of opam 2.2 is imminent,
       and will have arrived just a year after its predecessor. This talk
       presents features added to opam 2.1 intended to make dealing with multiple
@@ -1289,14 +1289,14 @@ papers:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/1rWj4jYyaDkmMjdH4KNcv6
     featured: false
-  - title: Flambda 2 Types: An abstract domain for static analysis of functional programs
+  - title: Flambda 2 Types: An Abstract Domain for Atatic Analysis of Functional Programs
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this talk, we will present an overview of the abstract domains that
-      drive the Flambda 2 optimizer for OCaml programs. Like most optimizing
-      compilers, Flambda 2 relies on static analysis to find optimization
+      drive the Flambda 2 optimiser for OCaml programs. Like most optimising
+      compilers, Flambda 2 relies on static analysis to find optimisation
       opportunities. There are several different analyses that are actually
-      performed, here we will focus on a forward value analysis that we call
+      performed. Here we will focus on a forward value analysis that we call
       Flambda 2 Types. Despite its name, it fits quite well the definition of
       an abstract domain (in the sense of abstract interpretation), and it is
       through that angle that we will introduce it.
@@ -1314,7 +1314,7 @@ papers:
       - description: "Read Online"
         uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/9/Flambda-2-Types-An-abstract-domain-for-static-analysis-of-functional-programs
     featured: false
-  - title: Efficient OCaml compilation with Flambda 2
+  - title: Efficient OCaml Compilation with Flambda 2
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       Flambda 2 is an IR and optimisation pass for OCaml centred around
@@ -1333,7 +1333,7 @@ papers:
       - description: "Read Online"
         uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/8/Efficient-OCaml-compilation-with-Flambda-2
     featured: false
-  - title: Wasocaml: a compiler from OCaml to WebAssembly
+  - title: Wasocaml: A Compiler From OCaml to WebAssembly
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
       In this presentation, we will explore the compilation of

--- a/data/papers.yml
+++ b/data/papers.yml
@@ -1003,7 +1003,23 @@ papers:
   - title: Improving OCaml high level optimisations
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-     TODO 
+      I spend a lot of time hacking the OCaml compiler. Hence when I write some
+      code, I have a good glimpse of what the generated assembly will look like.
+      This is nice when I want to write performance sensitive code, but as I
+      usually write code for which execution time doesn't matter much, this
+      mainly tends to torture me. A small voice in my head is telling me "you
+      shouldn't write it like that, you known you could avoid this allocation".
+      And usually, following that indication would only tend to make the code
+      less readable. But there is a solution to calm that voice\: making the
+      compiler smarter than me. OCaml compilation mechanisms are quite
+      predictable. There is no dark magic to replace your ugly code by a
+      well-behaving one, but it always generates reasonably efficient code. This
+      is a good thing in general, as you won't be surprised by code running more
+      slowly than what you usually expect. But it does not behave very well with
+      dumb code. This may not often seem like a problem with code written by
+      humans, but generated code, for example coming from camlp4/ppx, or compiled
+      from another language to OCaml, may fall into that category. In fact, there
+      is another common source for non-human written code: inlining.
     authors:
       - Pierre Chambart
     tags:
@@ -1019,7 +1035,14 @@ papers:
   - title: Ocamlot: OCaml Online Testing
     publication: International Conference on Functional Programming (ICFP)
     abstract: >
-      TODO
+      OCamlot provides a distributed, continuous testing service for OPAM
+      package quality and compatibility. Using signals from GitHub, OCamlot
+      ensures that, before being merged, patches submitted to the OPAM
+      repository are thoroughly tested on the variety of supported
+      configurations, architectures, and systems. The resulting improved build
+      and metadata quality in turn speeds up development on other aspects of
+      the Platform through earlier error feedback. A high-quality package
+      repository is also very important for new user retention.
     authors:
       - David Sheets
       - Anil Madhavapeddy
@@ -1029,6 +1052,8 @@ papers:
       - ocaml-workshop
     year: 2013
     links:
+      - description: "Download PDF"
+        uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/proposals/ocamlot.pdf
       - description: "Download PDF"
         uri: https://github.com/ocaml/v2.ocaml.org/blob/master/site/meetings/ocaml/2013/slides/sheets.pdf
     featured: false
@@ -1196,19 +1221,6 @@ papers:
     links:
       - description: "View Online"
         uri: https://watch.ocaml.org/w/c386fc95-092e-4ea7-9317-91edf287fea6
-    featured: false
-  - title: Partial evaluation and metaprogramming
-    publication: International Conference on Functional Programming (ICFP)
-    abstract: >
-      TODO
-    authors:
-      - Pierre Chambart
-    tags:
-      - ocaml-workshop
-    year: 2016
-    links:
-      - description: "N/A"
-        uri: N/A
     featured: false
   - title: Digodoc and Docs
     publication: International Conference on Functional Programming (ICFP)

--- a/src/ocamlorg_frontend/pages/papers.eml
+++ b/src/ocamlorg_frontend/pages/papers.eml
@@ -23,7 +23,7 @@ Layout.render
             </div>
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-10">
                 <% recommended_papers |> List.iter (fun (paper : Data.Paper.t) -> %>
-                    <a href="<%s paper.links |> List.hd |> (fun x -> x.uri) %>" class="flex-1 p-6 pb-4 border border-gray-200 rounded-xl bg-default dark:bg-dark-default card-hover">
+                    <a href="<%s paper.links |> List.hd |> (fun x -> x.uri) %>" class="flex-1 p-6 pb-4 border border-gray-200 rounded-xl text-default bg-default dark:bg-dark-default card-hover">
                         <div class="font-semibold text-base mb-3">
                             <%s paper.title %>
                         </div>


### PR DESCRIPTION
Hi,

I was reading through [this page](https://ocaml.org/papers) and figured it missed a lot of interesting talks made at the ICFP over the years.
I've scoured through what I believe is all relevant sources to find the papers, abstracts, and links to the relevant slides.

This is my first contribution to ocaml.org.

Thanks for your time