### PR TITLE
adjust list bullet color

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -108,6 +108,9 @@ module.exports = {
             'pre > code': {
               color: theme('colors.white'),
             }
+          },{
+            '--tw-prose-bullets': figma_colors.content,
+            '--tw-prose-invert-bullets': figma_colors.dark.content,
           }]
           
         },


### PR DESCRIPTION
Closes #2065.

![image_2024-02-17_124308102](https://github.com/ocaml/ocaml.org/assets/57372721/8786bcb8-9762-4ebb-aedc-8a5d49cf54fc)

the list bullet color is determined by `--tw-prose-bullets` and `--tw-prose-invert-bullets` css vars, so it was a matter of overriding them in the tailwind config file, you were right.
