### PR TITLE
Fix horizontal scrolling on ocaml ecosystem sec

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -27,7 +27,7 @@ body {
 }
 
 .container-fluid {
-  @apply max-w-7xl w-full mx-auto px-4;
+  @apply max-w-md md:max-w-7xl w-full mx-auto px-4;
 }
 
 @media (min-width: 40em) {

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -17,6 +17,7 @@ let render
 ~(lts_release: Data.Release.t)
 =
 Layout.render
+~use_swiper:true
 ~title:"Welcome to a World of OCaml"
 ~description:"OCaml is a general-purpose, industrial-strength programming language with an emphasis on expressiveness and safety."
 ~canonical:"" @@
@@ -453,3 +454,14 @@ Layout.render
     </div>
   </div>
 </div>
+<script>
+  var swiper = new Swiper(".mySwiper", {
+    loop: true,
+    autoplay: { delay: 5000, disableOnInteraction: false, },
+    slidesPerView: 'auto',
+    spaceBetween: 10,
+    thumbs: {
+      swiper: swiper,
+    },
+  });
+</script>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -298,7 +298,7 @@ Layout.render
     </div>
   </div>
  
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 py-16 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 py-16 md:gap-4 md:px-10 lg:px-20 relative">
     <%s! package_card
       ~href:"https://mirage.io/"
       ~img_path:"img/home/mirage.png"

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -298,7 +298,7 @@ Layout.render
     </div>
   </div>
  
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mx-auto max-w-md md:max-w-none gap-6 md:gap-4 py-8 px-4 md:px-10 lg:px-20 relative">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 w-11/12 mx-auto max-w-md md:max-w-none gap-6 md:gap-4 py-8 px-1 md:px-2 lg:px-2 xl:px-8 relative">
     <%s! package_card
       ~href:"https://mirage.io/"
       ~img_path:"img/home/mirage.png"

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -1,6 +1,6 @@
 let package_card ~href ~img_path ~name description =
   <a href="<%s href %>" target="_blank"
-    class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-6 rounded-xl items-center flex card-hover">
+    class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-4 rounded-xl flex gap-2 items-center card-hover">
       <div class="w-4/12">
         <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2">
       </div>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -1,6 +1,6 @@
 let package_card ~href ~img_path ~name description =
   <a href="<%s href %>" target="_blank"
-    class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-4 rounded-xl flex gap-2 items-center card-hover">
+    class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-4 rounded-xl flex md:gap-2 items-center card-hover">
       <div class="w-4/12">
         <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2 md:w-2/3">
       </div>
@@ -298,7 +298,7 @@ Layout.render
     </div>
   </div>
  
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-4 py-8 px-4 md:px-10 lg:px-20 relative">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mx-auto max-w-md md:max-w-none gap-6 md:gap-4 py-8 px-4 md:px-10 lg:px-20 relative">
     <%s! package_card
       ~href:"https://mirage.io/"
       ~img_path:"img/home/mirage.png"

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -2,8 +2,10 @@ let package_card ~href ~img_path ~name description =
   <a href="<%s href %>" target="_blank"
     class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-6 rounded-xl items-center flex card-hover">
     <div class="flex items-center">
-      <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-4/12 md:w-1/2">
-      <div class="flex-col px-6">
+      <div class="w-4/12">
+        <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2">
+      </div>
+      <div class="flex-col px-6 w-8/12">
         <div class="text-base font-semibold"><%s name %></div>
         <div class="font-normal text-xs mt-1">
           <%s description %>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -2,7 +2,7 @@ let package_card ~href ~img_path ~name description =
   <a href="<%s href %>" target="_blank"
     class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-6 rounded-xl items-center flex card-hover">
     <div class="flex items-center">
-      <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo">
+      <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-4/12 md:w-1/2">
       <div class="flex-col px-6">
         <div class="text-base font-semibold"><%s name %></div>
         <div class="font-normal text-xs mt-1">
@@ -17,7 +17,6 @@ let render
 ~(lts_release: Data.Release.t)
 =
 Layout.render
-~use_swiper:true
 ~title:"Welcome to a World of OCaml"
 ~description:"OCaml is a general-purpose, industrial-strength programming language with an emphasis on expressiveness and safety."
 ~canonical:"" @@
@@ -298,8 +297,8 @@ Layout.render
       </div>
     </div>
   </div>
-  <div class="grid grid-cols-4 gap-6 py-16 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16"
-    style="width: 1500px">
+ 
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 py-16 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16">
     <%s! package_card
       ~href:"https://mirage.io/"
       ~img_path:"img/home/mirage.png"
@@ -455,14 +454,3 @@ Layout.render
     </div>
   </div>
 </div>
-<script>
-  var swiper = new Swiper(".mySwiper", {
-    loop: true,
-    autoplay: { delay: 5000, disableOnInteraction: false, },
-    slidesPerView: 'auto',
-    spaceBetween: 10,
-    thumbs: {
-      swiper: swiper,
-    },
-  });
-</script>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -4,7 +4,7 @@ let package_card ~href ~img_path ~name description =
       <div class="w-4/12">
         <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2 md:w-2/3">
       </div>
-      <div class="flex-col px-6 w-8/12">
+      <div class="flex-col w-8/12">
         <div class="text-base font-semibold"><%s name %></div>
         <div class="font-normal text-xs mt-1">
           <%s description %>
@@ -298,7 +298,7 @@ Layout.render
     </div>
   </div>
  
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-4 py-16 px-4 md:px-10 lg:px-20 relative">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-4 py-8 px-4 md:px-10 lg:px-20 relative">
     <%s! package_card
       ~href:"https://mirage.io/"
       ~img_path:"img/home/mirage.png"

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -298,9 +298,7 @@ Layout.render
       </div>
     </div>
   </div>
-  <!-- FIXME: remove text-default here after all the package cards are using the component -->
-  <div class="text-default w-11/12 m-auto pl-7 md:pl-0 md:w-screen overflow-y-hidden md:overflow-hidden py-16 flex flex-col items-center">
-   
+  <div class="text-default w-11/12 m-auto pl-7 md:pl-0 md:w-screen overflow-y-hidden md:overflow-hidden py-16 flex flex-col items-center">  
       <div class="grid grid-cols-4 gap-6 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16"
         style="width: 1500px">
         <%s! package_card
@@ -308,59 +306,44 @@ Layout.render
           ~img_path:"img/home/mirage.png"
           ~name:"MirageOS"
           "Library operating system to construct unikernels" %>
-
-           <%s! package_card
+        <%s! package_card
           ~href:"https://mirage.io/"
           ~img_path:"img/home/js_of_ocaml.png"
           ~name:"Js_of_ocaml"
           "Compiler from OCaml to Javascript." %>
-
-           <%s! package_card
+        <%s! package_card
           ~href:"https://erratique.ch/software/cmdliner"
           ~img_path:"img/home/cmdliner.png"
           ~name:"Cmdliner"
           "Declarative definition of command line interfaces for OCaml" %>
-
-             <%s! package_card
+        <%s! package_card
           ~href:"https://irmin.org/"
           ~img_path:"img/home/irmin.png"
           ~name:"Irmin"
           "Distributed database that follows the same design principles as Git" %>
-
-        <!-- placeholder for Dune-->
-           <%s! package_card
+        <%s! package_card
           ~href:"https://dune.build/"
           ~img_path:"img/home/dune.png"
           ~name:"Dune"
           "A composable build system for OCaml" %>
-
-                  <!-- placeholder for Lwt-->
-           <%s! package_card
+        <%s! package_card
           ~href:"https://ocsigen.org/lwt/latest/manual/manual"
           ~img_path:"img/home/lwt.png"
           ~name:"Lwt"
           "OCaml promises and concurrent IO" %>
-
-           <!-- placeholder for Owl-->
-           <%s! package_card
+        <%s! package_card
           ~href:"https://ocaml.xyz/"
           ~img_path:"img/home/owl.png"
           ~name:"Owl"
           "OCaml Scientific and Engineering Computing" %>
-
-        <!-- placeholder for Dream-->
-           <%s! package_card
+        <%s! package_card
           ~href:"https://aantron.github.io/dream/"
           ~img_path:"img/home/dream.png"
           ~name:"Dream"
           "Tidy Web framework for OCaml and ReasonML" %>
-        <!-- FIXME: package_card component -->
-      </div>
-    
+      </div>  
   </div>
 </div>
-
-
 <div class="py-28 bg-default dark:bg-dark-default">
   <div class="container-fluid">
     <div class="text-center px-15">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -296,51 +296,50 @@ Layout.render
         </div>
       </div>
     </div>
-  </div>
- 
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 w-11/12 mx-auto max-w-md md:max-w-none gap-6 md:gap-4 py-8 px-1 md:px-2 lg:px-2 xl:px-8 relative">
-    <%s! package_card
-      ~href:"https://mirage.io/"
-      ~img_path:"img/home/mirage.png"
-      ~name:"MirageOS"
-      "Library operating system to construct unikernels" %>
-    <%s! package_card
-      ~href:"https://mirage.io/"
-      ~img_path:"img/home/js_of_ocaml.png"
-      ~name:"Js_of_ocaml"
-      "Compiler from OCaml to Javascript." %>
-    <%s! package_card
-      ~href:"https://erratique.ch/software/cmdliner"
-      ~img_path:"img/home/cmdliner.png"
-      ~name:"Cmdliner"
-      "Declarative definition of command line interfaces for OCaml" %>
-    <%s! package_card
-      ~href:"https://irmin.org/"
-      ~img_path:"img/home/irmin.png"
-      ~name:"Irmin"
-      "Distributed database that follows the same design principles as Git" %>
-    <%s! package_card
-      ~href:"https://dune.build/"
-      ~img_path:"img/home/dune.png"
-      ~name:"Dune"
-      "A composable build system for OCaml" %>
-    <%s! package_card
-      ~href:"https://ocsigen.org/lwt/latest/manual/manual"
-      ~img_path:"img/home/lwt.png"
-      ~name:"Lwt"
-      "OCaml promises and concurrent IO" %>
-    <%s! package_card
-      ~href:"https://ocaml.xyz/"
-      ~img_path:"img/home/owl.png"
-      ~name:"Owl"
-      "OCaml Scientific and Engineering Computing" %>
-    <%s! package_card
-      ~href:"https://aantron.github.io/dream/"
-      ~img_path:"img/home/dream.png"
-      ~name:"Dream"
-      "Tidy Web framework for OCaml and ReasonML" %>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-4 py-8 px-1 md:px-2 lg:px-2 xl:px-8 relative">
+      <%s! package_card
+        ~href:"https://mirage.io/"
+        ~img_path:"img/home/mirage.png"
+        ~name:"MirageOS"
+        "Library operating system to construct unikernels" %>
+      <%s! package_card
+        ~href:"https://mirage.io/"
+        ~img_path:"img/home/js_of_ocaml.png"
+        ~name:"Js_of_ocaml"
+        "Compiler from OCaml to Javascript." %>
+      <%s! package_card
+        ~href:"https://erratique.ch/software/cmdliner"
+        ~img_path:"img/home/cmdliner.png"
+        ~name:"Cmdliner"
+        "Declarative definition of command line interfaces for OCaml" %>
+      <%s! package_card
+        ~href:"https://irmin.org/"
+        ~img_path:"img/home/irmin.png"
+        ~name:"Irmin"
+        "Distributed database that follows the same design principles as Git" %>
+      <%s! package_card
+        ~href:"https://dune.build/"
+        ~img_path:"img/home/dune.png"
+        ~name:"Dune"
+        "A composable build system for OCaml" %>
+      <%s! package_card
+        ~href:"https://ocsigen.org/lwt/latest/manual/manual"
+        ~img_path:"img/home/lwt.png"
+        ~name:"Lwt"
+        "OCaml promises and concurrent IO" %>
+      <%s! package_card
+        ~href:"https://ocaml.xyz/"
+        ~img_path:"img/home/owl.png"
+        ~name:"Owl"
+        "OCaml Scientific and Engineering Computing" %>
+      <%s! package_card
+        ~href:"https://aantron.github.io/dream/"
+        ~img_path:"img/home/dream.png"
+        ~name:"Dream"
+        "Tidy Web framework for OCaml and ReasonML" %>
   </div>  
-
+    
+  </div>
 </div>
 <div class="py-28 bg-default dark:bg-dark-default">
   <div class="container-fluid">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -298,51 +298,50 @@ Layout.render
       </div>
     </div>
   </div>
-  <div class="text-default w-11/12 m-auto pl-7 md:pl-0 md:w-screen overflow-y-hidden md:overflow-hidden py-16 flex flex-col items-center">  
-      <div class="grid grid-cols-4 gap-6 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16"
-        style="width: 1500px">
-        <%s! package_card
-          ~href:"https://mirage.io/"
-          ~img_path:"img/home/mirage.png"
-          ~name:"MirageOS"
-          "Library operating system to construct unikernels" %>
-        <%s! package_card
-          ~href:"https://mirage.io/"
-          ~img_path:"img/home/js_of_ocaml.png"
-          ~name:"Js_of_ocaml"
-          "Compiler from OCaml to Javascript." %>
-        <%s! package_card
-          ~href:"https://erratique.ch/software/cmdliner"
-          ~img_path:"img/home/cmdliner.png"
-          ~name:"Cmdliner"
-          "Declarative definition of command line interfaces for OCaml" %>
-        <%s! package_card
-          ~href:"https://irmin.org/"
-          ~img_path:"img/home/irmin.png"
-          ~name:"Irmin"
-          "Distributed database that follows the same design principles as Git" %>
-        <%s! package_card
-          ~href:"https://dune.build/"
-          ~img_path:"img/home/dune.png"
-          ~name:"Dune"
-          "A composable build system for OCaml" %>
-        <%s! package_card
-          ~href:"https://ocsigen.org/lwt/latest/manual/manual"
-          ~img_path:"img/home/lwt.png"
-          ~name:"Lwt"
-          "OCaml promises and concurrent IO" %>
-        <%s! package_card
-          ~href:"https://ocaml.xyz/"
-          ~img_path:"img/home/owl.png"
-          ~name:"Owl"
-          "OCaml Scientific and Engineering Computing" %>
-        <%s! package_card
-          ~href:"https://aantron.github.io/dream/"
-          ~img_path:"img/home/dream.png"
-          ~name:"Dream"
-          "Tidy Web framework for OCaml and ReasonML" %>
-      </div>  
-  </div>
+  <div class="grid grid-cols-4 gap-6 py-16 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16"
+    style="width: 1500px">
+    <%s! package_card
+      ~href:"https://mirage.io/"
+      ~img_path:"img/home/mirage.png"
+      ~name:"MirageOS"
+      "Library operating system to construct unikernels" %>
+    <%s! package_card
+      ~href:"https://mirage.io/"
+      ~img_path:"img/home/js_of_ocaml.png"
+      ~name:"Js_of_ocaml"
+      "Compiler from OCaml to Javascript." %>
+    <%s! package_card
+      ~href:"https://erratique.ch/software/cmdliner"
+      ~img_path:"img/home/cmdliner.png"
+      ~name:"Cmdliner"
+      "Declarative definition of command line interfaces for OCaml" %>
+    <%s! package_card
+      ~href:"https://irmin.org/"
+      ~img_path:"img/home/irmin.png"
+      ~name:"Irmin"
+      "Distributed database that follows the same design principles as Git" %>
+    <%s! package_card
+      ~href:"https://dune.build/"
+      ~img_path:"img/home/dune.png"
+      ~name:"Dune"
+      "A composable build system for OCaml" %>
+    <%s! package_card
+      ~href:"https://ocsigen.org/lwt/latest/manual/manual"
+      ~img_path:"img/home/lwt.png"
+      ~name:"Lwt"
+      "OCaml promises and concurrent IO" %>
+    <%s! package_card
+      ~href:"https://ocaml.xyz/"
+      ~img_path:"img/home/owl.png"
+      ~name:"Owl"
+      "OCaml Scientific and Engineering Computing" %>
+    <%s! package_card
+      ~href:"https://aantron.github.io/dream/"
+      ~img_path:"img/home/dream.png"
+      ~name:"Dream"
+      "Tidy Web framework for OCaml and ReasonML" %>
+  </div>  
+
 </div>
 <div class="py-28 bg-default dark:bg-dark-default">
   <div class="container-fluid">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -1,7 +1,6 @@
 let package_card ~href ~img_path ~name description =
   <a href="<%s href %>" target="_blank"
     class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-6 rounded-xl items-center flex card-hover">
-    <div class="flex items-center">
       <div class="w-4/12">
         <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2">
       </div>
@@ -11,7 +10,6 @@ let package_card ~href ~img_path ~name description =
           <%s description %>
         </div>
       </div>
-    </div>
   </a>
   
 let render

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -2,7 +2,7 @@ let package_card ~href ~img_path ~name description =
   <a href="<%s href %>" target="_blank"
     class="bg-default dark:bg-dark-default text-default dark:text-dark-default p-4 rounded-xl flex gap-2 items-center card-hover">
       <div class="w-4/12">
-        <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2">
+        <img src="<%s Ocamlorg_static.Asset.url img_path %>" alt="<%s name %> logo" class="w-1/2 md:w-2/3">
       </div>
       <div class="flex-col px-6 w-8/12">
         <div class="text-base font-semibold"><%s name %></div>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -298,7 +298,7 @@ Layout.render
     </div>
   </div>
  
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 py-16 md:gap-4 md:px-10 lg:px-20 relative">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-4 py-16 px-4 md:px-10 lg:px-20 relative">
     <%s! package_card
       ~href:"https://mirage.io/"
       ~img_path:"img/home/mirage.png"

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -298,10 +298,9 @@ Layout.render
       </div>
     </div>
   </div>
-
   <!-- FIXME: remove text-default here after all the package cards are using the component -->
   <div class="text-default w-11/12 m-auto pl-7 md:pl-0 md:w-screen overflow-y-hidden md:overflow-hidden py-16 flex flex-col items-center">
-    <div class="w-full md:w-auto">
+   
       <div class="grid grid-cols-4 gap-6 md:gap-4 md:px-10 lg:px-20 relative left-5 lg:left-28 md:left-16"
         style="width: 1500px">
         <%s! package_card
@@ -309,104 +308,59 @@ Layout.render
           ~img_path:"img/home/mirage.png"
           ~name:"MirageOS"
           "Library operating system to construct unikernels" %>
-        <!-- FIXME: package_card component -->
-        <a href="http://ocsigen.org/js_of_ocaml/latest/manual/overview" target="_blank"
-          class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/js_of_ocaml.png" %>" alt="Js_of_ocaml logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Js_of_ocaml</div>
-              <div class="font-normal text-xs mt-1">
-                Compiler from OCaml to Javascript.
-              </div>
-            </div>
-          </div>
-        </a>
-        <!-- FIXME: package_card component -->
-        <a href="https://erratique.ch/software/cmdliner" target="_blank"
-          class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/cmdliner.png" %>" alt="Cmdliner logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Cmdliner</div>
-              <div class="font-normal text-xs mt-1">
-                Declarative definition of command line interfaces for OCaml
-              </div>
-            </div>
-          </div>
-        </a>
-        <!-- FIXME: package_card component -->
-        <a href="https://irmin.org/" target="_blank"
-          class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/irmin.png" %>" alt="Irmin logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Irmin</div>
-              <div class="font-normal text-xs mt-1">
-                Distributed database that follows the same design principles as Git
-              </div>
-            </div>
-          </div>
-        </a>
-      </div>
 
-      <div class="grid grid-cols-4 gap-6 md:gap-4 md:px-10 lg:px-20 mt-6 relative right-5 lg:right-28 md:right-16"
-        style="width: 1500px">
+           <%s! package_card
+          ~href:"https://mirage.io/"
+          ~img_path:"img/home/js_of_ocaml.png"
+          ~name:"Js_of_ocaml"
+          "Compiler from OCaml to Javascript." %>
+
+           <%s! package_card
+          ~href:"https://erratique.ch/software/cmdliner"
+          ~img_path:"img/home/cmdliner.png"
+          ~name:"Cmdliner"
+          "Declarative definition of command line interfaces for OCaml" %>
+
+             <%s! package_card
+          ~href:"https://irmin.org/"
+          ~img_path:"img/home/irmin.png"
+          ~name:"Irmin"
+          "Distributed database that follows the same design principles as Git" %>
+
+        <!-- placeholder for Dune-->
+           <%s! package_card
+          ~href:"https://dune.build/"
+          ~img_path:"img/home/dune.png"
+          ~name:"Dune"
+          "A composable build system for OCaml" %>
+
+                  <!-- placeholder for Lwt-->
+           <%s! package_card
+          ~href:"https://ocsigen.org/lwt/latest/manual/manual"
+          ~img_path:"img/home/lwt.png"
+          ~name:"Lwt"
+          "OCaml promises and concurrent IO" %>
+
+           <!-- placeholder for Owl-->
+           <%s! package_card
+          ~href:"https://ocaml.xyz/"
+          ~img_path:"img/home/owl.png"
+          ~name:"Owl"
+          "OCaml Scientific and Engineering Computing" %>
+
+        <!-- placeholder for Dream-->
+           <%s! package_card
+          ~href:"https://aantron.github.io/dream/"
+          ~img_path:"img/home/dream.png"
+          ~name:"Dream"
+          "Tidy Web framework for OCaml and ReasonML" %>
         <!-- FIXME: package_card component -->
-        <a href="https://dune.build/" target="_blank"
-          class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/dune.png" %>" alt="Dune logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Dune</div>
-              <div class="font-normal text-xs mt-1">
-                A composable build system for OCaml
-              </div>
-            </div>
-          </div>
-        </a>
-        <!-- FIXME: package_card component -->
-        <a href="https://ocsigen.org/lwt/latest/manual/manual" target="_blank"
-          class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/lwt.png" %>" alt="Lwt logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Lwt</div>
-              <div class="font-normal text-xs mt-1">
-                OCaml promises and concurrent IO
-              </div>
-            </div>
-          </div>
-        </a>
-        <!-- FIXME: package_card component -->
-        <a href="https://ocaml.xyz/" target="_blank" class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/owl.png" %>" alt="Owl logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Owl</div>
-              <div class="font-normal text-xs mt-1">
-                OCaml Scientific and Engineering Computing
-              </div>
-            </div>
-          </div>
-        </a>
-        <!-- FIXME: package_card component -->
-        <a href="https://aantron.github.io/dream/" target="_blank"
-          class="bg-default dark:bg-dark-default p-6 rounded-xl items-center flex card-hover">
-          <div class="flex items-center">
-            <img src="<%s Ocamlorg_static.Asset.url "img/home/dream.png" %>" alt="Dream logo">
-            <div class="flex-col px-6">
-              <div class="text-base font-semibold">Dream</div>
-              <div class="font-normal text-xs mt-1">
-                Tidy Web framework for OCaml and ReasonML
-              </div>
-            </div>
-          </div>
-        </a>
       </div>
-    </div>
+    
   </div>
 </div>
+
+
 <div class="py-28 bg-default dark:bg-dark-default">
   <div class="container-fluid">
     <div class="text-center px-15">


### PR DESCRIPTION
Resolves #819

This PR fixes this issue #819 . 
It:
- removes the swiper as it is no longer needed
- displays the cards in a single column on small screens and in 2 columns on mid sized screens
- uses the pre-existing package_card function to render the cards
- removes unnecessary tailwind classes and extra unused markup
- add padding on x axis on mobile screens
- improves alignment within the card containing the package image and description

Attached a screenshot of the results below:

![Screenshot 2023-10-17 at 12 41 03](https://github.com/ocaml/ocaml.org/assets/67555014/76ff3bbd-be02-4a06-ab16-4efd7bbed6b4)
![Screenshot 2023-10-17 at 12 43 41](https://github.com/ocaml/ocaml.org/assets/67555014/2b9e7c60-a651-4050-8855-5bf3cc88445a)
