### PR TITLE
added OCaml workshop 2023 to list of workshops

### DIFF
--- a/data/workshops/2023.md
+++ b/data/workshops/2023.md
@@ -1,0 +1,151 @@
+---
+title: OCaml Workshop 2023
+date: 2023-09-09
+location: Seattle, Washington, United States
+important_dates:
+  - date: 2023-06-01
+    info: Abstract submission deadline 
+  - date: 2023-07-06
+    info: Author notification
+  - date: 2023-09-09
+    info: OCaml Workshop
+presentations:
+  - title: "Eio 1.0 – Effects-based IO for OCaml 5"
+    authors:
+      - Thomas Leonard
+      - Patrick Ferris
+      - Christiano Haesbaert 
+      - Lucas Pluvinage
+      - Vesa Karvonen
+      - Sudha Parimala
+      - KC Sivaramakrishnan
+      - Vincent Balat 
+      - Anil Madhavapeddy
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/5/Eio-1-0-Effects-based-IO-for-OCaml-5"
+  - title: "Buck2 for OCaml Users & Developers"
+    authors:
+      - Shayne Fletcher
+      - Neil Mitchell
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/1/Buck2-for-OCaml-Users-Developers"
+  - title: "Building a lock-free STM for OCaml"
+    authors:
+      - Vesa Karvonen
+      - Bartosz Modelski
+      - Carine Morel
+      - Thomas Leonard
+      - KC Sivaramakrishnan
+      - YSS Narasimha Naidu
+      - Sudha Parimala
+    link: "https://polytypic.github.io/kcas-talk/#/5"
+  - title: "Efficient OCaml compilation with Flambda 2"
+    authors:
+      - Pierre Chambart
+      - Vincent LAVIRON
+      - Mark Shinwell
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/8/Efficient-OCaml-compilation-with-Flambda-2"
+  - title: "Flambda 2 Types: An abstract domain for static analysis of functional programs"
+    authors:
+      - Vincent LAVIRON
+      - Pierre Chambart
+      - Mark Shinwell
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/9/Flambda-2-Types-An-abstract-domain-for-static-analysis-of-functional-programs"
+  - title: "Less Power for More Learning: Restricting OCaml Features for Effective Teaching"
+    authors:
+      - Max Lang
+      - Nico Petzendorfer
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/11/Less-Power-for-More-Learning-Restricting-OCaml-Features-for-Effective-Teaching"
+  - title: "MetaOCaml Theory and Implementation"
+    authors:
+      - Oleg Kiselyov
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/3/MetaOCaml-Theory-and-Implementation"
+  - title: "Modern DSL compiler architecture in OCaml our experience with Catala"
+    authors:
+      - Louis Gesbert
+      - Denis Merigoux
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/4/Modern-DSL-compiler-architecture-in-OCaml-our-experience-with-Catala"
+  - title: "Osiris: an Iris-based program logic for OCaml"
+    authors:
+      - Arnaud Daby-Seesaram
+      - François Pottier
+      - Armaël Guéneau
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/7/Osiris-an-Iris-based-program-logic-for-OCaml"
+  - title: "Owi: an interpreter and a toolkit for WebAssembly written in OCaml"
+    authors:
+      - Léo Andrès
+      - Pierre Chambart
+      - Eric Patrizio
+      - Dario Pinto
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/14/Owi-an-interpreter-and-a-toolkit-for-WebAssembly-written-in-OCaml"
+  - title: "Parallel Sequences in Multicore OCaml"
+    authors:
+      - Andrew Tao
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/2/Parallel-Sequences-in-Multicore-OCaml"
+  - title: "Runtime Detection of Data Races in OCaml with ThreadSanitizer"
+    authors:
+      - Olivier Nicole
+      - Fabrice Buoro
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/12/Runtime-Detection-of-Data-Races-in-OCaml-with-ThreadSanitizer"
+  - title: "Safe and efficient generic functions with MacoCaml"
+    authors:
+      - Dmitrij Szamozvancev
+      - Leo White
+      - Ningning Xie
+      - Jeremy Yallop
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/16/Safe-and-efficient-generic-functions-with-MacoCaml"
+  - title: "State of the OCaml Platform 2023"
+    authors:
+      - Thibaut Mattio
+      - Anil Madhavapeddy
+      - Thomas Gazagnaire
+      - David Allsopp
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/15/State-of-the-OCaml-Platform-2023"
+  - title: "Targeted Static Analysis for OCaml C Stubs: Eliminating gremlins from the code"
+    authors:
+      - Edwin Török
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/10/Targeted-Static-Analysis-for-OCaml-C-Stubs-Eliminating-gremlins-from-the-code"
+  - title: "Wasocaml: a compiler from OCaml to WebAssembly"
+    authors:
+      - Léo Andrès
+      - Pierre Chambart
+    link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/13/Wasocaml-a-compiler-from-OCaml-to-WebAssembly"
+organising_committee: []
+program_committee: 
+  - name: Kenichi Asai
+    affiliation: Ochanomizu University 
+  - name: Jonah Beckford
+    affiliation: Diskuv 
+    role: co-chair
+  - name: Raja Boujbel
+    affiliation:  OCamlPro
+  - name: Chris Casinghino
+    affiliation:  Jane Street
+  - name: Nathanaëlle Courant
+    affiliation:  OCamlPro
+  - name: Jacques Garrigue
+    affiliation:  Nagoya University
+  - name: Kiran Gopinathan
+    affiliation:  National University of Singapore
+  - name: Oleg Kiselyov
+    affiliation:  Tohoku University
+  - name: Andrey Mokhov
+    affiliation: Jane Street 
+  - name: Benoît Montagu
+    affiliation:  Inria
+  - name: Sudha Parimala
+    affiliation:  Tarides
+  - name: Matija Pretnar
+    affiliation:  University of Ljubljana, Slovenia
+  - name: Jonathan Protzenko
+    affiliation:  Microsoft Research, Redmond
+  - name: Claude Rubinson
+    affiliation:  University of Houston-Downtown
+  - name: Gabriel Scherer
+    affiliation:  INRIA Saclay
+    role: co-chair
+---
+
+OCaml Workshop 2023 took place during ICFP 2023, in Seattle, Washington, United States.
+
+ACM Sigplan ICFP page: [OCaml Workskop 2023](https://icfp23.sigplan.org/home/ocaml-2023)
+
+The OCaml Users and Developers Workshop brings together the OCaml community, including users of OCaml in industry, academia, hobbyists, and the free software community.

--- a/data/workshops/2023.md
+++ b/data/workshops/2023.md
@@ -10,7 +10,7 @@ important_dates:
   - date: 2023-09-09
     info: OCaml Workshop
 presentations:
-  - title: "Eio 1.0 – Effects-based IO for OCaml 5"
+  - title: "Eio 1.0 – Effects-Based I/O for OCaml 5"
     authors:
       - Thomas Leonard
       - Patrick Ferris
@@ -27,7 +27,7 @@ presentations:
       - Shayne Fletcher
       - Neil Mitchell
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/1/Buck2-for-OCaml-Users-Developers"
-  - title: "Building a lock-free STM for OCaml"
+  - title: "Building a Lock-Free STM for OCaml"
     authors:
       - Vesa Karvonen
       - Bartosz Modelski
@@ -37,13 +37,13 @@ presentations:
       - YSS Narasimha Naidu
       - Sudha Parimala
     link: "https://polytypic.github.io/kcas-talk/#/5"
-  - title: "Efficient OCaml compilation with Flambda 2"
+  - title: "Efficient OCaml Compilation With Flambda 2"
     authors:
       - Pierre Chambart
       - Vincent LAVIRON
       - Mark Shinwell
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/8/Efficient-OCaml-compilation-with-Flambda-2"
-  - title: "Flambda 2 Types: An abstract domain for static analysis of functional programs"
+  - title: "Flambda 2 Types: An Abstract Domain for Static Analysis of Functional Programs"
     authors:
       - Vincent LAVIRON
       - Pierre Chambart
@@ -58,18 +58,18 @@ presentations:
     authors:
       - Oleg Kiselyov
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/3/MetaOCaml-Theory-and-Implementation"
-  - title: "Modern DSL compiler architecture in OCaml our experience with Catala"
+  - title: "Modern DSL Compiler Architecture in OCaml Our Experience With Catala"
     authors:
       - Louis Gesbert
       - Denis Merigoux
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/4/Modern-DSL-compiler-architecture-in-OCaml-our-experience-with-Catala"
-  - title: "Osiris: an Iris-based program logic for OCaml"
+  - title: "Osiris: An Iris-Based Program Logic for OCaml"
     authors:
       - Arnaud Daby-Seesaram
       - François Pottier
       - Armaël Guéneau
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/7/Osiris-an-Iris-based-program-logic-for-OCaml"
-  - title: "Owi: an interpreter and a toolkit for WebAssembly written in OCaml"
+  - title: "Owi: An Interpreter and a Toolkit for WebAssembly Written in OCaml"
     authors:
       - Léo Andrès
       - Pierre Chambart
@@ -85,7 +85,7 @@ presentations:
       - Olivier Nicole
       - Fabrice Buoro
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/12/Runtime-Detection-of-Data-Races-in-OCaml-with-ThreadSanitizer"
-  - title: "Safe and efficient generic functions with MacoCaml"
+  - title: "Safe and Efficient Generic Functions With MacoCaml"
     authors:
       - Dmitrij Szamozvancev
       - Leo White
@@ -103,7 +103,7 @@ presentations:
     authors:
       - Edwin Török
     link: "https://icfp23.sigplan.org/details/ocaml-2023-papers/10/Targeted-Static-Analysis-for-OCaml-C-Stubs-Eliminating-gremlins-from-the-code"
-  - title: "Wasocaml: a compiler from OCaml to WebAssembly"
+  - title: "Wasocaml: A Compiler From OCaml to WebAssembly"
     authors:
       - Léo Andrès
       - Pierre Chambart


### PR DESCRIPTION
Added the OCaml Workshop 2023 to the list of workshops on the community page. Fixes #1688. cc @SaySayo 