### PR TITLE
Prepend opam exec -- on all dune commands

### DIFF
--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -44,7 +44,7 @@ By default, OCaml comes with two compilers: one translating sources into native 
 We start by setting up a traditional “Hello World!” project using Dune. Make sure to have installed version 3.7 or later. The following creates a project named `hello`:
 
 ```shell
-$ dune init proj hello
+$ opam exec -- dune init proj hello
 Entering directory '/home/ocaml.org/hello'
 Success: initialized project component named hello
 ```
@@ -85,13 +85,13 @@ Each folder containing source files that need to be built must contain a `dune` 
 
 This builds the project:
 ```shell
-$ dune build
+$ opam exec -- dune build
 Entering directory '/home/ocaml.org'
 ```
 
 This launches the executable it creates:
 ```shell
-$ dune exec hello
+$ opam exec -- dune exec hello
 Entering directory '/home/ocaml.org'
 Hello, World!
 ```
@@ -140,7 +140,7 @@ Here is a new version of the `bin/main.ml` file:
 
 Now execute the resulting project:
  ```shell
- $ dune exec hello
+ $ opam exec -- dune exec hello
 Entering directory '/home/ocaml.org'
 Hello from a module
 ```
@@ -149,7 +149,7 @@ The file `lib/hello.ml` creates the module named `Hello`, which in turn defines 
 
 Dune can launch UTop to access the modules exposed by a project interactively. Here's how:
 ```shell
-$ dune utop
+$ opam exec -- dune utop
 ```
 
 Then, inside the `utop` toplevel, it is possible to inspect our `Hello` module:
@@ -185,7 +185,7 @@ let () = Printf.printf "%s\n" Hello.mundo
 
 Trying to compile this fails.
 ```shell
-$ dune build
+$ opam exec -- dune build
 Entering directory '/home/ocaml.org'
 File "hello/bin/main.ml", line 1, characters 30-41:
 1 | let () = Printf.printf "%s\n" Hello.mundo
@@ -238,7 +238,7 @@ You need to tell Dune it needs Dream to compile the project. Do this by adding t
 
 Launch the server from a new terminal.
 ```shell
-$ dune exec hello
+$ opam exec -- dune exec hello
 20.07.23 13:14:07.801                       0
 20.07.23 13:14:07.801                       Type Ctrl+C to stop
 ```
@@ -349,7 +349,7 @@ let () = print_endline "My name is Minimo"
 
 That's all! This is sufficient for Dune to build and execute the `minimo.ml` file.
 ```shell
-$ dune exec ./minimo.exe
+$ opam exec -- dune exec ./minimo.exe
 Entering directory '/home/ocaml.org'
 My name is Minimo
 ```

--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -49,6 +49,8 @@ Entering directory '/home/ocaml.org/hello'
 Success: initialized project component named hello
 ```
 
+**Note**: If you have used `eval $(opam env)`, or have answered yes to the question when you ran `opam init`, you can omit `opam exec --`.
+
 **Note**: Throughout this tutorial, outputs generated Dune might vary slightly because of the Dune version installed. This tutorial shows the output for Dune 3.7. If you'd like to get the most recent version of Dune, run `opam update; opam upgrade dune` in a terminal.
 
 The project is stored in a directory named `hello`. The `tree` command lists the files and directories created. It might be necessary to install `tree` if you don't see the following. Through Homebrew, for example, run `brew install tree`.

--- a/data/tutorials/guides/1wf_01_debugging.md
+++ b/data/tutorials/guides/1wf_01_debugging.md
@@ -448,8 +448,8 @@ Here is a corresponding `dune` file:
 If we compile and run the program using `dune` under a regular `5.0.0` switch the
 program appears to work:
 ```
-$ dune build ./race.exe
-$ dune exec ./race.exe
+$ opam exec -- dune build ./race.exe
+$ opam exec -- dune exec ./race.exe
 v.x is 11
 ```
 
@@ -457,8 +457,8 @@ However, if we compile and run the program with Dune from the new
 `5.0.0+tsan` switch TSan warns us of a data race:
 ```
 $ opam switch 5.0.0+tsan
-$ dune build ./race.exe
-$ dune exec ./race.exe
+$ opam exec -- dune build ./race.exe
+$ opam exec -- dune exec ./race.exe
 ==================
 WARNING: ThreadSanitizer: data race (pid=19414)
   Write of size 8 at 0x7fb9d72fe498 by thread T4 (mutexes: write M87):
@@ -518,8 +518,8 @@ let () =
 If we recompile and run our program with this change, it now completes
 without TSan warnings:
 ```
