### PR TITLE
Add Blog link in the summer internship post

### DIFF
--- a/data/outreachy.yml
+++ b/data/outreachy.yml
@@ -296,6 +296,7 @@ rounds:
           a publisher-subcriber based server-client model for MIDI messages.
         mentee: "Aryan Godara"
         source: https://github.com/AryanGodara/rtpmidi
+        blog: "https://medium.com/@aryangodara_19887"
         mentors:
         - Claes (rand)
         - Sonja Heinze


### PR DESCRIPTION
I accidentally left out the link to my blog in the Internship post. 