### PR TITLE
Adjust markdown of RWO integration to cmarkit

### DIFF
--- a/data/tutorials/language/5rt_00_memory_representation.md
+++ b/data/tutorials/language/5rt_00_memory_representation.md
@@ -59,15 +59,15 @@ cost via "Just-in-Time" dynamic patching, but OCaml prefers runtime
 simplicity instead.
 
 We'll explain this compilation pipeline in more detail in
-[The Compiler Frontend: Parsing And Type Checking](/docs/compiler-frontend){data-type=xref}
+[The Compiler Frontend: Parsing And Type Checking](/docs/compiler-frontend)
 and
-[The Compiler Backend: Byte Code And Native Code](/docs/compiler-backend){data-type=xref}.
+[The Compiler Backend: Byte Code And Native Code](/docs/compiler-backend).
 -->
 
 <!---->
 We'll cover how these values are
 managed by the runtime later on in
-[Understanding The Garbage Collector](/docs/garbage-collector){data-type=xref}.
+[Understanding The Garbage Collector](/docs/garbage-collector).
 
 ## OCaml Blocks and Values
 
@@ -97,7 +97,7 @@ needs to be able to distinguish between integer and pointer values, since it
 scans pointers to find further values but doesn't follow integers that don't
 point to anything meaningful beyond their immediate value.
 
-### Distinguishing Integers and Pointers at Runtime {#distinguishing-integer-and-pointers-at-runtime}
+### Distinguishing Integers and Pointers at Runtime <a name="distinguishing-integer-and-pointers-at-runtime"></a>
 
 Wrapping primitive types (such as integers) inside another data
 structure that records extra metadata about the value is known as
@@ -186,7 +186,7 @@ MB on that architecture. If you need bigger strings, either switch to a
 The 2-bit `color` field is used by the GC to keep track of its state during
 mark-and-sweep collection.
 We'll come back to this field in
-[Understanding The Garbage Collector](/docs/garbage-collector){data-type=xref}.
+[Understanding The Garbage Collector](/docs/garbage-collector).
 This tag isn't exposed to OCaml source code in any case.
 
 A block's tag byte is multipurpose, and indicates whether the data array
@@ -406,7 +406,7 @@ variants without parameters is the size of the native integer (either 31 or
 63 bits). This limit arises because of the size of the tag byte, and that
 some of the high-numbered tags are reserved.
 
-## Polymorphic Variants {#polymorphic-variants-1}
+## Polymorphic Variants <a name="polymorphic-variants-1"></a>
 
 <!-- FIXME: reference polymorphic variants tutorial from OCaml.org -->
 Polymorphic variants are more flexible than normal variants when writing code
@@ -529,7 +529,7 @@ comparison, hashing and binary marshaling. They also optionally contain a
 *finalizer* that the runtime calls just before the block is
 garbage-collected. This finalizer has nothing to do with ordinary OCaml
 finalizers (as created by `Gc.finalize` and explained in
-[Understanding The Garbage Collector](/docs/garbage-collector){data-type=xref}).
+[Understanding The Garbage Collector](/docs/garbage-collector)).
 They are instead used to call C cleanup functions such as `free`.
 
 ### Managing External Memory with Bigarray

