### PR TITLE
Books page padding and h1 font size

### DIFF
--- a/src/ocamlorg_frontend/pages/books.eml
+++ b/src/ocamlorg_frontend/pages/books.eml
@@ -47,7 +47,7 @@ Learn_layout.single_column_layout
 <div class="bg-default dark:bg-dark-default">
     <div class="container-fluid pt-10">
         <div class="prose mb-6">
-            <h1 class="font-bold">Books On OCaml (<%s string_of_int (List.length books) %>)</h2>
+            <h1>Books On OCaml (<%s string_of_int (List.length books) %>)</h2>
         </div>
         <form action="<%s Url.books %>" method="GET">
             <div class="flex mb-0 flex-col gap-4 sm:flex-row">

--- a/src/ocamlorg_frontend/pages/books.eml
+++ b/src/ocamlorg_frontend/pages/books.eml
@@ -45,8 +45,10 @@ Learn_layout.single_column_layout
 ~active_top_nav_item:Header.Learn 
 ~current:Books @@
 <div class="bg-default dark:bg-dark-default">
-    <div class="container-fluid">
-        <h2 class="font-bold mt-10 mb-6 lg:mt-0">Books On OCaml (<%s string_of_int (List.length books) %>)</h2>
+    <div class="container-fluid pt-10">
+        <div class="prose mb-6">
+            <h1 class="font-bold">Books On OCaml (<%s string_of_int (List.length books) %>)</h2>
+        </div>
         <form action="<%s Url.books %>" method="GET">
             <div class="flex mb-0 flex-col gap-4 sm:flex-row">
                 <%s! Forms.select


### PR DESCRIPTION
Adjust books page padding and `h1` element font size to be in line with other Learn Area pages.

|before|after|
|-|-|
|![Screenshot 2023-10-12 at 13-09-31 OCaml Books](https://github.com/ocaml/ocaml.org/assets/6594573/b1a1b95f-4bc9-47cb-b127-978779cdcb52)|![Screenshot 2023-10-12 at 13-09-34 OCaml Books](https://github.com/ocaml/ocaml.org/assets/6594573/34331f77-eeba-4a12-be17-e2e606880f2b)|
