### PR TITLE
Add link to english edition of the book

### DIFF
--- a/data/books/developpement-d-applications-avec-objective-caml.md
+++ b/data/books/developpement-d-applications-avec-objective-caml.md
@@ -14,6 +14,8 @@ isbn: "2-84177-121-0"
 links:
   - description: Read Online
     uri: https://www-apr.lip6.fr/~chaillou/Public/DA-OCAML/
+  - description: English Edition
+    uri: https://caml.inria.fr/pub/docs/oreilly-book/
   - description: Order at Amazon.fr
     uri: https://www.amazon.fr/exec/obidos/ASIN/2841771210
 featured: false


### PR DESCRIPTION
**Description:**
This task involves adding a direct link to the English translation of "Développement d'applications avec Objective Caml" on the OCaml website. The translated resource can be found at [caml.inria.fr/pub/docs/oreilly-book](https://caml.inria.fr/pub/docs/oreilly-book/).

**External link:**
You can check out [this link](https://github.com/ocaml/ocaml.org/issues/1632) for more info on the issue that prompted the creation of this task.