### PR TITLE
Deprecate OMP as a Platform tool

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -141,7 +141,7 @@ tools:
       This library converts parsetrees, outcometree and ast mappers between
       different OCaml versions. High-level functions help making PPX
       rewriters independent of a compiler version.
-    lifecycle: sustain
+    lifecycle: deprecate
 
   - name: OCamlbuild
     source: https://github.com/ocaml/ocamlbuild


### PR DESCRIPTION
We've deprecated ocaml-migrate-parsetree. We've had the impression that the community is behind it by observing strongly decreased interest in latest compiler support for a while. Now, I've tried to confirm that impression by writing a [discuss post](https://discuss.ocaml.org/t/rfc-deprecating-ocaml-migrate-parsetree-in-favor-of-ppxlib-also-as-a-platform-tool/13240) about deprecating it giving quite some context and asking for potential feedback. Out of the ones who've read it, nobody has objected or commented :)