### PR TITLE
Improve some wording in the functors tutorial

### DIFF
--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -482,16 +482,6 @@ Note that:
 - `unit` is a variant with a unique constructor, which does not carry data: `()`.
 - `bool` is also a variant with two constructors that doesn't carry data: `true` and `false`.
 
-#### Empty Variants
-
-Variants can optionally be defined with absolutely no constructors at all.
-
-```ocaml
-type void = |
-```
-
-Such types are not ordinarily useful in OCaml programs (as they do not have any constructible values), but they can be useful as temporary placeholders when defining types in a [functor](/docs/functors#writing-your-own-functors).
-
 #### Constructors With Data
 
 It is possible to wrap data in constructors. The following type has several constructors with data (e.g., `Hash of string`) and some without (e.g., `Head`). It represents the different means to refer to a Git [revision](https://git-scm.com/docs/gitrevisions).

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -482,6 +482,16 @@ Note that:
 - `unit` is a variant with a unique constructor, which does not carry data: `()`.
 - `bool` is also a variant with two constructors that doesn't carry data: `true` and `false`.
 
+#### Empty Variants
+
+Variants can optionally be defined with absolutely no constructors at all.
+
+```ocaml
+type void = |
+```
+
+Such types are not ordinarily useful in OCaml programs (as they do not have any constructible values), but they can be useful as temporary placeholders when defining types in a [functor](/docs/functors#writing-your-own-functors).
+
 #### Constructors With Data
 
 It is possible to wrap data in constructors. The following type has several constructors with data (e.g., `Hash of string`) and some without (e.g., `Head`). It represents the different means to refer to a Git [revision](https://git-scm.com/docs/gitrevisions).

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -242,8 +242,8 @@ module type S = sig
 end
 
 module Binary(Elt: OrderedType) : S = struct
-  type elt = | (* Replace by your own *)
-  type t = | (* Replace by your own *)
+  type elt (* = replace by your own *)
+  type t (* = replace by your own *)
   (* Add private functions here *)
   let empty = failwith "Not yet implemented"
   let is_empty h = failwith "Not yet implemented"

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -415,7 +415,7 @@ module Make(Dep: Iterable) : S with type 'a t := 'a Dep.t = struct
 end
 ```
 
-In the example above, the local type `t` does not shadow the type `t` exposed by the `with type` constraint and can be used for the implementation of the functor. However, it is generally better to avoid availing of this behaviour since it may make your code more difficult to understand.
+In the example above, `t` from `with type` takes precedence over the local `t`, which only has a local scope. However, it is generally better to avoid availing of this behaviour since it may make your code more difficult to understand.
 
 ## Write a Functor to Extend Modules
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -428,10 +428,10 @@ Another property of the `with type` constraint is that the type it exposes won't
 
 ```ocaml
 module Make(Dep: Iterable) : S with type 'a t := 'a Dep.t = struct
-  type 'a t = MkT
-  let g _ = "MkT"
+  type 'a t = LocalType
+  let g LocalType = "LocalType"
   let f = Dep.iter(fun s ->
-    Out_channel.output_string stdout (g MkT ^ "\n");
+    Out_channel.output_string stdout (g LocalType ^ "\n");
     Out_channel.output_string stdout (s ^ "\n"))
 end
 ```

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -63,7 +63,7 @@ Here is how this reads (starting from the bottom, then going up):
 
 **Note**: Most set operations need to compare elements to check if they are the same. To allow using a user-defined comparison algorithm, the `Set.Make` functor takes a module the specifies both the element type `t` and the `compare` function. Passing the comparison function as a higher-order parameter, as done in `Array.sort`, for example, would add a lot of boilerplate code. Providing set operations as a functor allows specifying the comparison function only once.
 
-Here is an example how to use `Set.Make`:
+Here is an example of how to use `Set.Make`:
 
 **`funkt.ml`**
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -80,10 +80,6 @@ This defines a module `Funkt.StringSet`. What `Set.Make` needs are:
 - Type `t`, here `string`
 - Function allowing to compare two values of type `t`, here `String.compare`
 
-However, since the module `String` defines
-- Type name `t`, which is an alias for `string`
-- Function `compare` of type `t -> t -> bool` compares two strings
-
 This can be simplified using an _anonymous module_ expression:
 ```ocaml
 module StringSet = Set.Make(struct
@@ -93,6 +89,10 @@ end)
 ```
 
 The module expression `struct ... end` is inlined in the `Set.Make` call.
+
+However, since the module `String` already defines
+- Type name `t`, which is an alias for `string`
+- Function `compare` of type `t -> t -> bool` compares two strings
 
 This can be simplified even further into this:
 ```ocaml

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -242,8 +242,8 @@ module type S = sig
 end
 
 module Binary(Elt: OrderedType) : S = struct
-  type elt (* = replace by your own *)
-  type t (* = replace by your own *)
+  type elt (* Add your own type definition *)
+  type t (* Add your own type definition *)
   (* Add private functions here *)
   let empty = failwith "Not yet implemented"
   let is_empty h = failwith "Not yet implemented"
@@ -377,7 +377,6 @@ Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 ### Naming and Scoping
 
 The `with type` constraint unifies types within a functor's parameter and result modules. We've used that in the previous section. This section addresses the naming and scoping mechanics of this constraint.
-``
 
 Naively, we might have defined `Iter.Make` as follows:
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -376,9 +376,10 @@ Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
 ### Naming and Scoping
 
-In the previous section, we learned how to use the `with type` constraint in order to unify types contained within both the parameter and result module of a functor. Let's go over a few more details concerning naming and scoping to get a better grasp of the mechanics of this constraint.
+The `with type` constraint unifies types within a functor's parameter and result modules. We've used that in the previous section. This section addresses the naming and scoping mechanics of this constraint.
+``
 
-When reading the source of `iterPrint.ml`, it may have seemed curious as to why we could not have simply defined `Make` as follows:
+Naively, we might have defined `Iter.Make` as follows:
 
 ```ocaml
 module Make(Dep: Iterable) : S = struct
@@ -401,9 +402,9 @@ Error: This expression has type string list
        but an expression was expected of type string IterPrint.t
 ```
 
-The key thing to realise is that, outside the functor, client code is not privy to the fact that `type 'a t` is being set equal to `Dep.t`. In `funkt.ml`, `IterPrint.t` simply appears as an abstract type exposed by the result of `Make`. This is precisely why the `with type` constraint is needed to propagate the knowledge that `IterPrint.t` is the same as the instantiation of `Dep.t` (`List.t` in this case).
+Outside the functor, it is not known that `type 'a t` is set to `Dep.t`. In `funkt.ml`, `IterPrint.t` appears as an abstract type exposed by the result of `Make`. This is why the `with type` constraint is needed. It propagates the knowledge that `IterPrint.t` is the same type as `Dep.t` (`List.t` in this case).
 
-Another property of the `with type` constraint is that the type it exposes won't be shadowed by definitions within the functor body. In fact, the `Make` functor could be redefined as follows without preventing the successful compilation of module `Funkt`:
+The type constrained using `with type` isn't shadowed by definitions within the functor body. In the example, the `Make` functor can be redefined as follows:
 
 ```ocaml
 module Make(Dep: Iterable) : S with type 'a t := 'a Dep.t = struct
@@ -415,7 +416,7 @@ module Make(Dep: Iterable) : S with type 'a t := 'a Dep.t = struct
 end
 ```
 
-In the example above, `t` from `with type` takes precedence over the local `t`, which only has a local scope. However, it is generally better to avoid availing of this behaviour since it may make your code more difficult to understand.
+In the example above, `t` from `with type` takes precedence over the local `t`, which only has a local scope. Don't shadow names too often because it makes the code harder to understand.
 
 ## Write a Functor to Extend Modules
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -388,7 +388,7 @@ module Make(Dep: Iterable) : S = struct
 end
 ```
 
-In the absence of code that utilises the function `f` provided by the output of `Make`, the project compiles without error.
+In the function `f` isn't used, the project compiles without error.
 
 However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project fails to compile with the following error message:
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -389,7 +389,7 @@ end
 
 In the absence of client code that utilises the function `f` provided by the output of `Make`, the project would compile without error.
 
-However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project will fail to compile:
+However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project will fail to compile with the following error message:
 
 ```shell
 5 | ..stdin

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -372,7 +372,7 @@ let _ =
 
 Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
-**Note**: Modules received and returned by `IterPrint.Make` both have a type `t`. The `with type ... :=` constraint is needed to make the two `t` identical. This allows functions from the injected dependency and result module to use the same type. When the parameter's contained type is not exposed by the result module (i.e. when it is an _implementation detail_), the `with type` constraint is unnecessary. 
+**Note**: Modules received and returned by `IterPrint.Make` both have a type `t`. The `with type ... :=` constraint is needed to make the two `t` identical. This allows functions from the injected dependency and result module to use the same type. When the parameter's contained type is not exposed by the result module (i.e., when it is an _implementation detail_), the `with type` constraint is unnecessary.
 
 ### Naming and Scoping
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -157,7 +157,7 @@ let _ =
 
 This allows the user to seemingly extend the module `String` with a submodule `Set`. Check the behaviour using `opam exec -- dune exec funkt < dune`.
 
-## Functors Allows Parametrising Modules
+## Functors Facilitate Parametrising Modules
 
 ### Functors From the Standard Library
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -387,9 +387,9 @@ module Make(Dep: Iterable) : S = struct
 end
 ```
 
-In the absence of code that utilises the function `f` provided by the output of `Make`, the project would compile without error.
+In the absence of code that utilises the function `f` provided by the output of `Make`, the project compiles without error.
 
-However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project will fail to compile with the following error message:
+However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project fails to compile with the following error message:
 
 ```shell
 5 | ..stdin

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -372,7 +372,7 @@ let _ =
 
 Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
-**Note**: Modules received and returned by `IterPrint.Make` both have a type `t`. The `with type ... :=` constraint is needed to make the two `t` identical. This allows functions from the injected dependency and result module to use the same type. When the parameter's contained type is not exposed by the result module (i.e., when it is an _implementation detail_), the `with type` constraint is unnecessary.
+**Note**: Modules received and returned by `IterPrint.Make` both have a type `t`. The `with type ... := ...` constraint exposes that the two types `t` are the same. This makes functions from the injected dependency and result module use the exact same type. When the parameter's contained type is not exposed by the result module (i.e., when it is an _implementation detail_), the `with type` constraint is not necessary.
 
 ### Naming and Scoping
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -245,6 +245,7 @@ module Binary(Elt: OrderedType) : S = struct
   type elt = | (* Replace by your own *)
   type t = | (* Replace by your own *)
   (* Add private functions here *)
+  let empty = failwith "Not yet implemented"
   let is_empty h = failwith "Not yet implemented"
   let insert h e = failwith "Not yet implemented"
   let merge h1 h2 = failwith "Not yet implemented"

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -401,27 +401,6 @@ Error: This expression has type string list
        but an expression was expected of type string IterPrint.t
 ```
 
-This may seem odd given the fact that the modified `Make` functor successfully compiles on its own. Indeed, if we had used an inappropriate definition such as `type 'a t = MkT`, the functor itself would have failed to compile:
-
-```shell
-11 | .................................struct
-12 |   type 'a t = MkT
-13 |   let f = Dep.iter (fun s -> Out_channel.output_string stdout (s ^ "\n"))
-14 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = MkT val f : string Dep.t -> unit end
-       is not included in
-         S
-       Values do not match:
-         val f : string Dep.t -> unit
-       is not included in
-         val f : string t -> unit
-       The type string Dep.t -> unit is not compatible with the type
-         string t -> unit
-       Type string Dep.t is not compatible with type string t
-```
-
 The key thing to realise is that, outside the functor, client code is not privy to the fact that `type 'a t` is being set equal to `Dep.t`. In `funkt.ml`, `IterPrint.t` simply appears as an abstract type exposed by the result of `Make`. This is precisely why the `with type` constraint is needed to propagate the knowledge that `IterPrint.t` is the same as the instantiation of `Dep.t` (`List.t` in this case).
 
 Another property of the `with type` constraint is that the type it exposes won't be shadowed by definitions within the functor body. In fact, the `Make` functor could be redefined as follows without preventing the successful compilation of module `Funkt`:

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -388,7 +388,7 @@ module Make(Dep: Iterable) : S = struct
 end
 ```
 
-In the function `f` isn't used, the project compiles without error.
+If the function `f` isn't used, the project compiles without error.
 
 However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project fails to compile with the following error message:
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -157,7 +157,7 @@ let _ =
 
 This allows the user to seemingly extend the module `String` with a submodule `Set`. Check the behaviour using `opam exec -- dune exec funkt < dune`.
 
-## Functors Facilitate Parametrising Modules
+## Parametrising Modules with Functors 
 
 ### Functors From the Standard Library
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -157,7 +157,7 @@ let _ =
 
 This allows the user to seemingly extend the module `String` with a submodule `Set`. Check the behaviour using `opam exec -- dune exec funkt < dune`.
 
-## Parametrising Modules with Functors 
+## Parametrising Modules with Functors
 
 ### Functors From the Standard Library
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -371,7 +371,7 @@ let _ =
 
 Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
-**Note**: The functor `IterPrint.Make` exposes the type from the injected dependency (here first `List.t` then `Array.t`) as the type `t` required of the result module. That's why a `with type` constraint is needed. When customising a type that's not exposed by the result module (i.e. an _implementation detail_), the `with type` constraint is not needed. As a further consequence of this, we could even define a local type `t` within the `struct` block for use within the implementation, and such a type `t` would not shadow the type `t` of the result module.
+**Note**: Modules received and returned by `IterPrint.Make` both have a type `t`. The `with type ... :=` constraint is needed to make the two `t` identical. This allows functions from the injected dependency and result module to use the same type. When the parameter's contained type is not exposed by the result module (i.e. when it is an _implementation detail_), the `with type` constraint is unnecessary. 
 
 ## Write a Functor to Extend Modules
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -371,7 +371,7 @@ let _ =
 
 Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
-**Note**: The functor `IterPrint.Make` returns a module that exposes the type from the injected dependency (here first `List.t` then `Array.t`). That's why a `with type` constraint is needed. When parametrising other something not exposed by the module (and _implementation detail_), the `with type` constraint is not needed.
+**Note**: The functor `IterPrint.Make` exposes the type from the injected dependency (here first `List.t` then `Array.t`) as the type `t` required of the result module. That's why a `with type` constraint is needed. When customising a type that's not exposed by the result module (i.e. an _implementation detail_), the `with type` constraint is not needed. As a further consequence of this, we could even define a local type `t` within the `struct` block for use within the implementation, and such a type `t` would not shadow the type `t` of the result module.
 
 ## Write a Functor to Extend Modules
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -164,7 +164,7 @@ This allows the user to seemingly extend the module `String` with a submodule `S
 A functor is almost a module, except it needs to be applied to a module. This turns it into a module. In that sense, a functor allows module parametrisation.
 
 That's the case for the sets, maps, and hash tables provided by the standard library. It works like a contract between the functor and the developer.
-* If you provide a module that implements what is expected, as described the parameter interface
+* If you provide a module that implements what is expected, as described by the parameter interface
 * The functor returns a module that implements what is promised, as described by the result interface
 
 Here is the module's signature that the functors `Set.Make` and `Map.Make` expect:

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -387,7 +387,7 @@ module Make(Dep: Iterable) : S = struct
 end
 ```
 
-In the absence of client code that utilises the function `f` provided by the output of `Make`, the project would compile without error.
+In the absence of code that utilises the function `f` provided by the output of `Make`, the project would compile without error.
 
 However, since `Make` is invoked to create module `IterPrint` in `funkt.ml`, the project will fail to compile with the following error message:
 

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -376,7 +376,7 @@ Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
 ### Naming and Scoping
 
-In the previous section, we learned how to use the `with type` constraint in order to unify a type `t` contained within both the parameter and result module of a functor. Let's go over a few more details concerning naming and scoping to get a better grasp of the mechanics of this constraint.
+In the previous section, we learned how to use the `with type` constraint in order to unify types contained within both the parameter and result module of a functor. Let's go over a few more details concerning naming and scoping to get a better grasp of the mechanics of this constraint.
 
 When reading the source of `iterPrint.ml`, it may have seemed curious as to why we could not have simply defined `Make` as follows:
 


### PR DESCRIPTION
This PR adds some minor grammatical and wording changes to the functors tutorial that will hopefully make things clearer for new users of OCaml.

In particular, I made some changes to the aside about the `with type` constraint that may need particular review to ensure I did not state something that is semantically incorrect.