### PR TITLE
Fix a typo in programming guidelines

### DIFF
--- a/data/tutorials/guides/rs_00_guidelines.md
+++ b/data/tutorials/guides/rs_00_guidelines.md
@@ -175,7 +175,7 @@ let rec print_lambda lam =
   | App (l1, l2) ->
      printf "(%a %a)" print_lambda l1 print_lambda l2
 ```
-####  Usage in Module iIterface
+####  Usage in Module Interface
 The function's usage must appear in the module's interface that
 exports it, not in the program that implements it. Choose comments as
 in the OCaml system's interface modules, which will subsequently automatically


### PR DESCRIPTION
Hi, thanks for great materials for the beginners! I found a simple typo in [OCaml Programming Guidelines](https://ocaml.org/docs/guidelines#usage-in-module-iiterface).
