### PR TITLE
cleaned up redirection urls

### DIFF
--- a/src/ocamlorg_web/lib/redirection.ml
+++ b/src/ocamlorg_web/lib/redirection.ml
@@ -198,13 +198,15 @@ let from_v2 =
     ( "/learn/tutorials/compiling_ocaml_projects.html",
       Url.tutorial "compiling-ocaml-projects" );
     ( "/learn/tutorials/data_types_and_matching.fr.html",
-      Url.tutorial "basic-data-types" ); 
+      Url.tutorial "basic-data-types" );
     ( "/learn/tutorials/data_types_and_matching.it.html",
       Url.tutorial "basic-data-types" );
     ( "/learn/tutorials/data_types_and_matching.ja.html",
       Url.tutorial "basic-data-types" );
     ("/learn/tutorials/data_types_and_matching.html", Url.tutorial "basic-data-types");
     ( "/learn/tutorials/data_types_and_matching.zh.html",
+      Url.tutorial "basic-data-types" );
+    ( Url.tutorial "data-types",
       Url.tutorial "basic-data-types" );
     ("/learn/tutorials/debug.html", Url.tutorial "debugging");
     ("/learn/tutorials/error_handling.html", Url.tutorial "error-handling");
@@ -215,6 +217,18 @@ let from_v2 =
       Url.tutorial "file-manipulation" );
     ("/learn/tutorials/format.fr.html", Url.tutorial "formatting-text");
     ("/learn/tutorials/format.html", Url.tutorial "formatting-text");
+    (* FIXME: uncomment when higher-order-functions is merged
+    ( "/learn/tutorials/functional_programming.fr.html",
+      Url.tutorial "higher-order-functions" );
+    ( "/learn/tutorials/functional_programming.it.html",
+      Url.tutorial "higher-order-functions" );
+    ( "/learn/tutorials/functional_programming.ja.html",
+      Url.tutorial "higher-order-functions" );
+    ( "/learn/tutorials/functional_programming.html",
+      Url.tutorial "higher-order-functions" );
+    ( "/learn/tutorials/functional_programming.zh.html",
+      Url.tutorial "higher-order-functions" );
+    *)
     ("/learn/tutorials/functors.html", Url.tutorial "functors");
     ( "/learn/tutorials/garbage_collection.ja.html",
       Url.tutorial "garbage-collection" );
@@ -256,6 +270,11 @@ let from_v2 =
     ("/learn/tutorials/map.ja.html", Url.tutorial "map");
     ("/learn/tutorials/map.html", Url.tutorial "map");
     ("/learn/tutorials/map.zh.html", Url.tutorial "map");
+    ("/learn/tutorials/modules.fr.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.ja.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.ko.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.html", Url.tutorial "modules");
+    ("/learn/tutorials/modules.zh.html", Url.tutorial "modules");
     ("/learn/tutorials/objects.ja.html", Url.tutorial "objects");
     ("/learn/tutorials/objects.html", Url.tutorial "objects");
     ("/learn/tutorials/objects.zh.html", Url.tutorial "objects");
@@ -268,6 +287,7 @@ let from_v2 =
     ("/learn/tutorials/set.ja.html", Url.tutorial "sets");
     ("/learn/tutorials/set.html", Url.tutorial "sets");
     ("/learn/tutorials/set.zh.html", Url.tutorial "sets");
+    ("/learn/tutorials/streams.html", Url.tutorial "sequences");
     ("/learn/tutorials/up_and_running.html", Url.tutorial "up-and-running");
     (Url.tutorial "first-hour", Url.tutorial "tour-of-ocaml");
     ("/meetings/index.fr.html", Url.community);

--- a/src/ocamlorg_web/lib/redirection.ml
+++ b/src/ocamlorg_web/lib/redirection.ml
@@ -203,11 +203,11 @@ let from_v2 =
       Url.tutorial "basic-data-types" );
     ( "/learn/tutorials/data_types_and_matching.ja.html",
       Url.tutorial "basic-data-types" );
-    ("/learn/tutorials/data_types_and_matching.html", Url.tutorial "basic-data-types");
+    ( "/learn/tutorials/data_types_and_matching.html",
+      Url.tutorial "basic-data-types" );
     ( "/learn/tutorials/data_types_and_matching.zh.html",
       Url.tutorial "basic-data-types" );
-    ( Url.tutorial "data-types",
-      Url.tutorial "basic-data-types" );
+    (Url.tutorial "data-types", Url.tutorial "basic-data-types");
     ("/learn/tutorials/debug.html", Url.tutorial "debugging");
     ("/learn/tutorials/error_handling.html", Url.tutorial "error-handling");
     ( "/learn/tutorials/file_manipulation.ja.html",
@@ -217,18 +217,17 @@ let from_v2 =
       Url.tutorial "file-manipulation" );
     ("/learn/tutorials/format.fr.html", Url.tutorial "formatting-text");
     ("/learn/tutorials/format.html", Url.tutorial "formatting-text");
