### PR TITLE
Patching Scraper

### DIFF
--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -72,4 +72,5 @@ dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
+  ["river.dev" "git+https://github.com/kayceesrk/river#b990f702d29c7a7139920d701154e9db595eae1f"]
 ]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,4 +1,5 @@
 pin-depends: [
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
+  ["river.dev" "git+https://github.com/kayceesrk/river#b990f702d29c7a7139920d701154e9db595eae1f"]
 ]

--- a/tool/ood-gen/bin/watch_scrape.ml
+++ b/tool/ood-gen/bin/watch_scrape.ml
@@ -52,7 +52,7 @@ let watch_to_yaml t =
         ("category", `String t.category);
       ])
 
-let to_yaml t = `O ["watch", `A (List.map watch_to_yaml t)]
+let to_yaml t = `O [ ("watch", `A (List.map watch_to_yaml t)) ]
 let videos_url = Uri.of_string "https://watch.ocaml.org/api/v1/videos"
 
 (* 100 is current maximum the API can return:

--- a/tool/ood-gen/bin/watch_scrape.ml
+++ b/tool/ood-gen/bin/watch_scrape.ml
@@ -52,7 +52,7 @@ let watch_to_yaml t =
         ("category", `String t.category);
       ])
 
-let to_yaml t = `A (List.map watch_to_yaml t)
+let to_yaml t = `O ["watch", `A (List.map watch_to_yaml t)]
 let videos_url = Uri.of_string "https://watch.ocaml.org/api/v1/videos"
 
 (* 100 is current maximum the API can return:

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -367,10 +367,7 @@ module Scraper = struct
     let slug = Utils.slugify title in
     let source_path = "data/planet/" ^ source_id in
     let output_file = source_path ^ "/" ^ slug ^ ".md" in
-    if Sys.file_exists output_file then
-      print_endline
-        (Printf.sprintf "%s/%s already exist, not scraping again" source_id slug)
-    else
+    if not (Sys.file_exists output_file) then
       let url = River.link post in
       let date = River.date post |> Option.map Syndic.Date.to_rfc3339 in
       match (url, date) with


### PR DESCRIPTION
Relating to https://github.com/ocaml/ocaml.org/pull/1776.

We updated River to fall back to the `id` tag of an entry when no `link`s are provided.

While we're at it: in the watch scraper, we add the missing wrapper object with field `watch:` and reduce the amount of logging in case a posts already exists. This will make it easier to see errors in the scraper log.

River can be unpinned after next release:
- https://github.com/ocaml/opam-repository/pull/24822