### PR TITLE
Make the playground cursor more obvious

### DIFF
--- a/asset/css/codemirror.css
+++ b/asset/css/codemirror.css
@@ -53,13 +53,13 @@
 /* CURSOR */
 
 .cm-editor .cm-cursor {
-  border-left: 1px solid black;
+  border-left: 0.75rem solid silver;
   border-right: none;
   width: 0;
 }
 /* Shown when moving in bi-directional text */
 .cm-editor div.cm-secondarycursor {
-  border-left: 1px solid silver;
+  border-left: 0.75rem solid gray;
 }
 
 .cm-editor .cm-fat-cursor .cm-cursor {


### PR DESCRIPTION
Increases the width of the cursor of the playground text editor and changes the color to be more obvious.

|before|after|
|-|-|
|![image](https://github.com/ocaml/ocaml.org/assets/6594573/b9acc879-eff5-4930-9b91-f0d5efa5c99a)|![Screenshot from 2024-02-20 08-51-08](https://github.com/ocaml/ocaml.org/assets/6594573/d6820648-90cb-4776-a722-5bc4117ba0f7)|