-    (* FIXME: uncomment when higher-order-functions is merged
-    ( "/learn/tutorials/functional_programming.fr.html",
-      Url.tutorial "higher-order-functions" );
-    ( "/learn/tutorials/functional_programming.it.html",
-      Url.tutorial "higher-order-functions" );
-    ( "/learn/tutorials/functional_programming.ja.html",
-      Url.tutorial "higher-order-functions" );
-    ( "/learn/tutorials/functional_programming.html",
-      Url.tutorial "higher-order-functions" );
-    ( "/learn/tutorials/functional_programming.zh.html",
-      Url.tutorial "higher-order-functions" );
-    *)
+    (* FIXME: uncomment when higher-order-functions is merged (
+       "/learn/tutorials/functional_programming.fr.html", Url.tutorial
+       "higher-order-functions" ); (
+       "/learn/tutorials/functional_programming.it.html", Url.tutorial
+       "higher-order-functions" ); (
+       "/learn/tutorials/functional_programming.ja.html", Url.tutorial
+       "higher-order-functions" ); (
+       "/learn/tutorials/functional_programming.html", Url.tutorial
+       "higher-order-functions" ); (
+       "/learn/tutorials/functional_programming.zh.html", Url.tutorial
+       "higher-order-functions" ); *)
     ("/learn/tutorials/functors.html", Url.tutorial "functors");
     ( "/learn/tutorials/garbage_collection.ja.html",
       Url.tutorial "garbage-collection" );

--- a/src/ocamlorg_web/lib/redirection.ml
+++ b/src/ocamlorg_web/lib/redirection.ml
@@ -198,14 +198,14 @@ let from_v2 =
     ( "/learn/tutorials/compiling_ocaml_projects.html",
       Url.tutorial "compiling-ocaml-projects" );
     ( "/learn/tutorials/data_types_and_matching.fr.html",
-      Url.tutorial "data-types" );
+      Url.tutorial "basic-data-types" ); 
     ( "/learn/tutorials/data_types_and_matching.it.html",
-      Url.tutorial "data-types" );
+      Url.tutorial "basic-data-types" );
     ( "/learn/tutorials/data_types_and_matching.ja.html",
-      Url.tutorial "data-types" );
-    ("/learn/tutorials/data_types_and_matching.html", Url.tutorial "data-types");
+      Url.tutorial "basic-data-types" );
+    ("/learn/tutorials/data_types_and_matching.html", Url.tutorial "basic-data-types");
     ( "/learn/tutorials/data_types_and_matching.zh.html",
-      Url.tutorial "data-types" );
+      Url.tutorial "basic-data-types" );
     ("/learn/tutorials/debug.html", Url.tutorial "debugging");
     ("/learn/tutorials/error_handling.html", Url.tutorial "error-handling");
     ( "/learn/tutorials/file_manipulation.ja.html",
@@ -215,16 +215,6 @@ let from_v2 =
       Url.tutorial "file-manipulation" );
     ("/learn/tutorials/format.fr.html", Url.tutorial "formatting-text");
     ("/learn/tutorials/format.html", Url.tutorial "formatting-text");
-    ( "/learn/tutorials/functional_programming.fr.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.it.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.ja.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.html",
-      Url.tutorial "functional-programming" );
-    ( "/learn/tutorials/functional_programming.zh.html",
-      Url.tutorial "functional-programming" );
     ("/learn/tutorials/functors.html", Url.tutorial "functors");
     ( "/learn/tutorials/garbage_collection.ja.html",
       Url.tutorial "garbage-collection" );
@@ -266,21 +256,6 @@ let from_v2 =
     ("/learn/tutorials/map.ja.html", Url.tutorial "map");
     ("/learn/tutorials/map.html", Url.tutorial "map");
     ("/learn/tutorials/map.zh.html", Url.tutorial "map");
-    ("/learn/tutorials/modules.fr.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.ja.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.ko.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.html", Url.tutorial "modules");
-    ("/learn/tutorials/modules.zh.html", Url.tutorial "modules");
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.fr.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.it.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.ja.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
-    ( "/learn/tutorials/null_pointers_asserts_and_warnings.zh.html",
-      Url.tutorial "null-pointers-asserts-and-warnings" );
     ("/learn/tutorials/objects.ja.html", Url.tutorial "objects");
     ("/learn/tutorials/objects.html", Url.tutorial "objects");
     ("/learn/tutorials/objects.zh.html", Url.tutorial "objects");
@@ -289,13 +264,10 @@ let from_v2 =
     ("/learn/tutorials/performance_and_profiling.html", Url.tutorial "profiling");
     ( "/learn/tutorials/performance_and_profiling_discussion.html",
       Url.tutorial "profiling" );
-    ("/learn/tutorials/pointers.html", Url.tutorial "pointers");
-    ("/learn/tutorials/pointers.zh.html", Url.tutorial "pointers");
     ("/learn/tutorials/set.fr.html", Url.tutorial "sets");
     ("/learn/tutorials/set.ja.html", Url.tutorial "sets");
     ("/learn/tutorials/set.html", Url.tutorial "sets");
     ("/learn/tutorials/set.zh.html", Url.tutorial "sets");
-    ("/learn/tutorials/streams.html", Url.tutorial "streams");
     ("/learn/tutorials/up_and_running.html", Url.tutorial "up-and-running");
     (Url.tutorial "first-hour", Url.tutorial "tour-of-ocaml");
     ("/meetings/index.fr.html", Url.community);


### PR DESCRIPTION
I changed the redirection links for:
- `data-types` to `basic-data-types`

I removed files redirects for:
- functional-programming
- modules
- null-pointers-asserts-and-warnings
- pointers
- streams

This PR closes the issue [Check tutorial redirection rules #1959](https://github.com/ocaml/ocaml.org/issues/1959)
