### PR TITLE
Make changelog reachable from the landing page

### DIFF
--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -313,7 +313,7 @@ Layout.render
               </div>
             </div>
             <% ); %>
-            <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">
+            <a href="<%s Url.changelog_entry item.slug %>" class="btn btn-lg btn-ghost rounded mt-8">
             <span>See Full Changelog</span>
             <%s! Icons.chevron_right "h-5 w-5" %>
             </a>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -269,9 +269,9 @@ Layout.render
         <h3 class="font-bold">Releases</h3>
         <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
           <a href="<%s Url.release latest_release.version %>">
-            <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
+            <div class="text-primary text-sm mb-4 uppercase">Recent Releases</div>
             <h3 class="font-bold mb-6">
-              <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
+              <%s latest_release.version %> <span class="text-sm">(<%s latest_release.date %>)</span>
             </h3>
           </a>
           <div class="prose prose-sm"><%s! latest_release.highlights_html %></div>
@@ -292,7 +292,8 @@ Layout.render
             </a>
             <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
             <div class="md:pl-8 md:border-l-2">
-              <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
+            <div class="flex gap-2">
+              <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10 basis-1/4">
                 <div class="relative md:w-72 pb-6 lg:pb-8">
                   <div class="sticky" style="top: 128px; word-break: keep-all;">
                     <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
@@ -306,11 +307,15 @@ Layout.render
                   </div>
                 </div>
               </article>
-              <div class="">
+              <div class="basis-3/4">
                 <div class="prose prose-orange">
                 part two
                 </div>
+                <a href="<%s Url.changelog %>" class="text-primary mt-2">
+                  See full changelog
+                </a>
               </div>
+            </div>
             </div>
             <% ); %>
             <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -265,7 +265,7 @@ Layout.render
   </div>
 </div>
 <div class="bg-legacy-default pt-24 pb-14 overflow-hidden">
-  <div class="container-fluid grid grid-cols-1 md:grid-cols-2 gap-10 items-stretch mb-14"> 
+  <div class="container-fluid grid grid-cols-1 lg:grid-cols-2 gap-10 items-stretch mb-14"> 
       <div class="flex flex-col">
         <h3 class="font-bold">Releases</h3>
         <div class="flex-grow p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -15,6 +15,7 @@ let package_card ~href ~img_path ~name description =
 let render
   ~(latest_release: Data.Release.t)
   ~(lts_release: Data.Release.t)
+  ~(releases : Data.Release.t list)
   ~(changelogs : Data.Changelog.t list)
 =
 Layout.render
@@ -268,14 +269,16 @@ Layout.render
       <div class="flex flex-col">
         <h3 class="font-bold">Releases</h3>
         <div class="flex-grow p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
-          <a href="<%s Url.release latest_release.version %>">
-            <div class="text-primary text-sm mb-4 uppercase">Recent Releases</div>
+        <div class="text-primary text-sm mb-4 uppercase">Recent Releases</div>
+        <% releases |> List.iter (fun (item : Data.Release.t) -> %>
+          <a href="<%s Url.release item.version %>">
             <h3 class="font-bold mb-6">
-              <%s latest_release.version %> <span class="text-sm">(<%s latest_release.date %>)</span>
+              <%s item.version %> <span class="text-sm">(<%s item.date %>)</span>
             </h3>
           </a>
-          <div class="prose prose-sm"><%s! latest_release.highlights_html %></div>
-          <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost rounded mt-8">
+          <div class="prose prose-sm"><%s! item.highlights_html %></div>
+        <% ); %>
+          <a href="<%s Url.releases %>" class="btn btn-ghost rounded mt-8">
             <span>See All Releases</span>
             <%s! Icons.chevron_right "h-5 w-5" %>
           </a>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -291,11 +291,11 @@ Layout.render
             </h3>
             </a>
             <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
