### PR TITLE
Fixed js-of-ocaml link on home

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -304,7 +304,7 @@ Layout.render
         ~name:"MirageOS"
         "Library operating system to construct unikernels" %>
       <%s! package_card
-        ~href:"https://mirage.io/"
+        ~href:"https://ocsigen.org/js_of_ocaml"
         ~img_path:"img/home/js_of_ocaml.png"
         ~name:"Js_of_ocaml"
         "Compiler from OCaml to Javascript." %>


### PR DESCRIPTION
Fixes #1704. The Js-of-Ocaml card link on www.ocaml.org lead to mirageOS, added the correct link. cc @SaySayo @sabine 