### PR TITLE
Fix type inconsistency in tutorial

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -459,7 +459,7 @@ Here is the definition of a variant type acting as an enumerated data type:
 type primary_colour = Red | Green | Blue
 
 # [Red; Blue; Red];;
-- : colour list = [Red; Blue; Red]
+- : primary_colour list = [Red; Blue; Red]
 ```
 
 Here is the definition of a variant type acting as a union type:


### PR DESCRIPTION
In [A Tour of OCaml](https://ocaml.org/docs/tour-of-ocaml), there is the following snippet:

```ocaml
# type primary_colour = Red | Green | Blue;;
type primary_colour = Red | Green | Blue

# [Red; Blue; Red];;
- : colour list = [Red; Blue; Red]
```

The type returned in the second example is wrong; it should be a list of `primary_colour` as defined in the first expression. This PR fixes it.