### PR TITLE
Provide valid Dune link, clarify ocaml-lsp-server in "Installing OCaml" Doc

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -144,7 +144,7 @@ Now that we've successfully installed the OCaml compiler and the opam package ma
 
 - [UTop](https://github.com/ocaml-community/utop), a modern interactive toplevel (REPL: Read-Eval-Print Loop)
 - [Dune](https://dune.build), a fast and full-featured build system
-- [`ocaml-lsp-server`](https://github.com/ocaml/ocaml-lsp) which implements the Language Server Protocol to enable editor support for OCaml, e.g. in VS Code, Vim, or Emacs. Under the hood, it uses [Merlin](https://ocaml.github.io/merlin/).
+- [`ocaml-lsp-server`](https://github.com/ocaml/ocaml-lsp) implements the Language Server Protocol to enable editor support for OCaml, e.g., in VS Code, Vim, or Emacs. Under the hood, it uses [Merlin](https://ocaml.github.io/merlin/).
 - [`odoc`](https://github.com/ocaml/odoc) to generate documentation from OCaml code
 - [OCamlFormat](https://opam.ocaml.org/packages/ocamlformat/) to automatically format OCaml code
 

--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -143,14 +143,14 @@ To learn more about Diskuv OCaml, see the [official Diskuv OCaml documentation](
 Now that we've successfully installed the OCaml compiler and the opam package manager, let's install some of the [OCaml Platform tools](https://ocaml.org/docs/platform), which you'll need to get the full developer experience in OCaml:
 
 - [UTop](https://github.com/ocaml-community/utop), a modern interactive toplevel (REPL: Read-Eval-Print Loop)
-- [Dune](https://dune.readthedocs.io/en/stable/~), a fast and full-featured build system
-- [Merlin](https://ocaml.github.io/merlin/) and [`ocaml-lsp-server`](https://github.com/ocaml/ocaml-lsp). Power tools for VS Code, Vim, or Emacs
+- [Dune](https://dune.build), a fast and full-featured build system
+- [`ocaml-lsp-server`](https://github.com/ocaml/ocaml-lsp) which implements the Language Server Protocol to enable editor support for OCaml, e.g. in VS Code, Vim, or Emacs. Under the hood, it uses [Merlin](https://ocaml.github.io/merlin/).
 - [`odoc`](https://github.com/ocaml/odoc) to generate documentation from OCaml code
 - [OCamlFormat](https://opam.ocaml.org/packages/ocamlformat/) to automatically format OCaml code
 
 All these tools can be installed using a single command:
 ```shell
-$ opam install dune merlin ocaml-lsp-server odoc ocamlformat utop
+$ opam install dune ocaml-lsp-server odoc ocamlformat utop
 ```
 
 You're now all set and ready to start hacking.


### PR DESCRIPTION
- Dune link to readthedocs.io would 404
- with `ocaml-lsp-server` seemingly becoming the default way to have editor support for OCaml, it should probably listed first - Merlin doesn't need to be explicitly installed as it comes as a dependency of `ocaml-lsp-server`.