### PR TITLE
Refactoring of Utils.human_date (src/ocamlorg_frontend/utils.ml)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -49,7 +49,7 @@
    (>= 0.2.0))
   opam-format
   (timedesc
-   (>= 1.1.1))
+   (>= 2.0.0))
   yojson
   lwt
   tailwindcss

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -33,7 +33,7 @@ depends: [
   "logs"
   "cmarkit" {>= "0.2.0"}
   "opam-format"
-  "timedesc" {>= "1.1.1"}
+  "timedesc" {>= "2.0.0"}
   "yojson"
   "lwt"
   "tailwindcss"

--- a/src/ocamlorg_frontend/utils.ml
+++ b/src/ocamlorg_frontend/utils.ml
@@ -1,10 +1,9 @@
 let human_date s =
   let open Timedesc in
   try
-    let date_s = Timedesc.Date.of_iso8601_exn s in
+    let date_s = Date.of_iso8601_exn s in
     let midnight = Time.make_exn ~hour:0 ~minute:0 ~second:0 () in
-    let zoneless_s = Zoneless.of_date_and_time date_s midnight in
-    let date_time = zoneless_s |> Zoneless.to_zoned_exn ~tz:Time_zone.utc in
+    let date_time = of_date_and_time_exn ~tz:Time_zone.utc date_s midnight in
     Format.asprintf "%a" (pp ~format:"{day:0X} {mon:Xxx} {year}" ()) date_time
   with Timedesc.ISO8601_parse_exn msg ->
     Logs.err (fun m -> m "Could not parse date %s: %s" s msg);


### PR DESCRIPTION
This is a minor refactoring of `Utils.human_date` (`src/ocamlorg_frontend/utils.ml`) by updating it to use newer Timedesc API that has less friction.