### PR TITLE
Add @avsm as a codeowner of the policies and Platform roadmap

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 /data/ @christinerose
+/data/pages/governance.md @avsm
+/data/pages/privacy_policy.md @avsm
+/data/tutorials/platform/op_00_principles.md @avsm
+/data/tutorials/platform/op_01_users.md @avsm
+/data/tutorials/guides/op_02_roadmap.md @avsm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 /data/ @christinerose
 /data/pages/governance.md @avsm
 /data/pages/privacy_policy.md @avsm
+/data/pages/carbon_footprint.md @avsm
 /data/tutorials/platform/op_00_principles.md @avsm
 /data/tutorials/platform/op_01_users.md @avsm
 /data/tutorials/guides/op_02_roadmap.md @avsm


### PR DESCRIPTION
To make clear that changes to the OCaml.org policies and Platform roadmap need to be approved by the [Owner/Delegate](https://ocaml.org/policies/governance#a.-owner-and-delegates).

@avsm let me know if there are any other pages that should be added here.