### PR TITLE
(changelog) Revert "Electrical work post"

### DIFF
--- a/data/changelog/infra/2024-01-14-electrical-work.md
+++ b/data/changelog/infra/2024-01-14-electrical-work.md
@@ -1,7 +1,0 @@
----
-title: Electrial Work in the Datacentre
-date: "2024-01-14"
-tags: [infrastructure]
----
-
-There is an electrical shutdown for essential maintenance this weekend, which will affect large parts of the cluster.  All Power9, ARM64, RISC-V, Windows and FreeBSD workers and docs.ci.ocaml.org, docs-data.ocaml.org and the benchmarking servers will be unavailable.  x86_64 workers will be substantially reduced.  Service is expected to resume late on Sunday evening.


### PR DESCRIPTION
Reverts ocaml/ocaml.org#1938 because this announcement is no longer needed.