### PR TITLE
Adding a tutorial on bytecode compiler

### DIFF
--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -37,7 +37,7 @@ When you work on several OCaml projects simultaneously, you should create more o
 
 ## Compiling OCaml Programs
 
-By default, OCaml comes with two compilers: one translating sources into native binaries and another turning sources into a bytecode format. OCaml also comes with an interpreter for that bytecode format. This tutorial demonstrates how to use the native compiler to write OCaml programs.
+By default, OCaml comes with two compilers: one translating sources into native binaries and another [turning sources into a bytecode format](/docs/ocaml-bytecode-compiler). OCaml also comes with an interpreter for that bytecode format. This tutorial demonstrates how to use the native compiler to write OCaml programs.
 
 <!-- Other compilers exist, for instance, [js_of_ocaml](https://ocsigen.org/js_of_ocaml) generates JavaScript. The toplevel uses the bytecode compiler; expressions are read, type-checked, compiled into bytecode, and executed. The previous tutorial was interactive because we used the toplevel. -->
 

--- a/data/tutorials/getting-started/2_03_bytecode_compiler.md
+++ b/data/tutorials/getting-started/2_03_bytecode_compiler.md
@@ -6,7 +6,7 @@ description: |
 category: "Tooling"
 ---
 
-Like in C/C++, we can just add OCaml code to a file, compile it and run it as an executable.
+Like in C/C++, we can just add OCaml code to a file, compile it, and run it as an executable.
 
 # Storing Code in Files
 
@@ -24,7 +24,7 @@ Next, create a file named `hello.ml` and add the following code with your favori
 let _ = print_endline "Hello OCaml!"
 ```
 
-**Note:** There are no double semicolons ;; at the end of that line of code.
+**Note:** There are no double semicolons `;;` at the end of that line of code.
 
 The *let _ =* signifies that we don't care to give a name to the code on the right-hand side of *=*, hence the `_`.
 
@@ -42,7 +42,7 @@ Now let's run the executable and see what happens:
 $ ./hello
 ```
 
-Voilà! It says, `Hello OCaml!`. Congratulations.
+Voilà! It says, `Hello OCaml!`. Congratulations!
 
 We can change the string or add more content, save the file, recompile, and rerun.
 

--- a/data/tutorials/getting-started/2_03_bytecode_compiler.md
+++ b/data/tutorials/getting-started/2_03_bytecode_compiler.md
@@ -26,7 +26,7 @@ let _ = print_endline "Hello OCaml!"
 
 **Note:** There are no double semicolons `;;` at the end of that line of code.
 
-The *let _ =* signifies that we don't care to give a name to the code on the right-hand side of *=*, hence the `_`.
+The `let _ =` signifies that we don't care to give a name to the code on the right-hand side of `=`, hence the `_`.
 
 Now, we are ready to run the code. Save the file and return to the command line. Let's compile the code:
 

--- a/data/tutorials/getting-started/2_03_bytecode_compiler.md
+++ b/data/tutorials/getting-started/2_03_bytecode_compiler.md
@@ -1,0 +1,53 @@
+---
+id: ocaml-bytecode-compiler
+title: Introduction to OCaml's Bytecode Compiler
+description: |
+  This page will give you a brief introduction to OCaml's Bytecode Compiler
+category: "Tooling"
+---
+
+Like in C/C++, we can just add OCaml code to a file, compile it and run it as an executable.
+
+# Storing Code in Files
+
+Create a new directory named `hello-ocaml` and navigate to the directory:
+
+```
+$ mkdir hello-ocaml
+
+$ cd hello-ocaml
+```
+
+Next, create a file named `hello.ml` and add the following code with your favorite text editor:
+
+```
+let _ = print_endline "Hello OCaml!"
+```
+
+**Note:** There are no double semicolons ;; at the end of that line of code.
+
+The *let _ =* signifies that we don't care to give a name to the code on the right-hand side of *=*, hence the `_`.
+
+Now, we are ready to run the code. Save the file and return to the command line. Let's compile the code:
+
+```
+ocamlc -o hello hello.ml
+```
+
+The compiler is named `ocamlc`. The `-o hello` option tells the compiler to name the output executable as `hello`. The executable `hello` contains compiled OCaml bytecode. In addition, two other files are produced, `hello.cmi and hello.cmo`. We don’t need to worry about those files for now. 
+
+Now let's run the executable and see what happens:
+
+```
+$ ./hello
+```
+
+Voilà! It says, `Hello OCaml!`. Congratulations.
+
+We can change the string or add more content, save the file, recompile, and rerun.
+
+We can clean up the generated files by:
+
+```
+$ rm hello hello.cmi hello.cmo
+```


### PR DESCRIPTION
Hey, in the **Your First OCaml Program** section, there's a sub heading _Compiling OCaml Programs_. It talks about OCaml's two compilers: one translating sources into native binaries and another turning sources into a bytecode format. As of now, the tutorial only demonstrates how to use the native compiler to write OCaml programs.

I've added a link to **turning sources into a bytecode format**, where I've written an entire, yet minimal tutorial, to explain how to compile OCaml programs to bytecode using **ocamlc**. 

Motivation: I proposed this idea in one of the meetings that I attended a few weeks ago.

Intent/usefulness: Well, this is definitely a knowledge addition. Moreover, the real intent is to motivate newcomers by showing them that this is similar, like in C/C++. Hopefully, this completes the loop of updating compilation using both native binaries and bytecode format.

Future prospects: This is just a simple tutorial to show how we can easily compile and run OCaml programs with **ocamlc**, as the documentation grows, if and only if it's required, we can update by explaining some more details on .cmi and .cmo and a few more examples.