-$ dune build ./race.exe
-$ dune exec ./race.exe
+$ opam exec -- dune build ./race.exe
+$ opam exec -- dune exec ./race.exe
 v is 11
 ```
 

--- a/data/tutorials/guides/1wf_04_multicore_ready.md
+++ b/data/tutorials/guides/1wf_04_multicore_ready.md
@@ -144,7 +144,7 @@ each and then runs two loops in parallel with:
 
 ``` shell
 $ opam switch 5.1.0
-$ dune runtest
+$ opam exec -- dune runtest
 0 100 1 100 2 100 3 100 4 100 5 100 6 100   total = 700
 0 100 1 100 2 100 3 100 4 100 5 100 6 100   total = 700
 0 100 1  99 2 100 3 100 4 101 5 100 6 100   total = 700
@@ -171,7 +171,7 @@ as follows and immediately complains about races:
 
 ``` shell
 $ opam switch 5.1.0+tsan
-$ dune runtest
+$ opam exec -- dune runtest
 File "test/dune", line 2, characters 7-16:
 2 |  (name bank_test)
            ^^^^^^^^^
@@ -248,7 +248,7 @@ let iter_accounts t f = (* inspect the bank accounts *)
 Rerunning our tests, we obtain:
 
 ``` shell
-$ dune runtest
+$ opam exec -- dune runtest
 File "test/dune", line 2, characters 7-16:
 2 |  (name bank_test)
            ^^^^^^^^^
@@ -285,7 +285,7 @@ let transfer t ~src_acc ~dst_acc ~amount =
 
 We can now rerun our tests under TSan to confirm the fix:
 ``` shell
-$ dune runtest
+$ opam exec -- dune runtest
 0 100 1 100 2 100 3 100 4 100 5 100 6 100   total = 700
 0 100 1 100 2 100 3 100 4 100 5 100 6 100   total = 700
 0 100 1  99 2 100 3 100 4 101 5 100 6 100   total = 700

--- a/data/tutorials/language/1ms_00_modules.md
+++ b/data/tutorials/language/1ms_00_modules.md
@@ -59,8 +59,8 @@ executable.
 ```bash
 $ echo "(lang dune 3.4)" > dune-project
 $ echo "(executable (name bmodule))" > dune
-$ dune build
-$ dune exec ./bmodule.exe
+$ opam exec -- dune build
+$ opam exec -- dune exec ./bmodule.exe
 Hello
 ```
 
@@ -209,10 +209,10 @@ of this example aside of the previous one.
 <!-- $MDX dir=examples -->
 ```bash
 $ echo "(executables (names bmodule bmodule2))" > dune
-$ dune build
-$ dune exec ./bmodule.exe
+$ opam exec -- dune build
+$ opam exec -- dune exec ./bmodule.exe
 Hello
-$ dune exec ./bmodule2.exe
+$ opam exec -- dune exec ./bmodule2.exe
 Hello 2
 ```
 

--- a/data/tutorials/language/4ad_00_metaprogramming.md
+++ b/data/tutorials/language/4ad_00_metaprogramming.md
@@ -437,7 +437,7 @@ type t = int [@@deriving_inline yojson]
 
 Now, we run the PPX and promote the generated code in the original file:
 ```shell
-$ dune build @lint
+$ opam exec -- dune build @lint
 File "lib/lib.ml", line 1, characters 0-0:
 diff --git a/_build/default/lib/lib.ml b/_build/default/lib/lib.ml.lint-corrected
 index 4999e06..5516d41 100644

--- a/data/tutorials/language/5rt_01_garbage-collector.md
+++ b/data/tutorials/language/5rt_01_garbage-collector.md
@@ -537,7 +537,7 @@ Compile and execute this with some extra options to show the amount of
 garbage collection occurring:
 
 ```sh dir=examples/barrier_bench,non-deterministic=command
-$ dune exec -- ./barrier_bench.exe -ascii alloc -quota 1
+$ opam exec -- dune exec -- ./barrier_bench.exe -ascii alloc -quota 1
 Estimated testing time 2s (2 benchmarks x 1s). Change using '-quota'.
 
   Name        Time/Run   mWd/Run   mjWd/Run   Prom/Run   Percentage
@@ -561,7 +561,7 @@ command-line benchmark binaries have a number of useful options that affect
 garbage collection behavior and the output format:
 
 ```sh dir=examples/barrier_bench
-$ dune exec -- ./barrier_bench.exe -help
+$ opam exec -- dune exec -- ./barrier_bench.exe -help
 Benchmark for mutable, immutable
 
   barrier_bench.exe [COLUMN ...]
@@ -651,7 +651,7 @@ let () =
 Building and running this should show the following output:
 
 ```sh dir=examples/finalizer
-$ dune exec -- ./finalizer.exe
+$ opam exec -- dune exec -- ./finalizer.exe
     allocated record: OK
     allocated string: OK
    allocated variant: OK

--- a/data/tutorials/language/5rt_02_compiler_frontend.md
+++ b/data/tutorials/language/5rt_02_compiler_frontend.md
@@ -802,8 +802,8 @@ The `:standard` directive will include all the default flags, and then
 `-principal` will be appended after those in the compiler build flags.
 
 ```sh dir=examples/front-end/
