### PR TITLE
Simplify typing of recommended next tutorials

### DIFF
--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -234,7 +234,7 @@ module Tutorial : sig
     body_md : string;
     toc : toc list;
     body_html : string;
-    recommended_next_tutorials : recommended_next_tutorials option;
+    recommended_next_tutorials : recommended_next_tutorials;
   }
 
   val all : t list

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -402,7 +402,7 @@ let tutorial req =
 
   let is_in_recommended_next (tested : Data.Tutorial.t) =
     List.exists (fun r -> r = tested.slug)
-    @@ match tutorial.recommended_next_tutorials with Some x -> x | None -> []
+    tutorial.recommended_next_tutorials
   in
 
   let recommended_next_tutorials =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -401,8 +401,7 @@ let tutorial req =
   in
 
   let is_in_recommended_next (tested : Data.Tutorial.t) =
-    List.exists (fun r -> r = tested.slug)
-    tutorial.recommended_next_tutorials
+    List.exists (fun r -> r = tested.slug) tutorial.recommended_next_tutorials
   in
 
   let recommended_next_tutorials =

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -50,14 +50,14 @@ type t = {
   toc : toc list;
   body_md : string;
   body_html : string;
-  recommended_next_tutorials : recommended_next_tutorials option;
+  recommended_next_tutorials : recommended_next_tutorials;
 }
 [@@deriving
-  stable_record ~version:metadata ~add:[ id ]
+  stable_record ~version:metadata ~add:[ id ] ~modify:[ recommended_next_tutorials ]
     ~remove:[ slug; fpath; section; toc; body_md; body_html ],
     show { with_path = false }]
 
-let of_metadata m = of_metadata m ~slug:m.id
+let of_metadata m = of_metadata m ~slug:m.id ~modify_recommended_next_tutorials:(function None -> [] | Some u -> u)
 
 let id_to_href id =
   match id with
@@ -168,7 +168,7 @@ type t =
   ; body_md : string
   ; toc : toc list
   ; body_html : string
-  ; recommended_next_tutorials : recommended_next_tutorials option
+  ; recommended_next_tutorials : recommended_next_tutorials
   }
   
 let all = %a

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -53,11 +53,15 @@ type t = {
   recommended_next_tutorials : recommended_next_tutorials;
 }
 [@@deriving
-  stable_record ~version:metadata ~add:[ id ] ~modify:[ recommended_next_tutorials ]
+  stable_record ~version:metadata ~add:[ id ]
+    ~modify:[ recommended_next_tutorials ]
     ~remove:[ slug; fpath; section; toc; body_md; body_html ],
     show { with_path = false }]
 
-let of_metadata m = of_metadata m ~slug:m.id ~modify_recommended_next_tutorials:(function None -> [] | Some u -> u)
+let of_metadata m =
+  of_metadata m ~slug:m.id ~modify_recommended_next_tutorials:(function
+    | None -> []
+    | Some u -> u)
 
 let id_to_href id =
   match id with


### PR DESCRIPTION
Make the type of `Data.Tutorial.t.recommended_next_tutorial` a `list`
instead of a `list option`. If the Yaml header is missing or if it
contains an empty list, it will result into a empty list. This avoids
having to handle the `Some []` case which is redundant.