-            <div class="md:pl-8 md:border-l-2">
-              <div class="flex gap-16">
+            <div class="pl-8 border-l-2">
+              <div class="flex flex-col lg:flex-row gap-0 lg:gap-16 mb-2 lg:mb-0">
                 <div class="flex flex-col lg:flex-row relative gap-6 lg:gap-10 basis-2/6">
                   <div class="relative pb-6 lg:pb-8">
-                      <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                      <div class="absolute block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
                         <%s! Icons.changelog "w-6 h-6" %>
                       </div>
                       <a href="<%s Url.changelog_entry item.slug %>" class="my-0 font-sans text-xl tracking-normal font-extrabold leading-7 changelog-title whitespace-normal break-all"><%s item.title %></a>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -288,22 +288,24 @@ Layout.render
     </div>
     <div>
         <h3 class="font-bold">Changelog</h3>
-        <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
-        <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
-          <div class="relative md:w-72 pb-6 lg:pb-8">
-            <div class="sticky" style="top: 128px; word-break: keep-all;">
-              <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
-                <%s! Icons.changelog "w-6 h-6" %>
+        <div class="mt-20 md:pl-8 md:border-l-2">
+          <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
+          <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
+            <div class="relative md:w-72 pb-6 lg:pb-8">
+              <div class="sticky" style="top: 128px; word-break: keep-all;">
+                <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                  <%s! Icons.changelog "w-6 h-6" %>
+                </div>
+                <h2
+                  class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
+                  <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
+                </h2>
+                <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
               </div>
-              <h2
-                class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
-                <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
-              </h2>
-              <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
             </div>
-          </div>
-        </article>
-        <% ); %>
+          </article>
+          <% ); %>
+        </div>
           <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
             <span>See all Releases</span>
             <%s! Icons.chevron_right "h-5 w-5" %>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -292,25 +292,25 @@ Layout.render
             </a>
             <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
             <div class="md:pl-8 md:border-l-2">
-            <div class="flex">
-              <div class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
-                <div class="relative md:w-72 pb-6 lg:pb-8">
-                    <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
-                      <%s! Icons.changelog "w-6 h-6" %>
-                    </div>
-                    <a href="<%s Url.changelog_entry item.slug %>" class="my-0 font-sans text-xl tracking-normal font-extrabold leading-7 changelog-title whitespace-normal"><%s item.title %></a>
-                    <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
+              <div class="flex gap-16">
+                <div class="flex flex-col lg:flex-row relative gap-6 lg:gap-10 basis-2/6">
+                  <div class="relative pb-6 lg:pb-8">
+                      <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                        <%s! Icons.changelog "w-6 h-6" %>
+                      </div>
+                      <a href="<%s Url.changelog_entry item.slug %>" class="my-0 font-sans text-xl tracking-normal font-extrabold leading-7 changelog-title whitespace-normal break-all"><%s item.title %></a>
+                      <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
+                  </div>
+                </div>
+                <div class="mb-8 basis-4/6">
+                  <div class="prose prose-orange">
+                    <%s! String.sub item.body_html 0 100 %>...
+                  </div>
+                  <a href="<%s Url.changelog %>" class="text-primary mt-2">
+                    See full changelog
+                  </a>
                 </div>
               </div>
-              <div class="mb-8">
-                <div class="prose prose-orange">
-                  <%s! String.sub item.body_html 0 100 %>...
-                </div>
-                <a href="<%s Url.changelog %>" class="text-primary mt-2">
-                  See full changelog
-                </a>
-              </div>
-            </div>
             </div>
             <% ); %>
             <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -270,14 +270,18 @@ Layout.render
         <h3 class="font-bold">Releases</h3>
         <div class="flex-grow p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
         <div class="text-primary text-sm mb-4 uppercase">Recent Releases</div>
+      
         <% releases |> List.iter (fun (item : Data.Release.t) -> %>
+          <div class="mb-4">
           <a href="<%s Url.release item.version %>">
             <h3 class="font-bold mb-6">
               <%s item.version %> <span class="text-sm">(<%s item.date %>)</span>
             </h3>
           </a>
           <div class="prose prose-sm"><%s! item.highlights_html %></div>
+           </div>
         <% ); %>
