### PR TITLE
Create tutorial on option

### DIFF
--- a/data/tutorials/language/3ds_06_options.md
+++ b/data/tutorials/language/3ds_06_options.md
@@ -10,7 +10,7 @@ category: "Introduction"
 
 ## Introduction
 
-An option is a value that wraps another value, or nothing if there isn't anything to wrap. The predefined type `option` is the 
+An option is a value that wraps another value or nothing, if there isn't anything to wrap. The predefined type `option` is the 
 <!-- $MDX non-deterministic=command -->
 ```ocaml
 # #show option;;
@@ -27,7 +27,7 @@ Here is 42, stored inside an `option` using the data carrying constructor
 
 The `None` constructor means no data is available.
 
-In other words, a value of type `t option` for some type `t` represents:
+In other words, a value of type `t option` for some type `t` represents
 * either a value `v` of type `t`, wrapped as `Some v`
 * no such value, then `o` has the value `None`
 
@@ -48,15 +48,15 @@ Exception: Not_found.
 - : string option = None
 ```
 
-See the [Error Handling](/docs/error-handling) for an longer discussion on error handling using options, exceptions and others means.
+See the [Error Handling](/docs/error-handling) for an longer discussion on error handling using options, exceptions, and others means.
 
 ## The Standard Library `Option` Module
 
