### PR TITLE
Set background color on learn tabs select el

### DIFF
--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -48,7 +48,7 @@ let tabs
               <span> <%s! Icons.chevron_right "w-3 h-3 ml-2" %> </span> </a>
         </li>
         <li class="inline-block">
-            <select onchange="location = this.value;" class="appearance-none bg-transparent border-2 border-b-4 bg-none font-bold border-none w-auto p-0 m-0 cursor-pointer focus:outline-none focus:ring-0">
+            <select onchange="location = this.value;" class="appearance-none bg-text-title border-2 border-b-4 bg-none font-bold border-none w-auto p-0 m-0 cursor-pointer focus:outline-none focus:ring-0">
              <%s! sections |> List.map options_list |> String.concat "" %>
             </select>
             <span class="text-orange-700 cursor-pointer">&#x25BE;</span>


### PR DESCRIPTION
Before this patch in Chromium:
![image](https://github.com/ocaml/ocaml.org/assets/6594573/a6f40403-4d29-4936-8a42-424c3882201c)
(select options appear with white text on white background)

After this patch:
![image](https://github.com/ocaml/ocaml.org/assets/6594573/4c016187-3746-4738-abec-1f36f201ee97)
(background of select options is the same as learn tabs background)