### PR TITLE
Adjust RSS changelog icon size+margin

### DIFF
--- a/src/ocamlorg_frontend/pages/changelog.eml
+++ b/src/ocamlorg_frontend/pages/changelog.eml
@@ -9,9 +9,9 @@ Layout.render
         <h1 class="m-0 font-sans text-3xl font-extrabold tracking-normal leading-8 capitalize lg:text-5xl lg:tracking-tight md:text-4xl text-zinc-800">
           OCaml Changelog
         </h1>
-        <a href="/changelog.xml" class="text-lighter hover:text-gray-500 ml-2">
+        <a href="/changelog.xml" class="text-lighter hover:text-gray-500 ml-4 lg:ml-6">
           <span class="sr-only">RSS</span>
-          <%s! Icons.rss "h-6 w-6" %>
+          <%s! Icons.rss "h-6 w-6 md:h-8 md:w-8 lg:h-10 lg:w-10" %>
         </a>
       </div>
 


### PR DESCRIPTION
In https://github.com/ocaml/ocaml.org/pull/1593, a RSS has been added for the OCaml Changelog. Here, we adjust the size + margin of the icon a bit.