### PR TITLE
DOC: note about windows ppx_show

### DIFF
--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -302,6 +302,8 @@ Let's assume we'd like `hello` to display its output as if it was a list of stri
 $ opam install ppx_show
 ```
 
+**Note**: This example does not work yet on Windows with the OCaml DKML installer due to a dependency issue. To run it, advanced users could switch to Cygwin or WSL2. However, even if you do not run it, it's still a good idea to read the rest of the section to see how it works.
+
 Dune needs to be told how to use it, which is done in the `lib/dune` file. Note that this is different from the `bin/dune` file that you edited earlier! Open up the `lib/dune` file, and edit it to look like this:
 ```lisp
 (library


### PR DESCRIPTION
Related to #1962 

What I took from the discussion on that issue  (https://github.com/ocaml/ocaml.org/issues/1962#issuecomment-1895866219 ) was it was still important to have ppx_show in there (as a simple example of using the preprocessor) - so this note might help windows users avoid some frustration. 

The dependency problem I see is in `stdcompat` when trying to install `ppx_show` 