### PR TITLE
Correct date of merlin 4.11 release

### DIFF
--- a/data/changelog/merlin/2023-09-22-merlin-4.11.md
+++ b/data/changelog/merlin/2023-09-22-merlin-4.11.md
@@ -1,6 +1,6 @@
 ---
-title: Merlin 4.9
-date: "2023-05-31"
+title: Merlin 4.11
+date: "2023-09-22"
 tags: [merlin, platform, release]
 changelog: |
   + Merlin binary


### PR DESCRIPTION
I'm assuming the 2023-09-22 from the file name is the correct date for Merlin 4.11 release as added in https://github.com/ocaml/ocaml.org/pull/1538

@voodoos is this correct?