### PR TITLE
Turn link from 'Unknown docs' to be a span

### DIFF
--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -63,7 +63,7 @@ Layout.render
             </li>
             <% | Unknown -> ( %>
             <li class="flex flex-auto">
-              <a title="Documentation status is unknown" class="w-full h-10 flex justify-center gap-2 rounded-r-lg p-1 items-center font-semibold border border-l-0 border-gray-400 <%s (match path with | Documentation _ -> "bg-primary-700 text-white" | _ -> "text-gray-500 bg-mild-contrast")%>" href="<%s Url.Package.documentation package.name ?version:(Package.url_version package) %>"><%s! Icons.error "" %> No Docs</a>
+              <span aria-label="Documentation status is unknown" class="w-full h-10 flex justify-center gap-2 rounded-r-lg p-1 items-center font-semibold border border-l-0 border-gray-400 <%s (match path with | Documentation _ -> "bg-primary-700 text-white" | _ -> "text-gray-500 bg-mild-contrast")%>"><%s! Icons.error "" %> No Docs</span>
             </li>
             <% )
             | Failure -> ( %>
@@ -169,7 +169,7 @@ Layout.render
     function perform_search() {
       let q = document.getElementById("in-package-search-input").value;
       results = miniSearch.search(q, {
-        fields: ['name', 'prefixname', 'comment'], 
+        fields: ['name', 'prefixname', 'comment'],
         prefix: true,
         boost: {
           name: 6,


### PR DESCRIPTION
Looks like detecting if there's Docs or not could disable the button. Not entirely sure if it's desired, but instead of opening an issue, I changed the template directly.

<img width="557" alt="Screenshot 2023-10-12 at 13 48 48" src="https://github.com/ocaml/ocaml.org/assets/3763599/417797c8-0fde-415c-b5c3-d79bd90c3b21">
