### PR TITLE
changelog: entry for OCaml 5.1.1~rc1

### DIFF
--- a/data/changelog/ocaml/2023-12-1-ocaml-5.1.1.rc1.md
+++ b/data/changelog/ocaml/2023-12-1-ocaml-5.1.1.rc1.md
@@ -1,0 +1,110 @@
+---
+title: OCaml 5.1.1 - First Release Candidate
+description: First Release Candidate of OCaml 5.1.1
+date: "2023-12-01"
+tags: [ocaml]
+changelog: |
+  ## Changes in OCaml 5.1.1
+
+  ### Standard Library Dependency Fix:
+
+  * (*breaking change*) [#12562](https://github.com/ocaml/ocaml/issues/12562), [#12734](https://github.com/ocaml/ocaml/issues/12734), [#12783](https://github.com/ocaml/ocaml/issues/12783): Remove the `Marshal.Compression` flag to the
+    `Marshal.to_*` functions introduced in 5.1 by [#12006](https://github.com/ocaml/ocaml/issues/12006), as it cannot
+    be implemented without risking to link -lzstd with all
+    ocamlopt-generated executables.  The compilers are still able to use
+    ZSTD compression for compilation artefacts.
+    (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
+     Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).
+  
+  ### Type System Bug Fix:
+  
+  - [#12623](https://github.com/ocaml/ocaml/issues/12623), fix the computation of variance composition
+    (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+  
+  ### GC Performance Regression Fixes
+  
+  - [#12590](https://github.com/ocaml/ocaml/issues/12590), [#12595](https://github.com/ocaml/ocaml/issues/12595): Move `caml_collect_gc_stats_sample` in
+    `caml_empty_minor_heap_promote` before barrier arrival.
+    (B. Szilvasy, review by Gabriel Scherer)
+  
+  - [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of custom_minor_max_size: blocks with
+    out-of-heap memory above this limit are now allocated directly in
+    the major heap.
+    (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer)
+  
+  - [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalize and collect dead custom blocks during minor collection
+    (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
+    Sivaramakrishnan)
+  
+  
+  - [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
+    sub-arrays of bigarrays
+    (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
+  
+  ### Miscellaneous Bug Fixes
+  
+  - [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
+    to correctly handle nested packs
+    (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)
+  
+  - [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix ocamlnat (native toplevel) by registering frametables correctly
+    (Stephen Dolan, Nick Barnes and Mark Shinwell,
+     review by Vincent Laviron and Sébastien Hinderer)
+  
+  - [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649) fix error messages for cyclic type definitions in presence of
+    the `-short-paths` flag.
+    (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+  
+  
+---
+
+Two months (and half) after the release of OCaml 5.1.0, we have discovered three
+significant regressions in OCaml 5.1.0, affecting the packaging of executables,
+the typechecking of OCaml programs, and the performance of numerical codes.
+
+Since those regressions affect many users and could have lasting effects, we
+have decided to cut a patch release of OCaml 5.1 with fixes for those issues
+next week.
+
+To give time for opam packages to test this patch version, we
+have just published a first release candidate for OCaml 5.1.1 .
+The full list of changes in this release candidate is available below.
+
+As a major exception to our policy for patch releases, OCaml 5.1.1 will
+contain one breaking change in the standard library: the `Compression` flag has
+been removed from the `Marshal` module.
+This drastic measure was taken because supporting zstd compression in the
+standard library made zstd a dependency of all OCaml executables. Since the
+compiler should not impose its dependency on end-users, the support for
+compressed marshaling has been moved to a compiler internal library in 5.1.1.
+This internally library might be released as an independent library in later
+releases of OCaml but not in OCaml 5.1.1 to give us time to polish the library
+integration and packaging.
+
+
+Installation Instructions
+--------------------------
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1 and later:
+
+    opam update
+    opam switch create 5.1.1~rc1
+
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.1-rc1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.1~rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+    opam update
+    opam switch create <switch_name> ocaml-variants.5.1.1~rc1+options <option_list>
+
+where `option_list` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+
+    opam switch create 5.1.1~rc1+flambda+nffa ocaml-variants.5.1.1~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+
+All available options can be listed with `opam search ocaml-option`.
+


### PR DESCRIPTION
This PR adds a changelog entry for the first (and hopefully last) release candidate for OCaml 5.1.1 which is an unusually large patch release for OCaml 5.1.0 which fixes one major packaging issue, one major type system bug, and one major performance regression (for numerical code).