### PR TITLE
(ood-gen) Adjust type of fields with `list option` type to `list` in Changelog, News, Planet, and Workshop

### DIFF
--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -303,7 +303,7 @@ module Planet : sig
       slug : string;
       source : source;
       description : string option;
-      authors : string list option;
+      authors : string list;
       date : string;
       preview_image : string option;
       featured : bool;

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -365,7 +365,7 @@ module Workshop : sig
     video : string option;
     slides : string option;
     poster : bool option;
-    additional_links : string list;
+    additional_links : string list option;
   }
 
   type t = {

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -416,6 +416,7 @@ module News : sig
     date : string;
     tags : string list;
     body_html : string;
+    authors : string list;
   }
 
   val all : t list

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -58,6 +58,7 @@ module Changelog : sig
     changelog_html : string option;
     body_html : string;
     body : string;
+    authors : string list;
   }
 
   val all : t list

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -365,7 +365,7 @@ module Workshop : sig
     video : string option;
     slides : string option;
     poster : bool option;
-    additional_links : string list option;
+    additional_links : string list;
   }
 
   type t = {

--- a/src/ocamlorg_frontend/pages/blog_post.eml
+++ b/src/ocamlorg_frontend/pages/blog_post.eml
@@ -23,9 +23,7 @@ Layout.render
     <article class="prose dark:prose-invert prose-orange mx-auto max-w-5xl">
       <header>
         <h1><%s blog_post.title %></h1>
-        <% (match blog_post.authors with None -> () | Some authors -> %>
-        <i>Authored by: <%s String.concat ", " authors %></i>
-        <% ); %>
+        <i>Authored by: <%s String.concat ", " blog_post.authors %></i>
       </header>
       <%s! blog_post.body_html %>
     </article>

--- a/src/ocamlorg_frontend/pages/blog_post.eml
+++ b/src/ocamlorg_frontend/pages/blog_post.eml
@@ -23,7 +23,9 @@ Layout.render
     <article class="prose dark:prose-invert prose-orange mx-auto max-w-5xl">
       <header>
         <h1><%s blog_post.title %></h1>
-        <i>Authored by: <%s String.concat ", " blog_post.authors %></i>
+        <% (match blog_post.authors with [] -> () | authors -> %>
+        <i>Authored by: <%s String.concat ", " authors %></i>
+        <% ); %>
       </header>
       <%s! blog_post.body_html %>
     </article>

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -23,10 +23,7 @@ type t = {
     ~remove:[ slug; changelog_html; body_html; body; date ],
     show { with_path = false }]
 
-let of_metadata m =
-  of_metadata m ~modify_authors:(function
-    | None -> []
-    | Some authors -> authors)
+let of_metadata m = of_metadata m ~modify_authors:(Option.value ~default:[])
 
 let re_date_slug =
   let open Re in

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -18,7 +18,8 @@ type t = {
   authors : string list;
 }
 [@@deriving
-  stable_record ~version:metadata ~add:[ changelog; description ]
+  stable_record ~version:metadata
+    ~add:[ changelog; description ]
     ~modify:[ authors ]
     ~remove:[ slug; changelog_html; body_html; body; date ],
     show { with_path = false }]

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -15,12 +15,18 @@ type t = {
   changelog_html : string option;
   body_html : string;
   body : string;
+  authors : string list;
 }
 [@@deriving
-  stable_record ~version:metadata
-    ~add:[ authors; changelog; description ]
+  stable_record ~version:metadata ~add:[ changelog; description ]
+    ~modify:[ authors ]
     ~remove:[ slug; changelog_html; body_html; body; date ],
     show { with_path = false }]
+
+let of_metadata m =
+  of_metadata m ~modify_authors:(function
+    | None -> []
+    | Some authors -> authors)
 
 let re_date_slug =
   let open Re in
@@ -135,6 +141,7 @@ type t =
   ; changelog_html : string option
   ; body_html : string
   ; body : string
+  ; authors : string list
   }
   
 let all = %a

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -18,8 +18,7 @@ type t = {
   authors : string list;
 }
 [@@deriving
-  stable_record ~version:metadata
-    ~add:[ changelog; description ]
+  stable_record ~version:metadata ~add:[ changelog; description ]
     ~modify:[ authors ]
     ~remove:[ slug; changelog_html; body_html; body; date ],
     show { with_path = false }]

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -17,8 +17,7 @@ type t = {
   authors : string list;
 }
 [@@deriving
-  stable_record ~version:metadata ~modify:[ authors ]
-    ~remove:[ slug; body_html ],
+  stable_record ~version:metadata ~modify:[ authors ] ~remove:[ slug; body_html ],
     show { with_path = false }]
 
 let of_metadata m = of_metadata m ~modify_authors:(Option.value ~default:[])

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -21,10 +21,7 @@ type t = {
     ~remove:[ slug; body_html ],
     show { with_path = false }]
 
