### PR TITLE
Add workspace file for use with dune-pkg

### DIFF
--- a/dune-workspace-pkg
+++ b/dune-workspace-pkg
@@ -1,0 +1,16 @@
+(lang dune 3.6)
+
+(pin
+ (name tailwindcss)
+ (url "git+https://github.com/tmattio/opam-tailwindcss#3e60fc32bbcf82525999d83ad0f395e16107026b")
+ (package (name tailwindcss)))
+
+(pin
+ (name olinkcheck)
+ (url "git+https://github.com/tarides/olinkcheck")
+ (package (name olinkcheck)))
+
+(lock_dir
+ (constraints ocaml-system)
+ (pins tailwindcss olinkcheck))
+


### PR DESCRIPTION
Pass `--workspace=dune-workspace-pkg` to each invocation of dune to use dune's experimental package management features.

For context for this change, see the discussion here: https://github.com/ocaml/dune/issues/10120