### PR TITLE
(docs) Include as syntax for function parameters

### DIFF
--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -601,6 +601,7 @@ val spicy_cat : string * string -> string = <fun>
 # spicy_cat ("hello", "world");;
 - : string = "hello world"
 ```
+
 It looks like two arguments have been passed: `"hello"` and `"world"`. However, only one, the `("hello", "world")` tuple, has been passed. Inspection of the generated assembly would show it isn't the same function as `sweet_cat`. It contains some more code. The contents of the tuple passed to `spicy_cat` (`x` and `y`) must be extracted before evaluation of the `x ^ " " ^ y` expression. This is the role of the additional assembly instructions.
 
 In many imperative languages, the `spicy_cat ("hello", "world")` syntax reads as a function call with two parameters; but in OCaml, it denotes applying the function `spicy_cat` to a tuple containing `"hello"` and `"world"`.
@@ -751,3 +752,4 @@ One may wonder:
 
 The answer to this question goes beyond the scope of this tutorial. This comes from the [λ-calculus](https://en.wikipedia.org/wiki/Lambda_calculus), the mathematical theory underneath functional programming. In that formalism, there are nothing but functions. Everything, including data, is a function, and computation reduces to parameter passing. In functional programming (and thus OCaml), having functions and values at the same level is an invitation to think this way. This is different from the imperative programming approach where everything reduces to reading and writing into the memory.
 -->
+

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -180,6 +180,19 @@ This also works with user-defined types.
 # type live_person = int * name;;
 type live_person = int * name
 
+# let robin_with_age : live_person = (20, robin);;
+val robin_with_age : live_person = (20, {first = "Robin"; last = "Milner"})
+
+# let (years, { first; last }) = robin_with_age;;
+val years : int = 20
+val first : string = "Robin"
+val last : string = "Milner"
+```
+
+### Pattern Matching on Function Parameters
+
+Pattern matching can also be used on function parameters.
+```ocaml
 # let age ((years, { first; last }) : live_person) = years;;
 val age : live_person -> int = <fun>
 ```

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -156,6 +156,23 @@ val first : string = "Robin"
 val last : string = "Milner"
 ```
 
+### Pattern Matching in Function Parameters
+
+It is possible to use pattern matching to specify function parameters. For tuples:
+```ocaml
+# type live_person = int * name;;
+type live_person = int * name
+
+# let age ((years, full_name) : live_person) = years;;
+val age : live_person -> int = <fun>
+```
+
+For records:
+```ocaml
+# let introduce ({first; last}) : name) = "I am " ^ first ^ " " ^ last;;
+val introduce : name -> string = <fun>
+```
+
 ### Pattern Matching on `unit`
 <!--Unit example-->
 A special case of combined definition and pattern matching involves the `unit` type:
@@ -177,9 +194,6 @@ Above, the pattern does not contain any identifier, meaning no name is defined. 
 
 This also works with user-defined types.
 ```ocaml
-# type live_person = int * name;;
-type live_person = int * name
-
 # let robin_with_age : live_person = (20, robin);;
 val robin_with_age : live_person = (20, {first = "Robin"; last = "Milner"})
 
@@ -187,14 +201,6 @@ val robin_with_age : live_person = (20, {first = "Robin"; last = "Milner"})
 val years : int = 20
 val first : string = "Robin"
 val last : string = "Milner"
