### PR TITLE
Packages: Changed the version select dropdown

### DIFF
--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -38,24 +38,56 @@ let render_package_and_version
     | Overview _ -> Url.Package.overview package.name ?version
     | Documentation _ -> Url.Package.documentation package.name ?version ?hash ?page
   in
-  let version_options v =
-    <% if v = package.latest_version then ( %>
-    <option value="<%s url None %>" <%s if package.version = Latest then "selected" else "" %>>
-      <%s "latest (" ^ package.latest_version ^ ")" %>
-    </option>
-    <% ); %>
-    <option value="<%s url (Some v) %>" <%s if package.version = Specific v then "selected" else "" %>>
-      <%s v %>
-    </option>
-  in
-  <div class="flex gap-4">
-    <h1 class="m-0 text-3xl"><span class="sr-only">package </span><a class="font-semibold text-3xl" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a></h1>
-    <select id="version" name="version" aria-label="version" onchange="location = this.value;"
-      class="leading-8 appearance-none cursor-pointer py-0 rounded-md border border-gray-400 pr-8"
-      style="background-position: right 0.25rem center">
-      <%s! package.versions |> List.map version_options |> String.concat "" %>
-    </select>
-  </div>
+   <div class="flex gap-4 justify-center">
+   <h1 class="m-0 text-3xl"><span class="sr-only">package </span><a class="font-semibold text-3xl" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a></h1>     
+     <div
+      x-data="{ open: false, selectedOption: '<%s "latest (" ^ package.latest_version ^ ")" %>', 
+       options: [       
+        <%s! package.versions |> List.map (fun v -> "'" ^ v ^ "'") |> String.concat ", " %>
+      ]
+      }"
+      @click.away="open = false"
+      x-on:keydown.escape.prevent.stop="close($refs.button)"
+      x-on:focusin.window="!$refs.panel.contains($event.target) && close()"
+      class="relative z-30"
+      >
+      <!-- Button -->
+
+
+      <button
+        onclick="this.style.boxShadow = '0 0 1px white'; this.style.borderColor = 'orange';"
+        @click="open = !open"
+        x-ref="button"
+        :aria-expanded="open"
+        type="button"
+        class="flex h-10 items-center gap-2 bg-white p-4  rounded-md shadow
+          leading-8 appearance-none focus:outline-none focus:ring-4  cursor-pointer  rounded-md border border-gray-400"
+      >
+        <span x-text="selectedOption"></span>
+        <!-- Heroicon: chevron-down -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+      </button>
+
+
+      <!-- Panel -->
+      <div
+        x-ref="panel"
+        x-show="open"
+        x-transition.origin.top.left
+        x-on:click.outside="close($refs.button)"
+        class="absolute z-24 w-80 p-4 left-0 mt-2 rounded-md bg-white h-[510px] shadow-md overflow-y-auto"
+      >
+
+        <template x-for="option in options" :key="option">
+          <a href="<%s url None%>"  x-on:click="selectedOption = option; open = false" x-bind:class="{ 'bg-blue-900 text-white': selectedOption === option }" class="flex items-center gap-2 w-full first-of-type:rounded-t-md last-of-type:rounded-b-md px-4 py-2.5 text-left text-sm disabled:text-gray-500">
+            <span x-bind:value="version"  x-text="option"></span>
+          </a>
+        </template>
+      </div>
+      </div>
+      </div>
 
 type breadcrumb = {
   name: string;

--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -40,12 +40,48 @@ let render_package_and_version
   in
    <div class="flex gap-4 justify-center">
    <h1 class="m-0 text-3xl"><span class="sr-only">package </span><a class="font-semibold text-3xl" href="<%s Url.Package.overview package.name ?version %>"><%s package.name %></a></h1>     
-     <div
-      x-data="{ open: false, selectedOption: '<%s "latest (" ^ package.latest_version ^ ")" %>', 
-       options: [       
+     <details
+   x-data="{
+    open: false, 
+    selectedOption: '<%s "latest (" ^ package.latest_version ^ ")" %>',
+    options: [      
         <%s! package.versions |> List.map (fun v -> "'" ^ v ^ "'") |> String.concat ", " %>
-      ]
-      }"
+    ],
+    moveSelection(offset) {
+        const currentIndex = this.options.indexOf(this.selectedOption);
+
+        if (!this.open) {
+            this.open = true;
+        } else {
+            const newIndex = currentIndex + offset;
+
+            if (newIndex >= 0 && newIndex < this.options.length) {
+                this.selectedOption = this.options[newIndex];
+
+                this.$nextTick(() => {
+                    const dropdown = this.$refs.dropdown;
+                    const selectedOptionElement = dropdown.querySelector('.selected');
+
+                    if (selectedOptionElement) {
+                        const isAboveViewport = selectedOptionElement.offsetTop < dropdown.scrollTop;
+                        const isBelowViewport = (selectedOptionElement.offsetTop + selectedOptionElement.offsetHeight) > (dropdown.scrollTop + dropdown.offsetHeight);
+
+                        if (isAboveViewport) {
+                            dropdown.scrollTop = selectedOptionElement.offsetTop;
+                        } else if (isBelowViewport) {
+                            dropdown.scrollTop = selectedOptionElement.offsetTop + selectedOptionElement.offsetHeight - dropdown.offsetHeight;
+                        }
+                    }
+                });
+            }
+        }
+    },
+    closePanel() {
+        this.open = false;
+    }
+
+    }"
+
       @click.away="open = false"
       x-on:keydown.escape.prevent.stop="close($refs.button)"
       x-on:focusin.window="!$refs.panel.contains($event.target) && close()"
