### PR TITLE
Fix constructor name for variant examples

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -518,7 +518,7 @@ val http_status_code : http_response -> int = <fun>
     match range with
     | All -> true
     | Current -> 0 <= cur && cur < page_count
-    | Range (lo, hi) -> 0 <= lo && lo <= hi && hi < page_count
+    | Range (lo, hi) -> 0 <= lo && lo <= hi && hi < page_count;;
 val is_printable : int -> int -> page_range -> bool = <fun>
 ```
 

--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -511,7 +511,7 @@ val colour_to_rgb : primary_colour -> int * int * int = <fun>
 # let http_status_code response =
     match response with
     | Data _ -> 200
-    | Error code -> code;;
+    | Error_code code -> code;;
 val http_status_code : http_response -> int = <fun>
 
 # let is_printable page_count cur range =


### PR DESCRIPTION
This PR fixes constructor name used in an example showcasing pattern matching with variants.
Previous example uses the constructor `Error_code` for type `http_response`, so this makes it consistent across examples.