### PR TITLE
Update to Tailwind CSS 3.3.6

### DIFF
--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -70,6 +70,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
+  ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
 ]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#7ef5bebbf48958370051b2368a4dd57b69627cf6"]
+  ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
 ]


### PR DESCRIPTION
Both opam and ocaml-ci support pinning tar.gz packages, which are lighter to download than the whole git history.