### PR TITLE
OCaml 5.1.1 release

### DIFF
--- a/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
+++ b/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
@@ -1,0 +1,110 @@
+---
+title: Release of OCaml 5.1.1
+description: Release of OCaml 5.1.1
+date: "2023-12-8"
+tags: [ocaml]
+changelog: |
+
+  ### Standard library:
+  
+  * (*breaking change*) [#12562](https://github.com/ocaml/ocaml/issues/12562), [#12734](https://github.com/ocaml/ocaml/issues/12734), [#12783](https://github.com/ocaml/ocaml/issues/12783): Remove the `Marshal.Compression` flag to the
+    `Marshal.to_*` functions introduced in 5.1 by [#12006](https://github.com/ocaml/ocaml/issues/12006), as it cannot
+    be implemented without risking to link -lzstd with all
+    ocamlopt-generated executables.  The compilers are still able to use
+    ZSTD compression for compilation artefacts.
+    (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
+     Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).
+  
+  ### Bug fixes:
+  
+  - [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): fix an assertion race condition in `install_backup_thread`
+    (Jan Midtgaard, review by Gabriel Scherer)
+  
+  - [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of custom_minor_max_size: blocks with
+    out-of-heap memory above this limit are now allocated directly in
+    the major heap.
+    (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer)
+  
+  - [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalize and collect dead custom blocks during minor collection
+    (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
+    Sivaramakrishnan)
+  
+  - [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on amd64 with
+    --enable-frame-pointers
+    (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
+  
+  - [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
+    to correctly handle nested packs
+    (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)
+  
+  - [#12590](https://github.com/ocaml/ocaml/issues/12590), [#12595](https://github.com/ocaml/ocaml/issues/12595): Move `caml_collect_gc_stats_sample` in
+    `caml_empty_minor_heap_promote` before barrier arrival.
+    (B. Szilvasy, review by Gabriel Scherer)
+  
+  - [#12623](https://github.com/ocaml/ocaml/issues/12623), fix the computation of variance composition
+    (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+  
+  - [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649) fix error messages for cyclic type definitions in presence of
+    the `-short-paths` flag.
+    (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+  
+  - [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): fix an assertion boundary case in `caml_reset_young_limit`
+    (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
+  
+  - [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): disable common subexpression elimination for atomic loads
+    (Gabriel Scherer and Vincent Laviron,
+     review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
+     report by Vesa Karvonen and Carine Morel)
+  
+  - [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix ocamlnat (native toplevel) by registering frametables correctly
+    (Stephen Dolan, Nick Barnes and Mark Shinwell,
+     review by Vincent Laviron and Sébastien Hinderer)
+  
+  - [#12791](https://github.com/ocaml/ocaml/issues/12791): `extern` is applied to definitions of `caml_builtin_cprim`
+    and `caml_names_of_builtin_cprim` when linking bytecode '-custom'
+    executables with a C++ linker.
+    (Shayne Fletcher, review by Antonin Décimo and Xavier Leroy)
+  
+  
+  - [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
+    sub-arrays of bigarrays
+    (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
+     review by Gabriel Scherer and Fabrice Buoro)
+  
+---
+
+In the last three months after the release of OCaml 5.1.0, three
+significant regressions have been discovered in OCaml 5.1.0.
+Those regressions concern the packaging of executables,
+the typechecking of OCaml programs, and the performance of numerical codes.
+
+Since those regressions affect many users and could have lasting effects, we
+have published patch release OCaml 5.1.1 fixing those issues. Accounting for the
+still experimental nature of the multicore runtime, this patch release 5.1.1
+also contains safe fixes for subtle concurrency issues in the OCaml runtime.
+
+As a major exception to our policy for patch releases, OCaml 5.1.1 will contain
+one breaking change in the standard library: the `Compression` flag has been
+removed from the `Marshal` module.
+
+This drastic measure was taken because supporting zstd compression in the
+standard library made zstd a dependency of all OCaml executables. Since the
+compiler should not impose its dependency on end-users, the support for
+compressed marshaling has been moved to a compiler internal library in 5.1.1.
+
+The full list of changes is available below for more details.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+
+```bash
+opam update
+opam switch create 5.1.1
+```
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz)
+* [Inria archive](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.1.tar.gz)

--- a/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
+++ b/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
@@ -4,7 +4,6 @@ description: Release of OCaml 5.1.1
 date: "2023-12-08"
 tags: [ocaml]
 changelog: |
-
   ### Standard library:
   
   * (*breaking change*) [#12562](https://github.com/ocaml/ocaml/issues/12562), [#12734](https://github.com/ocaml/ocaml/issues/12734), [#12783](https://github.com/ocaml/ocaml/issues/12783): Remove the `Marshal.Compression` flag to the
@@ -15,10 +14,24 @@ changelog: |
     (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
      Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).
   
-  ### Bug Fixes:
+  ### Runtime Bug Fixes:
   
   - [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): Fix an assertion race condition in `install_backup_thread`
     (Jan Midtgaard, review by Gabriel Scherer)
+
+  - [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on AMD64 with
+   `--enable-frame-pointers`
+    (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
+
+  - [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): Fix an assertion boundary case in `caml_reset_young_limit`
+    (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
+  
+  - [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): Disable common subexpression elimination for atomic loads
+    (Gabriel Scherer and Vincent Laviron,
+     review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
+     report by Vesa Karvonen and Carine Morel)
+
+  ### GC Performance Regression Bug Fixes:
   
   - [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of `custom_minor_max_size:` blocks with
     out-of-heap memory above this limit are now allocated directly in
@@ -28,33 +41,30 @@ changelog: |
   - [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalise and collect dead custom blocks during minor collection
     (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
     Sivaramakrishnan)
-  
-  - [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on AMD64 with
-   `--enable-frame-pointers`
-    (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
-  
-  - [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
-    to correctly handle nested packs
-    (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)
-  
+
   - [#12590](https://github.com/ocaml/ocaml/issues/12590), [#12595](https://github.com/ocaml/ocaml/issues/12595): Move `caml_collect_gc_stats_sample` in
     `caml_empty_minor_heap_promote` before barrier arrival.
     (B. Szilvasy, review by Gabriel Scherer)
   
+  - [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
+    subarrays of bigarrays
+    (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
+     review by Gabriel Scherer and Fabrice Buoro)
+
+  ### Bug Fixes
+
+  - [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
+    to correctly handle nested packs
+    (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)
+  
   - [#12623](https://github.com/ocaml/ocaml/issues/12623): Fix the computation of variance composition
     (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
-  
+
+
   - [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649): Fix error messages for cyclic type definitions in presence of
     the `-short-paths` flag.
     (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
   
-  - [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): Fix an assertion boundary case in `caml_reset_young_limit`
-    (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
-  
-  - [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): Disable common subexpression elimination for atomic loads
-    (Gabriel Scherer and Vincent Laviron,
-     review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
-     report by Vesa Karvonen and Carine Morel)
   
   - [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix `ocamlnat` (native toplevel) by registering frametables correctly
     (Stephen Dolan, Nick Barnes and Mark Shinwell,
@@ -64,13 +74,7 @@ changelog: |
     and `caml_names_of_builtin_cprim` when linking bytecode `-custom`
     executables with a C++ linker.
     (Shayne Fletcher, review by Antonin Décimo and Xavier Leroy)
-  
-  
-  - [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
-    subarrays of bigarrays
-    (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
-     review by Gabriel Scherer and Fabrice Buoro)
-  
+
 ---
 
 In the last three months after the release of OCaml 5.1.0, three

--- a/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
+++ b/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
@@ -1,7 +1,7 @@
 ---
 title: Release of OCaml 5.1.1
 description: Release of OCaml 5.1.1
-date: "2023-12-8"
+date: "2023-12-08"
 tags: [ocaml]
 changelog: |
 
@@ -79,9 +79,7 @@ Those regressions concern the packaging of executables,
 the typechecking of OCaml programs, and the performance of numerical codes.
 
 Since those regressions affect many users and could have lasting effects, we
-have published patch release OCaml 5.1.1 fixing those issues. Accounting for the
-still-experimental nature of the Multicore runtime, this patch release 5.1.1
-also contains safe fixes for subtle concurrency issues in the OCaml runtime.
+have published patch release OCaml 5.1.1 fixing those issues. 
 
 As a major exception to our policy for patch releases, OCaml 5.1.1 will contain
 one breaking change in the standard library: the `Compression` flag has been
@@ -91,6 +89,10 @@ This drastic measure was taken because supporting ZSTD compression in the
 standard library made ZSTD a dependency of all OCaml executables. Since the
 compiler should not impose its dependency on end users, the support for
 compressed marshaling has been moved to a compiler internal library in 5.1.1.
+
+Accounting for the still-experimental nature of the Multicore runtime, this
+patch release 5.1.1 also contains safe fixes for subtle concurrency issues in
+the OCaml runtime.
 
 The full list of changes is available below for more details.
 

--- a/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
+++ b/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
@@ -87,8 +87,8 @@ As a major exception to our policy for patch releases, OCaml 5.1.1 will contain
 one breaking change in the standard library: the `Compression` flag has been
 removed from the `Marshal` module.
 
-This drastic measure was taken because supporting zstd compression in the
-standard library made zstd a dependency of all OCaml executables. Since the
+This drastic measure was taken because supporting ZSTD compression in the
+standard library made ZSTD a dependency of all OCaml executables. Since the
 compiler should not impose its dependency on end users, the support for
 compressed marshaling has been moved to a compiler internal library in 5.1.1.
 

--- a/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
+++ b/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
@@ -9,28 +9,28 @@ changelog: |
   
   * (*breaking change*) [#12562](https://github.com/ocaml/ocaml/issues/12562), [#12734](https://github.com/ocaml/ocaml/issues/12734), [#12783](https://github.com/ocaml/ocaml/issues/12783): Remove the `Marshal.Compression` flag to the
     `Marshal.to_*` functions introduced in 5.1 by [#12006](https://github.com/ocaml/ocaml/issues/12006), as it cannot
-    be implemented without risking to link -lzstd with all
-    ocamlopt-generated executables.  The compilers are still able to use
+    be implemented without risking to link `-lzstd` with all
+   `ocamlopt`-generated executables. The compilers are still able to use
     ZSTD compression for compilation artefacts.
     (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
      Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).
   
-  ### Bug fixes:
+  ### Bug Fixes:
   
-  - [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): fix an assertion race condition in `install_backup_thread`
+  - [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): Fix an assertion race condition in `install_backup_thread`
     (Jan Midtgaard, review by Gabriel Scherer)
   
-  - [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of custom_minor_max_size: blocks with
+  - [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of `custom_minor_max_size:` blocks with
     out-of-heap memory above this limit are now allocated directly in
     the major heap.
     (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer)
   
-  - [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalize and collect dead custom blocks during minor collection
+  - [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalise and collect dead custom blocks during minor collection
     (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
     Sivaramakrishnan)
   
-  - [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on amd64 with
-    --enable-frame-pointers
+  - [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on AMD64 with
+   `--enable-frame-pointers`
     (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
   
   - [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
@@ -41,33 +41,33 @@ changelog: |
     `caml_empty_minor_heap_promote` before barrier arrival.
     (B. Szilvasy, review by Gabriel Scherer)
   
-  - [#12623](https://github.com/ocaml/ocaml/issues/12623), fix the computation of variance composition
+  - [#12623](https://github.com/ocaml/ocaml/issues/12623): Fix the computation of variance composition
     (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
   
-  - [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649) fix error messages for cyclic type definitions in presence of
+  - [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649): Fix error messages for cyclic type definitions in presence of
     the `-short-paths` flag.
     (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
   
-  - [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): fix an assertion boundary case in `caml_reset_young_limit`
+  - [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): Fix an assertion boundary case in `caml_reset_young_limit`
     (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
   
-  - [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): disable common subexpression elimination for atomic loads
+  - [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): Disable common subexpression elimination for atomic loads
     (Gabriel Scherer and Vincent Laviron,
      review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
      report by Vesa Karvonen and Carine Morel)
   
-  - [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix ocamlnat (native toplevel) by registering frametables correctly
+  - [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix `ocamlnat` (native toplevel) by registering frametables correctly
     (Stephen Dolan, Nick Barnes and Mark Shinwell,
      review by Vincent Laviron and Sébastien Hinderer)
   
   - [#12791](https://github.com/ocaml/ocaml/issues/12791): `extern` is applied to definitions of `caml_builtin_cprim`
-    and `caml_names_of_builtin_cprim` when linking bytecode '-custom'
+    and `caml_names_of_builtin_cprim` when linking bytecode `-custom`
     executables with a C++ linker.
     (Shayne Fletcher, review by Antonin Décimo and Xavier Leroy)
   
   
   - [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
-    sub-arrays of bigarrays
+    subarrays of bigarrays
     (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
      review by Gabriel Scherer and Fabrice Buoro)
   
@@ -80,7 +80,7 @@ the typechecking of OCaml programs, and the performance of numerical codes.
 
 Since those regressions affect many users and could have lasting effects, we
 have published patch release OCaml 5.1.1 fixing those issues. Accounting for the
-still experimental nature of the multicore runtime, this patch release 5.1.1
+still-experimental nature of the Multicore runtime, this patch release 5.1.1
 also contains safe fixes for subtle concurrency issues in the OCaml runtime.
 
 As a major exception to our policy for patch releases, OCaml 5.1.1 will contain
@@ -89,7 +89,7 @@ removed from the `Marshal` module.
 
 This drastic measure was taken because supporting zstd compression in the
 standard library made zstd a dependency of all OCaml executables. Since the
-compiler should not impose its dependency on end-users, the support for
+compiler should not impose its dependency on end users, the support for
 compressed marshaling has been moved to a compiler internal library in 5.1.1.
 
 The full list of changes is available below for more details.

--- a/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
+++ b/data/changelog/ocaml/2023-12-8-ocaml-5.1.1.md
@@ -106,7 +106,7 @@ The base compiler can be installed as an opam switch with the following commands
 opam update
 opam switch create 5.1.1
 ```
-The source code for the release candidate is also directly available on:
+The source code for the release is also directly available on:
 
 * [GitHub](https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz)
 * [Inria archive](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.1.tar.gz)

--- a/data/releases/5.1.0.md
+++ b/data/releases/5.1.0.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 5.1.0
 date: 2023-09-14
-is_latest: true
+is_latest: false
 intro: |
   This page describes OCaml version **5.1.0**, released on
   2023-09-14. Go [here](/releases) for a list of all releases.

--- a/data/releases/5.1.0.md
+++ b/data/releases/5.1.0.md
@@ -64,7 +64,7 @@ opam update
 opam switch create 5.1.0
 ```
 
-The source code for the release candidate is also directly available on:
+The source code for OCaml 5.1.0 is also directly available on:
 
 * [GitHub](https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz)
 * [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.1/ocaml-5.1.0.tar.gz)

--- a/data/releases/5.1.1.md
+++ b/data/releases/5.1.1.md
@@ -1,0 +1,141 @@
+---
+kind: compiler
+version: 5.1.2
+date: 2024-12-8
+is_latest: true
+intro: |
+  This page describes OCaml version **5.1.1**, released on
+  Dec 8, 2023. Go [here](/releases) for a list of all releases.
+
+  This is a bug-fix release of [OCaml 5.1.0](/releases/5.1.0).
+highlights: |
+  - Marshall.Compression flag removed from the standard library
+  - Bug fixes for 5.1.0
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 5.1.1
+```
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: set OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: compile OCaml without the native-code compiler
+- `ocaml-option-flambda`: set OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: set OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: set OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: set OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-address-sanitizer`: set OCaml to be compiled with address sanitiser
+- `ocaml-option-leak-sanitizer`: set OCaml to be compiled with leak sanitiser
+- `ocaml-option-fp`: set OCaml to be compiled with frame pointers
+
+For instance, one can install a switch with both `flambda` and the `--disable-flat-float-array` option with
+
+```
+opam switch create 5.1.0+flambda+nffa ocaml-variants.5.1.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+
+Source Distribution
+-------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/5.1.1.zip)
+  format.
+- [Opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://v2.ocaml.org/releases/5.1/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions. See also the [Windows release
+notes](https://v2.ocaml.org/releases/5.1/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+## Changes 
+
+
+This is the
+[changelog](https://v2.ocaml.org/releases/5.1/notes/Changes).
+(Changes that can break existing programs are marked with a  "breaking change" warning)
+
+
+### Standard library:
+
+* (*breaking change*) [#12562](https://github.com/ocaml/ocaml/issues/12562), [#12734](https://github.com/ocaml/ocaml/issues/12734), [#12783](https://github.com/ocaml/ocaml/issues/12783): Remove the `Marshal.Compression` flag to the
+  `Marshal.to_*` functions introduced in 5.1 by [#12006](https://github.com/ocaml/ocaml/issues/12006), as it cannot
+  be implemented without risking to link -lzstd with all
+  ocamlopt-generated executables.  The compilers are still able to use
+  ZSTD compression for compilation artefacts.
+  (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
+   Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).
+
+### Bug fixes:
+
+- [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): fix an assertion race condition in `install_backup_thread`
+  (Jan Midtgaard, review by Gabriel Scherer)
+
+- [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of custom_minor_max_size: blocks with
+  out-of-heap memory above this limit are now allocated directly in
+  the major heap.
+  (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer)
+
+- [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalize and collect dead custom blocks during minor collection
+  (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
+  Sivaramakrishnan)
+
+- [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on amd64 with
+  --enable-frame-pointers
+  (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
+
+- [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
+  to correctly handle nested packs
+  (Vincent Laviron, report by Javier Chávarri, review by Pierre Chambart)
+
+- [#12590](https://github.com/ocaml/ocaml/issues/12590), [#12595](https://github.com/ocaml/ocaml/issues/12595): Move `caml_collect_gc_stats_sample` in
+  `caml_empty_minor_heap_promote` before barrier arrival.
+  (B. Szilvasy, review by Gabriel Scherer)
+
+- [#12623](https://github.com/ocaml/ocaml/issues/12623), fix the computation of variance composition
+  (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+
+- [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649) fix error messages for cyclic type definitions in presence of
+  the `-short-paths` flag.
+  (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
+
+- [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): fix an assertion boundary case in `caml_reset_young_limit`
+  (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
+
+- [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): disable common subexpression elimination for atomic loads
+  (Gabriel Scherer and Vincent Laviron,
+   review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
+   report by Vesa Karvonen and Carine Morel)
+
+- [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix ocamlnat (native toplevel) by registering frametables correctly
+  (Stephen Dolan, Nick Barnes and Mark Shinwell,
+   review by Vincent Laviron and Sébastien Hinderer)
+
+- [#12791](https://github.com/ocaml/ocaml/issues/12791): `extern` is applied to definitions of `caml_builtin_cprim`
+  and `caml_names_of_builtin_cprim` when linking bytecode '-custom'
+  executables with a C++ linker.
+  (Shayne Fletcher, review by Antonin Décimo and Xavier Leroy)
+
+
+- [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
+  sub-arrays of bigarrays
+  (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
+   review by Gabriel Scherer and Fabrice Buoro)

--- a/data/releases/5.1.1.md
+++ b/data/releases/5.1.1.md
@@ -71,22 +71,22 @@ instructions on how to build under Windows.
 
 This is the
 [changelog](https://v2.ocaml.org/releases/5.1/notes/Changes).
-(Changes that can break existing programs are marked with a  "breaking change" warning)
+(Changes that can break existing programs are marked with a "breaking change" warning)
 
 
 ### Standard library:
 
 * (*breaking change*) [#12562](https://github.com/ocaml/ocaml/issues/12562), [#12734](https://github.com/ocaml/ocaml/issues/12734), [#12783](https://github.com/ocaml/ocaml/issues/12783): Remove the `Marshal.Compression` flag to the
   `Marshal.to_*` functions introduced in 5.1 by [#12006](https://github.com/ocaml/ocaml/issues/12006), as it cannot
-  be implemented without risking to link -lzstd with all
-  ocamlopt-generated executables.  The compilers are still able to use
+  be implemented without risking to link `-lzstd` with all
+  `ocamlopt`-generated executables. The compilers are still able to use
   ZSTD compression for compilation artefacts.
   (Xavier Leroy and David Allsopp, report by Kate Deplaix, review by
    Nicolás Ojeda Bär, Kate Deplaix, and Damien Doligez).
 
 ### Bug fixes:
 
-- [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): fix an assertion race condition in `install_backup_thread`
+- [#11800](https://github.com/ocaml/ocaml/issues/11800), [#12707](https://github.com/ocaml/ocaml/issues/12707): Fix an assertion race condition in `install_backup_thread`
   (Jan Midtgaard, review by Gabriel Scherer)
 
 - [#12318](https://github.com/ocaml/ocaml/issues/12318): GC: simplify the meaning of custom_minor_max_size: blocks with
@@ -94,12 +94,12 @@ This is the
   the major heap.
   (Damien Doligez, report by Stephen Dolan, review by Gabriel Scherer)
 
-- [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalize and collect dead custom blocks during minor collection
+- [#12439](https://github.com/ocaml/ocaml/issues/12439): Finalise and collect dead custom blocks during minor collection
   (Damien Doligez, review by Xavier Leroy, Gabriel Scherer and KC
   Sivaramakrishnan)
 
-- [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on amd64 with
-  --enable-frame-pointers
+- [#12486](https://github.com/ocaml/ocaml/issues/12486), [#12535](https://github.com/ocaml/ocaml/issues/12535): Fix delivery of unhandled effect exceptions on AMD64 with
+ `--enable-frame-pointers`
   (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
 
 - [#12581](https://github.com/ocaml/ocaml/issues/12581), [#12609](https://github.com/ocaml/ocaml/issues/12609): Fix error on uses of packed modules outside their pack
@@ -110,32 +110,32 @@ This is the
   `caml_empty_minor_heap_promote` before barrier arrival.
   (B. Szilvasy, review by Gabriel Scherer)
 
-- [#12623](https://github.com/ocaml/ocaml/issues/12623), fix the computation of variance composition
+- [#12623](https://github.com/ocaml/ocaml/issues/12623): Fix the computation of variance composition
   (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
 
-- [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649) fix error messages for cyclic type definitions in presence of
+- [#12645](https://github.com/ocaml/ocaml/issues/12645), [#12649](https://github.com/ocaml/ocaml/issues/12649): Fix error messages for cyclic type definitions in presence of
   the `-short-paths` flag.
   (Florian Angeletti, report by Vesa Karvonen, review by Gabriel Scherer)
 
-- [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): fix an assertion boundary case in `caml_reset_young_limit`
+- [#12712](https://github.com/ocaml/ocaml/issues/12712), [#12742](https://github.com/ocaml/ocaml/issues/12742): Fix an assertion boundary case in `caml_reset_young_limit`
   (Jan Midtgaard, review by Guillaume Munch-Maccagnoni)
 
-- [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): disable common subexpression elimination for atomic loads
+- [#12713](https://github.com/ocaml/ocaml/issues/12713), [#12715](https://github.com/ocaml/ocaml/issues/12715): Disable common subexpression elimination for atomic loads
   (Gabriel Scherer and Vincent Laviron,
    review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
    report by Vesa Karvonen and Carine Morel)
 
-- [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix ocamlnat (native toplevel) by registering frametables correctly
+- [#12757](https://github.com/ocaml/ocaml/issues/12757): Fix `ocamlnat` (native toplevel) by registering frametables correctly
   (Stephen Dolan, Nick Barnes and Mark Shinwell,
    review by Vincent Laviron and Sébastien Hinderer)
 
 - [#12791](https://github.com/ocaml/ocaml/issues/12791): `extern` is applied to definitions of `caml_builtin_cprim`
-  and `caml_names_of_builtin_cprim` when linking bytecode '-custom'
+  and `caml_names_of_builtin_cprim` when linking bytecode `-custom`
   executables with a C++ linker.
   (Shayne Fletcher, review by Antonin Décimo and Xavier Leroy)
 
 
 - [#12491](https://github.com/ocaml/ocaml/issues/12491), [#12493](https://github.com/ocaml/ocaml/issues/12493), [#12500](https://github.com/ocaml/ocaml/issues/12500), [#12754](https://github.com/ocaml/ocaml/issues/12754): Do not change GC pace when creating
-  sub-arrays of bigarrays
+  subarrays of bigarrays
   (Xavier Leroy, report by Ido Yariv, analysis by Gabriel Scherer,
    review by Gabriel Scherer and Fabrice Buoro)

--- a/data/releases/5.1.1.md
+++ b/data/releases/5.1.1.md
@@ -1,6 +1,6 @@
 ---
 kind: compiler
-version: 5.1.2
+version: 5.1.1
 date: 2024-12-8
 is_latest: true
 intro: |


### PR DESCRIPTION
This PR adds the release and the changelog entry for OCaml 5.1.1 (whose release should be officially tomorrow Paris time).