-let of_metadata m =
-  of_metadata m ~modify_authors:(function
-    | None -> []
-    | Some authors -> authors)
+let of_metadata m = of_metadata m ~modify_authors:(Option.value ~default:[])
 
 let decode (fname, (head, body)) =
   let slug = Filename.basename (Filename.remove_extension fname) in

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -14,10 +14,17 @@ type t = {
   slug : string;
   tags : string list;
   body_html : string;
+  authors : string list;
 }
 [@@deriving
-  stable_record ~version:metadata ~add:[ authors ] ~remove:[ slug; body_html ],
+  stable_record ~version:metadata ~modify:[ authors ]
+    ~remove:[ slug; body_html ],
     show { with_path = false }]
+
+let of_metadata m =
+  of_metadata m ~modify_authors:(function
+    | None -> []
+    | Some authors -> authors)
 
 let decode (fname, (head, body)) =
   let slug = Filename.basename (Filename.remove_extension fname) in
@@ -45,6 +52,7 @@ type t =
   ; date : string
   ; tags : string list
   ; body_html : string
+  ; authors: string list
   }
   
 let all = %a

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -17,7 +17,8 @@ type t = {
   authors : string list;
 }
 [@@deriving
-  stable_record ~version:metadata ~modify:[ authors ] ~remove:[ slug; body_html ],
+  stable_record ~version:metadata ~modify:[ authors ]
+    ~remove:[ slug; body_html ],
     show { with_path = false }]
 
 let of_metadata m = of_metadata m ~modify_authors:(Option.value ~default:[])

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -15,7 +15,7 @@ type post = {
          hosted on ocaml.org *)
   slug : string;
   description : string option;
-  authors : string list option;
+  authors : string list;
   date : string;
   preview_image : string option;
   featured : bool;
@@ -78,7 +78,7 @@ module Local = struct
         slug;
         url = None;
         description = Some m.description;
-        authors = m.authors;
+        authors = Option.value ~default:[] m.authors;
         date = m.date;
         preview_image = m.preview_image;
         featured = Option.value ~default:false m.featured;
@@ -195,7 +195,7 @@ module External = struct
         url = Some m.url;
         slug = "";
         description = m.description;
-        authors = m.authors;
+        authors = Option.value ~default:[] m.authors;
         date = m.date;
         preview_image = m.preview_image;
         featured = Option.value ~default:false m.featured;
@@ -241,7 +241,7 @@ module External = struct
 end
 
 let feed_authors source authors =
-  match Option.fold ~none:[] ~some:(List.map Syndic.Atom.author) authors with
+  match List.map Syndic.Atom.author authors with
   | x :: xs -> (x, xs)
   | [] -> (Syndic.Atom.author source.name, [])
 
@@ -302,7 +302,7 @@ module Post = struct
     ; slug : string
     ; source : source
     ; description : string option
-    ; authors : string list option
+    ; authors : string list
     ; date : string
     ; preview_image : string option
     ; featured : bool

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -20,7 +20,7 @@ type committee_member = {
 }
 [@@deriving of_yaml, show { with_path = false }]
 