-```
-
-### Pattern Matching on Function Parameters
-
-Pattern matching can also be used on function parameters.
-```ocaml
-# let age ((years, { first; last }) : live_person) = years;;
-val age : live_person -> int = <fun>
 ```
 
 ### Discarding Values Using Pattern Matching
@@ -606,19 +612,6 @@ It looks like two arguments have been passed: `"hello"` and `"world"`. However, 
 
 In many imperative languages, the `spicy_cat ("hello", "world")` syntax reads as a function call with two parameters; but in OCaml, it denotes applying the function `spicy_cat` to a tuple containing `"hello"` and `"world"`.
 
-### Records as Function Paramters
-
-It is possible to use the record syntax to specify function parameters. Here is how it can be used to define yet another version of the running example:
-```ocaml
-# type cat_args = {x : string; y : string};;
-type cat_args = { x : string; y : string; }
-
-# let happy_cat ({x; y}: cat_args) = x ^ " " ^ y;;
-val happy_cat : cat_args -> string = <fun>
-
-# happy_cat {x = "hello"; y = "world"};;
-- : string = "hello world
-```
 
 ### Currying and Uncurrying
 
@@ -752,4 +745,3 @@ One may wonder:
 
 The answer to this question goes beyond the scope of this tutorial. This comes from the [λ-calculus](https://en.wikipedia.org/wiki/Lambda_calculus), the mathematical theory underneath functional programming. In that formalism, there are nothing but functions. Everything, including data, is a function, and computation reduces to parameter passing. In functional programming (and thus OCaml), having functions and values at the same level is an invitation to think this way. This is different from the imperative programming approach where everything reduces to reading and writing into the memory.
 -->
-

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -158,20 +158,26 @@ val last : string = "Milner"
 
 ### Pattern Matching in Function Parameters
 
-It is possible to use pattern matching to specify function parameters. For tuples:
-```ocaml
-# type live_person = int * name;;
-type live_person = int * name
+Single-case pattern matching can also be used for parameter declaration.
 
-# let age ((years, full_name) : live_person) = years;;
-val age : live_person -> int = <fun>
+Here is an example with tuples:
+```ocaml
+# let get_country ((country, { first; last }) : citizen) = country;;
+val get_countruy : citizen -> string = <fun>
 ```
 
-For records:
+Here is an example with the `name` record:
 ```ocaml
-# let introduce ({first; last}) : name) = "I am " ^ first ^ " " ^ last;;
+# let introduce {first; last} = "I am " ^ first ^ " " ^ last;;
 val introduce : name -> string = <fun>
 ```
+
+**Note** Using the `discard` pattern for parameter declaration is also possible.
+```ocaml
+# let get_meaning _ = 42;;
+val get_meaning : 'a -> int = <fun>
+```
+
 
 ### Pattern Matching on `unit`
 <!--Unit example-->

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -601,6 +601,9 @@ val spicy_cat : string * string -> string = <fun>
 # spicy_cat ("hello", "world");;
 - : string = "hello world"
 ```
+It looks like two arguments have been passed: `"hello"` and `"world"`. However, only one, the `("hello", "world")` tuple, has been passed. Inspection of the generated assembly would show it isn't the same function as `sweet_cat`. It contains some more code. The contents of the tuple passed to `spicy_cat` (`x` and `y`) must be extracted before evaluation of the `x ^ " " ^ y` expression. This is the role of the additional assembly instructions.
+
+In many imperative languages, the `spicy_cat ("hello", "world")` syntax reads as a function call with two parameters; but in OCaml, it denotes applying the function `spicy_cat` to a tuple containing `"hello"` and `"world"`.
 
 ### Records as Function Paramters
 
@@ -615,11 +618,6 @@ val happy_cat : cat_args -> string = <fun>
 # happy_cat {x = "hello"; y = "world"};;
 - : string = "hello world
 ```
