### PR TITLE
Pull request submitted for #1584, Add a "Standard Library API" link to the mobile navigation menu

### DIFF
--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -113,6 +113,9 @@ in
       <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Community) ~href:Url.community ~title:"Community" () %></li>
       <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Blog) ~href:Url.blog ~title:"Blog" () %></li>
       <li><%s! menu_link ~_class:"block" ~active:(active_top_nav_item=Some Playground) ~href:Url.playground ~title:"Playground" () %></li>
+      <li>
+        <a href="<%s Url.api %>" class="flex py-3 px-1 gap-4 font-semibold text-primary-600">Standard Library API<%s! Icons.arrow_top_right_on_square "w-6 h-6" %></a>
+      </li>
       <li class="mt-3 mb-6">
         <a href="<%s Url.getting_started %>" class="btn w-full">Get started</a>
       </li>


### PR DESCRIPTION
I added the "Standard Library API" to the mobile version 

<img width="472" alt="Screenshot 2023-10-09 010410" src="https://github.com/ocaml/ocaml.org/assets/89003403/2bc26998-f8da-429c-8f95-9610526adb18">