@@ -54,7 +90,10 @@ let render_package_and_version
       <!-- Button -->
 
 
-      <button
+      <summary
+      @keydown.arrow-down.prevent="moveSelection(1)"
+        @keydown.arrow-up.prevent="moveSelection(-1)"
+        @keydown.enter.prevent="selectOption(selectedOption)"
         onclick="this.style.boxShadow = '0 0 1px white'; this.style.borderColor = 'orange';"
         @click="open = !open"
         x-ref="button"
@@ -63,31 +102,36 @@ let render_package_and_version
         class="flex h-10 items-center gap-2 bg-white p-4  rounded-md shadow
           leading-8 appearance-none focus:outline-none focus:ring-4  cursor-pointer  rounded-md border border-gray-400"
       >
-        <span x-text="selectedOption"></span>
+        <span x-html="selectedOption"></span>
         <!-- Heroicon: chevron-down -->
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
           <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
-      </button>
+      </summary>
 
 
       <!-- Panel -->
-      <div
-        x-ref="panel"
-        x-show="open"
-        x-transition.origin.top.left
-        x-on:click.outside="close($refs.button)"
-        class="absolute z-24 w-80 p-4 left-0 mt-2 rounded-md bg-white h-[510px] shadow-md overflow-y-auto"
-      >
+     <div
+            x-show="open"
+            @click.away="closePanel"
+            x-ref="dropdown"
+            class="absolute max-h-[500px] z-24 w-80 p-4 overflow-y-auto left-0 mt-2 rounded-md bg-white shadow-md"
+        >
+            <template x-for="(option, index) in options" :key="index">
+                <a  x-bind:href="option" href="#" x-on:click="selectOption(option); closePanel"
+               
+                    x-bind:class="{ 'bg-blue-900 text-white': selectedOption === option, 'selected': selectedOption === option }"
+                    class="focus:outline-none  focus-visible:bg-blue-900 focus-visible:text-white flex items-center gap-2 w-full first-of-type:rounded-t-md last-of-type:rounded-b-md px-4 py-2.5 text-left text-sm disabled:text-gray-500"
+                >
+                    <span x-html=" option"></span>
+                </a>
+                <a href="<%s url None %>"> hi </a>
+            </template>
+        </div>
+      </details>
+      </div>
 
-        <template x-for="option in options" :key="option">
-          <a href="<%s url None%>"  x-on:click="selectedOption = option; open = false" x-bind:class="{ 'bg-blue-900 text-white': selectedOption === option }" class="flex items-center gap-2 w-full first-of-type:rounded-t-md last-of-type:rounded-b-md px-4 py-2.5 text-left text-sm disabled:text-gray-500">
-            <span x-bind:value="version"  x-text="option"></span>
-          </a>
-        </template>
-      </div>
-      </div>
-      </div>
+
 
 type breadcrumb = {
   name: string;


### PR DESCRIPTION
Resolves: https://github.com/ocaml/ocaml.org/issues/1612

This is a PR draft on changing the dropdown for version selection on packages page to continually contribute to the Ocaml task.
Used **`Alpine.js`** for the dropdown

changes made are shown in the screenshot below

- Before
<img width="542" alt="Screenshot 2023-10-30 at 16 12 28" src="https://github.com/ocaml/ocaml.org/assets/87182204/583e455a-ee25-4973-a6a6-b90f7d19137d">

- After
<img width="691" alt="Screenshot 2023-10-30 at 16 11 49" src="https://github.com/ocaml/ocaml.org/assets/87182204/ea389c21-27c0-4c86-8077-1681cf771020">

Changes yet to be made

- Links to each version are yet to be updated

- Web Content Accessibility Guidelines (WCAG) have not been checked yet.