### PR TITLE
Link exercises to turorials

### DIFF
--- a/data/exercises/001_tail.md
+++ b/data/exercises/001_tail.md
@@ -4,7 +4,7 @@ number: "1"
 difficulty: beginner
 tags: [ "list" ]
 description: "Write a function that returns the last element of a list."
-tutorials: [ "data-types", "functionnal-programming"]
+tutorials: [ "lists"]
 ---
 
 # Solution

--- a/data/exercises/001_tail.md
+++ b/data/exercises/001_tail.md
@@ -4,6 +4,7 @@ number: "1"
 difficulty: beginner
 tags: [ "list" ]
 description: "Write a function that returns the last element of a list."
+tutorials: [ "data-types", "functionnal-programming"]
 ---
 
 # Solution

--- a/data/exercises/002_tail_penultimate.md
+++ b/data/exercises/002_tail_penultimate.md
@@ -4,6 +4,7 @@ number: "2"
 difficulty: beginner
 tags: [ "list" ]
 description: "Find the last and penultimate elements of a list."
+tutorials: [ "data-types", "functionnal-programming"]
 ---
 
 # Solution

--- a/data/exercises/002_tail_penultimate.md
+++ b/data/exercises/002_tail_penultimate.md
@@ -4,7 +4,7 @@ number: "2"
 difficulty: beginner
 tags: [ "list" ]
 description: "Find the last and penultimate elements of a list."
-tutorials: [ "data-types", "functionnal-programming"]
+tutorials: [ "lists"]
 ---
 
 # Solution

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -165,6 +165,7 @@ module Exercise : sig
     description : string;
     statement : string;
     solution : string;
+    tutorials : string list option;
   }
 
   val all : t list

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -24,9 +24,23 @@ let of_tutorial_section (s: Data.Tutorial.Section.t) =
   | Platform -> Learn_layout.Platform
   | Guides -> Learn_layout.Guides
 
+let render_related_exercises exercises =
+  if List.length exercises > 0 then
+    <div class='related-exercises'>
+      <h3>Related exercises :</h3>
+      <ul>
+        <% exercises |> List.iter (fun (exercise : Data.Exercise.t) -> %>
+          <li><a href='/exercises#<%s exercise.number %>'><%s exercise.title %></a></li>
+        <% ); %>
+      </ul>
+    </div>
+  else
+    ""
+
 let render
 (tutorial : Data.Tutorial.t)
 ~tutorials
+~related_exercises
 ~canonical
 =
 Learn_layout.render
@@ -39,5 +53,6 @@ Learn_layout.render
 ~current:(of_tutorial_section tutorial.section) @@
   <div class="prose prose-orange max-w-full">
     <%s! tutorial.body_html %>
+    <%s! render_related_exercises related_exercises %>
     <%s! Learn_components.contribute_footer ~href:("https://github.com/ocaml/ocaml.org/blob/"^ Commit.hash ^"/data/"^ tutorial.fpath) %>
   </div>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -385,9 +385,18 @@ let tutorial req =
     Data.Tutorial.all
     |> List.filter (fun (t : Data.Tutorial.t) -> t.section = tutorial.section)
   in
+  let all_exercises = Data.Exercise.all in
+  let related_exercises =
+    List.filter (fun (e : Data.Exercise.t) ->
+      match e.tutorials with
+      | Some tutorials_list -> List.mem slug tutorials_list
+      | None -> false
+    ) all_exercises
+  in
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials
        ~canonical:(Url.tutorial tutorial.slug)
+       ~related_exercises
        tutorial)
 
 let exercises req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -387,17 +387,17 @@ let tutorial req =
   in
   let all_exercises = Data.Exercise.all in
   let related_exercises =
-    List.filter (fun (e : Data.Exercise.t) ->
-      match e.tutorials with
-      | Some tutorials_list -> List.mem slug tutorials_list
-      | None -> false
-    ) all_exercises
+    List.filter
+      (fun (e : Data.Exercise.t) ->
+        match e.tutorials with
+        | Some tutorials_list -> List.mem slug tutorials_list
+        | None -> false)
+      all_exercises
   in
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials
        ~canonical:(Url.tutorial tutorial.slug)
-       ~related_exercises
-       tutorial)
+       ~related_exercises tutorial)
 
 let exercises req =
   let all_exercises = Data.Exercise.all in

--- a/tool/ood-gen/lib/exercise.ml
+++ b/tool/ood-gen/lib/exercise.ml
@@ -17,6 +17,7 @@ type metadata = {
   difficulty : Proficiency.t;
   tags : string list;
   description : string;
+  tutorials : string list option;
 }
 [@@deriving of_yaml]
 
@@ -55,6 +56,7 @@ type t = {
   description : string;
   statement : string;
   solution : string;
+  tutorials : string list option;
 }
 [@@deriving
   stable_record ~version:metadata ~remove:[ statement; solution ],
@@ -88,6 +90,7 @@ type t =
   ; description : string
   ; statement : string
   ; solution : string
+  ; tutorials : string list option;
   }
   
 let all = %a


### PR DESCRIPTION
Related to issue #1562 

I've just added the `tutorials` field to the types `metadata` and `t` to open the draft PR. This is a WIP.