### PR TITLE
Fixed bug in responsiveness in the language manual banner

### DIFF
--- a/src/ocamlorg_frontend/components/learn_components.eml
+++ b/src/ocamlorg_frontend/components/learn_components.eml
@@ -173,14 +173,13 @@ let contribute_footer ~href =
   </div>
 
 let lang_manual_banner =
-  <div class="bg-learn-area-orange w-full py-5 flex px-3 flex-col items-center justify-center sm:px-16 md:flex-row md:gap-x-16 lg:gap-x-20 lg:px-20 xl:px-48 xl:gap-x-36 xl:px-48">
+  <div class="bg-learn-area-orange flex w-full flex-col items-center justify-center px-3 py-5 sm:px-16 md:flex-row md:gap-x-16 lg:gap-x-20 lg:px-20 xl:gap-x-36 xl:px-48">
     <div class="mb-2 flex flex-col items-start sm:max-w-sm md:max-w-none">
       <h2 class="mb-2 text-white text-center text-sm font-medium leading-5 tracking-widest md:text-left lg:leading-7">GUIDE</h2>
       <h3 class="mb-4 text-white text-center text-lg font-normal leading-5 md:leading-10 md:text-xl lg:text-2xl md:text-left">Language Manual</h3>
       <p class="mb-4 text-white text-sm font-normal leading-5 max-w-prose md:text-md lg:leading-7 xl:text-lg">OCaml language manuals are comprehensive guides covering syntax, features, and usage. They assist developers and learners in understanding capabilities, best practices, and exploring functionalities.</p>
       <a href="<%s Url.manual %>" class="block mt-5 py-2 px-24 bg-default text-sm rounded-sm items-center text-center text-primary-700 sm:px-20 sm:text-md font-medium leading-7 md:text-lg">Take Me There</a>
     </div>
-    <div class="flex justify-start">
-      <img src="../img/home/ocaml_camel.png" alt="camel image" class="rounded-full h-40 w-40 shrink-0 object-cover sm:h-48 sm:w-48 sm:ml-auto md:h-52 md:w-52 lg:h-64 lg:w-64 lg:ml-0 xl:h-72 xl:w-72">
-    </div> 
+    <div class="min-w-[200px] min-h-[200px] overflow-hidden rounded-full bg-cover bg-center bg-no-repeat md:min-w-[240px] md:min-h-[240px]" style="background-image: url('../img/home/ocaml_camel.png')">
+    </div>
   </div>

--- a/src/ocamlorg_frontend/components/learn_components.eml
+++ b/src/ocamlorg_frontend/components/learn_components.eml
@@ -173,12 +173,12 @@ let contribute_footer ~href =
   </div>
 
 let lang_manual_banner =
-  <div class="bg-learn-area-orange flex w-full flex-col items-center justify-center px-3 py-5 sm:px-16 md:flex-row md:gap-x-16 lg:gap-x-20 lg:px-20 xl:gap-x-36 xl:px-48">
-    <div class="mb-2 flex flex-col items-start sm:max-w-sm md:max-w-none">
+  <div class="bg-learn-area-orange flex w-full flex-col items-center justify-center px-3 py-5 sm:px-16 md:flex-row gap-6 md:gap-x-16 lg:gap-x-20 lg:px-20 xl:gap-x-36 xl:px-48">
+    <div class="mb-2 flex flex-col items-start max-w-sm md:max-w-none">
       <h2 class="mb-2 text-white text-center text-sm font-medium leading-5 tracking-widest md:text-left lg:leading-7">GUIDE</h2>
       <h3 class="mb-4 text-white text-center text-lg font-normal leading-5 md:leading-10 md:text-xl lg:text-2xl md:text-left">Language Manual</h3>
       <p class="mb-4 text-white text-sm font-normal leading-5 max-w-prose md:text-md lg:leading-7 xl:text-lg">OCaml language manuals are comprehensive guides covering syntax, features, and usage. They assist developers and learners in understanding capabilities, best practices, and exploring functionalities.</p>
-      <a href="<%s Url.manual %>" class="block mt-5 py-2 px-24 bg-default text-sm rounded-sm items-center text-center text-primary-700 sm:px-20 sm:text-md font-medium leading-7 md:text-lg">Take Me There</a>
+      <a href="<%s Url.manual %>" class="w-full md:w-auto mt-5 py-2 px-24 bg-default text-sm rounded-sm items-center text-center text-primary-700 sm:px-20 sm:text-md font-medium leading-7 md:text-lg">Take Me There</a>
     </div>
     <div class="min-w-[200px] min-h-[200px] overflow-hidden rounded-full bg-cover bg-center bg-no-repeat md:min-w-[240px] md:min-h-[240px]" style="background-image: url('../img/home/ocaml_camel.png')">
     </div>


### PR DESCRIPTION
Fixed a bug in responsiveness in the language manual banner display image.
<img width="1728" alt="Screenshot 2023-09-30 at 11 23 13" src="https://github.com/ocaml/ocaml.org/assets/75541866/30d49a56-4749-491a-8a42-173bdfd027c3">
