### PR TITLE
(docs) Set “Sets“ as Set's tutorial title

### DIFF
--- a/data/tutorials/language/3ds_03_sets.md
+++ b/data/tutorials/language/3ds_03_sets.md
@@ -1,6 +1,6 @@
 ---
 id: sets
-title: Set
+title: Sets
 description: >
   The standard library's Set module
 category: "Data Structures"


### PR DESCRIPTION
Fix first item in issue #2072 