### PR TITLE
add comparison of std containers guide to v3 docs

### DIFF
--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -38,8 +38,7 @@ Arrays are mutable data structures with a fixed length and random access.
 * accessing cell `i`: _O(1)_
 * finding an element: _O(n)_
 
-Well-suited for sets of elements of known size, access by numeric index,
-in-place modification. Basic arrays have a fixed length.
+Well-suited for the following cases: dealing with sets of elements of known size, accessing elements by numeric index, and in-place element modification. Basic arrays have a fixed length.
 
 ## Strings: Immutable Vectors
 Strings are very similar to arrays, but the are immutable. Strings are

--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -7,24 +7,24 @@ category: "Resources"
 ---
 
 # Comparison of Standard Containers
-This is a rough comparison of the different container types that are
-provided by the OCaml language or by the OCaml standard library. In each
-case, n is the number of valid elements in the container.
+This is a rough comparison of the different container types 
+provided by the OCaml standard library. In each
+case, _n_ is the number of valid elements in the container.
 
 Note that the big-O cost given for some operations reflects the current
 implementation but is not guaranteed by the official documentation.
 Hopefully it will not become worse. Anyway, if you want more details,
-you should read the documentation about each of the modules. Often, it
+you should read the [documentation](/api/index.html) about each of the modules, or the OCaml [source code](https://github.com/ocaml/ocaml/tree/trunk/stdlib). Often, it
 is also instructive to read the corresponding implementation.
 
 ## Lists: immutable singly-linked lists
-Adding an element always creates a new list l from an element x and list
-tl. tl remains unchanged, but it is not copied either.
+Adding an element always creates a new list _l_ from an element _x_ and list
+_tl_. _tl_ remains unchanged, but it is not copied either.
 
-* "adding" an element: O(1), cons operator `::`
-* length: O(n), function `List.length`
-* accessing cell `i`: O(i)
-* finding an element: O(n)
+* "adding" an element: _O(1)_, [cons](https://en.wikipedia.org/wiki/Cons) operator `::`
+* length: _O(n)_, function `List.length`
+* accessing cell `i`: _O(i)_
+* finding an element: _O(n)_
 
 Well-suited for: IO, pattern-matching
 
@@ -33,10 +33,10 @@ Not very efficient for: random access, indexed elements
 ## Arrays: mutable vectors
 Arrays are mutable data structures with a fixed length and random access.
 
-* "adding" an element (by creating a new array): O(n)
-* length: O(1), function `Array.length`
-* accessing cell `i`: O(1)
-* finding an element: O(n)
+* "adding" an element (by creating a new array): _O(n)_
+* length: _O(1)_, function `Array.length`
+* accessing cell `i`: _O(1)_
+* finding an element: _O(n)_
 
 Well-suited for sets of elements of known size, access by numeric index,
 in-place modification. Basic arrays have a fixed length.
@@ -47,18 +47,18 @@ specialized for storing chars (bytes) and have some convenient syntax.
 Strings have a fixed length. For extensible strings, the standard Buffer
 module can be used (see below).
 
-* "adding" an element (by creating a new string): O(n)
-* length: O(1)
-* accessing character `i`: O(1)
-* finding an element: O(n)
+* "adding" an element (by creating a new string): _O(n)_
+* length: _O(1)_
+* accessing character `i`: _O(1)_
+* finding an element: _O(n)_
 
 ## Set and Map: immutable trees
 Like lists, these are immutable and they may share some subtrees. They
 are a good solution for keeping older versions of sets of items.
 
-* "adding" an element: O(log n)
-* returning the number of elements: O(n)
-* finding an element: O(log n)
+* "adding" an element: _O(log n)_
+* returning the number of elements: _O(n)_
+* finding an element: _O(log n)_
 
 Sets and maps are very useful in compilation and meta-programming, but
 in other situations hash tables are often more appropriate (see below).
@@ -67,36 +67,36 @@ in other situations hash tables are often more appropriate (see below).
 Ocaml hash tables are mutable data structures, which are a good solution
 for storing (key, data) pairs in one single place.
 
-* adding an element: O(1) if the initial size of the table is larger
- than the number of elements it contains; O(log n) on average if n
+* adding an element: _O(1)_ if the initial size of the table is larger
+ than the number of elements it contains; _O(log n)_ on average if _n_
  elements have been added in a table which is initially much smaller
- than n.
-* returning the number of elements: O(1)
-* finding an element: O(1)
+ than _n_.
+* returning the number of elements: _O(1)_
+* finding an element: _O(1)_
 
 ## Buffer: extensible strings
 Buffers provide an efficient way to accumulate a sequence of bytes in a
 single place. They are mutable.
 
-* adding a char: O(1) if the buffer is big enough, or O(log n) on
+* adding a char: _O(1)_ if the buffer is big enough, or _O(log n)_ on
  average if the initial size of the buffer was much smaller than the
- number of bytes n.
-* adding a string of k chars: O(k * "adding a char")
-* length: O(1)
-* accessing cell `i`: O(1)
+ number of bytes _n_.
+* adding a string of _k_ chars: _O(k * "adding a char")_
+* length: _O(1)_
+* accessing cell `i`: _O(1)_
 
 ## Queue
 OCaml queues are mutable first-in-first-out (FIFO) data structures.
 
-* adding an element: O(1)
-* taking an element: O(1)
-* length: O(1)
+* adding an element: _O(1)_
+* taking an element: _O(1)_
+* length: _O(1)_
 
 ## Stack
 OCaml stacks are mutable last-in-first-out (LIFO) data structures. They
 are just like lists, except that they are mutable, i.e. adding an
 element doesn't create a new stack but simply adds it to the stack.
 
-* adding an element: O(1)
-* taking an element: O(1)
-* length: O(1)
+* adding an element: _O(1)_
+* taking an element: _O(1)_
+* length: _O(1)_

--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -17,7 +17,7 @@ Hopefully it will not become worse. Anyway, if you want more details,
 you should read the [documentation](/api/index.html) about each of the modules, or the OCaml [source code](https://github.com/ocaml/ocaml/tree/trunk/stdlib). Often, it
 is also instructive to read the corresponding implementation.
 
-## Lists: immutable singly-linked lists
+## Lists: Immutable singly-linked lists
 Adding an element always creates a new list _l_ from an element _x_ and list
 _tl_. _tl_ remains unchanged, but it is not copied either.
 
@@ -26,11 +26,11 @@ _tl_. _tl_ remains unchanged, but it is not copied either.
 * accessing cell `i`: _O(i)_
 * finding an element: _O(n)_
 
-Well-suited for: IO, pattern-matching
+Well-suited for: I/O, pattern-matching
 
 Not very efficient for: random access, indexed elements
 
-## Arrays: mutable vectors
+## Arrays: Mutable Vectors
 Arrays are mutable data structures with a fixed length and random access.
 
 * "adding" an element (by creating a new array): _O(n)_
@@ -41,10 +41,10 @@ Arrays are mutable data structures with a fixed length and random access.
 Well-suited for sets of elements of known size, access by numeric index,
 in-place modification. Basic arrays have a fixed length.
 
-## Strings: immutable vectors
-Strings are very similar to arrays but are immutable. Strings are
-specialized for storing chars (bytes) and have some convenient syntax.
-Strings have a fixed length. For extensible strings, the standard Buffer
+## Strings: Immutable Vectors
+Strings are very similar to arrays, but the are immutable. Strings are
+specialised for storing chars (bytes) and have some convenient syntax.
+Strings have a fixed length. For extensible strings, the standard buffer
 module can be used (see below).
 
 * "adding" an element (by creating a new string): _O(n)_
@@ -52,19 +52,19 @@ module can be used (see below).
 * accessing character `i`: _O(1)_
 * finding an element: _O(n)_
 
-## Set and Map: immutable trees
-Like lists, these are immutable and they may share some subtrees. They
+## Set and Map: Immutable Trees
+Like lists, these are immutable, and they may share some subtrees. These trees
 are a good solution for keeping older versions of sets of items.
 
 * "adding" an element: _O(log n)_
 * returning the number of elements: _O(n)_
 * finding an element: _O(log n)_
 
-Sets and maps are very useful in compilation and meta-programming, but
-in other situations hash tables are often more appropriate (see below).
+Sets and maps are very useful in compilation and metaprogramming, but
+in other situations, hash tables are often more appropriate (see below).
 
-## Hashtbl: automatically growing hash tables
-Ocaml hash tables are mutable data structures, which are a good solution
+## Hashtbl: Automatically Growing Hash Tables
+OCaml hash tables are mutable data structures, which are a good solution
 for storing (key, data) pairs in one single place.
 
 * adding an element: _O(1)_ if the initial size of the table is larger
@@ -74,8 +74,8 @@ for storing (key, data) pairs in one single place.
 * returning the number of elements: _O(1)_
 * finding an element: _O(1)_
 
-## Buffer: extensible strings
-Buffers provide an efficient way to accumulate a sequence of bytes in a
+## Buffer: Extensible Strings
+Buffers provide an efficient way to accumulate a byte sequence in a
 single place. They are mutable.
 
 * adding a char: _O(1)_ if the buffer is big enough, or _O(log n)_ on
@@ -94,7 +94,7 @@ OCaml queues are mutable first-in-first-out (FIFO) data structures.
 
 ## Stack
 OCaml stacks are mutable last-in-first-out (LIFO) data structures. They
-are just like lists, except that they are mutable, i.e. adding an
+are just like lists except they are mutable, i.e., adding an
 element doesn't create a new stack but simply adds it to the stack.
 
 * adding an element: _O(1)_

--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -14,17 +14,17 @@ case, _n_ is the number of valid elements in the container.
 Note that the big-O cost given for some operations reflects the current
 implementation but is not guaranteed by the official documentation.
 Hopefully it will not become worse. Anyway, if you want more details,
-you should read the [documentation](/api/index.html) about each of the modules, or the OCaml [source code](https://github.com/ocaml/ocaml/tree/trunk/stdlib). Often, it
+you can read the [documentation](/api/index.html) about each of the modules or the OCaml [source code](https://github.com/ocaml/ocaml/tree/trunk/stdlib). Often, it
 is also instructive to read the corresponding implementation.
 
-## Lists: Immutable singly-linked lists
-Adding an element always creates a new list _l_ from an element _x_ and list
+## Lists: Immutable Singly-Linked Lists
+Adding an element always creates a new list _l_ from an element _x_ List
 _tl_. _tl_ remains unchanged, but it is not copied either.
 
-* "adding" an element: _O(1)_, [cons](https://en.wikipedia.org/wiki/Cons) operator `::`
-* length: _O(n)_, function `List.length`
-* accessing cell `i`: _O(i)_
-* finding an element: _O(n)_
+* Adding an element: _O(1)_, [cons](https://en.wikipedia.org/wiki/Cons) operator `::`
+* Length: _O(n)_, function `List.length`
+* Accessing cell `i`: _O(i)_
+* Finding an element: _O(n)_
 
 Well-suited for: I/O, pattern-matching
 
@@ -33,31 +33,31 @@ Not very efficient for: random access, indexed elements
 ## Arrays: Mutable Vectors
 Arrays are mutable data structures with a fixed length and random access.
 
-* "adding" an element (by creating a new array): _O(n)_
-* length: _O(1)_, function `Array.length`
-* accessing cell `i`: _O(1)_
-* finding an element: _O(n)_
+* Adding an element (by creating a new array): _O(n)_
+* Length: _O(1)_, function `Array.length`
+* Accessing cell `i`: _O(1)_
+* Finding an element: _O(n)_
 
-Well-suited for the following cases: dealing with sets of elements of known size, accessing elements by numeric index, and in-place element modification. Basic arrays have a fixed length.
+Well-suited for the following cases: dealing with sets of elements of known size, accessing elements by numeric index, and modifying in-place elements. Basic arrays have a fixed length.
 
 ## Strings: Immutable Vectors
-Strings are very similar to arrays, but the are immutable. Strings are
+Strings are very similar to arrays, but they are immutable. Strings are
 specialised for storing chars (bytes) and have some convenient syntax.
 Strings have a fixed length. For extensible strings, the standard buffer
 module can be used (see below).
 
-* "adding" an element (by creating a new string): _O(n)_
-* length: _O(1)_
-* accessing character `i`: _O(1)_
-* finding an element: _O(n)_
+* Adding an element (by creating a new string): _O(n)_
+* Length: _O(1)_
+* Accessing character `i`: _O(1)_
+* Finding an element: _O(n)_
 
 ## Set and Map: Immutable Trees
 Like lists, these are immutable, and they may share some subtrees. These trees
 are a good solution for keeping older versions of sets of items.
 
-* "adding" an element: _O(log n)_
-* returning the number of elements: _O(n)_
-* finding an element: _O(log n)_
+* Adding an element: _O(log n)_
+* Returning the number of elements: _O(n)_
+* Finding an element: _O(log n)_
 
 Sets and maps are very useful in compilation and metaprogramming, but
 in other situations, hash tables are often more appropriate (see below).
@@ -66,36 +66,36 @@ in other situations, hash tables are often more appropriate (see below).
 OCaml hash tables are mutable data structures, which are a good solution
 for storing (key, data) pairs in one single place.
 
-* adding an element: _O(1)_ if the initial size of the table is larger
+* Adding an element: _O(1)_ if the initial size of the table is larger
  than the number of elements it contains; _O(log n)_ on average if _n_
  elements have been added in a table which is initially much smaller
  than _n_.
-* returning the number of elements: _O(1)_
-* finding an element: _O(1)_
+* Returning the number of elements: _O(1)_
+* Finding an element: _O(1)_
 
 ## Buffer: Extensible Strings
 Buffers provide an efficient way to accumulate a byte sequence in a
 single place. They are mutable.
 
-* adding a char: _O(1)_ if the buffer is big enough, or _O(log n)_ on
- average if the initial size of the buffer was much smaller than the
+* Adding a char: _O(1)_ if the buffer is big enough, or _O(log n)_ on
+ average if the initial buffer size was much smaller than the
  number of bytes _n_.
-* adding a string of _k_ chars: _O(k * "adding a char")_
-* length: _O(1)_
-* accessing cell `i`: _O(1)_
+* Adding a string of _k_ chars: _O(k * "adding a char")_
+* Length: _O(1)_
+* Accessing cell `i`: _O(1)_
 
 ## Queue
 OCaml queues are mutable first-in-first-out (FIFO) data structures.
 
-* adding an element: _O(1)_
-* taking an element: _O(1)_
-* length: _O(1)_
+* Adding an element: _O(1)_
+* Taking an element: _O(1)_
+* Length: _O(1)_
 
 ## Stack
 OCaml stacks are mutable last-in-first-out (LIFO) data structures. They
 are just like lists except they are mutable, i.e., adding an
 element doesn't create a new stack but simply adds it to the stack.
 
-* adding an element: _O(1)_
-* taking an element: _O(1)_
-* length: _O(1)_
+* Adding an element: _O(1)_
+* Taking an element: _O(1)_
+* Length: _O(1)_

--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -1,0 +1,102 @@
+---
+id: data-structures-comparison 
+title: Comparison of Standard Containers
+description: >
+  Rough comparison of the different container types in OCaml
+category: "Resources"
+---
+
+# Comparison of Standard Containers
+This is a rough comparison of the different container types that are
+provided by the OCaml language or by the OCaml standard library. In each
+case, n is the number of valid elements in the container.
+
+Note that the big-O cost given for some operations reflects the current
+implementation but is not guaranteed by the official documentation.
+Hopefully it will not become worse. Anyway, if you want more details,
+you should read the documentation about each of the modules. Often, it
+is also instructive to read the corresponding implementation.
+
+## Lists: immutable singly-linked lists
+Adding an element always creates a new list l from an element x and list
+tl. tl remains unchanged, but it is not copied either.
+
+* "adding" an element: O(1), cons operator `::`
+* length: O(n), function `List.length`
+* accessing cell `i`: O(i)
+* finding an element: O(n)
+
+Well-suited for: IO, pattern-matching
+
+Not very efficient for: random access, indexed elements
+
+## Arrays: mutable vectors
+Arrays are mutable data structures with a fixed length and random access.
+
+* "adding" an element (by creating a new array): O(n)
+* length: O(1), function `Array.length`
+* accessing cell `i`: O(1)
+* finding an element: O(n)
+
+Well-suited for sets of elements of known size, access by numeric index,
+in-place modification. Basic arrays have a fixed length.
+
+## Strings: immutable vectors
+Strings are very similar to arrays but are immutable. Strings are
+specialized for storing chars (bytes) and have some convenient syntax.
+Strings have a fixed length. For extensible strings, the standard Buffer
+module can be used (see below).
+
+* "adding" an element (by creating a new string): O(n)
+* length: O(1)
+* accessing character `i`: O(1)
+* finding an element: O(n)
+
+## Set and Map: immutable trees
+Like lists, these are immutable and they may share some subtrees. They
+are a good solution for keeping older versions of sets of items.
+
+* "adding" an element: O(log n)
+* returning the number of elements: O(n)
+* finding an element: O(log n)
+
+Sets and maps are very useful in compilation and meta-programming, but
+in other situations hash tables are often more appropriate (see below).
+
+## Hashtbl: automatically growing hash tables
+Ocaml hash tables are mutable data structures, which are a good solution
+for storing (key, data) pairs in one single place.
+
+* adding an element: O(1) if the initial size of the table is larger
+ than the number of elements it contains; O(log n) on average if n
+ elements have been added in a table which is initially much smaller
+ than n.
+* returning the number of elements: O(1)
+* finding an element: O(1)
+
+## Buffer: extensible strings
+Buffers provide an efficient way to accumulate a sequence of bytes in a
+single place. They are mutable.
+
+* adding a char: O(1) if the buffer is big enough, or O(log n) on
+ average if the initial size of the buffer was much smaller than the
+ number of bytes n.
+* adding a string of k chars: O(k * "adding a char")
+* length: O(1)
+* accessing cell `i`: O(1)
+
+## Queue
+OCaml queues are mutable first-in-first-out (FIFO) data structures.
+
+* adding an element: O(1)
+* taking an element: O(1)
+* length: O(1)
+
+## Stack
+OCaml stacks are mutable last-in-first-out (LIFO) data structures. They
+are just like lists, except that they are mutable, i.e. adding an
+element doesn't create a new stack but simply adds it to the stack.
+
+* adding an element: O(1)
+* taking an element: O(1)
+* length: O(1)


### PR DESCRIPTION
Addresses #1821 by adding the dedicated guide page from docs v2 ([source](https://github.com/ocaml/v2.ocaml.org/blob/master/site/learn/tutorials/comparison_of_standard_containers.md)).

There was no need to update [redirection.ml](https://github.com/ocaml/ocaml.org/blob/main/src/ocamlorg_web/lib/redirection.ml) as it already contained required entries.

**Question:** docs v2 also have this article in 3 more languages, although I didn't find examples of how translations are handled in docs v3. What would be the best way to address that?