### PR TITLE
(doc) how to generate odoc .mld documentation pages with dune

### DIFF
--- a/data/tutorials/platform/bp_08_odoc.md
+++ b/data/tutorials/platform/bp_08_odoc.md
@@ -6,7 +6,7 @@ description: |
 category: "Best Practices"
 ---
 
-# Generating Documentation With Odoc
+# Generating Documentation With `odoc`
 
 The documentation rendering tool `odoc` generates documentation
 in the form of HTML, LaTeX, or man pages,
@@ -24,7 +24,7 @@ $ open _build/default/_doc/_html/index.html
 $ explorer _build\default\_doc\_html\index.html
 ```
 
-## Generating .mld Documentation Pages
+## Generating `.mld` Documentation Pages
 
 In addition to documenting the publicly-visible API of your project,
 `odoc` also gives you the ability to add individual documentation pages.
@@ -32,8 +32,8 @@ In addition to documenting the publicly-visible API of your project,
 For example, to replace the automatically generated documentation
 index file, you have to add a file `index.mld` to your project.
 
-To make `dune` find your `.mld` pages and process them with `odoc`,
-the dune file in the same directory as your `.mld` files needs to
+To make Dune find your `.mld` pages and process them with `odoc`,
+the `dune` file in the same directory as your `.mld` files needs to
 include this stanza:
 
 ```
@@ -41,7 +41,7 @@ include this stanza:
  (package name-of-your-package))
 ```
 
-A common place to put `.mld` files is a folder named `doc`, or `docs`.
+A common place to put `.mld` files is a folder named `doc` or `docs`.
 
 For more information on how to write documentation pages for `odoc`,
-see the [odoc for authors documentation](https://ocaml.github.io/odoc/odoc_for_authors.html#doc-pages).
+see the [`odoc` for authors documentation](https://ocaml.github.io/odoc/odoc_for_authors.html#doc-pages).

--- a/data/tutorials/platform/bp_08_odoc.md
+++ b/data/tutorials/platform/bp_08_odoc.md
@@ -23,3 +23,25 @@ $ open _build/default/_doc/_html/index.html
 # Windows
 $ explorer _build\default\_doc\_html\index.html
 ```
+
+## Generating .mld Documentation Pages
+
+In addition to documenting the publicly-visible API of your project,
+`odoc` also gives you the ability to add individual documentation pages.
+
+For example, to replace the automatically generated documentation
+index file, you have to add a file `index.mld` to your project.
+
+To make `dune` find your `.mld` pages and process them with `odoc`,
+the dune file in the same directory as your `.mld` files needs to
+include this stanza:
+
+```
+(documentation
+ (package name-of-your-package))
+```
+
+A common place to put `.mld` files is a folder named `doc`, or `docs`.
+
+For more information on how to write documentation pages for `odoc`,
+see the [odoc for authors documentation](https://ocaml.github.io/odoc/odoc_for_authors.html#doc-pages).


### PR DESCRIPTION
I struggled with getting dune to pick up my custom `index.mld`.

That's why I propose adding this subsection.