### PR TITLE
metaprogramming_tutorial_example_issue

### DIFF
--- a/data/tutorials/language/3mt_04_metaprogramming.md
+++ b/data/tutorials/language/3mt_04_metaprogramming.md
@@ -21,21 +21,20 @@ preprocessor](https://github.com/ocaml-ppx/ppxlib/tree/main/examples/simple-exte
 
 <!-- $MDX skip -->
 ```ocaml
-Printf.printf "This program has been compiled on %s" [%get_env "OSTYPE"]
+Printf.printf "This program has been compiled by user: %s" [%get_env "USER"]
+
 ```
 
-would become:
+When you compile the code with the preprocessor, it will replace [%get_env "USER"] with the content of the USER environment variable. If the USER environment variable is set to "JohnDoe" for example, the line would become:
 
 <!-- $MDX skip -->
 ```ocaml
-Printf.printf "This program has been compiled on %s" "linux-gnu"
+Printf.printf "This program has been compiled on %s" "JohnDoe"
+
 ```
 
 
-At compile time, the preprocessor would replace `[%get_env "OSTYPE"]` by a
-string with the content of the `OSTYPE` environment variable. Note that this
-happens at _compile time_, so at _run time_ the value of the `OSTYPE` variable
-would have no effect.
+With this modification, the preprocessor will replace [%get_env "USER"] with the content of the USER environment variable during compile time, and this code should work on most systems without any additional configuration.At compile time, the preprocessor would replace [%get_env "USER"] by a string with the content of the USER environment variable, which usually contains the username of the person compiling the program. This happens at compile time, so at runtime, the value of the USER variable would have no effect, as it's used purely for informational purposes in the compiled program.
 
 In this guide, we explain the different mechanism behind preprocessors in OCaml,
 with as few prerequisite as possible. If you are only interested in how to use a

--- a/data/tutorials/language/3mt_04_metaprogramming.md
+++ b/data/tutorials/language/3mt_04_metaprogramming.md
@@ -29,7 +29,7 @@ When you compile the code with the preprocessor, it will replace [%get_env "USER
 
 <!-- $MDX skip -->
 ```ocaml
-Printf.printf "This program has been compiled on %s" "JohnDoe"
+Printf.printf "This program has been compiled by user: %s" "JohnDoe"
 
 ```
 

--- a/data/tutorials/language/3mt_04_metaprogramming.md
+++ b/data/tutorials/language/3mt_04_metaprogramming.md
@@ -34,7 +34,7 @@ Printf.printf "This program has been compiled on %s" "JohnDoe"
 ```
 
 
-With this modification, the preprocessor will replace [%get_env "USER"] with the content of the USER environment variable during compile time, and this code should work on most systems without any additional configuration.At compile time, the preprocessor would replace [%get_env "USER"] by a string with the content of the USER environment variable, which usually contains the username of the person compiling the program. This happens at compile time, so at runtime, the value of the USER variable would have no effect, as it's used purely for informational purposes in the compiled program.
+With this modification, the preprocessor will replace [%get_env "USER"] with the content of the USER environment variable during compile time, and this code should work on most systems without any additional configuration. At compile time, the preprocessor would replace [%get_env "USER"] by a string with the content of the USER environment variable, which usually contains the username of the person compiling the program. This happens at compile time, so at runtime, the value of the USER variable would have no effect, as it's used purely for informational purposes in the compiled program.
 
 In this guide, we explain the different mechanism behind preprocessors in OCaml,
 with as few prerequisite as possible. If you are only interested in how to use a


### PR DESCRIPTION
I have made the relevant changes to this issue .With this modification, the preprocessor will replace [%get_env "USER"] with the content of the USER environment variable during compile time, and this code should work on most systems without any additional configuration . Kindly review @christinerose 