### PR TITLE
(bug) Fix String.sub exception if changelog length < 100

### DIFF
--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -57,6 +57,7 @@ module Changelog : sig
     tags : string list;
     changelog_html : string option;
     body_html : string;
+    body : string;
   }
 
   val all : t list

--- a/src/ocamlorg_frontend/pages/home.eml
+++ b/src/ocamlorg_frontend/pages/home.eml
@@ -310,7 +310,7 @@ Layout.render
                         <time datetime="<%s item.date %>" class="block mt-1 font-sans text-sm text-legacy-lighter"><%s Utils.human_date item.date %></time>
                     </div>
                     <div class="prose prose-orange">
-                      <%s! String.sub item.body_html 0 100 %>...
+                      <%s! String.sub item.body 0 (min (String.length item.body - 1) 100) %>...
                     </div>
                     <a href="<%s Url.changelog %>" class="text-primary mt-2">
                       See full changelog

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -15,11 +15,12 @@ type t = {
   tags : string list;
   changelog_html : string option;
   body_html : string;
+  body : string;
 }
 [@@deriving
   stable_record ~version:metadata
     ~add:[ authors; changelog; description ]
-    ~remove:[ slug; changelog_html; body_html ],
+    ~remove:[ slug; changelog_html; body_html; body ],
     show { with_path = false }]
 
 let decode (fname, (head, body)) =
@@ -42,7 +43,7 @@ let decode (fname, (head, body)) =
               |> Hilite.Md.transform
               |> Cmarkit_html.of_doc ~safe:false)
       in
-      of_metadata ~slug ~changelog_html ~body_html metadata)
+      of_metadata ~slug ~changelog_html ~body ~body_html metadata)
     metadata
 
 let all () =
@@ -97,6 +98,7 @@ type t =
   ; tags : string list
   ; changelog_html : string option
   ; body_html : string
+  ; body : string
   }
   
 let all = %a


### PR DESCRIPTION
When changelog entry's `body_html` was shorter than 100 characters, `String.sub` call would cause an exception.

Also fixes invalid HTML by introducing a `body` field on changelog entry so that we can truncate this without leaving HTML tags unclosed.