### PR TITLE
Introduce word-wrap: break-word to prose class to prevent prose content from overflowing (#1656)

### DIFF
--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -28,7 +28,6 @@ body {
 
 .container-fluid {
   @apply max-w-md md:max-w-7xl w-full mx-auto px-4;
-  word-wrap: break-word;
 }
 
 @media (min-width: 40em) {
@@ -113,6 +112,10 @@ body {
 }
 .output-bg {
     background: rgba(39, 39, 39, 1);
+}
+
+.prose {
+  word-wrap: break-word;
 }
 
 .prose [id] {

--- a/src/ocamlorg_frontend/css/styles.css
+++ b/src/ocamlorg_frontend/css/styles.css
@@ -28,6 +28,7 @@ body {
 
 .container-fluid {
   @apply max-w-md md:max-w-7xl w-full mx-auto px-4;
+  word-wrap: break-word;
 }
 
 @media (min-width: 40em) {


### PR DESCRIPTION
Resolves #1656

I inserted a css attribute "word-wrap: break-word;" in the path ~/ocaml.org/src/ocamlorg_frontend/css/styles.css inside the .container_fluid class to clear the issue of the overflowing page(width) of change log page