### PR TITLE
Incorrect Media query of Changelog page for Mobile screen size #1656

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -28,6 +28,7 @@ body {
 
 .container-fluid {
   @apply max-w-7xl w-full mx-auto px-4;
+  word-wrap: break-word;
 }
 
 @media (min-width: 40em) {


### PR DESCRIPTION
Inserted word-wrap attribute in container-fluid class in ~/ocaml.org/src/ocamlorg_frontend/css/styles.css. The word-wrap attribute simply breaks the typography element upon reaching the maximum width of the parent container