-$ dune build principal.exe
-$ dune build non_principal.exe
+$ opam exec -- dune build principal.exe
+$ opam exec -- dune build non_principal.exe
 File "non_principal.ml", line 6, characters 4-7:
 6 |   x.foo
         ^^^
@@ -999,7 +999,7 @@ If we now build this library, we can look at how dune assembles the modules
 into a `Hello` library.
 
 ```sh dir=examples/packing
-$ dune build
+$ opam exec -- dune build
 $ cat _build/default/hello.ml-gen
 (** @canonical Hello.A *)
 module A = Hello__A

--- a/data/tutorials/language/5rt_03_compiler_backend.md
+++ b/data/tutorials/language/5rt_03_compiler_backend.md
@@ -269,7 +269,7 @@ Building and executing this example will run for around 30 seconds by
 default, and you'll see the results summarized in a neat table:
 
 ```sh dir=examples/back-end/bench_patterns,non-deterministic=command
-$ dune exec -- ./bench_patterns.exe -ascii -quota 0.25
+$ opam exec -- dune exec -- ./bench_patterns.exe -ascii -quota 0.25
 Estimated testing time 750ms (3 benchmarks x 250ms). Change using '-quota'.
 
   Name                        Time/Run   Percentage
@@ -736,7 +736,7 @@ let () =
 Running this shows quite a significant runtime difference between the two:
 
 ```sh dir=examples/back-end/bench_poly_and_mono,non-deterministic=command
-$ dune exec -- ./bench_poly_and_mono.exe -ascii -quota 1
+$ opam exec -- dune exec -- ./bench_poly_and_mono.exe -ascii -quota 1
 Estimated testing time 2s (2 benchmarks x 1s). Change using '-quota'.
 
   Name                       Time/Run   Percentage
@@ -852,7 +852,7 @@ output:
 
 
 ```sh dir=examples/back-end/alternate_list
-$ dune build alternate_list.exe
+$ opam exec -- dune build alternate_list.exe
 $ ./_build/default/alternate_list.exe -ascii -quota 1
 1,3,5,7,9
 ```

--- a/data/tutorials/platform/bp_00_bootstrap_project.md
+++ b/data/tutorials/platform/bp_00_bootstrap_project.md
@@ -13,7 +13,7 @@ category: "Best Practices"
 To start a new project, you can run:
 
 ```sh
-$ dune init project hello_world
+$ opam exec -- dune init project hello_world
 Success: initialized project component named hello_world
 ```
 
@@ -21,28 +21,28 @@ You can now build and run your new project:
 
 ```sh
 $ cd hello_world
-$ dune exec bin/main.exe
+$ opam exec -- dune exec bin/main.exe
 Hello, world!
 ```
 
 To create a new library in the current project, use:
 
 ```sh
-$ dune init lib my_lib ./path/to/my_lib
+$ opam exec -- dune init lib my_lib ./path/to/my_lib
 Success: initialized library component named my_lib
 ```
 
 To create a new executable in the current project, use:
 
 ```sh
-$ dune init exec my_bin ./path/to/my_bin
+$ opam exec -- dune init exec my_bin ./path/to/my_bin
 Success: initialized executable component named my_bin 
 ```
 
 To create a new test in the current project, use:
 
 ```sh
-$ dune init test my_test ./path/to/my_test
+$ opam exec -- dune init test my_test ./path/to/my_test
 Success: initialized test component named my_test 
 ```
 

--- a/data/tutorials/platform/bp_07_ocamlformat.md
+++ b/data/tutorials/platform/bp_07_ocamlformat.md
@@ -22,5 +22,5 @@ creates a configuration file for the currently installed version of OCamlFormat.
 In addition to editor plugins that use OCamlFormat for automatic code formatting, Dune also offers a command to run OCamlFormat to automatically format all files from your codebase:
 
 ```shell
-$ dune fmt
+$ opam exec -- dune fmt
 ```

--- a/data/tutorials/platform/bp_08_odoc.md
+++ b/data/tutorials/platform/bp_08_odoc.md
@@ -15,7 +15,7 @@ from the docstrings and interfaces of the project's modules
 Dune can run `odoc` on your project to generate HTML documentation with this command:
 
 ```shell
-$ dune build @doc
+$ opam exec -- dune build @doc
 
 # Unix or macOS
 $ open _build/default/_doc/_html/index.html


### PR DESCRIPTION
Resolves #1819 by prepending `opam exec --` on all `dune` invocations.