### PR TITLE
(feat) add recommended_next_tutorials capability

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -4,6 +4,13 @@ title: A Tour of OCaml
 description: >
   Hop on the OCaml sightseeing bus. This absolute beginner tutorial will drive you through the marvels and wonders of OCaml. We'll have a look at the most commonly used language features.
 category: "First Steps"
+recommended_next_tutorials: 
+  [
+    "values-and-functions",
+    "basic-data-types",
+    "if-statements-and-loops",
+    "lists"
+  ]
 ---
 
 # A Tour of OCaml
@@ -745,10 +752,3 @@ Module also allows efficient separated compilation. This is illustrated in the n
 -->
 
 In this tutorial, OCaml was used interactively. The next tutorial, [Your First OCaml Program](/docs/your-first-program), shows you how to write OCaml files, how to compile them, and how to kickstart a project.
-
-Other recommended tutorials:
-
-1. [Values and Functions](/docs/values-and-functions)
-1. [Basic Data Types and Pattern Matching](/docs/basic-data-types)
-1. [If Statements and Recursions](/docs/if-statements-and-loops)
-1. [Lists](/docs/lists)

--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -4,6 +4,13 @@ title: Your First OCaml Program
 description: >
   Learn how to write your very first OCaml program.
 category: "First Steps"
+recommended_next_tutorials: 
+  [
+    "values-and-functions",
+    "basic-data-types",
+    "if-statements-and-loops",
+    "lists"
+  ]
 ---
 
 # Your First OCaml Program
@@ -356,12 +363,6 @@ My name is Minimo
 ## Conclusion
 
 This tutorial is the last of the "Getting Started" series. Moving forward, you have enough to pick and choose among the other tutorials to follow your own learning path.
-
-Recommended next tutorials:
-1. [Values and Functions](/docs/values-and-functions)
-1. [Basic Data Types and Pattern Matching](/docs/basic-data-types)
-1. [If Statements and Recursions](/docs/if-statements-and-loops)
-1. [Lists](/docs/lists)
 
 <!--
 TODO: link Project Quickstart If you're already familiar with lists, maps, and folds, and need to be productive as fast as possible, dive into the “Project Quickstart” guide.

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -233,7 +233,7 @@ module Tutorial : sig
     body_md : string;
     toc : toc list;
     body_html : string;
-    recommended_next_tutorials: recommended_next_tutorials option
+    recommended_next_tutorials : recommended_next_tutorials option;
   }
 
   val all : t list

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -220,6 +220,8 @@ module Tutorial : sig
     contribute_link : contribute_link;
   }
 
+  type recommended_next_tutorials = string list
+
   type t = {
     title : string;
     fpath : string;
@@ -231,6 +233,7 @@ module Tutorial : sig
     body_md : string;
     toc : toc list;
     body_html : string;
+    recommended_next_tutorials: recommended_next_tutorials option
   }
 
   val all : t list

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -37,10 +37,24 @@ let render_related_exercises exercises =
   else
     ""
 
+let render_recommended_next_tutorials tutorials =
+  if List.length tutorials > 0 then
+    <div class='related-exercises'>
+      <h3>Recommended next tutorials:</h3>
+      <ul>
+        <% tutorials |> List.iter (fun (tutorial : Data.Tutorial.t) -> %>
+          <li><a href='/docs/<%s tutorial.slug %>'><%s tutorial.title %></a></li>
+        <% ); %>
+      </ul>
+    </div>
+  else
+    ""
+
 let render
 (tutorial : Data.Tutorial.t)
 ~tutorials
 ~related_exercises
+~recommended_next_tutorials
 ~canonical
 =
 let href, description = match tutorial.external_tutorial with
@@ -70,5 +84,6 @@ Learn_layout.three_column_layout
     <%s! render_external_tutorial_banner tutorial.external_tutorial %>
     <%s! tutorial.body_html %>
     <%s! render_related_exercises related_exercises %>
+    <%s! render_recommended_next_tutorials recommended_next_tutorials %>
     <%s! Learn_components.contribute_footer ~href ~description %>
   </div>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -400,14 +400,11 @@ let tutorial req =
       all_exercises
   in
 
-  let next_rec_ids = match tutorial.recommended_next_tutorials with 
-    | Some(x) -> x
-    | None -> []
-  in
-
   let is_in_recommended_next (tested : Data.Tutorial.t) = List.exists
     (fun r -> r = tested.slug)