+       
           <a href="<%s Url.releases %>" class="btn btn-ghost rounded mt-8">
             <span>See All Releases</span>
             <%s! Icons.chevron_right "h-5 w-5" %>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -12,9 +12,15 @@ let package_card ~href ~img_path ~name description =
       </div>
   </a>
   
+let getChangelogHtmlHtml (item : Data.Changelog.t) : string =
+  match item.changelog_html with
+  | Some(html) -> html
+  | None -> ""
+
 let render
-~(latest_release: Data.Release.t)
-~(lts_release: Data.Release.t)
+  ~(latest_release: Data.Release.t)
+  ~(lts_release: Data.Release.t)
+  ~(changelogs : Data.Changelog.t list)
 =
 Layout.render
 ~use_swiper:true
@@ -214,7 +220,6 @@ Layout.render
           </div>
         </div>
       </div>
-
       <div class="flex gap-10 lg:gap-24 flex-col lg:flex-row-reverse justify-between">
         <div class="lg:flex-1">
           <div class="text-legacy-lighter text-base">
@@ -282,21 +287,27 @@ Layout.render
       </a>
     </div>
     <div>
-    <h3 class="font-bold">Changelog</h3>
-      <div class="bg-pattern p-6 mt-8 rounded-xl w-full lg:w-2/3 text-white">
-        <a href="<%s Url.release latest_release.version %>">
-          <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
-          <h3 class="font-bold mb-6">
-            <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
-          </h3>
-        </a>
-        <div class="prose prose-sm text-white"><%s! latest_release.highlights_html %></div>
-         <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
-        <span>See all Releases</span>
-        <%s! Icons.chevron_right "h-5 w-5" %>
-      </a>
-      </div>
-     
+        <h3 class="font-bold">Changelog</h3>
+        <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
+        <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
+          <div class="relative md:w-72 pb-6 lg:pb-8">
+            <div class="sticky" style="top: 128px; word-break: keep-all;">
+              <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                <%s! Icons.changelog "w-6 h-6" %>
+              </div>
+              <h2
+                class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
+                <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
+              </h2>
+              <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
+            </div>
+          </div>
+        </article>
+        <% ); %>
+          <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
+            <span>See all Releases</span>
+            <%s! Icons.chevron_right "h-5 w-5" %>
+          </a>
     </div>
   </div>
 </div>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -292,24 +292,19 @@ Layout.render
             </a>
             <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
             <div class="md:pl-8 md:border-l-2">
-            <div class="flex gap-2">
-              <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10 basis-1/4">
+            <div class="flex">
+              <div class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
                 <div class="relative md:w-72 pb-6 lg:pb-8">
-                  <div class="sticky" style="top: 128px; word-break: keep-all;">
                     <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
                       <%s! Icons.changelog "w-6 h-6" %>
                     </div>
-                    <h2
-                      class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
-                      <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
-                    </h2>
+                    <a href="<%s Url.changelog_entry item.slug %>" class="my-0 font-sans text-xl tracking-normal font-extrabold leading-7 changelog-title whitespace-normal"><%s item.title %></a>
                     <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
-                  </div>
                 </div>
-              </article>
-              <div class="basis-3/4">
+              </div>
+              <div class="mb-8">
                 <div class="prose prose-orange">
-                part two
+                  <%s! String.sub item.body_html 0 100 %>...
                 </div>
                 <a href="<%s Url.changelog %>" class="text-primary mt-2">
                   See full changelog

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -264,7 +264,7 @@ Layout.render
   </div>
 </div>
 <div class="bg-legacy-default pt-24 pb-14 overflow-hidden">
-  <div class="container-fluid flex gap-10 items-stretch mb-14"> 
+  <div class="container-fluid flex flex-col md:flex-row gap-10 items-stretch mb-14"> 
       <div class="basis-1/2">
         <h3 class="font-bold">Releases</h3>
         <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -292,28 +292,26 @@ Layout.render
             </a>
             <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
             <div class="pl-8 border-l-2">