-type presentation' = {
+type presentation = {
   title : string;
   authors : string list;
   link : string option;
@@ -36,22 +36,11 @@ type metadata = {
   location : string;
   date : string;
   important_dates : important_date list;
-  presentations : presentation' list;
+  presentations : presentation list;
   program_committee : committee_member list;
   organising_committee : committee_member list;
 }
 [@@deriving of_yaml]
-
-type presentation = {
-  title : string;
-  authors : string list;
-  link : string option;
-  video : string option;
-  slides : string option;
-  poster : bool option;
-  additional_links : string list;
-}
-[@@deriving show { with_path = false }]
 
 type t = {
   title : string;
@@ -66,25 +55,10 @@ type t = {
   body_html : string;
 }
 [@@deriving
-  stable_record ~version:metadata
-    ~remove:[ slug; body_md; body_html ]
-    ~modify:[ presentations ],
+  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ],
     show { with_path = false }]
 
-let transform_presentation (p : presentation') =
-  {
-    title = p.title;
-    authors = p.authors;
-    link = p.link;
-    video = p.video;
-    slides = p.slides;
-    poster = p.poster;
-    additional_links = Option.value ~default:[] p.additional_links;
-  }
-
-let of_metadata m =
-  of_metadata m ~slug:(Utils.slugify m.title)
-    ~modify_presentations:(List.map transform_presentation)
+let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
 
 let decode (fpath, (head, body_md)) =
   let metadata =
@@ -122,7 +96,7 @@ type presentation = {
   video : string option;
   slides : string option;
   poster : bool option;
-  additional_links : string list;
+  additional_links : string list option;
 }
 
 type t = {

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -66,8 +66,8 @@ type t = {
   body_html : string;
 }
 [@@deriving
-  stable_record ~version:metadata ~modify:[ presentations ]
-    ~remove:[ slug; body_md; body_html ],
+  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]
+    ~modify:[ presentations ],
     show { with_path = false }]
 
 let transform_presentation (p : presentation') =

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -66,7 +66,8 @@ type t = {
   body_html : string;
 }
 [@@deriving
-  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ]
+  stable_record ~version:metadata
+    ~remove:[ slug; body_md; body_html ]
     ~modify:[ presentations ],
     show { with_path = false }]
 

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -78,8 +78,7 @@ let transform_presentation (p : presentation') =
     video = p.video;
     slides = p.slides;
     poster = p.poster;
-    additional_links =
-      (match p.additional_links with None -> [] | Some links -> links);
+    additional_links = Option.value ~default:[] p.additional_links;
   }
 
 let of_metadata m =

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -20,7 +20,7 @@ type committee_member = {
 }
 [@@deriving of_yaml, show { with_path = false }]
 
-type presentation = {
+type presentation' = {
   title : string;
   authors : string list;
   link : string option;
@@ -36,11 +36,22 @@ type metadata = {
   location : string;
   date : string;
   important_dates : important_date list;
-  presentations : presentation list;
+  presentations : presentation' list;
   program_committee : committee_member list;
   organising_committee : committee_member list;
 }
 [@@deriving of_yaml]
+
+type presentation = {
+  title : string;
+  authors : string list;
+  link : string option;
+  video : string option;
+  slides : string option;
+  poster : bool option;
+  additional_links : string list;
+}
+[@@deriving show { with_path = false }]
 
 type t = {
   title : string;
@@ -55,10 +66,25 @@ type t = {
   body_html : string;
 }
 [@@deriving
-  stable_record ~version:metadata ~remove:[ slug; body_md; body_html ],
+  stable_record ~version:metadata ~modify:[ presentations ]
+    ~remove:[ slug; body_md; body_html ],
     show { with_path = false }]
 
-let of_metadata m = of_metadata m ~slug:(Utils.slugify m.title)
+let transform_presentation (p : presentation') =
+  {
+    title = p.title;
+    authors = p.authors;
+    link = p.link;
+    video = p.video;
+    slides = p.slides;
+    poster = p.poster;
+    additional_links =
+      (match p.additional_links with None -> [] | Some links -> links);
+  }
+
+let of_metadata m =
+  of_metadata m ~slug:(Utils.slugify m.title)
+    ~modify_presentations:(List.map transform_presentation)
 
 let decode (fpath, (head, body_md)) =
   let metadata =
@@ -96,7 +122,7 @@ type presentation = {
   video : string option;
   slides : string option;
   poster : bool option;
-  additional_links : string list option;
+  additional_links : string list;
 }
 
 type t = {


### PR DESCRIPTION
Removed `option` from type of fields:
- `Changelog.t.authors`
- `News.t.authors`
- `Planet.t.authors`
- `Workshop.presentations.additional_links`

This and #2039 might close #1970.