### PR TITLE
Add OCaml Language Manual button on Learn Overview hero section

### DIFF
--- a/src/ocamlorg_frontend/pages/learn.eml
+++ b/src/ocamlorg_frontend/pages/learn.eml
@@ -25,14 +25,10 @@ Learn_layout.single_column_layout
         </form>
       </div>
 
-      <div class="flex flex-col gap-6 md:gap-10 md:w-80">
+      <div class="flex flex-col gap-4 md:gap-6 md:w-80">
         <%s!  Hero_section.hero_button ~left_icon:(Icons.ocaml "w-5 h-5") ~right_icon:(Icons.download "w-5 h-5") ~text:("Install OCaml " ^ latest_version) ~href:(Url.install) %>
-        <div class="flex flex-col gap-4">
-          <%s!  Hero_section.hero_button ~left_icon:(Icons.book "w-5 h-5") ~right_icon:(Icons.link "w-5 h-5") ~text:("Standard Library API") ~href:(Url.api) %>
-          <div class="text-sm text-content dark:text-dark-content">
-            The index of types, exceptions, values, modules, and module types of the OCaml Standard Library
-          </div>
-        </div>
+        <%s!  Hero_section.hero_button ~left_icon:(Icons.book "w-5 h-5") ~right_icon:(Icons.link "w-5 h-5") ~text:("Standard Library API") ~href:(Url.api) %>
+        <%s!  Hero_section.hero_button ~left_icon:(Icons.book "w-5 h-5") ~right_icon:(Icons.link "w-5 h-5") ~text:("OCaml Language Manual") ~href:(Url.manual) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Resolves https://github.com/ocaml/ocaml.org/issues/2089.

|before|after|
|-|-|
|![Screenshot 2024-02-29 at 09-43-13 Learn OCaml](https://github.com/ocaml/ocaml.org/assets/6594573/bebde05d-cbde-4320-8124-5ca643c4a502)|![Screenshot 2024-02-29 at 09-42-56 Learn OCaml](https://github.com/ocaml/ocaml.org/assets/6594573/365c9104-c970-4576-ac16-dc811707a30a)|