-Most of the functions in this section as well as other useful ones are provided by the OCaml standard library in the [`Stdlib.Option`](https://ocaml.org/api/Option.html) supporting module.
+Most of the functions in this section, as well as other useful ones, are provided by the OCaml standard library in the [`Stdlib.Option`](https://ocaml.org/api/Option.html) supporting module.
 
 ### Map an Option
 
-Using pattern-matching, it is possible to define functions, allowing users to easily work with option values. Here is `map` of type `('a -> 'b) -> 'a option -> 'b option`. It allows us to apply a function to the value wrapped inside an `option`, if present:
+Using pattern matching, it is possible to define functions, allowing users to easily work with option values. Here is `map` of type `('a -> 'b) -> 'a option -> 'b option`. It allows us to apply a function to the value wrapped inside an `option`, if present:
 ```ocaml
 # let map f = function
   | None -> None
@@ -116,7 +116,7 @@ The function `fold` of type `fold : ('a -> 'b) -> 'b -> 'a option -> 'b` combine
 val fold : ('a -> 'b) -> 'b -> 'a option -> 'b = <fun>
 ```
 
-The `fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version is using pattern-matching.
+The `fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version is using pattern matching.
 ```ocaml
 # let path () =
     let opt = Sys.getenv_opt "PATH" in

--- a/data/tutorials/language/3ds_06_options.md
+++ b/data/tutorials/language/3ds_06_options.md
@@ -31,7 +31,7 @@ In other words, a value of type `t option` for some type `t` represents
 * either a value `v` of type `t`, wrapped as `Some v`
 * no such value, then `o` has the value `None`
 
-The option type is very useful when lack of data is better handled as a special value (_i.e.,_ `None`) rather than an exception. It is the type-safe version of returning error values such as in C, for instance. Since no data has any special meaning, confusion between regular values and absence of value is impossible. In computer science, this type is called the [option
+The option type is very useful when lack of data is better handled as a special value (_i.e.,_ `None`) rather than an exception. It is the type-safe version of returning error values such as in C, for instance. Since no data has any special meaning, confusion between regular values and the absence of value is impossible. In computer science, this type is called the [option
 type](https://en.wikipedia.org/wiki/Option_type). OCaml has supported `option` since its inception.
 
 ## Exceptions _vs_ Options
@@ -48,7 +48,7 @@ Exception: Not_found.
 - : string option = None
 ```
 
-See the [Error Handling](/docs/error-handling) for an longer discussion on error handling using options, exceptions, and others means.
+See [Error Handling](/docs/error-handling) for a longer discussion on error handling using options, exceptions, and others means.
 
 ## The Standard Library `Option` Module
 
@@ -159,6 +159,7 @@ The `bind` function of type `'a option -> ('a -> 'b option) -> 'b option` works 
 In other words, `Option.bind` is the same as this:
 ```ocaml
 # let bind o f = Option.(o |> map f |> join);;
+val bind : 'a option -> ('a -> 'b option) -> 'b option = <fun>
 ```
 
 ## Conclusion

--- a/data/tutorials/language/3ds_06_options.md
+++ b/data/tutorials/language/3ds_06_options.md
@@ -1,0 +1,167 @@
+---
+id: options
+title: Options
+description: >
+  Add nothing-as-value to anything to avoid confusion between something and “no such thing“.
+category: "Introduction"
+---
+
+# Options
+
+## Introduction
+
+An option is a value that wraps another value, or nothing if there isn't anything to wrap. The predefined type `option` is the 
+<!-- $MDX non-deterministic=command -->
+```ocaml
+# #show option;;
+type 'a option = None | Some of 'a
+```
+
+Here is 42, stored inside an `option` using the data carrying constructor
+`Some`:
+
+```ocaml
+# Some 42;;
+- : int option = Some 42
+```
+
+The `None` constructor means no data is available.
+
+In other words, a value of type `t option` for some type `t` represents:
+* either a value `v` of type `t`, wrapped as `Some v`
+* no such value, then `o` has the value `None`
+
+The option type is very useful when lack of data is better handled as a special value (_i.e.,_ `None`) rather than an exception. It is the type-safe version of returning error values such as in C, for instance. Since no data has any special meaning, confusion between regular values and absence of value is impossible. In computer science, this type is called the [option
+type](https://en.wikipedia.org/wiki/Option_type). OCaml has supported `option` since its inception.
+
+## Exceptions _vs_ Options
+
+The function `Sys.getenv : string -> string` from the OCaml standard library
+allows us to query the value of an environment variable; however, it throws an exception if the variable is not defined. On the other hand, the function
+`Sys.getenv_opt : string -> string option` does the same, except it returns
+`None` as the variable is not defined. Here is what may happen if we try to
+access an undefined environment variable:
+```ocaml
+# Sys.getenv "UNDEFINED_ENVIRONMENT_VARIABLE";;
+Exception: Not_found.
+# Sys.getenv_opt "UNDEFINED_ENVIRONMENT_VARIABLE";;
+- : string option = None
+```
+
+See the [Error Handling](/docs/error-handling) for an longer discussion on error handling using options, exceptions and others means.
+
+## The Standard Library `Option` Module
+
+Most of the functions in this section as well as other useful ones are provided by the OCaml standard library in the [`Stdlib.Option`](https://ocaml.org/api/Option.html) supporting module.
+
+### Map an Option
+
+Using pattern-matching, it is possible to define functions, allowing users to easily work with option values. Here is `map` of type `('a -> 'b) -> 'a option -> 'b option`. It allows us to apply a function to the value wrapped inside an `option`, if present:
+```ocaml
+# let map f = function
+  | None -> None
+  | Some v -> Some (f v);;
+val map : ('a -> 'b) -> 'a option -> 'b option = <fun>
+```
+
+`map` takes two parameters: the function `f` to be applied and an option value. `map f o` returns `Some (f v)` if `o` is `Some v` and `None` if `o` is `None`.
+
+In the standard library, this is `Option.map`.
+
+### Peel-Off Doubly Wrapped Options
+
+Here is `join` of type `'a option option -> 'a option`. It peels off one layer from a doubly wrapped option:
+
+```ocaml
+# let join = function
+  | Some Some v -> Some v
+  | Some None -> None
+  | None -> None;;
+val join : 'a option option -> 'a option = <fun>
+```
+`join` takes a single `option option` parameter and returns an `option`
+parameter.
+
+In the standard library, this is `Option.join`.
+
+### Access the Content of an Option
+
+The function `get` of type `'a option -> 'a` allows access to the value contained inside an `option`.
+```ocaml
+# let get = function
+  | Some v -> v
+  | None -> raise (Invalid_argument "option is None");;
+val get : 'a option -> 'a = <fun>
+```
+But beware, `get o` throws an exception if `o` is `None`. To access the content of an `option` without risking to raise an exception, the function `value` of type `'a option -> 'a -> 'a` can be used
+```ocaml
+# let value default = function
+  | Some v -> v
+  | None -> default;;
+val value : 'a -> 'a option -> 'a = <fun>
+```
+However it takes a default value as an additional parameter.
+
+In the standard library, these function are `Option.get` and `Option.value`. The latter is defined using a labelled parameter:
+```ocaml
+# Option.value;;
+- : 'a option -> default:'a -> 'a = <fun>
+```
+
+### Fold an Option
+
+The function `fold` of type `fold : ('a -> 'b) -> 'b -> 'a option -> 'b` combines `map` and `value`
+```ocaml
+# let fold f default o = o |> Option.map f |> value default;;
+val fold : ('a -> 'b) -> 'b -> 'a option -> 'b = <fun>
+```
+
+The `fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version is using pattern-matching.
+```ocaml
+# let path () =
+    let opt = Sys.getenv_opt "PATH" in
+    match opt with
+    | Some s -> String.split_on_char ':' s
+    | None -> [];;
+val path : unit -> string list = <fun>
+```
+
+This versions calls `fold`.
+```ocaml
+# let path () = Sys.getenv_opt "PATH" |> fold (String.split_on_char ':') [];;
+val path : unit -> string list = <fun>
+```
+
+In the standard library, this function is defined using labelled arguments:
+```ocaml
+# Option.fold;;
+- : none:'a -> some:('b -> 'a) -> 'b option -> 'a = <fun>
+```
+
+### Unfold an Option
+
+To build a function going the other way round, which creates an `option` one can define `unfold` of type `('a -> bool) -> ('a -> 'b) -> 'a -> 'b option` the following way:
+```ocaml
+# let unfold p f x =
+    if p x then
+      Some (f x)
+    else
+      None;;
+val unfold : ('a -> bool) -> ('a -> 'b) -> 'a -> 'b option = <fun>
+```
+
+This does not exist in the standard library.
+
+### Bind an Option
+
+The `bind` function of type `'a option -> ('a -> 'b option) -> 'b option` works like `map`. But whilst `map` expects a function-as-parameter `f` that returns an unwrapped value of type `b`, `bind` expects a function-as-parameter `f` that returns a value already wrapped in a option `'b option`.
+
+In other words, `Option.bind` is the same as this:
+```ocaml
+# let bind o f = Option.(o |> map f |> join);;
+```
+
+## Conclusion
+
+By the way, any type where `map` and `join` functions can be implemented, with similar behaviour, can be called a _monad_, and `option` is often used to introduce monads. But don't freak out! You absolutely don't need to know what a monad is to use the `option` type.
+

--- a/data/tutorials/language/3ds_06_options.md
+++ b/data/tutorials/language/3ds_06_options.md
@@ -64,7 +64,7 @@ Using pattern matching, it is possible to define functions, allowing users to ea
 val map : ('a -> 'b) -> 'a option -> 'b option = <fun>
 ```
 
-`map` takes two parameters: the function `f` to be applied and an option value. `map f o` returns `Some (f v)` if `o` is `Some v` and `None` if `o` is `None`.
+`map` takes two parameters: the function `f` to be applied and an option value. `map f o` returns `Some (f v)` if `o` is `Some v`, and `None` if `o` is `None`.
 
 In the standard library, this is `Option.map`.
 
@@ -93,7 +93,7 @@ The function `get` of type `'a option -> 'a` allows access to the value containe
   | None -> raise (Invalid_argument "option is None");;
 val get : 'a option -> 'a = <fun>
 ```
-But beware, `get o` throws an exception if `o` is `None`. To access the content of an `option` without risking to raise an exception, the function `value` of type `'a option -> 'a -> 'a` can be used
+But beware, `get o` throws an exception if `o` is `None`. To access the content of an `option` without the risk of raising an exception, the function `value` of type `'a option -> 'a -> 'a` can be used:
 ```ocaml
 # let value default = function
   | Some v -> v
@@ -116,7 +116,7 @@ The function `fold` of type `fold : ('a -> 'b) -> 'b -> 'a option -> 'b` combine
 val fold : ('a -> 'b) -> 'b -> 'a option -> 'b = <fun>
 ```
 
-The `fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version is using pattern matching.
+The `fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version is using pattern matching:
 ```ocaml
 # let path () =
     let opt = Sys.getenv_opt "PATH" in
@@ -126,7 +126,7 @@ The `fold` function can be used to implement a fall-back logic without writing p
 val path : unit -> string list = <fun>
 ```
 
-This versions calls `fold`.
+This versions calls `fold`:
 ```ocaml
 # let path () = Sys.getenv_opt "PATH" |> fold (String.split_on_char ':') [];;
 val path : unit -> string list = <fun>
@@ -140,7 +140,7 @@ In the standard library, this function is defined using labelled arguments:
 
 ### Unfold an Option
 
-To build a function going the other way round, which creates an `option` one can define `unfold` of type `('a -> bool) -> ('a -> 'b) -> 'a -> 'b option` the following way:
+To build a function going the other way round, which creates an `option`, one can define `unfold` of type `('a -> bool) -> ('a -> 'b) -> 'a -> 'b option` the following way:
 ```ocaml
 # let unfold p f x =
     if p x then

--- a/data/tutorials/language/3ds_06_options.md
+++ b/data/tutorials/language/3ds_06_options.md
@@ -42,7 +42,7 @@ Exception: Not_found.
 - : string option = None
 ```
 
-See [Error Handling](/docs/error-handling) for a longer discussion on error handling using options, exceptions, and others means.
+See [Error Handling](/docs/error-handling) for a longer discussion on error handling using options, exceptions, and other means.
 
 ## The Standard Library `Option` Module
 
@@ -58,9 +58,14 @@ Using pattern matching, it is possible to define functions, allowing users to ea
 val map : ('a -> 'b) -> 'a option -> 'b option = <fun>
 ```
 
-`map` takes two parameters: the function `f` to be applied and an option value. `map f o` returns `Some (f v)` if `o` is `Some v`, and `None` if `o` is `None`.
-
 In the standard library, this is `Option.map`.
+```ocaml
+# Option.map (fun x -> x * x) (Some 3);;
+- : int option = Some 9
+
+# Option.map (fun x -> x * x) None;;
+- : int option : None
+```
 
 ### Peel-Off Doubly Wrapped Options
 
@@ -73,10 +78,18 @@ Here is `join` of type `'a option option -> 'a option`. It peels off one layer f
   | None -> None;;
 val join : 'a option option -> 'a option = <fun>
 ```
-`join` takes a single `option option` parameter and returns an `option`
-parameter.
 
 In the standard library, this is `Option.join`.
+```ocaml
+# Option.join (Some (Some 42));;
+- : int option = Some 42
+
+# Option.join (Some None);;
+- : 'a option = None
+
+# Option.join None;;
+- : 'a option = None
+```
 
 ### Access the Content of an Option
 
@@ -121,16 +134,17 @@ The `fold` function can be used to implement a fall-back logic without writing p
 val path : unit -> string list = <fun>
 ```
 
-This version uses `fold`:
-```ocaml
-# let path () = Sys.getenv_opt "PATH" |> fold (String.split_on_char ':') [];;
-val path : unit -> string list = <fun>
-```
-
-In the standard library, this function is defined using labelled arguments:
+In the standard library, this `fold` is defined using labelled arguments:
 ```ocaml
 # Option.fold;;
 - : none:'a -> some:('b -> 'a) -> 'b option -> 'a = <fun>
+```
+
+```ocaml
+# let path () =
+    let split_on_colon = String.split_on_char ':' in
+    Sys.getenv_opt "PATH" |> Option.fold ~some:split_on_colon ~none:[];;
+val path : unit -> string list = <fun>
 ```
 
 ### Unfold an Option
@@ -154,10 +168,10 @@ val g : 'a list -> 'a option = <fun>
 ```
 
 The types of `f` and `g` are reversed. Functions `Option.fold` and `unfold_try` work a reversed manner
-* `Option.fold` take an option parameter to build something
+* `Option.fold` takes an option parameter to build something
 * `unfold_try` returns an option result from some parameter
 
-The standard library does not contain an `unfold_try` function.
+The standard library does not contain any option unfolding function.
 
 ### Bind an Option
 

--- a/data/tutorials/language/3ds_06_options.md
+++ b/data/tutorials/language/3ds_06_options.md
@@ -122,9 +122,10 @@ In the standard library, this function is `Option.fold`.
 The `Option.fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version uses pattern matching:
 ```ocaml
 # let path () =
+    let split_on_colon = String.split_on_char ':' in
     let opt = Sys.getenv_opt "PATH" in
     match opt with
-    | Some s -> String.split_on_char ':' s
+    | Some s -> split_on_colon s
     | None -> [];;
 val path : unit -> string list = <fun>
 ```


### PR DESCRIPTION
This is derived from the text I had written on options that was deleted when replacing "Data Types and Matching" by "Basic Data TYpes and Pattern Matching" (PR https://github.com/ocaml/ocaml.org/pull/1514) (lines 308 to 428)

https://github.com/ocaml/ocaml.org/pull/1514/files#diff-e613ae223854664d9552a5b8419fc0374782edb328918d85eac23d49ec4f57bd