### PR TITLE
(ood-gen) Adjust type of fields with bool option type to bool in Release

### DIFF
--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -392,8 +392,8 @@ module Release : sig
     kind : kind;
     version : string;
     date : string;
-    is_latest : bool option;
-    is_lts : bool option;
+    is_latest : bool;
+    is_lts : bool;
     intro_md : string;
     intro_html : string;
     highlights_md : string;

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -23,8 +23,8 @@ type t = {
   kind : Kind.t;
   version : string;
   date : string;
-  is_latest : bool option;
-  is_lts : bool option;
+  is_latest : bool;
+  is_lts : bool;
   intro_md : string;
   intro_html : string;
   highlights_md : string;
@@ -34,6 +34,7 @@ type t = {
 }
 [@@deriving
   stable_record ~version:metadata ~add:[ intro; highlights ]
+    ~modify:[ is_latest; is_lts ]
     ~remove:
       [
         intro_md; intro_html; highlights_md; highlights_html; body_md; body_html;
@@ -50,6 +51,8 @@ let of_metadata m =
       (Cmarkit.Doc.of_string ~strict:true m.highlights
       |> Hilite.Md.transform
       |> Cmarkit_html.of_doc ~safe:false)
+    ~modify_is_latest:(Option.value ~default:false)
+    ~modify_is_lts:(Option.value ~default:false)
 
 let sort_by_decreasing_version x y =
   let to_list s = List.map int_of_string_opt @@ String.split_on_char '.' s in
@@ -72,7 +75,7 @@ let all () =
 let template () =
   let all = all () in
   let latest =
-    try List.find (fun r -> r.is_latest = Some true) all
+    try List.find (fun r -> r.is_latest) all
     with Not_found ->
       raise
         (Invalid_argument
@@ -80,7 +83,7 @@ let template () =
             true")
   in
   let lts =
-    try List.find (fun r -> r.is_lts = Some true) all
+    try List.find (fun r -> r.is_lts) all
     with Not_found ->
       raise
         (Invalid_argument
@@ -94,8 +97,8 @@ type t =
   { kind : kind
   ; version : string
   ; date : string
-  ; is_latest: bool option
-  ; is_lts: bool option
+  ; is_latest: bool
+  ; is_lts: bool
   ; intro_md : string
   ; intro_html : string
   ; highlights_md : string


### PR DESCRIPTION
Solves task no. 2 of #2051, for now.

In `planet.ml` (task no. 1) there is nothing to do because all fields with type `bool option` belong to `metadata`-like types (I am including here `External.Source.t`)

In `workshop.ml` (task no. 3) I can adjust the type of `Workshop.presentation.poster` but the [solution might not improve the code](https://github.com/ocaml/ocaml.org/pull/2042#discussion_r1487478833) as well. IMO the only way to handle the fields of `Workshop.presentation` with `option` type is by creating another type from it, and use the latter in `Workshop.t.presentations` instead, only this time I would use ppx_stable and rename `presentation` to `presentation_metadata` or something more readable.