### PR TITLE
Add table of contents to jump to individual sections on "Is OCaml Web yet"

### DIFF
--- a/src/ocamlorg_frontend/pages/is_ocaml_yet.eml
+++ b/src/ocamlorg_frontend/pages/is_ocaml_yet.eml
@@ -8,6 +8,12 @@ let render
 ~tutorials
 ~packages
 =
+let toc = 
+  let category_to_toc_entry (category: Data.Is_ocaml_yet.category) =
+    Toc.{ href = "#" ^ Utils.slugify category.name; title = category.name; children = [] }
+  in
+  List.map category_to_toc_entry meta.categories
+in
 Learn_layout.three_column_layout
 ~title:meta.question
 ~description:(meta.question ^ " " ^ meta.answer)
@@ -15,7 +21,7 @@ Learn_layout.three_column_layout
 ~active_top_nav_item:Header.Learn
 ~current:Learn_layout.Guides
 ~left_sidebar_html:(Some(left_sidebar ~current_tutorial:(Some (Printf.sprintf "is-ocaml-%s-yet" meta.id)) ~tutorials))
-~right_sidebar_html:None @@
+~right_sidebar_html:(Some (Toc.render toc)) @@
 <h1 class="font-bold mb-8"><%s meta.question %></h1>
 <p class="mt-6 text-xl leading-8"><%s meta.answer %></p>
 <div class="mt-10 prose prose-orange max-w-3xl">


### PR DESCRIPTION
|before|after|
|-|-|
|![Screenshot 2023-12-12 at 12-12-30 Is OCaml Web yet](https://github.com/ocaml/ocaml.org/assets/6594573/b7f822e1-b73c-4cc9-b4eb-cc046b90a48a)|![Screenshot 2023-12-12 at 12-12-33 Is OCaml Web yet](https://github.com/ocaml/ocaml.org/assets/6594573/111e3141-db61-4eba-ab0a-c173b1723f8e)|
