### PR TITLE
fix a typo in the "Values and Functions" chapter

### DIFF
--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -202,7 +202,7 @@ Execution evaluates each item from top to bottom.
 
 At any time during evaluation, the _environment_ is the ordered sequence of available definitions. The *environment* is also known as *context* in other languages.
 
-Here, the name `tau` is added to the top-level environment.
+Here, the name `twenty` is added to the top-level environment.
 ```ocaml
 # let twenty = 20;;
 val twenty : int = 20


### PR DESCRIPTION
i think i found a typo in the [_Scopes and Environments_ section of _Values and Functions_](https://ocaml.org/docs/values-and-functions#scopes-and-environments), there is no `tau` global variable in the whole page :open_mouth: 
so i replaced it with `twenty`, which makes a bit more sense to me :yum: 

let me know if i did anything wrong, that's the first time i contribute to OCaml :relieved: 