### PR TITLE
Fix search bar misplacement on medium-sized screens

### DIFF
--- a/data/books/developpement-d-applications-avec-objective-caml.md
+++ b/data/books/developpement-d-applications-avec-objective-caml.md
@@ -14,6 +14,8 @@ isbn: "2-84177-121-0"
 links:
   - description: Read Online
     uri: https://www-apr.lip6.fr/~chaillou/Public/DA-OCAML/
+  - description: English Edition
+    uri: https://caml.inria.fr/pub/docs/oreilly-book/
   - description: Order at Amazon.fr
     uri: https://www.amazon.fr/exec/obidos/ASIN/2841771210
 featured: false

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -15,7 +15,7 @@ Layout.render
                 class="flex justify-center flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-auto lg:w-auto mt-16">
                 <form
                   <%s! Packages_autocomplete_fragment.form_attributes %>
-                  action="/packages/search" method="GET" class="flex flex-col justify-center"
+                  action="/packages/search" method="GET" class="flex flex-col items-center"
                   >
 
                   <%s! Forms.search_input
@@ -23,7 +23,7 @@ Layout.render
                     ~label:"Search OCaml packages"
                     ~button_attrs:{|type="submit"|}
                     ~input_attrs:(Packages_autocomplete_fragment.input_attributes ~target_sel:"#packages-search-results" ~indicator_sel:"#packages-search-indicator")
-                    "md:w-96 lg:w-[32rem] xl:w-[32rem]"
+                    "w-full md:w-96 lg:w-[32rem] xl:w-[32rem]"
                     %>
 
                   <div>


### PR DESCRIPTION

**Description:**

This pull request addresses the issue of misaligned search bar placement on medium-sized screens. The improvements made here enhance the responsiveness of the search bar, ensuring a more consistent user experience across various screen sizes.

**Changes Made:**

- Replaced the `justify-center` class with `items-center` within a `flex-col` context, rectifying the alignment of the search bar.
- Added a default width attribute (`w-full`) to ensure correct sizing on smaller screens while maintaining responsiveness.

**Screenshots:**
| Before | After |
|--------|-------|
| ![before](https://github.com/ocaml/ocaml.org/assets/68381641/b0e27cff-d8e6-4da8-bbbb-927a6d5ed6d4) | ![after](https://github.com/ocaml/ocaml.org/assets/68381641/356af7d3-c719-4111-b658-087098f95f93) |

**Related Issue:**

You can check out [this link](https://github.com/ocaml/ocaml.org/issues/1661) for more info on the issue that prompted the creation of this task.