-              <div class="flex flex-col lg:flex-row gap-0 lg:gap-16 mb-2 lg:mb-0">
-                <div class="flex flex-col lg:flex-row relative gap-6 lg:gap-10 basis-2/6">
-                  <div class="relative pb-6 lg:pb-8">
-                      <div class="absolute block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
-                        <%s! Icons.changelog "w-6 h-6" %>
-                      </div>
-                      <a href="<%s Url.changelog_entry item.slug %>" class="my-0 font-sans text-xl tracking-normal font-extrabold leading-7 changelog-title whitespace-normal break-all"><%s item.title %></a>
-                      <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
-                  </div>
-                </div>
-                <div class="mb-8 basis-4/6">
-                  <div class="prose prose-orange">
-                    <%s! String.sub item.body_html 0 100 %>...
-                  </div>
-                  <a href="<%s Url.changelog %>" class="text-primary mt-2">
-                    See full changelog
-                  </a>
+              <div class="flex flex-col">   
+                <div class="mb-6">
+                    <div class="relative pb-2">
+                        <div class="absolute block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                          <%s! Icons.changelog "w-6 h-6" %>
+                        </div>
+                        <a href="<%s Url.changelog_entry item.slug %>" class="my-0 font-sans text-xl tracking-normal font-extrabold leading-7 changelog-title whitespace-normal break-all"><%s item.title %></a>
+                        <time datetime="<%s item.date %>" class="block mt-1 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
+                    </div>
+                    <div class="prose prose-orange">
+                      <%s! String.sub item.body_html 0 100 %>...
+                    </div>
+                    <a href="<%s Url.changelog %>" class="text-primary mt-2">
+                      See full changelog
+                    </a>
                 </div>
               </div>
             </div>
             <% ); %>
-            <a href="<%s Url.changelog_entry item.slug %>" class="btn btn-lg btn-ghost rounded mt-8">
+            <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">
             <span>See Full Changelog</span>
             <%s! Icons.chevron_right "h-5 w-5" %>
             </a>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -12,11 +12,6 @@ let package_card ~href ~img_path ~name description =
       </div>
   </a>
   
-let getChangelogHtmlHtml (item : Data.Changelog.t) : string =
-  match item.changelog_html with
-  | Some(html) -> html
-  | None -> ""
-
 let render
   ~(latest_release: Data.Release.t)
   ~(lts_release: Data.Release.t)
@@ -269,9 +264,7 @@ Layout.render
   </div>
 </div>
 <div class="bg-legacy-default pt-24 pb-14 overflow-hidden">
-  <div class="container-fluid flex gap-10 items-stretch mb-14">
-
-     
+  <div class="container-fluid flex gap-10 items-stretch mb-14"> 
       <div class="basis-1/2">
         <h3 class="font-bold">Releases</h3>
         <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
@@ -288,40 +281,44 @@ Layout.render
           </a>
        </div>
       </div>
-
-    <div class="basis-1/2">
-        <h3 class="font-bold">Changelog</h3>
-        <div class="p-10 mt-7 border-2 shadow-md rounded-2xl h-full">
-          <a href="<%s Url.changelog %>">
-          <div class="text-primary text-sm mb-4 uppercase">Releases & Updates</div>
-          <h3 class="font-bold mb-6">
-            Compiler and Platform Tools
-          </h3>
-        </a>
-          <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
-          <div class="md:pl-8 md:border-l-2">
-            <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
-              <div class="relative md:w-72 pb-6 lg:pb-8">
-                <div class="sticky" style="top: 128px; word-break: keep-all;">
-                  <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
-                    <%s! Icons.changelog "w-6 h-6" %>
+      <div class="basis-1/2">
+          <h3 class="font-bold">Changelog</h3>
+          <div class="p-10 mt-7 border-2 shadow-md rounded-2xl h-full">
+            <a href="<%s Url.changelog %>">
+            <div class="text-primary text-sm mb-4 uppercase">Releases & Updates</div>
+            <h3 class="font-bold mb-6">
+              Compiler and Platform Tools
+            </h3>
+            </a>
+            <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
+            <div class="md:pl-8 md:border-l-2">
+              <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
+                <div class="relative md:w-72 pb-6 lg:pb-8">
+                  <div class="sticky" style="top: 128px; word-break: keep-all;">
+                    <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                      <%s! Icons.changelog "w-6 h-6" %>
+                    </div>
+                    <h2
+                      class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
+                      <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
+                    </h2>
+                    <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
                   </div>
