### PR TITLE
Add Capability to Recommend Follow-Up Tutorials on Tutorials

### DIFF
--- a/data/tutorials/recommendation/recommendation-test.md
+++ b/data/tutorials/recommendation/recommendation-test.md
@@ -1,5 +1,4 @@
-tutorils:
-
+tutorials:
   - title: "tutorial1"
     slug: "to be added"
     recommended_next_tutorials: 

--- a/data/tutorials/recommendation/recommendation-test.md
+++ b/data/tutorials/recommendation/recommendation-test.md
@@ -1,0 +1,7 @@
+tutorils:
+
+  - title: "tutorial1"
+    slug: "to be added"
+    recommended_next_tutorials: 
+      -tutorial2 
+      -tutorial3

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -40,4 +40,5 @@ Learn_layout.render
   <div class="prose prose-orange max-w-full">
     <%s! tutorial.body_html %>
     <%s! Learn_components.contribute_footer ~href:("https://github.com/ocaml/ocaml.org/blob/"^ Commit.hash ^"/data/"^ tutorial.fpath) %>
+    (* To add to recommendation here *)
   </div>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -40,5 +40,5 @@ Learn_layout.render
   <div class="prose prose-orange max-w-full">
     <%s! tutorial.body_html %>
     <%s! Learn_components.contribute_footer ~href:("https://github.com/ocaml/ocaml.org/blob/"^ Commit.hash ^"/data/"^ tutorial.fpath) %>
-    (* To add to recommendation here *)
+    (* CHORE: To add to recommendation here *)
   </div>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -368,10 +368,17 @@ let tutorial req =
     Data.Tutorial.all
     |> List.filter (fun (t : Data.Tutorial.t) -> t.section = tutorial.section)
   in
+  let recommended_tutorials =
+    Data.Tutorial.all
+    |> List.filter (fun (t : Data.Tutorial.t) ->
+           List.mem slug t.recommended_next_tutorials)
+  in
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials
        ~canonical:(Url.tutorial tutorial.slug)
-       tutorial)
+       ~recommended:recommended_tutorials tutorial)
+(* Chore: handle the error *)
+(* |> None -> *)
 
 let exercises req =
   let all_exercises = Data.Exercise.all in

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -18,6 +18,7 @@ type metadata = {
   title : string;
   description : string;
   category : string;
+  recommended_next_tutorials : string list;
 }
 [@@deriving of_yaml]
 
@@ -31,6 +32,7 @@ type t = {
   toc : toc list;
   body_md : string;
   body_html : string;
+  recommended_next_tutorials : string list;
 }
 [@@deriving
   stable_record ~version:metadata ~add:[ id ]


### PR DESCRIPTION
Resolves #1589

This Pull Request aims to solve the "Add Capability to Recommend Follow-Up Tutorials on Tutorials #1589" https://github.com/ocaml/ocaml.org/issues/1589  medium task issue for application of the GUI project.

I  encountered an issue writing filter that should recommend the next tutorial- the slug to recommend the tutorial. Your Input would be greatly appreciated Thanks
@sabine  
cc @gpetiot 
