### PR TITLE
Display search bar with appropriate width

### DIFF
--- a/src/ocamlorg_frontend/components/forms.eml
+++ b/src/ocamlorg_frontend/components/forms.eml
@@ -25,7 +25,7 @@ let search_input ?button_attrs ?input_attrs ?dropdown_html ~label ~name _class =
 
 let select ~options ?attrs ?selected _class =
     <select
-        class="w-full appearance-none text-default border rounded-md py-3 pl-6 border-gray-200 pr-14 h-12 <%s _class %>"
+        class="w-full lg:w-auto appearance-none text-default border rounded-md py-3 pl-6 border-gray-200 pr-14 h-12 <%s _class %>"
         <%s! Option.value ~default:"" attrs %>
         >
         <% options |> List.iter (fun (value, display) -> %>


### PR DESCRIPTION
closes #1518 
cc @sabine @SaySayo 

This PR will make sure search input bars have the appropriate width. 
The issue for this PR was to correct the search box on the `/academic-users` endpoint. 
The reason for this mishap was the select dropdown component next to it which was set to full-width at all screen sizes. Given that both these components were placed together in a flex box, the search bar became truncated. 
The drop-down component just needs to be full width on smaller screens and on larger screens we can let the system calculate it's width automatically. 
With the change made, both the search component and the drop down component will display correctly accross all pages and on all screen sizes. 
Below are some screenshots on the different pages the select dropdown is used on and also the final `academic-users` page.

1) Fixed search input (Desktop and Mobile)
<img width="1280" alt="academic users" src="https://github.com/ocaml/ocaml.org/assets/112827178/1e4f9761-0c95-48ac-96d3-f83b27299257">
<img width="792" alt="mobile academic users" src="https://github.com/ocaml/ocaml.org/assets/112827178/77422424-4d8b-43f5-948a-84e554ceac32">

2) `/jobs` endpoint
<img width="1280" alt="jobs" src="https://github.com/ocaml/ocaml.org/assets/112827178/d0b75d47-a6d9-4226-9798-843c3a7c307f">

3) `/books` endpoint
<img width="1280" alt="books" src="https://github.com/ocaml/ocaml.org/assets/112827178/84ed6d3c-6bc0-4def-9224-4fa98bb54c4f">

4) `/problems` endpoint
<img width="1280" alt="Dropdown at problem" src="https://github.com/ocaml/ocaml.org/assets/112827178/aafe8f92-ec71-45a4-897e-72883a6141d8">