-                  <h2
-                    class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
-                    <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
-                  </h2>
-                  <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
+                </div>
+              </article>
+              <div class="">
+                <div class="prose prose-orange">
+                part two
                 </div>
               </div>
-            </article>
-          </div>
-          <% ); %>
-             <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">
+            </div>
+            <% ); %>
+            <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">
             <span>See Full Changelog</span>
             <%s! Icons.chevron_right "h-5 w-5" %>
-          </a>
-        </div>
-    </div>
+            </a>
+          </div>
+      </div>
   </div>
 </div>
 <div class="bg-pattern py-24 overflow-hidden">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -269,10 +269,10 @@ Layout.render
   </div>
 </div>
 <div class="bg-legacy-default py-12 overflow-hidden">
-  <div class="container-fluid flex items-center justify-between">
-    <div>
+  <div class="container-fluid flex gap-10">
+    <div class="basis-1/2 ">
       <h3 class="font-bold">Releases</h3>
-      <div class="bg-pattern p-6 mt-8 rounded-xl w-full lg:w-2/3 text-white">
+      <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl">
         <a href="<%s Url.release latest_release.version %>">
           <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
           <h3 class="font-bold mb-6">
@@ -280,36 +280,44 @@ Layout.render
           </h3>
         </a>
         <div class="prose prose-sm text-white"><%s! latest_release.highlights_html %></div>
-      </div>
-      <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
-        <span>See all Releases</span>
+          <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost rounded mt-8">
+        <span>See All Releases</span>
         <%s! Icons.chevron_right "h-5 w-5" %>
       </a>
+      </div>
     </div>
-    <div>
+    <div class="basis-1/2 ">
         <h3 class="font-bold">Changelog</h3>
-        <div class="mt-20 md:pl-8 md:border-l-2">
+        <div class="p-10 mt-7 border-2 shadow-md rounded-2xl">
+          <a href="<%s Url.changelog %>">
+          <div class="text-primary text-sm mb-4 uppercase">Releases & Updates</div>
+          <h3 class="font-bold mb-6">
+            Compiler and Platform Tools
+          </h3>
+        </a>
           <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
-          <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
-            <div class="relative md:w-72 pb-6 lg:pb-8">
-              <div class="sticky" style="top: 128px; word-break: keep-all;">
-                <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
-                  <%s! Icons.changelog "w-6 h-6" %>
+          <div class="md:pl-8 md:border-l-2">
+            <article class="flex flex-col lg:flex-row relative gap-6 lg:gap-10">
+              <div class="relative md:w-72 pb-6 lg:pb-8">
+                <div class="sticky" style="top: 128px; word-break: keep-all;">
+                  <div class="hidden md:absolute md:block -left-11 bg-legacy-default dark:bg-legacy-dark-default w-6 h-6 mt-0.5 text-primary">
+                    <%s! Icons.changelog "w-6 h-6" %>
+                  </div>
+                  <h2
+                    class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
+                    <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
+                  </h2>
+                  <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
                 </div>
-                <h2
-                  class="my-0 font-sans text-2xl tracking-normal font-extrabold leading-7 changelog-title">
-                  <a href="<%s Url.changelog_entry item.slug %>"><%s item.title %></a>
-                </h2>
-                <time datetime="<%s item.date %>" class="block mt-3 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
               </div>
-            </div>
-          </article>
+            </article>
+          </div>
           <% ); %>