--- a/data/tutorials/language/5rt_01_garbage-collector.md
+++ b/data/tutorials/language/5rt_01_garbage-collector.md
@@ -23,7 +23,7 @@ This is an adaptation of the chapter [Understanding the Garbage Collector](https
 *This chapter includes contributions from Stephen Weeks and Sadiq Jaffer.*
 
 We've described the runtime format of individual OCaml variables earlier, in
-[Memory Representation Of Values](/docs/runtime-memory-layoutl#memory-representation-of-values){data-type=xref}.
+[Memory Representation Of Values](/docs/runtime-memory-layoutl#memory-representation-of-values).
 When you execute your program, OCaml manages the lifecycle of these variables
 by regularly scanning allocated values and freeing them when they're no
 longer needed. This in turn means that your applications don't need to
@@ -455,7 +455,7 @@ allocation patterns that are causing a higher-than-usual rate of compactions:
 - : unit = ()
 ```
 
-### Intergenerational Pointers {#inter-generational-pointers}
+### Intergenerational Pointers <a name="inter-generational-pointers"></a>
 
 One complexity of generational collection arises from the fact that minor
 heap sweeps are much more frequent than major heap collections. In order to
@@ -611,7 +611,7 @@ registering finalizers in the `Core.Gc.Expert` module. Finalizers
 can run at any time in any thread, so they can be pretty hard to reason
 about in multi-threaded contexts.
 Async, which we discussed in [Concurrent Programming with
-Async](https://dev.realworldocaml.org/concurrent-programming.html#concurrent-programming-with-async){data-type=xref},
+Async](https://dev.realworldocaml.org/concurrent-programming.html#concurrent-programming-with-async),
 shadows the `Gc` module with its own module that contains a function,
 `Gc.add_finalizer`, which is concurrency-safe.  In particular,
 finalizers are scheduled in their own Async job, and care is taken by

--- a/data/tutorials/language/5rt_02_compiler_frontend.md
+++ b/data/tutorials/language/5rt_02_compiler_frontend.md
@@ -46,7 +46,7 @@ In this chapter, we'll cover the following topics:
 The details of the remainder of the compilation process, which gets
 all the way to executable code comes next, in [The Compiler Backend:
 Byte Code And Native
-Code](/docs/compiler-backend#the-compiler-backend-byte-code-and-native-code){data-type=xref}.
+Code](/docs/compiler-backend#the-compiler-backend-byte-code-and-native-code).
 
 ## An Overview of the Toolchain
 
@@ -141,7 +141,7 @@ be useful to you during day-to-day OCaml development.
 When a source file is passed to the OCaml compiler, its first task is to
 parse the text into a more structured abstract syntax tree (AST). The parsing
 logic is implemented in OCaml itself using the techniques described in
-[Parsing With Ocamllex And Menhir](https://dev.realworldocaml.org/parsing-with-ocamllex-and-menhir.html#parsing-with-ocamllex-and-menhir){data-type=xref}.
+[Parsing With Ocamllex And Menhir](https://dev.realworldocaml.org/parsing-with-ocamllex-and-menhir.html#parsing-with-ocamllex-and-menhir).
 The lexer and parser rules can be found in the `parsing` directory in the
 source distribution.
 
@@ -254,7 +254,7 @@ options to control the output for the various backends. Refer to the
 for the complete list.
 
 You can also use `odoc` to generate complete snapshots of your project via
-integration with dune, as described in ["Generating Documentation"](/docs/generating-documentation){data-type=xref}.
+integration with dune, as described in ["Generating Documentation"](/docs/generating-documentation).
 
 ## Preprocessing with ppx
 
@@ -366,7 +366,7 @@ val exit_with : program_result -> int = <fun>
 ### Commonly Used Extension Attributes
 
 We have already used extension points in [Data Serialization With S
-Expressions](https://dev.realworldocaml.org/data-serialization.html#data-serialization-with-s-expressions){data-type=xref}
+Expressions](https://dev.realworldocaml.org/data-serialization.html#data-serialization-with-s-expressions)
 to generate boilerplate code for handling s-expressions.  These are
 introduced by a third-party library using the `(preprocess)` directive
 in a dune file, for example:
@@ -539,7 +539,7 @@ the implementation to native code.
 </div>
 
 
-### Type Inference {#type-inference-1}
+### Type Inference <a name="type-inference-1"></a>
 
 Type inference is the process of determining the appropriate types for
 expressions based on their use. It's a feature that's partially present in
@@ -832,11 +832,11 @@ clean source tree.
 The OCaml module system enables smaller components to be reused effectively
 in large projects while still retaining all the benefits of static type
 safety. We covered the basics of using modules earlier in
-[Files Modules And Programs](https://dev.realworldocaml.org/files-modules-and-programs.html#files-modules-and-programs){data-type=xref}.
+[Files Modules And Programs](https://dev.realworldocaml.org/files-modules-and-programs.html#files-modules-and-programs).
 The module language that operates over these signatures also extends to
 functors and first-class modules, described in
-[Functors](https://dev.realworldocaml.org/functors.html#functors){data-type=xref} and
-[First Class Modules](https://dev.realworldocaml.org/first-class-modules.html#first-class-modules){data-type=xref},
+[Functors](https://dev.realworldocaml.org/functors.html#functors) and
+[First Class Modules](https://dev.realworldocaml.org/first-class-modules.html#first-class-modules),
 respectively.
 
 This section discusses how the compiler implements them in more detail.
@@ -1139,7 +1139,7 @@ The `cmt` files are particularly useful for IDE tools to match up OCaml
 source code at a specific location to the inferred or external types.
 For example, the `merlin` and `ocaml-lsp-server` opam packages both use
 this information to provide you with tooltips and docstrings within your
-editor, as described in [OCaml Platform](/docs/set-up-editor){data-type=xref}.
+editor, as described in [OCaml Platform](/docs/set-up-editor).
 
 ### Examining the Typed Syntax Tree Directly
 
@@ -1259,4 +1259,4 @@ You'll rarely need to look at this raw output from the compiler unless you're
 building IDE tools, or are hacking on extensions to the
 core compiler itself. However, it's useful to know that this intermediate
 form exists before we delve further into the code generation process next, in
-[The Compiler Backend: Byte Code And Native Code](/docs/compiler-backend#the-compiler-backend-byte-code-and-native-code){data-type=xref}.
+[The Compiler Backend: Byte Code And Native Code](/docs/compiler-backend#the-compiler-backend-byte-code-and-native-code).

--- a/data/tutorials/language/5rt_03_compiler_backend.md
+++ b/data/tutorials/language/5rt_03_compiler_backend.md
@@ -18,7 +18,7 @@ external_tutorial:
 This is an adaptation of the chapter [The Compiler Backend: Bytecode and Native code](https://dev.realworldocaml.org/compiler-backend.html) from the book [Real World OCaml](https://dev.realworldocaml.org/), reproduced here with permission.
 
 
-# The Compiler Backend: Bytecode and Native code {#the-compiler-backend-byte-code-and-native-code}
+# The Compiler Backend: Bytecode and Native code <a name="the-compiler-backend-byte-code-and-native-code"></a>
 
 Once OCaml has passed the type checking stage, it can stop emitting syntax
 and type errors and begin the process of compiling the well-formed modules
@@ -44,7 +44,7 @@ also analyzed and compiled into highly optimized automata.
 The lambda form is the key stage that discards the OCaml type
 information and maps the source code to the runtime memory model
 described in [Memory Representation Of
-Values](/docs/runtime-memory-layout#memory-representation-of-values){data-type=xref}.
+Values](/docs/runtime-memory-layout#memory-representation-of-values).
 This stage also performs some optimizations, most notably converting
 pattern-match statements into more optimized but low-level statements.
 
@@ -94,7 +94,7 @@ Despite these caveats, some interesting points emerge from reading it:
   are created via `setglobal`, and OCaml values are constructed by
   `makeblock`.  The blocks are the runtime values you should remember
   from [Memory Representation Of
-  Values](/docs/runtime-memory-layout#memory-representation-of-values){data-type=xref}.
+  Values](/docs/runtime-memory-layout#memory-representation-of-values).
 
 - The pattern match has turned into a switch case that jumps to the
   right case depending on the header tag of `v`. Recall that variants
@@ -160,7 +160,7 @@ $ ocamlc -dlambda -c pattern_polymorphic.ml 2>&1
     (makeblock 0 test/267)))
 ```
 
-We mentioned in [Variants](https://dev.realworldocaml.org/variants.html#variants){data-type=xref} that
+We mentioned in [Variants](https://dev.realworldocaml.org/variants.html#variants) that
 pattern matching over polymorphic variants is slightly less efficient, and it
 should be clearer why this is the case now. Polymorphic variants have a
 runtime value that's calculated by hashing the variant name, and so the
@@ -595,7 +595,7 @@ picture of the code if you get lost in the more verbose assembly.
 #### The Impact of Polymorphic Comparison
 
 We warned you in [Maps And Hash
-Tables](https://dev.realworldocaml.org/maps-and-hashtables.html#maps-and-hash-tables){data-type=xref}
+Tables](https://dev.realworldocaml.org/maps-and-hashtables.html#maps-and-hash-tables)
 that using polymorphic comparison is both convenient and
 perilous. Let's look at precisely what the difference is at the
 assembly language level now.
@@ -762,7 +762,7 @@ comparison, you may have noticed that we prepended the comparison
 functions with `Stdlib`.  This is because the Core module explicitly
 redefines the `>` and `<` and `=` operators to be specialized for
 operating over `int` types, as explained in [Maps and
-Hashtables](https://dev.realworldocaml.org/maps-and-hashtables.html#the-polymorphic-comparator){data-type=xref}.
+Hashtables](https://dev.realworldocaml.org/maps-and-hashtables.html#the-polymorphic-comparator).
 You can always recover any of the OCaml standard library functions by
 accessing them through the `Stdlib` module, as we did in our
 benchmark.


### PR DESCRIPTION
It seems that when I reviewed the integration, we were still using `omd`. We have since migrated to `cmarkit`, so here's a few changes relating to this.