### PR TITLE
Reduce the number of News in the Blog page

### DIFF
--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -246,7 +246,11 @@ let blog req =
          Data.Planet.Post.all)
   in
   let featured = Data.Planet.featured_posts |> List.take 3 in
-  let news = Data.News.all |> List.take 20 in
+  let number_of_news =
+    List.length featured + List.length current_items
+    |> float_of_int |> ( *. ) 1.2 |> int_of_float
+  in
+  let news = Data.News.all |> List.take number_of_news in
   Dream.html
     (Ocamlorg_frontend.blog ~featured ~planet:current_items ~planet_page:page
        ~planet_pages_number:number_of_pages ~news)

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -248,7 +248,7 @@ let blog req =
   let featured = Data.Planet.featured_posts |> List.take 3 in
   let number_of_news =
     List.length featured + List.length current_items
-    |> float_of_int |> ( *. ) 1.2 |> int_of_float
+    |> float_of_int |> ( *. ) 1.3 |> int_of_float
   in
   let news = Data.News.all |> List.take number_of_news in
   Dream.html


### PR DESCRIPTION
I did an analysis and, on average, the smaller `Post` items have a height 1.2 times greater than the `News` items. So, I reduced the number of `News` items in the Blog page to 1.2 of the number of `Post` items. (featured + posts)

This is my fix for #1624 