-
-
-It looks like two arguments have been passed: `"hello"` and `"world"`. However, only one, the `("hello", "world")` tuple, has been passed. Inspection of the generated assembly would show it isn't the same function as `sweet_cat`. It contains some more code. The contents of the tuple passed to `spicy_cat` (`x` and `y`) must be extracted before evaluation of the `x ^ " " ^ y` expression. This is the role of the additional assembly instructions.
-
-In many imperative languages, the `spicy_cat ("hello", "world")` syntax reads as a function call with two parameters; but in OCaml, it denotes applying the function `spicy_cat` to a tuple containing `"hello"` and `"world"`.
 
 ### Currying and Uncurrying
 

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -602,6 +602,21 @@ val spicy_cat : string * string -> string = <fun>
 - : string = "hello world"
 ```
 
+### Records as Function Paramters
+
+It is possible to use the record syntax to specify function parameters. Here is how it can be used to define yet another version of the running example:
+```ocaml
+# type cat_args = {x : string; y : string};;
+type cat_args = { x : string; y : string; }
+
+# let happy_cat ({x; y}: cat_args) = x ^ " " ^ y;;
+val happy_cat : cat_args -> string = <fun>
+
+# happy_cat {x = "hello"; y = "world"};;
+- : string = "hello world
+```
+
+
 It looks like two arguments have been passed: `"hello"` and `"world"`. However, only one, the `("hello", "world")` tuple, has been passed. Inspection of the generated assembly would show it isn't the same function as `sweet_cat`. It contains some more code. The contents of the tuple passed to `spicy_cat` (`x` and `y`) must be extracted before evaluation of the `x ^ " " ^ y` expression. This is the role of the additional assembly instructions.
 
 In many imperative languages, the `spicy_cat ("hello", "world")` syntax reads as a function call with two parameters; but in OCaml, it denotes applying the function `spicy_cat` to a tuple containing `"hello"` and `"world"`.

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -194,13 +194,13 @@ Above, the pattern does not contain any identifier, meaning no name is defined. 
 
 This also works with user-defined types.
 ```ocaml
-# let robin_with_age : live_person = (20, robin);;
-val robin_with_age : live_person = (20, {first = "Robin"; last = "Milner"})
+# type citizen = string * name;;
+type citizen = string * name
 
-# let (years, { first; last }) = robin_with_age;;
-val years : int = 20
-val first : string = "Robin"
-val last : string = "Milner"
+# let ((country, { first = forename; last = surname }) : citizen) = ("United Kingdom", robin);;
+val country : string = "United Kingdom"
+val forename : string = "Robin"
+val surname : string = "Milner"
 ```
 
 ### Discarding Values Using Pattern Matching

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -729,6 +729,36 @@ type latitude_longitude = float * float
 
 This is mostly useful as a means of documentation or to shorten long type expressions.
 
+### Function Parameter Aliases
+
+Function parameters can also be given a name with pattern matching for tuples and records.
+```ocaml
+(* Tuples as parameters *)
+# let tuple_sum (x, y) = x + y;;
+val tuple_sum : int * int -> int = <fun>
+
+# let f ((x, y) as arg) = tuple_sum arg;;
+val f : int * int -> int = <fun>
+
+
+(* Records as parameters *)
+# type dummy_record = {a: int; b: int};;
+type dummy_record = { a : int; b : int; }
+
+# let record_sum ({a; b}: dummy_record) = a + b;;
+val record_sum : dummy_record -> int = <fun>
+
+# let f ({a;b} as arg) = record_sum arg;;
+val f : dummy_record -> int = <fun>
+```
+
+This is useful for matching variant values of parameters.
+
+```ocaml
+# let meaning_of_life = function Some _ as opt -> opt | None -> Some 42;;
+val meaning_of_life : int option -> int option = <fun>
+```
+
 ## A Complete Example: Mathematical Expressions
 
 This example shows how to represent simple mathematical expressions like `n * (x + y)` and multiply them out symbolically to get `n * x + n * y`:

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -719,7 +719,9 @@ Note that records behave like single constructor variants. That allows pattern m
 - : int = 17
 ```
 
-### Type Aliases
+### Aliases
+
+#### Type Aliases
 
 Just like values, any type can be given a name.
 ```ocaml
@@ -729,7 +731,7 @@ type latitude_longitude = float * float
 
 This is mostly useful as a means of documentation or to shorten long type expressions.
 
-### Function Parameter Aliases
+#### Function Parameter Aliases
 
 Function parameters can also be given a name with pattern matching for tuples and records.
 ```ocaml


### PR DESCRIPTION
closes https://github.com/ocaml/ocaml.org/issues/1852

- Added use of pattern matching in function parameters
- Mention Record type for function parameters
- Function Parameter Alias for tuples and records
- Use alias in variant values for parameter