### PR TITLE
Task #1607: Apply New Styles to Package Documentation Module Navigation

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -34,7 +34,7 @@ div.odoc .spec a.anchor {
   position: absolute;
   left: 0;
   top:0.3em;
-  opacity: 1;
+  opacity: 0;
   text-decoration: none;
   color: rgb(156 163 175);
   box-shadow: none;
@@ -47,15 +47,11 @@ div.odoc .spec a.anchor::after {
   padding: 0.6em;
 }
 
-/* div.odoc *:hover > a.anchor {
+ div.odoc *:hover > a.anchor {
   opacity: 1;
 }
 
 div.odoc *:hover > a.anchor:hover {
-  color: rgb(75 85 99);
-} */
-
-div.odoc *>a.anchor {
   color: rgb(75 85 99);
 }
 
@@ -206,11 +202,6 @@ div.odoc .comment-delim {
   cursor: pointer;
 }
 
-/* span.icon-expand:not(.open)>.navmap-tag,
-span.no-expand>.navmap-tag {
-  background: white;
-} */
-
 .navmap-tag {
   display:flex;
   align-items: center;
@@ -285,8 +276,8 @@ span.no-expand>.navmap-tag {
   border-color: rgb(32, 68, 165);
 }
 
-span.icon-expand>.navmap-tag,
-span.no-expand>.navmap-tag {
+span.icon-expand > .navmap-tag,
+span.no-expand > .navmap-tag {
   color: white;
 }
 
@@ -300,6 +291,7 @@ div.nav-expand::before {
   position: absolute;
   margin: 3px 0 3px;
   margin-left: -0.65rem;
+  border-radius: 30px;
 }
 
 .xref-unresolved {

--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -47,7 +47,7 @@ div.odoc .spec a.anchor::after {
   padding: 0.6em;
 }
 
- div.odoc *:hover > a.anchor {
+div.odoc *:hover > a.anchor {
   opacity: 1;
 }
 

--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -285,10 +285,6 @@ span.no-expand>.navmap-tag {
   border-color: rgb(32, 68, 165);
 }
 
-span.no-expand > .navmap-tag {
-  margin-left: 12px;
-}
-
 span.icon-expand>.navmap-tag,
 span.no-expand>.navmap-tag {
   color: white;

--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -34,7 +34,7 @@ div.odoc .spec a.anchor {
   position: absolute;
   left: 0;
   top:0.3em;
-  opacity: 0;
+  opacity: 1;
   text-decoration: none;
   color: rgb(156 163 175);
   box-shadow: none;
@@ -47,11 +47,15 @@ div.odoc .spec a.anchor::after {
   padding: 0.6em;
 }
 
-div.odoc *:hover > a.anchor {
+/* div.odoc *:hover > a.anchor {
   opacity: 1;
 }
 
 div.odoc *:hover > a.anchor:hover {
+  color: rgb(75 85 99);
+} */
+
+div.odoc *>a.anchor {
   color: rgb(75 85 99);
 }
 
@@ -60,6 +64,7 @@ div.odoc *:hover > a.anchor:hover {
 div.odoc .spec:target {
   background: rgb(255, 248, 206);
 }
+
 div.odoc .anchored:target,
 div.odoc h1:target,
 div.odoc h2:target,
@@ -187,7 +192,7 @@ div.odoc .comment-delim {
 
 /* package explorer navmap and breadcrumb tag */
 
-.navmap:hover ul {
+.navmap ul {
   border-color: gainsboro;
 }
 
@@ -201,9 +206,10 @@ div.odoc .comment-delim {
   cursor: pointer;
 }
 
-span.icon-expand:not(.open) > .navmap-tag , span.no-expand > .navmap-tag {
-  background:white;
-}
+/* span.icon-expand:not(.open)>.navmap-tag,
+span.no-expand>.navmap-tag {
+  background: white;
+} */
 
 .navmap-tag {
   display:flex;
@@ -227,19 +233,23 @@ span.icon-expand:not(.open) > .navmap-tag , span.no-expand > .navmap-tag {
 .navmap-tag.library-tag::after {
   content: "lib";
 }
+
 .library-tag {
   color: rgb(91, 102, 114);
   background-color: rgb(91, 102, 114);
   border-color: rgb(91, 102, 114);
 }
+
 .navmap-tag.module-tag::after {
   content: "M";
 }
+
 .module-tag {
   color: #cc4e0c;
   background-color: #cc4e0c;
   border-color: #cc4e0c;
 }
+
 .navmap-tag.module-type-tag::after {
   content: "Mt";
 }
@@ -248,6 +258,7 @@ span.icon-expand:not(.open) > .navmap-tag , span.no-expand > .navmap-tag {
   background-color: #027491;
   border-color: #027491;
 }
+
 .navmap-tag.parameter-tag::after {
   content: "P";
 }
@@ -264,6 +275,7 @@ span.icon-expand:not(.open) > .navmap-tag , span.no-expand > .navmap-tag {
   background-color: rgb(163, 34, 34);
   border-color: rgb(163, 34, 34);
 }
+
 .navmap-tag.class-type-tag::after {
   content: "Ct";
 }
@@ -277,26 +289,43 @@ span.no-expand > .navmap-tag {
   margin-left: 12px;
 }
 
-span.icon-expand.open > .navmap-tag {
-  color:white;
+span.icon-expand>.navmap-tag,
+span.no-expand>.navmap-tag {
+  color: white;
 }
 
-span.icon-expand::before {
-  font-weight: bold;
-  content: " \25B8";
-  text-align: center;
-  box-sizing: border-box;
-  display:flex;
+div.nav-expand::before {
+  content: "";
+  display: flex;
   align-items: center;
-  padding-right:4px;
-}
-
-span.icon-expand.open::before {
-  content: " \25BE";
+  background-color: #cc4e0c;
+  height: 22px;
+  width: 2px;
+  position: absolute;
+  margin: 3px 0 3px;
+  margin-left: -0.65rem;
 }
 
 .xref-unresolved {
   text-decoration: underline;
   font-weight: 700;
   color: gray;
+}
+
+span.arrow-expand.open {
+  color: #cc4e0c;
+  transform: rotate(180deg);
+}
+
+span.sign-expand::before {
+  content: " \002B";
+  display: flex;
+  align-items: center;
+  font-size: 1.25rem;
+  margin-top: -0.25rem;
+}
+
+span.sign-expand.open::before {
+  content: " \2212";
+  color: #cc4e0c;
 }

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -117,7 +117,7 @@ let render
       </a>
     <ul>
       <% maptoc |> List.iter begin fun item -> %>
-      <li>
+      <li class="pl-0.5">
         <%s! nested_render ~path item %>
       </li>
       <% end; %>

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -48,7 +48,7 @@ let rec nested_render ~path (item : toc) =
       | v :: _ -> v
       | [] -> ""
     in
-    let active_style = if item.title = fragment then "bg-gray-200 border-gray-500 font-medium" else "border-transparent" in
+    let active_style = if item.title = fragment then "bg-gray-200 font-medium" else "border-transparent" in
     if fragment != "" && item.kind = Library && fragment != item.title then "" else
     <div class="box-border border <%s active_style %> pl-1 ml-1">
       <div class="flex flex-nowrap" title="<%s kind_title item.kind ^ " " ^ item.title %>">
@@ -72,23 +72,27 @@ let rec nested_render ~path (item : toc) =
       | v :: _ -> (item.kind = Library && (List.length item.children <= 2), [], v)
       | [] -> (item.kind = Library && (List.length item.children <= 2), [], "")
     in
-    let active_style = if item.title = fragment then (if List.length path = 0 then "bg-gray-200 border-gray-500 font-medium" else "border-transparent bg-gray-100 font-medium") else "border-transparent" in
+    let active_style = if item.title = fragment then (if List.length path = 0 then "bg-gray-200 font-medium" else "border-transparent bg-gray-100 font-medium") else "border-transparent" in
     <div x-data="{ open: <%s if default_open then "true" else "false" %> }">
-      <div class="box-border border <%s active_style %> cursor-pointer ml-1 pl-1">
+      <div class="box-border border <%s active_style %> cursor-pointer pl-1 ml-1"  :class="open ? 'nav-expand' : ''">
         <div class="flex flex-nowrap" title="<%s kind_title item.kind ^ " " ^ item.title %>">
           <span class="icon-expand" x-on:click="open = ! open" :class="open ? 'open' : ''" >
             <span class="<%s if item.title = fragment then "" else "opacity-80" %> <%s icon_style item.kind %>"></span>
           </span>
           <% (match item.href with | None -> %>
-            <span x-on:click="open = ! open" class="<%s title_style %> <%s if item.title = fragment then "white-200" else "gray-900" %>"><%s! item.title %></span>
+            <span x-on:click="open = ! open" class="<%s title_style %> <%s if item.title = fragment then "white-200" else "gray-900" %>" :class="open ? 'text-primary-600' : ''">
+              <%s! item.title %> 
+              <span class="arrow-expand absolute right-0.5" :class="open ? 'open' : ''"><%s! Icons.chevron_down "h-5 w-5" %></span>
+            </span>
           <% | Some href -> %>
-          <a href="<%s href %>" <%s! htmx_attributes %> class="<%s title_style %> overflow-hidden truncate text-default transition-colors hover:text-primary-600">
+          <a href="<%s href %>" <%s! htmx_attributes %> class="<%s title_style %> overflow-hidden truncate text-default transition-colors hover:text-primary-600" :class="open ? 'text-primary-600' : ''">
             <%s! item.title %>
           </a>
+          <span x-on:click="open = ! open" class="sign-expand mr-1" :class="open ? 'open' : ''"></span>
           <% ); %>
         </div>
       </div>
-      <ul x-show="open" class="ml-1 border-l border-white transition-colors">
+      <ul x-show="open" class="ml-2.5 border-l border-white transition-colors">
         <% children |> List.iter begin fun item -> %>
           <li>
             <%s! nested_render ~path item %>
@@ -124,11 +128,11 @@ let render
   <% | _ -> %>
     <div class="py-24">
     Legend:<br>
-    <span class="<%s icon_style Library %>" style="display:inline-block;background-color:white"></span>Library<br>
-    <span class="<%s icon_style Module %>" style="display:inline-block;background-color:white"></span>Module<br>
-    <span class="<%s icon_style Module_type %>" style="display:inline-block;background-color:white"></span>Module type<br>
-    <span class="<%s icon_style Parameter %>" style="display:inline-block;background-color:white"></span>Parameter<br>
-    <span class="<%s icon_style Class %>" style="display:inline-block;background-color:white"></span>Class<br>
-    <span class="<%s icon_style Class_type %>" style="display:inline-block;background-color:white"></span>Class type
+    <span class="<%s icon_style Library %>" style="display:inline-block;color:white"></span>Library<br>
+    <span class="<%s icon_style Module %>" style="display:inline-block;color:white"></span>Module<br>
+    <span class="<%s icon_style Module_type %>" style="display:inline-block;color:white"></span>Module type<br>
+    <span class="<%s icon_style Parameter %>" style="display:inline-block;color:white"></span>Parameter<br>
+    <span class="<%s icon_style Class %>" style="display:inline-block;color:white"></span>Class<br>
+    <span class="<%s icon_style Class_type %>" style="display:inline-block;color:white"></span>Class type
     </div>
   <% ); %>

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -82,13 +82,13 @@ let rec nested_render ~path (item : toc) =
           <% (match item.href with | None -> %>
             <span x-on:click="open = ! open" class="<%s title_style %> <%s if item.title = fragment then "white-200" else "gray-900" %>" :class="open ? 'text-primary-600' : ''">
               <%s! item.title %> 
-              <span class="arrow-expand absolute right-0.5" :class="open ? 'open' : ''"><%s! Icons.chevron_down "h-5 w-5" %></span>
+              <span class="arrow-expand absolute right-0.5 px-3" :class="open ? 'open' : ''"><%s! Icons.chevron_down "h-5 w-5" %></span>
             </span>
           <% | Some href -> %>
           <a href="<%s href %>" <%s! htmx_attributes %> class="<%s title_style %> overflow-hidden truncate text-default transition-colors hover:text-primary-600" :class="open ? 'text-primary-600' : ''">
             <%s! item.title %>
           </a>
-          <span x-on:click="open = ! open" class="sign-expand mr-1" :class="open ? 'open' : ''"></span>
+          <span x-on:click="open = ! open" class="sign-expand mr-2 px-2" :class="open ? 'open' : ''"></span>
           <% ); %>
         </div>
       </div>


### PR DESCRIPTION
Resolves #1607

This PR addresses issue #1607, focusing on applying new style to Package Documentation Module Navigation of the OCaml.org website. [Here's a Figma reference design](https://www.figma.com/file/J0w4b9exaHhVpvabKoGqTn/Design-Github-Issues?type=design&node-id=27%3A136&mode=design&t=KUzqK4w2r2nJuXGF-1). 

## Screenshots of New Style

![Doc Ocaml 1](https://github.com/ocaml/ocaml.org/assets/34880491/4ffd4e33-26f1-4a6a-84ba-e05dff05f5df)

![Doc Ocaml 3](https://github.com/ocaml/ocaml.org/assets/34880491/11c7306e-3d6f-45f6-9a9c-9a52a98d4e62)


Please review the changes and let me know if any further adjustments are needed. Thank you!