### PR TITLE
(data) Add OCaml Retreat Auroville

### DIFF
--- a/data/events/2024-03-10-ocaml-retreat-auroville.md
+++ b/data/events/2024-03-10-ocaml-retreat-auroville.md
@@ -1,8 +1,8 @@
 ---
-title: "OCaml Retreat at Auroville"
+title: "OCaml Retreat"
 textual_location: "Auroville, India"
 url: https://ocamlretreat.org/
-recurring_event_slug: ocaml-retreat-auroville
+recurring_event_slug: ocaml-retreat
 starts:
   yyyy_mm_dd: "2024-03-10"
 ends:

--- a/data/events/2024-03-10-ocaml-retreat-auroville.md
+++ b/data/events/2024-03-10-ocaml-retreat-auroville.md
@@ -1,0 +1,10 @@
+---
+title: "OCaml Retreat at Auroville"
+textual_location: "Auroville, India"
+url: https://ocamlretreat.org/
+recurring_event_slug: ocaml-retreat-auroville
+starts:
+  yyyy_mm_dd: "2024-03-10"
+ends:
+  yyyy_mm_dd: "2024-03-15"
+---

--- a/data/events/recurring.yml
+++ b/data/events/recurring.yml
@@ -38,7 +38,7 @@ recurring:
     slug: "s-repls-programming-languages-seminar"
     textual_location: "London, United Kingdom"
     url: https://srepls.github.io/
-  - title: "OCaml Retreat at Auroville"
-    slug: "ocaml-retreat-auroville"
+  - title: "OCaml Retreat"
+    slug: "ocaml-retreat"
     textual_location: "Auroville, India"
     url: https://ocamlretreat.org/

--- a/data/events/recurring.yml
+++ b/data/events/recurring.yml
@@ -38,3 +38,7 @@ recurring:
     slug: "s-repls-programming-languages-seminar"
     textual_location: "London, United Kingdom"
     url: https://srepls.github.io/
+  - title: "OCaml Retreat at Auroville"
+    slug: "ocaml-retreat-auroville"
+    textual_location: "Auroville, India"
+    url: https://ocamlretreat.org/


### PR DESCRIPTION
Add the OCaml Retreat as a recurring event.

Adjust title and location as necessary. To be merged after the website at https://ocamlretreat.org/ is up and running.