### PR TITLE
Add Title for Breadcrumb Subnav (e.g. "Learn" / "Community")

### DIFF
--- a/src/ocamlorg_frontend/layouts/community_layout.eml
+++ b/src/ocamlorg_frontend/layouts/community_layout.eml
@@ -12,7 +12,7 @@ let tabs
     | Overview -> "Overview"
     | Jobs -> "Jobs"
   in
-  Layout.subnav_tabs ~current ~sections:[Overview; Jobs] ~url_of_section ~title_of_section
+  Layout.subnav_tabs ~title:"Community" ~current ~sections:[Overview; Jobs] ~url_of_section ~title_of_section
 
 let single_column_layout
 ?use_swiper

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -1,5 +1,5 @@
 let subnav_tabs
-~sections ~url_of_section ~title_of_section
+~title ~sections ~url_of_section ~title_of_section
 ~current =
   let link ~href ~title ~current =
     <a href="<%s href %>" class="justify-start px-4 py-2 text-white dark:text-dark-title items-center font-normal border-2 border-b-4 border-transparent rounded <%s if current then "border-b-primary dark:border-b-dark-primary" else "opacity-80 hover:text-primary dark:hover:text-dark-primary" %>">
@@ -17,7 +17,7 @@ let subnav_tabs
     <nav aria-label="breadcrumbs" class="px-4 flex text-white dark:text-dark-title bg-title md:hidden">
       <ul>
         <li class="inline-block"> 
-            <a href="<%s url_of_section first_section %>" class="flex items-center px-2 py-2 border-transparent border-2 border-b-4"> <%s title_of_section first_section %>
+            <a href="<%s url_of_section first_section %>" class="flex items-center px-2 py-2 border-transparent border-2 border-b-4"> <%s title %>
               <span> <%s! Icons.chevron_right "w-3 h-3 ml-2" %> </span> </a>
         </li>
         <li class="inline-block">

--- a/src/ocamlorg_frontend/layouts/learn_layout.eml
+++ b/src/ocamlorg_frontend/layouts/learn_layout.eml
@@ -27,7 +27,7 @@ let tabs
     | Exercises -> "Exercises"
     | Books -> "Books"
   in
-  Layout.subnav_tabs ~current ~sections:[Overview; GetStarted; Language; Platform; Guides; Exercises; Books] ~url_of_section ~title_of_section
+  Layout.subnav_tabs ~title:"Learn" ~current ~sections:[Overview; GetStarted; Language; Platform; Guides; Exercises; Books] ~url_of_section ~title_of_section
 
 let sidebar
 ~current_tutorial


### PR DESCRIPTION
When I factored out the subnav tabs into `learn.eml`, I assigned the wrong title for the first element of the breadcrumb on the mobile view. This patch assigns "Learn", and, respectively, "Community" for the first element of the breadcrumb on the respective pages.