### PR TITLE
(feat) add prerequisite_tutorials capability

### DIFF
--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -5,6 +5,9 @@ short_title: Values and Functions
 description: |
   Functions, values, definitions, environments, scopes, closures, and shadowing. This tutorial will help you master the fundamentals.
 category: "Introduction"
+prerequisite_tutorials:
+  - "toplevel-introduction"
+  - "installing-ocaml"
 ---
 
 ## Introduction
@@ -12,10 +15,6 @@ category: "Introduction"
 In OCaml, functions are treated as values, so you can use functions as arguments to functions and return them from functions. This tutorial introduces the relationship between expressions, values, and names. The first four sections address non-function values. The following sections, starting at [Function as Values](#function-as-values), address functions.
 
 We use UTop to understand these concepts by example. You are encouraged to modify the examples to gain a better understanding. 
-
-**Prerequisites**: 
-- The [Introduction to the OCaml Toplevel](https://ocaml.org/docs/toplevel-introduction) guide covers how to use UTop.
-- Ensure you have completed the [Get Started](https://ocaml.org/docs/installing-ocaml) series before proceeding with this tutorial.
 
 ## What is a Value?
 

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -6,7 +6,7 @@ description: |
   Predefined Types, Variants, Records, and Pattern Matching
 category: "Introduction"
 prerequisite_tutorials: 
-  - tour-of-ocaml"
+  - "tour-of-ocaml"
   - "values-and-functions"
 ---
 
@@ -15,8 +15,6 @@ prerequisite_tutorials:
 This document covers atomic types, such as integers and Booleans; predefined compound types, like strings and lists; and user-defined types, namely variants and records. We show how to pattern matching on those types.
 
 In OCaml, there are no type checks at runtime, and values don't change type unless explicitly converted. This is what being statically- and strongly-typed means. This allows safe processing of structured data.
-
-<!--End edit-->
 
 **Note**: As in previous tutorials, expressions after `#` and ending with `;;` are for the toplevel, like UTop.
 

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -5,6 +5,11 @@ short_title: Basic Data Types and Pattern Matching
 description: |
   Predefined Types, Variants, Records, and Pattern Matching
 category: "Introduction"
+prerequisites_tutorials: 
+  [
+    "tour-of-ocaml",
+    "values-and-functions",
+  ]
 ---
 
 ## Introduction

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -5,7 +5,7 @@ short_title: Basic Data Types and Pattern Matching
 description: |
   Predefined Types, Variants, Records, and Pattern Matching
 category: "Introduction"
-prerequisites_tutorials: 
+prerequisite_tutorials: 
   [
     "tour-of-ocaml",
     "values-and-functions",

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -18,7 +18,7 @@ In OCaml, there are no type checks at runtime, and values don't change type unle
 
 <!--End edit-->
 
-**Prerequisites**: Before proceeding, it's necessary to have completed the [Get Started](https://ocaml.org/docs/get-started) series of tutorials as well as [Functions and Values](/docs/values-and-functions). As in previous tutorials, expressions after `#` and ending with `;;` are for the toplevel, like UTop.
+**Note**: As in previous tutorials, expressions after `#` and ending with `;;` are for the toplevel, like UTop.
 
 <!--
 The goal of this tutorial is to provide for the following capabilities:

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -6,10 +6,8 @@ description: |
   Predefined Types, Variants, Records, and Pattern Matching
 category: "Introduction"
 prerequisite_tutorials: 
-  [
-    "tour-of-ocaml",
-    "values-and-functions",
-  ]
+  - tour-of-ocaml"
+  - "values-and-functions"
 ---
 
 ## Introduction

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -5,7 +5,7 @@ short_title: Labelled and Optional Arguments
 description: >
   Provide labels to your functions arguments
 category: "Introduction"
-prerequisites_tutorials: 
+prerequisite_tutorials: 
   [
     "values-and-functions"
   ]

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -5,10 +5,8 @@ short_title: Labelled and Optional Arguments
 description: >
   Provide labels to your functions arguments
 category: "Introduction"
-prerequisite_tutorials: 
-  [
-    "values-and-functions"
-  ]
+prerequisite_tutorials:
+  - "values-and-functions"
 ---
 
 It is possible to give names and default values to function parameters. This is broadly known as labels. In this tutorial, we learn how to use labels.

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -5,13 +5,15 @@ short_title: Labelled and Optional Arguments
 description: >
   Provide labels to your functions arguments
 category: "Introduction"
+prerequisites_tutorials: 
+  [
+    "values-and-functions"
+  ]
 ---
 
 It is possible to give names and default values to function parameters. This is broadly known as labels. In this tutorial, we learn how to use labels.
 
 Throughout this tutorial, the code is written in UTop. In this document parameters that are not labelled are called _positional parameters_.
-
-**Prerequisites**: [Values and Functions](/docs/values-and-functions)
 
 ## Passing Labelled Arguments
 

--- a/data/tutorials/language/0it_05_imperative.md
+++ b/data/tutorials/language/0it_05_imperative.md
@@ -5,6 +5,11 @@ short_title: Mutability and Imperative Control Flow
 description: >
   Write stateful programs in OCaml. Use for and while loops, if-then-else, mutable record fields, and references.
 category: "Introduction"
+prerequisite_tutorials:
+  - "basic-data-types"
+  - "values-and-functions"
+  - "lists"
+  - "modules"
 ---
 
 <!--
@@ -26,8 +31,6 @@ This document has two main teaching goals:
 -->
 
 Imperative and functional programming both have unique merits, and OCaml allows combining them efficiently. In the first part of this tutorial, we introduce mutable state and imperative control flow. See the second part for examples of recommended or discouraged use of these features.
-
-**Prerequisites**: [Basic Data Types](/docs/basic-data-types), [Values and Functions](/docs/values-and-functions), [Lists](/docs/lists), and [Modules](/docs/modules).
 
 ## Immutable vs Mutable Data
 

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -5,11 +5,10 @@ short_title: Sequences
 description: >
   Learn about sequences, of OCaml's most-used, built-in data types
 category: "Data Structures"
+prerequisite_tutorials:
+  - "lists"
+  - "options"
 ---
-
-## Prerequisites
-
-You should be comfortable with writing functions over lists and options.
 
 ## Introduction
 

--- a/data/tutorials/language/5rt_00_memory_representation.md
+++ b/data/tutorials/language/5rt_00_memory_representation.md
@@ -14,6 +14,8 @@ external_tutorial:
   contribute_link:
     url: https://github.com/realworldocaml/book/blob/master/book/runtime-memory-layout/README.md
     description: "You are encouraged to contribute to the original sources of this page at the Real World OCaml GitHub repository."
+prerequisite_tutorials:
+  - "basic-data-types"
 ---
 
 This is an adaptation of the chapter [Memory Representation of Values](https://dev.realworldocaml.org/runtime-memory-layout.html) from the book [Real World OCaml](https://dev.realworldocaml.org/), reproduced here with permission.
@@ -35,8 +37,6 @@ code is spending its time.
 
 At the end of this document, you will be able to translate between OCaml
 values and their memory representation.
-
-**Prerequisites:** [Basic Data Types and Pattern Matching](/docs/basic-data-types)
 
 ## OCaml Types Disappear at Runtime
 

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -216,6 +216,7 @@ module Tutorial : sig
   }
 
   type recommended_next_tutorials = string list
+  type prerequisite_tutorials = string list
 
   type t = {
     title : string;
@@ -229,7 +230,8 @@ module Tutorial : sig
     body_md : string;
     toc : toc list;
     body_html : string;
-    recommended_next_tutorials : recommended_next_tutorials;
+    recommended_next_tutorials : recommended_next_tutorials option;
+    prerequisite_tutorials : prerequisite_tutorials option;
   }
 
   val all : t list

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -230,8 +230,8 @@ module Tutorial : sig
     body_md : string;
     toc : toc list;
     body_html : string;
-    recommended_next_tutorials : recommended_next_tutorials option;
-    prerequisite_tutorials : prerequisite_tutorials option;
+    recommended_next_tutorials : recommended_next_tutorials;
+    prerequisite_tutorials : prerequisite_tutorials;
   }
 
   val all : t list

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -40,7 +40,7 @@ let render_related_exercises exercises =
   else
     ""
 
-let render_prerequisites_tutorials tutorials =
+let render_prerequisite_tutorials tutorials =
   if List.length tutorials > 0 then
     <div class="mb-6 pt-8 border-t border-gray-200">
         <h2 class="mb-4 mt-0 text-3xl font-bold leading-6">Prerequisites</h2>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -60,7 +60,7 @@ let render
 ~tutorials
 ~related_exercises
 ~recommended_next_tutorials
-~prerequisites_tutorials
+~prerequisite_tutorials
 ~canonical
 =
 let href, description = match tutorial.external_tutorial with
@@ -87,7 +87,7 @@ Learn_layout.three_column_layout
 ~right_sidebar_html:(Some(right_sidebar tutorial))
 ~current:(of_tutorial_section tutorial.section) @@
   <div class="prose prose-orange dark:prose-invert max-w-full">
-    <%s! render_prerequisites_tutorials prerequisites_tutorials %>
+    <%s! render_prerequisite_tutorials prerequisite_tutorials %>
     <%s! render_external_tutorial_banner tutorial.external_tutorial %>
     <%s! render_title tutorial %>
     <%s! tutorial.body_html %>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -40,11 +40,27 @@ let render_related_exercises exercises =
   else
     ""
 
+let render_prerequisites_tutorials tutorials =
+  if List.length tutorials > 0 then
+    <div class="mb-6 pt-8 border-t border-gray-200">
+        <h2 class="mb-4 mt-0 text-3xl font-bold leading-6">Prerequisites</h2>
+        <ul class="list-disc marker:text-primary">
+          <% tutorials |> List.iter (fun (tutorial : Data.Tutorial.t) -> %>
+            <li class="mb-1">
+              <a href='/docs/<%s tutorial.slug %>'><%s tutorial.title %></a>
+            </li>
+          <% ); %>
+        </ul>
+      </div>
+  else
+    ""
+
 let render
 (tutorial : Data.Tutorial.t)
 ~tutorials
 ~related_exercises
 ~recommended_next_tutorials
+~prerequisites_tutorials
 ~canonical
 =
 let href, description = match tutorial.external_tutorial with
@@ -71,6 +87,7 @@ Learn_layout.three_column_layout
 ~right_sidebar_html:(Some(right_sidebar tutorial))
 ~current:(of_tutorial_section tutorial.section) @@
   <div class="prose prose-orange dark:prose-invert max-w-full">
+    <%s! render_prerequisites_tutorials prerequisites_tutorials %>
     <%s! render_external_tutorial_banner tutorial.external_tutorial %>
     <%s! render_title tutorial %>
     <%s! tutorial.body_html %>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -43,7 +43,7 @@ let render_related_exercises exercises =
 let render_prerequisite_tutorials tutorials =
   if List.length tutorials > 0 then
     <div class="mb-6 pt-8 border-t border-gray-200">
-        <h2 class="mb-4 mt-0 text-3xl font-bold leading-6">Prerequisites</h2>
+        <h2 class="mb-4 mt-0 text-lg font-bold leading-6"">Prerequisites</h2>
         <ul class="list-disc marker:text-primary">
           <% tutorials |> List.iter (fun (tutorial : Data.Tutorial.t) -> %>
             <li class="mb-1">
@@ -87,9 +87,9 @@ Learn_layout.three_column_layout
 ~right_sidebar_html:(Some(right_sidebar tutorial))
 ~current:(of_tutorial_section tutorial.section) @@
   <div class="prose prose-orange dark:prose-invert max-w-full">
-    <%s! render_prerequisite_tutorials prerequisite_tutorials %>
     <%s! render_external_tutorial_banner tutorial.external_tutorial %>
     <%s! render_title tutorial %>
+    <%s! render_prerequisite_tutorials prerequisite_tutorials %>
     <%s! tutorial.body_html %>
     <%s! render_related_exercises related_exercises %>
     <%s! Learn_components.contribute_footer ~href ~description ~recommended_next_tutorials %>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -414,7 +414,7 @@ let tutorial req =
       (Option.value tutorial.prerequisite_tutorials ~default:[])
   in
 
-  let prerequisites_tutorials = all_tutorials |> List.filter is_prerequisite in
+  let prerequisite_tutorials = all_tutorials |> List.filter is_prerequisite in
 
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -411,7 +411,7 @@ let tutorial req =
   let is_prerequisite (tested : Data.Tutorial.t) =
     List.exists
       (fun r -> r = tested.slug)
-      (Option.value tutorial.prerequisites_tutorials ~default:[])
+      (Option.value tutorial.prerequisite_tutorials ~default:[])
   in
 
   let prerequisites_tutorials = all_tutorials |> List.filter is_prerequisite in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -408,10 +408,19 @@ let tutorial req =
     all_tutorials |> List.filter is_in_recommended_next
   in
 
+  let is_prerequisite (tested : Data.Tutorial.t) =
+    List.exists
+      (fun r -> r = tested.slug)
+      (Option.value tutorial.prerequisites_tutorials ~default:[])
+  in
+
+  let prerequisites_tutorials = all_tutorials |> List.filter is_prerequisite in
+
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials
        ~canonical:(Url.tutorial tutorial.slug)
-       ~related_exercises ~recommended_next_tutorials tutorial)
+       ~related_exercises ~recommended_next_tutorials ~prerequisites_tutorials
+       tutorial)
 
 let exercises req =
   let all_exercises = Data.Exercise.all in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -409,9 +409,7 @@ let tutorial req =
   in
 
   let is_prerequisite (tested : Data.Tutorial.t) =
-    List.exists
-      (fun r -> r = tested.slug)
-      (Option.value tutorial.prerequisite_tutorials ~default:[])
+    List.exists (fun r -> r = tested.slug) tutorial.prerequisite_tutorials
   in
 
   let prerequisite_tutorials = all_tutorials |> List.filter is_prerequisite in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -419,7 +419,7 @@ let tutorial req =
   Dream.html
     (Ocamlorg_frontend.tutorial ~tutorials
        ~canonical:(Url.tutorial tutorial.slug)
-       ~related_exercises ~recommended_next_tutorials ~prerequisites_tutorials
+       ~related_exercises ~recommended_next_tutorials ~prerequisite_tutorials
        tutorial)
 
 let exercises req =

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -56,7 +56,7 @@ type t = {
   toc : toc list;
   body_md : string;
   body_html : string;
-  recommended_next_tutorials : recommended_next_tutorials option;
+  recommended_next_tutorials : recommended_next_tutorials;
   prerequisite_tutorials : prerequisite_tutorials option;
 }
 [@@deriving

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -57,18 +57,18 @@ type t = {
   body_md : string;
   body_html : string;
   recommended_next_tutorials : recommended_next_tutorials;
-  prerequisite_tutorials : prerequisite_tutorials option;
+  prerequisite_tutorials : prerequisite_tutorials;
 }
 [@@deriving
   stable_record ~version:metadata ~add:[ id ]
-    ~modify:[ recommended_next_tutorials ]
+    ~modify:[ recommended_next_tutorials; prerequisite_tutorials ]
     ~remove:[ slug; fpath; section; toc; body_md; body_html ],
     show { with_path = false }]
 
 let of_metadata m =
-  of_metadata m ~slug:m.id ~modify_recommended_next_tutorials:(function
-    | None -> []
-    | Some u -> u)
+  of_metadata m ~slug:m.id
+    ~modify_recommended_next_tutorials:(function None -> [] | Some u -> u)
+    ~modify_prerequisite_tutorials:(function None -> [] | Some u -> u)
 
 let id_to_href id =
   match id with
@@ -202,8 +202,8 @@ type t =
   ; body_md : string
   ; toc : toc list
   ; body_html : string
-  ; recommended_next_tutorials : recommended_next_tutorials option
-  ; prerequisite_tutorials : prerequisite_tutorials option
+  ; recommended_next_tutorials : recommended_next_tutorials
+  ; prerequisite_tutorials : prerequisite_tutorials
   }
   
 let all = %a

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -137,7 +137,10 @@ let check_tutorial_references all =
     ^ " were not found: [" ^ String.concat "; " missing ^ "]"
   in
   let has_missing_tuts_exn t =
-    match List.filter tut_is_missing t.recommended_next_tutorials with
+    match
+      List.filter tut_is_missing t.recommended_next_tutorials
+      @ List.filter tut_is_missing t.prerequisite_tutorials
+    with
     | [] -> ()
     | missing -> raise (Missing_Tutorial (missing_tut_msg t missing))
   in

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -29,6 +29,9 @@ type external_tutorial = {
 type recommended_next_tutorials = string list
 [@@deriving of_yaml, show { with_path = false }]
 
+type prerequisite_tutorials = string list
+[@@deriving of_yaml, show { with_path = false }]
+
 type metadata = {
   id : string;
   title : string;
@@ -37,6 +40,7 @@ type metadata = {
   category : string;
   external_tutorial : external_tutorial option;
   recommended_next_tutorials : recommended_next_tutorials option;
+  prerequisite_tutorials : prerequisite_tutorials option;
 }
 [@@deriving of_yaml]
 
@@ -52,7 +56,8 @@ type t = {
   toc : toc list;
   body_md : string;
   body_html : string;
-  recommended_next_tutorials : recommended_next_tutorials;
+  recommended_next_tutorials : recommended_next_tutorials option;
+  prerequisite_tutorials : prerequisite_tutorials option;
 }
 [@@deriving
   stable_record ~version:metadata ~add:[ id ]
@@ -184,6 +189,7 @@ type external_tutorial =
   ; contribute_link : contribute_link
   }
 type recommended_next_tutorials = string list
+type prerequisite_tutorials = string list
 type t =
   { title : string
   ; short_title: string
@@ -196,7 +202,8 @@ type t =
   ; body_md : string
   ; toc : toc list
   ; body_html : string
-  ; recommended_next_tutorials : recommended_next_tutorials
+  ; recommended_next_tutorials : recommended_next_tutorials option
+  ; prerequisite_tutorials : prerequisite_tutorials option
   }
   
 let all = %a


### PR DESCRIPTION
Here's how it looks like at the moment:
![image](https://github.com/ocaml/ocaml.org/assets/17282221/880cec5f-46fd-4a6a-8bdd-f2f87ab50d6e)

Made the field an option because I get this error otherwise:
```
OCAMLORG_HTTP_PORT=8000 make start
opam exec -- dune build --root .
File "src/ocamlorg_data/dune", line 98, characters 0-126:
 98 | (rule
 99 |  (target tutorial.ml)
100 |  (action
101 |   (with-stdout-to
102 |    %{target}
103 |    (run %{dep:../../tool/ood-gen/bin/gen.exe} tutorial))))
ood-gen: internal error, uncaught exception:
         Ood_gen.Exn.Decode_error("Didn't find the function for key: prerequisites_tutorials")
         Raised at Ocamlorg__Import.Result.get_ok.(fun) in file "src/global/import.ml", line 103, characters 55-70
         Called from Ood_gen__Tutorial.all in file "tool/ood-gen/lib/tutorial.ml", line 136, characters 2-41
         Called from Ood_gen__Tutorial.template in file "tool/ood-gen/lib/tutorial.ml", line 184, characters 4-12
         Called from Dune__exe__Gen.cmds.(fun) in file "tool/ood-gen/bin/gen.ml", line 39, characters 48-61
         Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
         Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
make: *** [Makefile:5: all] Error 1      
```

Closes https://github.com/ocaml/ocaml.org/issues/1945