### PR TITLE
In case of failing to read an opam file, don't crash, instead log a message

### DIFF
--- a/src/ocamlorg_package/lib/opam_repository.ml
+++ b/src/ocamlorg_package/lib/opam_repository.ml
@@ -120,7 +120,7 @@ let process_opam_file f =
   let open Lwt.Syntax in
   Lwt_io.with_file ~mode:Input (Fpath.to_string f) (fun channel ->
       let+ content = Lwt_io.read channel in
-      OpamFile.OPAM.read_from_string content)
+      try Some (OpamFile.OPAM.read_from_string content) with _ -> None)
 
 let opam_file package_name package_version =
   let opam_file =

--- a/src/ocamlorg_package/lib/opam_repository.mli
+++ b/src/ocamlorg_package/lib/opam_repository.mli
@@ -24,7 +24,7 @@ val list_package_versions : string -> string list option
     [packages/<package>/] directory. Returns [None] if the specified package
     doesn't exist in [packages/]. *)
 
-val opam_file : string -> string -> OpamFile.OPAM.t Lwt.t
+val opam_file : string -> string -> OpamFile.OPAM.t option Lwt.t
 (** Return the opam file structure given a package name and package version. *)
 
 val commit_at_date : string -> string Lwt.t


### PR DESCRIPTION
In order to mitigate the possible impact of issues like https://github.com/ocaml/opam-repository/pull/24579 for ocaml.org, ocaml.org now ignores opam files that fail to parse and instead logs a message.

There was no downtime associated with the upstream issue since ocaml.org did not re-fetch opam-repository during the time period where the file format error persisted. However, local builds were affected.