-    next_rec_ids
+    @@ match tutorial.recommended_next_tutorials with 
+    | Some(x) -> x
+    | None -> []
   in
 
   let recommended_next_tutorials = all_tutorials

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -400,15 +400,13 @@ let tutorial req =
       all_exercises
   in
 
-  let is_in_recommended_next (tested : Data.Tutorial.t) = List.exists
-    (fun r -> r = tested.slug)
-    @@ match tutorial.recommended_next_tutorials with 
-    | Some(x) -> x
-    | None -> []
+  let is_in_recommended_next (tested : Data.Tutorial.t) =
+    List.exists (fun r -> r = tested.slug)
+    @@ match tutorial.recommended_next_tutorials with Some x -> x | None -> []
   in
 
-  let recommended_next_tutorials = all_tutorials
-    |> List.filter is_in_recommended_next
+  let recommended_next_tutorials =
+    all_tutorials |> List.filter is_in_recommended_next
   in
 
   Dream.html

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -384,8 +384,10 @@ let tutorial req =
   let</>? tutorial =
     List.find_opt (fun x -> x.Data.Tutorial.slug = slug) Data.Tutorial.all
   in
+  let all_tutorials = Data.Tutorial.all in
+
   let tutorials =
-    Data.Tutorial.all
+    all_tutorials
     |> List.filter (fun (t : Data.Tutorial.t) -> t.section = tutorial.section)
   in
   let all_exercises = Data.Exercise.all in
@@ -397,10 +399,25 @@ let tutorial req =
         | None -> false)
       all_exercises
   in
+
+  let next_rec_ids = match tutorial.recommended_next_tutorials with 
+    | Some(x) -> x
+    | None -> []
+  in
+
+  let is_in_recommended_next (tested : Data.Tutorial.t) = List.exists
+    (fun r -> r = tested.slug)
+    next_rec_ids
+  in
+
+  let recommended_next_tutorials = all_tutorials
+    |> List.filter is_in_recommended_next
+  in
+
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials
        ~canonical:(Url.tutorial tutorial.slug)
-       ~related_exercises tutorial)
+       ~related_exercises ~recommended_next_tutorials tutorial)
 
 let exercises req =
   let all_exercises = Data.Exercise.all in

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -26,7 +26,7 @@ type external_tutorial = {
 }
 [@@deriving of_yaml, show { with_path = false }]
 
-type recommended_next_tutorials = string list 
+type recommended_next_tutorials = string list
 [@@deriving of_yaml, show { with_path = false }]
 
 type metadata = {
@@ -35,7 +35,7 @@ type metadata = {
   description : string;
   category : string;
   external_tutorial : external_tutorial option;
-  recommended_next_tutorials : recommended_next_tutorials option
+  recommended_next_tutorials : recommended_next_tutorials option;
 }
 [@@deriving of_yaml]
 

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -26,12 +26,16 @@ type external_tutorial = {
 }
 [@@deriving of_yaml, show { with_path = false }]
 
+type recommended_next_tutorials = string list 
+[@@deriving of_yaml, show { with_path = false }]
+
 type metadata = {
   id : string;
   title : string;
   description : string;
   category : string;
   external_tutorial : external_tutorial option;
+  recommended_next_tutorials : recommended_next_tutorials option
 }
 [@@deriving of_yaml]
 
@@ -46,6 +50,7 @@ type t = {
   toc : toc list;
   body_md : string;
   body_html : string;
+  recommended_next_tutorials : recommended_next_tutorials option;
 }
 [@@deriving
   stable_record ~version:metadata ~add:[ id ]
@@ -151,6 +156,7 @@ type external_tutorial =
   ; banner : banner
   ; contribute_link : contribute_link
   }
+type recommended_next_tutorials = string list
 type t =
   { title : string
   ; fpath : string
@@ -162,6 +168,7 @@ type t =
   ; body_md : string
   ; toc : toc list
   ; body_html : string
+  ; recommended_next_tutorials : recommended_next_tutorials option
   }
   
 let all = %a


### PR DESCRIPTION
Adds ability to recommend next tutorial in the head / metadata of an existing tutorial.md file. E.g.:

`recommended_next_tutorials: 
  [
    "values-and-functions",
    "basic-data-types",
    "if-statements-and-loops",
    "lists"
  ]`

Examples have been added to "A Tour of OCaml" and "Your First Ocaml Program" 