### PR TITLE
(ood-gen) Adjust type of fields with `option` type in Workshop

### DIFF
--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -364,7 +364,7 @@ module Workshop : sig
     link : string option;
     video : string option;
     slides : string option;
-    poster : bool option;
+    poster : bool;
     additional_links : string list option;
   }
 

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -365,7 +365,7 @@ module Workshop : sig
     video : string option;
     slides : string option;
     poster : bool;
-    additional_links : string list option;
+    additional_links : string list;
   }
 
   type t = {

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -49,10 +49,11 @@ type presentation = {
   video : string option;
   slides : string option;
   poster : bool;
-  additional_links : string list option;
+  additional_links : string list;
 }
 [@@deriving
-  stable_record ~version:presentation_metadata ~modify:[ poster ],
+  stable_record ~version:presentation_metadata
+    ~modify:[ poster; additional_links ],
     show { with_path = false }]
 
 type t = {
@@ -75,6 +76,7 @@ type t = {
 let of_presentation_metadata pm =
   presentation_of_presentation_metadata pm
     ~modify_poster:(Option.value ~default:false)
+    ~modify_additional_links:(Option.value ~default:[])
 
 let of_metadata m =
   of_metadata m ~slug:(Utils.slugify m.title)
@@ -116,7 +118,7 @@ type presentation = {
   video : string option;
   slides : string option;
   poster : bool;
-  additional_links : string list option;
+  additional_links : string list;
 }
 
 type t = {


### PR DESCRIPTION
Handles task no. 3 of #2051 and task left behind in #2042 (merged).

I think this is cleaner than my attempt at #2042 because of the use of `ppx_stable` to transform presentation metadata