-        </div>
-          <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
-            <span>See all Releases</span>
+             <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">
+            <span>See Full Changelog</span>
             <%s! Icons.chevron_right "h-5 w-5" %>
           </a>
+        </div>
     </div>
   </div>
 </div>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -264,10 +264,10 @@ Layout.render
   </div>
 </div>
 <div class="bg-legacy-default pt-24 pb-14 overflow-hidden">
-  <div class="container-fluid flex flex-col md:flex-row gap-10 items-stretch mb-14"> 
-      <div class="basis-1/2">
+  <div class="container-fluid grid grid-cols-1 md:grid-cols-2 gap-10 items-stretch mb-14"> 
+      <div class="flex flex-col">
         <h3 class="font-bold">Releases</h3>
-        <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
+        <div class="flex-grow p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
           <a href="<%s Url.release latest_release.version %>">
             <div class="text-primary text-sm mb-4 uppercase">Recent Releases</div>
             <h3 class="font-bold mb-6">
@@ -281,9 +281,9 @@ Layout.render
           </a>
        </div>
       </div>
-      <div class="basis-1/2">
+      <div class="flex flex-col">
           <h3 class="font-bold">Changelog</h3>
-          <div class="p-10 mt-7 border-2 shadow-md rounded-2xl h-full">
+          <div class="flex-grow p-10 mt-7 border-2 shadow-md rounded-2xl h-full">
             <a href="<%s Url.changelog %>">
             <div class="text-primary text-sm mb-4 uppercase">Releases & Updates</div>
             <h3 class="font-bold mb-6">
@@ -312,7 +312,7 @@ Layout.render
               </div>
             </div>
             <% ); %>
-            <a href="<%s Url.changelog %>" class="btn btn-lg btn-ghost rounded mt-8">
+            <a href="<%s Url.changelog %>" class="btn btn-ghost rounded mt-8">
             <span>See Full Changelog</span>
             <%s! Icons.chevron_right "h-5 w-5" %>
             </a>

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -268,27 +268,30 @@ Layout.render
     </div>
   </div>
 </div>
-<div class="bg-legacy-default py-12 overflow-hidden">
-  <div class="container-fluid flex gap-10">
-    <div class="basis-1/2 ">
-      <h3 class="font-bold">Releases</h3>
-      <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl">
-        <a href="<%s Url.release latest_release.version %>">
-          <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
-          <h3 class="font-bold mb-6">
-            <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
-          </h3>
-        </a>
-        <div class="prose prose-sm text-white"><%s! latest_release.highlights_html %></div>
+<div class="bg-legacy-default pt-24 pb-14 overflow-hidden">
+  <div class="container-fluid flex gap-10 items-stretch mb-14">
+
+     
+      <div class="basis-1/2">
+        <h3 class="font-bold">Releases</h3>
+        <div class="p-10 mt-7 w-full border-2 shadow-md rounded-2xl h-full">
+          <a href="<%s Url.release latest_release.version %>">
+            <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
+            <h3 class="font-bold mb-6">
+              <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
+            </h3>
+          </a>
+          <div class="prose prose-sm"><%s! latest_release.highlights_html %></div>
           <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost rounded mt-8">
-        <span>See All Releases</span>
-        <%s! Icons.chevron_right "h-5 w-5" %>
-      </a>
+            <span>See All Releases</span>
+            <%s! Icons.chevron_right "h-5 w-5" %>
+          </a>
+       </div>
       </div>
-    </div>
-    <div class="basis-1/2 ">
+
+    <div class="basis-1/2">
         <h3 class="font-bold">Changelog</h3>
-        <div class="p-10 mt-7 border-2 shadow-md rounded-2xl">
+        <div class="p-10 mt-7 border-2 shadow-md rounded-2xl h-full">
           <a href="<%s Url.changelog %>">
           <div class="text-primary text-sm mb-4 uppercase">Releases & Updates</div>
           <h3 class="font-bold mb-6">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -290,8 +290,9 @@ Layout.render
               Compiler and Platform Tools
             </h3>
             </a>
