### PR TITLE
An update to the odoc 2.3.0 release announcement

### DIFF
--- a/data/changelog/odoc/2023-10-02-odoc-2.3.0.md
+++ b/data/changelog/odoc/2023-10-02-odoc-2.3.0.md
@@ -30,26 +30,6 @@ changelog: |
 
 We are thrilled to announce the release of odoc 2.3.0! 🎉 This release is the result of almost a year of diligent work from the odoc team since the last major release of odoc 2.2.0, it comes packed with significant new features and improvements!
 
-## 🗺️ Background & Roadmap
-
-Before we delve into the feature highlights, some background on our roadmap and what comes next.
-
-The lack of access to comprehensive documentation for OCaml libraries is one of the biggest pain points reported by the OCaml community, as highlighted in the [2022 OCaml survey](https://ocaml-sf.org/docs/2022/ocaml-user-survey-2022.pdf) (c.f. Q50).
-
-This motivated the odoc and OCaml.org teams to jointly work on a centralised package documentation, that [went live in April 2022](https://discuss.ocaml.org/t/v3-ocaml-org-we-are-live/9747), as part of the new version of OCaml.org.
-
-With documentation for OCaml libraries [readily available on OCaml.org](https://ocaml.org/packages), we now turn our focus on making sure that library authors have the tooling they need to create high-quality documentation.
-
-Our [roadmap](https://github.com/ocaml/odoc/blob/master/ROADMAP.md) highlights some features we believe will make the generated documentation significantly better for readers, and documentation-writing much more pleasant and rewarding.
-
-This release is a significant milestone in implementing the features on our roadmap and is the precursor to a series of upcoming releases. Odoc 2.4.0 will follow shortly and will bring support for search. Stay tuned and follow our progress through the [OCaml Platform newsletter](https://discuss.ocaml.org/tag/platform-newsletter)!
-
-## 🤝 Join Our Mission
-
-While we are dedicated to developing the best tooling to generate and serve documentation on OCaml.org, creating a well-documented library ecosystem can only be a collective effort. Package authors: we're working hard to give you great tools, but we'll need all your help to create an ecosystem of well-documented libraries for OCaml!
-
-If you find that writing documentation for your library isn't as straightforward as you would like, please do share your feedback with us.
-
 ## 🌟 Spotlight Features of Odoc 2.3.0
 
 Here are a couple of the new features introduced in Odoc 2.3.0 that we'd like to highlight.
@@ -105,3 +85,23 @@ have a preview of the feature by going to the odoc API website, which was built
 with the feature enabled. For instance, the Odoc_html 19 module is now populated
 with many Source links, jumping right into the implementation file 5! Directory
 pages to browser the implementation are also included 8 :smiley:
+
+## 🗺️ Background & Roadmap
+
+Some background on our roadmap and what comes next.
+
+The lack of access to comprehensive documentation for OCaml libraries is one of the biggest pain points reported by the OCaml community, as highlighted in the [2022 OCaml survey](https://ocaml-sf.org/docs/2022/ocaml-user-survey-2022.pdf) (c.f. Q50).
+
+This motivated the odoc and OCaml.org teams to jointly work on a centralised package documentation, that [went live in April 2022](https://discuss.ocaml.org/t/v3-ocaml-org-we-are-live/9747), as part of the new version of OCaml.org.
+
+With documentation for OCaml libraries [readily available on OCaml.org](https://ocaml.org/packages), we now turn our focus on making sure that library authors have the tooling they need to create high-quality documentation.
+
+Our [roadmap](https://github.com/ocaml/odoc/blob/master/ROADMAP.md) highlights some features we believe will make the generated documentation significantly better for readers, and documentation-writing much more pleasant and rewarding.
+
+This release is a significant milestone in implementing the features on our roadmap and is the precursor to a series of upcoming releases. Odoc 2.4.0 will follow shortly and will bring support for search. Stay tuned and follow our progress through the [OCaml Platform newsletter](https://discuss.ocaml.org/tag/platform-newsletter)!
+
+## 🤝 Join Our Mission
+
+While we are dedicated to developing the best tooling to generate and serve documentation on OCaml.org, creating a well-documented library ecosystem can only be a collective effort. Package authors: we're working hard to give you great tools, but we'll need all your help to create an ecosystem of well-documented libraries for OCaml!
+
+If you find that writing documentation for your library isn't as straightforward as you would like, please do share your feedback with us.

--- a/data/changelog/odoc/2023-10-02-odoc-2.3.0.md
+++ b/data/changelog/odoc/2023-10-02-odoc-2.3.0.md
@@ -54,48 +54,54 @@ If you find that writing documentation for your library isn't as straightforward
 
 Here are a couple of the new features introduced in Odoc 2.3.0 that we'd like to highlight.
 
-1. **Table Support**
+### Table Support
 
-    Table support is the last addition to the odoc language, and comes with two syntax flavours: a light one, and a
-    heavy one. The light markup is similar to markdown's markup for table,
-    producing tables that are readable in the source file as
-    well.
+Table support is the last addition to the odoc language, and comes with two
+syntax flavours: a light one, and a heavy one. The light markup is similar to
+markdown's markup for table, producing tables that are readable in the source
+file as well.
 
-    However, this markup has some limitation, since it only allows inline
-    content in cells. It can also be difficult to read and mantain for big
-    tables, without a proper editor support. For this reason, Odoc also
-    provides a "heavy" markup, closer to the html one, with fewer limitations!
+However, this markup has some limitation, since it only allows inline content in
+cells. It can also be difficult to read and mantain for big tables, without a
+proper editor support. For this reason, Odoc also provides a "heavy" markup,
+closer to the html one, with fewer limitations!
 
-    Here is a table in heavy, light, and rendered form:
+Here is a table in heavy, light, and rendered form:
 
-    ```
-    {t
-    Table | support
-    ------|--------
-    is    | cool!
-    }
-    ```
-    ```
-    {table
-    {tr {th Table} {th support}}
-    {tr {td is} {td cool!}}
-    }
-    ```
+```
+{t
+Table | support
+------|--------
+is    | cool!
+}
+```
+```
+{table
+{tr {th Table} {th support}}
+{tr {td is} {td cool!}}
+}
+```
 
-    Table | support
-    ------|--------
-    is    | cool!
+Table | support
+------|--------
+is    | cool!
 
-2. **Source Code Rendering**
+### Source Code Rendering
 
-    Source code rendering is an extremely exciting new feature. Not only
-    `odoc` is now able to generate a rendering of the source files (and
-    source hierarchy) of a project, but it is also able to create direct
-    links from the documentation to the implementation!
+Source code rendering is an extremely exciting new feature. Not only odoc is now
+able to generate a rendering of the source files (and source hierarchy) of a
+project, but it is also able to create direct links from the documentation to
+the implementation!
 
-    This puts the documentation browsing to a new level, by helping to
-    quickly answer any implementation-related question!
+This puts the documentation browsing to a new level, by helping to quickly
+answer any implementation-related question!
 
-    The source code rendering is also tailored to OCaml, for instance with
-    links from variables to their definition, something missing from
-    traditional html-based source viewing such as github!
+The source code rendering is also tailored to OCaml, for instance with links
+from variables to their definition, something missing from traditional
+html-based source viewing such as github!
+
+Using this features in odoc’s driver will require some work, but you can already
+have a preview of the feature by going to the odoc API website, which was built
+with the feature enabled. For instance, the Odoc_html 19 module is now populated
+with many Source links, jumping right into the implementation file 5! Directory
+pages to browser the implementation are also included 8 :smiley:


### PR DESCRIPTION
This PR is made of two commits:

- One which adds some links to example for the "render source code" feature. I think it is a nice improvement, since otherwise, there is no way to preview this exciting feature!
- The second one which puts the feature highlights first. I think the roadmap is well explained elsewhere in the site, and that the importance should be given to the changes to odoc!

Feel free to revert the second commit if the current order feels more appropriate to you!