### PR TITLE
footer: Rearranged and changed link in footer

### DIFF
--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -43,7 +43,7 @@ let render () =
       <div class="mt-16 grid grid-cols-2 gap-8 xl:col-span-2 xl:mt-0">
         <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-default">About Ocaml</h3>
+            <h3 class="text-base font-semibold leading-6 text-default">About OCaml</h3>
             <ul class="mt-6 space-y-4">
               <li>
                 <a href="<%s Url.changelog %>" class="text-base leading-6 text-lighter">Changelog</a>

--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -43,8 +43,16 @@ let render () =
       <div class="mt-16 grid grid-cols-2 gap-8 xl:col-span-2 xl:mt-0">
         <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-default">About Us</h3>
+            <h3 class="text-base font-semibold leading-6 text-default">About Ocaml</h3>
             <ul class="mt-6 space-y-4">
+              <li>
+                <a href="<%s Url.changelog %>" class="text-base leading-6 text-lighter">Changelog</a>
+              </li>
+
+              <li>
+                <a href="<%s Url.releases %>" class="text-base leading-6 text-lighter">Releases</a>
+              </li>
+
               <li>
                 <!-- TODO: create footer_link component -->
                 <a href="<%s Url.industrial_users %>" class="text-base leading-6 text-lighter">Industrial Users</a>
@@ -83,21 +91,33 @@ let render () =
               </li>
 
               <li>
-                <a href="<%s Url.releases %>" class="text-base leading-6 text-lighter">Releases</a>
+                <a href="<%s Url.exercises %>" class="text-base leading-6 text-lighter">Exercises</a>
+              </li>
+
+              <li>
+                <a href="<%s Url.papers %>" class="text-base leading-6 text-lighter">Papers</a>
+              </li>
+
+              <li>
+                <a href="<%s Url.playground %>" class="text-base leading-6 text-lighter">OCaml Playground</a>
               </li>
             </ul>
           </div>
         </div>
-        <div class="md:grid md:grid-cols-2 md:gap-8">
+        <div class="md:grid md:grid-cols-2 md:gap-16">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-default">Community</h3>
+            <h3 class="text-base font-semibold leading-6 text-default whitespace-nowrap">Ecosystem & Community</h3>
             <ul class="mt-6 space-y-4">
-              <li>
-                <a href="<%s Url.blog %>" class="text-base leading-6 text-lighter">Blog</a>
+               <li>
+                <a href="<%s Url.packages %>" class="text-base leading-6 text-lighter">Packages</a>
+              </li>
+
+               <li>
+                <a href="<%s Url.community %>" class="text-base leading-6 text-lighter">Community</a>
               </li>
 
               <li>
-                <a href="<%s Url.changelog %>" class="text-base leading-6 text-lighter">Changelog</a>
+                <a href="<%s Url.blog %>" class="text-base leading-6 text-lighter">Blog</a>
               </li>
 
               <li>
@@ -105,7 +125,7 @@ let render () =
               </li>
             </ul>
           </div>
-          <div class="mt-10 md:mt-0">
+          <div class="mt-20 md:mt-0">
             <h3 class="text-base font-semibold leading-6 text-default">Policies</h3>
             <ul class="mt-6 space-y-4">
               <li>

--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -106,7 +106,7 @@ let render () =
         </div>
         <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-default whitespace-nowrap">Ecosystem</h3>
+            <h3 class="text-base font-semibold leading-6 text-default">Ecosystem</h3>
             <ul class="mt-6 space-y-4">
                <li>
                 <a href="<%s Url.packages %>" class="text-base leading-6 text-lighter">Packages</a>

--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -104,9 +104,9 @@ let render () =
             </ul>
           </div>
         </div>
-        <div class="md:grid md:grid-cols-2 md:gap-16">
+        <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
-            <h3 class="text-base font-semibold leading-6 text-default whitespace-nowrap">Ecosystem & Community</h3>
+            <h3 class="text-base font-semibold leading-6 text-default whitespace-nowrap">Ecosystem</h3>
             <ul class="mt-6 space-y-4">
                <li>
                 <a href="<%s Url.packages %>" class="text-base leading-6 text-lighter">Packages</a>


### PR DESCRIPTION
Rearranged the links in the footer template **`footer.eml`**.

fixes: #1581

 **Before the changes on web**

<img width="1280" alt="before web" src="https://github.com/ocaml/ocaml.org/assets/87182204/771f5ad9-ea59-481a-ac32-3dec927330b5">

**For mobile**

<img width="292" alt="before mobile" src="https://github.com/ocaml/ocaml.org/assets/87182204/9229985e-7f84-4120-90cb-2aa3083520ea">




Also updated:

- The **`href`** attribute in each update link .
- If the links in footer are rearranged the css style will change, so the styles were updated for better user experience.

**After the changes on web**

<img width="1280" alt="after web" src="https://github.com/ocaml/ocaml.org/assets/87182204/0ef3c67e-5709-49b1-8b52-8346a64d4ebf">

**For mobile**
<img width="289" alt="after mobile" src="https://github.com/ocaml/ocaml.org/assets/87182204/12ad4e27-cfb7-4665-8589-bbe09f79ea36">



