### PR TITLE
Package Search UX Improvements

### DIFF
--- a/asset/opensearch.xml
+++ b/asset/opensearch.xml
@@ -1,0 +1,6 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<ShortName>OCaml Packages</ShortName>
+<Description>Search for packages on ocaml.org</Description>
+<Image type="image/png">https://ocaml.org/asset/logo.svg</Image>
+<Url type="text/html" method="get" template="https://ocaml.org/packages/search?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/src/ocamlorg_frontend/components/header.eml
+++ b/src/ocamlorg_frontend/components/header.eml
@@ -30,8 +30,8 @@ in
 <header
   class="h-20 flex items-center bg-mild-contrast dark:bg-dark-mild-contrast"
   x-data="{ open: false }">
-  <nav class="container-fluid wide header flex justify-between items-center">
-    <ul class="space space-x-5 xl:space-x-8 items-center flex text-lighter font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
+  <nav class="container-fluid wide header flex justify-between items-center gap-5 xl:gap-8">
+    <ul class="order-1 space space-x-5 xl:space-x-8 items-center flex text-lighter font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
       <li style="width:132px">
         <a href="<%s Url.index %>" class="block pb-2">
           <img src="<%s Ocamlorg_static.Asset.url "logo-with-name.svg" %>" width="132" alt="OCaml logo" class="dark:hidden">
@@ -39,14 +39,7 @@ in
         </a>
       </li>
     </ul>
-    <ul class="ml-5 xl:ml-8 mr-auto items-center hidden lg:flex font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
-      <li><%s! menu_link ~active:(active_top_nav_item=Some Learn) ~href:Url.learn ~title:"Learn" () %></li>
-      <li><%s! menu_link ~active:(active_top_nav_item=Some Packages) ~href:Url.packages ~title:"Packages" () %></li>
-      <li><%s! menu_link ~active:(active_top_nav_item=Some Community) ~href:Url.community ~title:"Community" () %></li>
-      <li><%s! menu_link ~active:(active_top_nav_item=Some Blog) ~href:Url.blog ~title:"Blog" () %></li>
-      <li><%s! menu_link ~active:(active_top_nav_item=Some Playground) ~href:Url.playground ~title:"Playground" () %></li>
-    </ul>
-    <ul class="hidden lg:flex items-center space-x-4 xl:space-x-8">
+    <ul class="order-3 hidden lg:flex items-center">
       <li>
         <form
           <%s! Packages_autocomplete_fragment.form_attributes %>
@@ -61,10 +54,19 @@ in
           %>
         </form>
       </li>
-      <% if show_get_started then (%>
-        <li><a href="<%s Url.getting_started %>" class="btn btn-secondary btn-sm">Get Started</a></li>
-      <% ); %>
     </ul>
+    <ul class="order-2 mr-auto items-center hidden lg:flex font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
+      <li><%s! menu_link ~active:(active_top_nav_item=Some Learn) ~href:Url.learn ~title:"Learn" () %></li>
+      <li><%s! menu_link ~active:(active_top_nav_item=Some Packages) ~href:Url.packages ~title:"Packages" () %></li>
+      <li><%s! menu_link ~active:(active_top_nav_item=Some Community) ~href:Url.community ~title:"Community" () %></li>
+      <li><%s! menu_link ~active:(active_top_nav_item=Some Blog) ~href:Url.blog ~title:"Blog" () %></li>
+      <li><%s! menu_link ~active:(active_top_nav_item=Some Playground) ~href:Url.playground ~title:"Playground" () %></li>
+    </ul>
+    <% if show_get_started then (%>
+    <ul class="order-4 hidden lg:flex items-center">
+      <li><a href="<%s Url.getting_started %>" class="btn btn-secondary btn-sm">Get Started</a></li>
+    </ul>
+    <% ); %>
     <ul class="lg:hidden flex items-center">
       <li
         class="h-12 w-12 hover:bg-primary-100 flex items-center justify-center rounded-full text-lighter dark:text-white">

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -49,6 +49,7 @@ inner =
       <link rel="alternate" type="application/rss+xml" title="OCaml RSS Feed" href="/feed.xml">
       <script src="<%s Ocamlorg_static.Asset.url "vendors/swiper-bundle.min.js" %>"></script>
       <% ); %>
+      <link rel="search" href="<%s Ocamlorg_static.Open_search.manifest %>" type="application/opensearchdescription+xml" title="OCaml">
       <title><%s title %></title>
     </head>
 

--- a/src/ocamlorg_frontend/layouts/package_layout.eml
+++ b/src/ocamlorg_frontend/layouts/package_layout.eml
@@ -77,6 +77,7 @@ Layout.base
           <div class="flex w-full items-center overflow-hidden">
             <% if Option.is_some search_index_digest then (%>
               <input id="in-package-search-input" type="search" name="q" class="min-w-0 focus:border-gray-800 text-gray-800 border-primary-600 h-10 rounded-l-md appearance-none px-4 flex-grow"
+                tabindex="1"
                 autocomplete="off"
                 aria-owns="in-package-search-results"
                 aria-expanded="false"

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -119,3 +119,6 @@ let render ~total ~search ~page ~number_of_pages (packages : Package.package lis
     </div>
   </div>
 </div>
+<script>
+  document.querySelector("main input[type=search]").focus()
+</script>

--- a/src/ocamlorg_static/ocamlorg_static.ml
+++ b/src/ocamlorg_static/ocamlorg_static.ml
@@ -1,5 +1,9 @@
 let of_url_path = File.of_url_path
 
+module Open_search = struct
+  let manifest = "/opensearch.xml"
+end
+
 module Media = struct
   let url_root = "/media"
   let digest = Media.hash


### PR DESCRIPTION
Hello ocaml fam 👋🏼 – i had a moment and i figured i'd pitch y'all some ux improvements that would make package search a little more comfortable :)

Let me know what you think and ofc happy to answer any questions and do any tweaks.

### Fix dynamic search results wobblynes


https://github.com/ocaml/ocaml.org/assets/854222/52cb2dfb-e1ec-4b9e-928f-85e27e5255d1



### Make Search Bars the first focused or focusable element

In the top-level search pages, we'd like the Search bar to be already in focus by the time we land. Most people go to packages to search for packages, and this is the default behavior in many package registries (crates.io, rubygems.org, cocoapods.org, pkg.go.dev, etc).

https://github.com/ocaml/ocaml.org/assets/854222/a68b1663-8cee-4beb-877a-f48f05c27a33

### When to show the Search Bar

First, the package search is great, but it doesn't need to be shown twice in any page, so I've made it configurable and removed it from the core search pages.

<img width="1302" alt="Screenshot 2023-10-20 at 07 03 39" src="https://github.com/ocaml/ocaml.org/assets/854222/918596b9-8043-4660-8598-03a8d70b878d">
<img width="1302" alt="Screenshot 2023-10-20 at 07 03 57" src="https://github.com/ocaml/ocaml.org/assets/854222/eb03c945-ccf6-473c-9a79-ce34c4cf5f9f">

It is however still available on the slide-over menu: 
<img width="949" alt="Screenshot 2023-10-20 at 07 04 25" src="https://github.com/ocaml/ocaml.org/assets/854222/edbc6724-82b5-4c5a-b974-9142a8ab85a2">

### OpenSearch integration

I've also added a small manifest file to allow browsers to show a `Search OCaml Packages` action when someone is typing `ocaml.org` on their browser. This is in the same spirit as Crates.io and other websites use, to make it easier to jump to the search.