-            <% changelogs |> List.iter (fun (item : Data.Changelog.t) -> %>
-            <div class="pl-8 border-l-2">
+            <% let changelogs_length = List.length changelogs in changelogs |> 
+                    List.iteri (fun index (item : Data.Changelog.t) -> %>
+            <div class="<%s if index = changelogs_length - 1 then "pl-8" else "pl-8 border-l-2" %>">
               <div class="flex flex-col">   
                 <div class="mb-6">
                     <div class="relative pb-2">

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -264,21 +264,40 @@ Layout.render
   </div>
 </div>
 <div class="bg-legacy-default py-12 overflow-hidden">
-  <div class="container-fluid flex flex-col items-center">
-    <h3 class="font-bold">Releases</h3>
-    <div class="bg-pattern p-6 mt-8 rounded-xl w-full lg:w-2/3 text-white">
-      <a href="<%s Url.release latest_release.version %>">
-        <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
-        <h3 class="font-bold mb-6">
-          <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
-        </h3>
+  <div class="container-fluid flex items-center justify-between">
+    <div>
+      <h3 class="font-bold">Releases</h3>
+      <div class="bg-pattern p-6 mt-8 rounded-xl w-full lg:w-2/3 text-white">
+        <a href="<%s Url.release latest_release.version %>">
+          <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
+          <h3 class="font-bold mb-6">
+            <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
+          </h3>
+        </a>
+        <div class="prose prose-sm text-white"><%s! latest_release.highlights_html %></div>
+      </div>
+      <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
+        <span>See all Releases</span>
+        <%s! Icons.chevron_right "h-5 w-5" %>
       </a>
-      <div class="prose prose-sm text-white"><%s! latest_release.highlights_html %></div>
     </div>
-    <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
-      <span>See all Releases</span>
-      <%s! Icons.chevron_right "h-5 w-5" %>
-    </a>
+    <div>
+    <h3 class="font-bold">Changelog</h3>
+      <div class="bg-pattern p-6 mt-8 rounded-xl w-full lg:w-2/3 text-white">
+        <a href="<%s Url.release latest_release.version %>">
+          <div class="text-primary text-sm mb-4 uppercase">Recent Release</div>
+          <h3 class="font-bold mb-6">
+            <%s latest_release.version %> <span class="text-sm font-medium">(<%s latest_release.date %>)</span>
+          </h3>
+        </a>
+        <div class="prose prose-sm text-white"><%s! latest_release.highlights_html %></div>
+         <a href="<%s Url.releases %>" class="btn btn-lg btn-ghost mt-8">
+        <span>See all Releases</span>
+        <%s! Icons.chevron_right "h-5 w-5" %>
+      </a>
+      </div>
+     
+    </div>
   </div>
 </div>
 <div class="bg-pattern py-24 overflow-hidden">

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -10,7 +10,8 @@ let ( let</>? ) opt = http_or_404 opt
 let index _req =
   Dream.html
     (Ocamlorg_frontend.home ~latest_release:Data.Release.latest
-       ~lts_release:Data.Release.lts)
+       ~lts_release:Data.Release.lts
+       ~changelogs:(List.take 3 Data.Changelog.all))
 
 let install _req = Dream.html (Ocamlorg_frontend.install ())
 

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -11,6 +11,7 @@ let index _req =
   Dream.html
     (Ocamlorg_frontend.home ~latest_release:Data.Release.latest
        ~lts_release:Data.Release.lts
+       ~releases:(List.take 2 Data.Release.all)
        ~changelogs:(List.take 3 Data.Changelog.all))
 
 let install _req = Dream.html (Ocamlorg_frontend.install ())


### PR DESCRIPTION
This PR closes #1463 
It:
- adjusts designs for releases card 
- Includes a new card for latest 3 changelog
- updates styling and links to new designs

Progress: 
![Screenshot 2023-12-20 at 01 44 57](https://github.com/ocaml/ocaml.org/assets/67555014/efc4d40e-af2e-4e39-9f23-89945fef30c4)
