### PR TITLE
Fix function types in tour of ocaml pattern matching continued section

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -400,7 +400,7 @@ In this other example, the same comparison is made, using `if … then … else 
   else if x = "baz" then 3
   else if x = "qux" then 4
   else 0;;
-val g : int -> string = <fun>
+val g : string -> int = <fun>
 
 # let g' x = match x with
     | "foo" -> 1
@@ -408,7 +408,7 @@ val g : int -> string = <fun>
     | "baz" -> 3
     | "qux" -> 4
     | _ -> 0;;
-val g' : int -> string = <fun>
+val g' : string -> int = <fun>
 ```
 
 The underscore symbol is a catch-all pattern; it matches with anything.


### PR DESCRIPTION
## Details

Minor issue in types on the following getting started section: https://ocaml.org/docs/tour-of-ocaml#pattern-matching-contd.

Sorry if these kinds of problems are meant to go through a different process, if this is more of a bug I can create an issue instead, or whatever is most appropriate.

## Testing

Validated types are correct in ocaml REPL:

```
# let g x =
  if x = "foo" then 1
  else if x = "bar" then 2
  else if x = "baz" then 3
  else if x = "qux" then 4
  else 0;;
val g : string -> int = <fun>
```

```
# let g' x = match x with
    | "foo" -> 1
    | "bar" -> 2
    | "baz" -> 3
    | "qux" -> 4
    | _ -> 0;;
val g' : string -> int = <fun>
```
