### PR TITLE
Changelog entry for OCaml 5.2.0~alpha1

### DIFF
--- a/data/changelog/ocaml/2024-02-05-ocaml-5.2.0-alpha1.md
+++ b/data/changelog/ocaml/2024-02-05-ocaml-5.2.0-alpha1.md
@@ -1,0 +1,69 @@
+---
+title: OCaml 5.2.0 - First Alpha
+description: First Alpha Release of OCaml 5.2.0
+tags: [ocaml]
+---
+
+Two months after the release of OCaml 5.1.1, the set of new features for the
+future version 5.2.0 of OCaml has been frozen. We are thus happy to announce the
+first alpha release for OCaml 5.2.0.
+
+This alpha version is here to help fellow hackers join us early in our bug
+hunting and opam ecosystem fixing fun (see below for the installation instructions).
+
+The progresses on stabilising the ecosystem are tracked on the
+[opam readiness for 5.2.0 meta-issue](https://github.com/ocaml/opam-repository/issues/25182).
+The full release is expected around April.
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+If you are interested in the ongoing list of new features and bug fixes, the
+updated change log for OCaml 5.2.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.2/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1 and later:
+
+```bash
+opam update
+opam switch create 5.2.0~alpha1
+```
+
+For previous version of opam, the switch creation command line is slightly more verbose:
+
+```bash
+opam update
+opam switch create 5.2.0~alpha1 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+
+The source code for the alpha is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-alpha1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~alpha1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.2.0~alpha1+options <option_list>
+```
+
+where `option_list` is a space separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
+
+```bash
+opam switch create 5.2.0~alpha1+flambda+nffa ocaml-variants.5.2.0~alpha1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+The command line above is slightly more complicated for opam version anterior to 2.1:
+
+
+```bash
+opam update
+opam switch create <switch_name> --packages=ocaml-variants.5.2.0~alpha1+options,<option_list> --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+In both cases, all available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
As described in the title, this is the changelog entry for the first alpha of OCaml 5.2.0
(which is being published to opam right now).
