### PR TITLE
Add spacing below "See All Releases" button

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -263,7 +263,7 @@ Layout.render
     </div>
   </div>
 </div>
-<div class="bg-default pt-12 lg:py-12 overflow-hidden">
+<div class="bg-default py-12 overflow-hidden">
   <div class="container-fluid flex flex-col items-center">
     <h3 class="font-bold">Releases</h3>
     <div class="bg-pattern p-6 mt-8 rounded-xl w-full lg:w-2/3 text-white">


### PR DESCRIPTION
Closes #1738 

This PR:
- Adds padding on the bottom of the section to match the one given at the top
- Removes unnecessary media condition on padding keeping the padding similar on smaller screens

Screenshots showcasing the diff:

Before: 

![Screenshot 2023-11-01 at 19 28 29](https://github.com/ocaml/ocaml.org/assets/67555014/f608458c-a82c-4164-b1fc-f703e85c8c77)

After:

![Screenshot 2023-11-01 at 23 42 07](https://github.com/ocaml/ocaml.org/assets/67555014/339af2de-c5cb-43b1-8036-b37bd8bac0b6)

