### PR TITLE
Changelog entry for OCaml 4.14.2~rc1

### DIFF
--- a/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
+++ b/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
@@ -98,11 +98,7 @@ The base compiler can be installed as an opam switch with the following commands
 opam update
 opam switch create 4.14.2~rc1
 ```
-For previous version of opam, the switch creation command line is slightly more verbose:
-```
-opam update
-opam switch create 4.14.2~rc1 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
-```
+
 
 The source code for the release candidate is available on
 

--- a/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
+++ b/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
@@ -1,10 +1,10 @@
 ---
-title: OCaml 4.14.2 - Release candidate
+title: OCaml 4.14.2 - Release Candidate
 description: Release Candidate of OCaml 4.12.1
 tags: [ocaml]
 changelog: |
   ## Changes Since OCaml 4.14.1
-  ### Runtime system:
+  ### Runtime System:
 
   - [#11764](https://github.com/ocaml/ocaml/issues/11764), [#12577](https://github.com/ocaml/ocaml/issues/12577): Add prototypes to old-style C function definitions
      and declarations.
@@ -14,18 +14,18 @@ changelog: |
     (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
      Hinderer and Nick Barnes)
   
-  * (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): do not use `-flat-namespace` linking for macOS.
+  * (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): Do not use `-flat-namespace` linking for macOS.
     (Carlo Cabrera, review by Damien Doligez)
   
-  - [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+  - [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): Make sure `Bool_val(v)` has type `bool` in C++
     (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
   
-  ### Build system:
+  ### Build System:
   
-  - [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces.
+  - [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces
     (Élie Brami, review by Sébastien Hinderer and David Allsopp)
   
-  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option `-no-execute-only` to the linker for OpenBSD >= 7.3
     so that code sections remain readable, as needed for closure marshaling.
     (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
     Sébastien Hinderer)
@@ -36,18 +36,18 @@ changelog: |
   
   ### Bug fixes:
   
-  - [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): don't add inconsistent equalities when computing
+  - [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): Don't add inconsistent equalities when computing
     high-level error messages for functor applications and inclusions.
     (Florian Angeletti, review by Gabriel Scherer)
   
-  - [#12878](https://github.com/ocaml/ocaml/issues/12878): fix incorrect treatment of injectivity for private recursive types.
+  - [#12878](https://github.com/ocaml/ocaml/issues/12878): Fix incorrect treatment of injectivity for private recursive types.
     (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
   
-  - [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+  - [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): Fix an uncaught Ctype. Escape exception on some
     invalid programs forming recursive types.
     (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
   
-  - [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix compact_allocate to avoid a pathological case
+  - [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix `compact_allocate` to avoid a pathological case
     that causes very slow compaction.
     (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
   
@@ -58,17 +58,17 @@ changelog: |
     (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
      Sébastien Hinderer)
   
-  - [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): bugfix in caml_unregister_frametable
+  - [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): Bug fix in `caml_unregister_frametable`
     (Frédéric Recoules, review by Gabriel Scherer)
   
-  - [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialization of I/O mutexes after a fork()
+  - [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialisation of I/O mutexes after a fork()
     (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
   
-  * (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
+  * (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on AMD64 BSD (OpenBSD, FreeBSD, NetBSD) systems
     (emitted for Linux in [#8805](https://github.com/ocaml/ocaml/issues/8805))
     (Hannes Mehnert, review by Nicolás Ojeda Bär)
   
-  - [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+  - [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix `tail-modulo-cons` compilation of `try-with`, `&&`, and `||`
     expressions.
     (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
     Gabriel Scherer)
@@ -80,7 +80,7 @@ The release of OCaml version 4.14.2 is imminent.
 
 OCaml 4.14.2 is a new update to the stable 4.14 branch of OCaml. This new
 release backports many safe bug fixes from the OCaml 5 branch and fixes
-a handful of compatibility issues of OCaml 4.14.1 with newer Operating System versions.
+a handful of compatibility issues of OCaml 4.14.1 with newer operating system versions.
 
 A full list of bug fixes is available below.
 

--- a/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
+++ b/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
@@ -1,0 +1,123 @@
+---
+title: OCaml 4.14.2 - Release candidate
+description: Release Candidate of OCaml 4.12.1
+tags: [ocaml]
+changelog: |
+  ## Changes Since OCaml 4.14.1
+  ### Runtime system:
+
+- [#11764](https://github.com/ocaml/ocaml/issues/11764), [#12577](https://github.com/ocaml/ocaml/issues/12577): Add prototypes to old-style C function definitions
+   and declarations.
+  (Antonin Décimo, review by Xavier Leroy and Nick Barnes)
+
+- [#11763](https://github.com/ocaml/ocaml/issues/11763), [#11759](https://github.com/ocaml/ocaml/issues/11759), [#11861](https://github.com/ocaml/ocaml/issues/11861), [#12509](https://github.com/ocaml/ocaml/issues/12509), [#12577](https://github.com/ocaml/ocaml/issues/12577): Use strict prototypes on primitives.
+  (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
+   Hinderer and Nick Barnes)
+
+* (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): do not use `-flat-namespace` linking for macOS.
+  (Carlo Cabrera, review by Damien Doligez)
+
+- [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+  (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+
+  ### Build system:
+
+- [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces.
+  (Élie Brami, review by Sébastien Hinderer and David Allsopp)
+
+- [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  so that code sections remain readable, as needed for closure marshaling.
+  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+  Sébastien Hinderer)
+
+- [#12903](https://github.com/ocaml/ocaml/issues/12903): Disable control flow integrity on OpenBSD >= 7.4 to avoid
+  illegal instruction errors on certain CPUs.
+  (Michael Hendricks, review by Miod Vallat)
+
+  ### Bug fixes:
+
+- [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): don't add inconsistent equalities when computing
+  high-level error messages for functor applications and inclusions.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#12878](https://github.com/ocaml/ocaml/issues/12878): fix incorrect treatment of injectivity for private recursive types.
+  (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
+
+- [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+  invalid programs forming recursive types.
+  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+
+- [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix compact_allocate to avoid a pathological case
+  that causes very slow compaction.
+  (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
+
+- [#12513](https://github.com/ocaml/ocaml/issues/12513), [#12518](https://github.com/ocaml/ocaml/issues/12518): Automatically enable emulated `fma` for Visual Studio 2019+
+  to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
+  in VirtualBox. Restores parity with the other Windows ports, which don't
+  require explicit `--enable-imprecise-c99-float-ops`.
+  (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
+   Sébastien Hinderer)
+
+- [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): bugfix in caml_unregister_frametable
+  (Frédéric Recoules, review by Gabriel Scherer)
+
+- [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialization of I/O mutexes after a fork()
+  (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
+
+* (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
+  (emitted for Linux in [#8805](https://github.com/ocaml/ocaml/issues/8805))
+  (Hannes Mehnert, review by Nicolás Ojeda Bär)
+
+- [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+  expressions.
+  (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
+  Gabriel Scherer)
+
+---
+
+The release of OCaml version 4.14.2 is imminent.
+
+OCaml 4.14.2 is a new update to the stable 4.14 branch of OCaml. This new
+release backports many safe bug fixes from the OCaml 5 branch and fixes
+a handful of compatibility issues of OCaml 4.14.1 with newer Operating System versions.
+
+A full list of bug fixes is available below.
+
+In order to ensure that the future release works as expected, we are planning to test a release candidate during the upcoming week.
+
+If you find any bugs, please report them here on [GitHub](https://github.com/ocaml/ocaml/issues).
+
+----
+
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1:
+```
+opam update
+opam switch create 4.14.2~rc1
+```
+For previous version of opam, the switch creation command line is slightly more verbose:
+```
+opam update
+opam switch create 4.14.2~rc1 --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+```
+
+The source code for the release candidate is available on
+
+- [GitHub](https://github.com/ocaml/ocaml/archive/4.14.2-rc1.tar.gz)
+- [Inria archives](https://caml.inria.fr/pub/distrib/ocaml-4.14/4.14.2-rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.4.14.2~rc1+options <option_list>
+```
+where `<option_list>` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 4.14.2~rc1+flambda+nffa ocaml-variants.4.14.2~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.

--- a/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
+++ b/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
@@ -6,73 +6,74 @@ changelog: |
   ## Changes Since OCaml 4.14.1
   ### Runtime system:
 
-- [#11764](https://github.com/ocaml/ocaml/issues/11764), [#12577](https://github.com/ocaml/ocaml/issues/12577): Add prototypes to old-style C function definitions
-   and declarations.
-  (Antonin Décimo, review by Xavier Leroy and Nick Barnes)
-
-- [#11763](https://github.com/ocaml/ocaml/issues/11763), [#11759](https://github.com/ocaml/ocaml/issues/11759), [#11861](https://github.com/ocaml/ocaml/issues/11861), [#12509](https://github.com/ocaml/ocaml/issues/12509), [#12577](https://github.com/ocaml/ocaml/issues/12577): Use strict prototypes on primitives.
-  (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
-   Hinderer and Nick Barnes)
-
-* (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): do not use `-flat-namespace` linking for macOS.
-  (Carlo Cabrera, review by Damien Doligez)
-
-- [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
-  (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
-
+  - [#11764](https://github.com/ocaml/ocaml/issues/11764), [#12577](https://github.com/ocaml/ocaml/issues/12577): Add prototypes to old-style C function definitions
+     and declarations.
+    (Antonin Décimo, review by Xavier Leroy and Nick Barnes)
+  
+  - [#11763](https://github.com/ocaml/ocaml/issues/11763), [#11759](https://github.com/ocaml/ocaml/issues/11759), [#11861](https://github.com/ocaml/ocaml/issues/11861), [#12509](https://github.com/ocaml/ocaml/issues/12509), [#12577](https://github.com/ocaml/ocaml/issues/12577): Use strict prototypes on primitives.
+    (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
+     Hinderer and Nick Barnes)
+  
+  * (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): do not use `-flat-namespace` linking for macOS.
+    (Carlo Cabrera, review by Damien Doligez)
+  
+  - [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+    (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+  
   ### Build system:
-
-- [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces.
-  (Élie Brami, review by Sébastien Hinderer and David Allsopp)
-
-- [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
-  so that code sections remain readable, as needed for closure marshaling.
-  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
-  Sébastien Hinderer)
-
-- [#12903](https://github.com/ocaml/ocaml/issues/12903): Disable control flow integrity on OpenBSD >= 7.4 to avoid
-  illegal instruction errors on certain CPUs.
-  (Michael Hendricks, review by Miod Vallat)
-
+  
+  - [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces.
+    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
+  
+  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+    so that code sections remain readable, as needed for closure marshaling.
+    (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+    Sébastien Hinderer)
+  
+  - [#12903](https://github.com/ocaml/ocaml/issues/12903): Disable control flow integrity on OpenBSD >= 7.4 to avoid
+    illegal instruction errors on certain CPUs.
+    (Michael Hendricks, review by Miod Vallat)
+  
   ### Bug fixes:
-
-- [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): don't add inconsistent equalities when computing
-  high-level error messages for functor applications and inclusions.
-  (Florian Angeletti, review by Gabriel Scherer)
-
-- [#12878](https://github.com/ocaml/ocaml/issues/12878): fix incorrect treatment of injectivity for private recursive types.
-  (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
-
-- [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
-  invalid programs forming recursive types.
-  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
-
-- [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix compact_allocate to avoid a pathological case
-  that causes very slow compaction.
-  (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
-
-- [#12513](https://github.com/ocaml/ocaml/issues/12513), [#12518](https://github.com/ocaml/ocaml/issues/12518): Automatically enable emulated `fma` for Visual Studio 2019+
-  to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
-  in VirtualBox. Restores parity with the other Windows ports, which don't
-  require explicit `--enable-imprecise-c99-float-ops`.
-  (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
-   Sébastien Hinderer)
-
-- [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): bugfix in caml_unregister_frametable
-  (Frédéric Recoules, review by Gabriel Scherer)
-
-- [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialization of I/O mutexes after a fork()
-  (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
-
-* (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
-  (emitted for Linux in [#8805](https://github.com/ocaml/ocaml/issues/8805))
-  (Hannes Mehnert, review by Nicolás Ojeda Bär)
-
-- [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
-  expressions.
-  (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
-  Gabriel Scherer)
-
+  
+  - [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): don't add inconsistent equalities when computing
+    high-level error messages for functor applications and inclusions.
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#12878](https://github.com/ocaml/ocaml/issues/12878): fix incorrect treatment of injectivity for private recursive types.
+    (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
+  
+  - [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+    invalid programs forming recursive types.
+    (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+  
+  - [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix compact_allocate to avoid a pathological case
+    that causes very slow compaction.
+    (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
+  
+  - [#12513](https://github.com/ocaml/ocaml/issues/12513), [#12518](https://github.com/ocaml/ocaml/issues/12518): Automatically enable emulated `fma` for Visual Studio 2019+
+    to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
+    in VirtualBox. Restores parity with the other Windows ports, which don't
+    require explicit `--enable-imprecise-c99-float-ops`.
+    (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
+     Sébastien Hinderer)
+  
+  - [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): bugfix in caml_unregister_frametable
+    (Frédéric Recoules, review by Gabriel Scherer)
+  
+  - [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialization of I/O mutexes after a fork()
+    (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
+  
+  * (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
+    (emitted for Linux in [#8805](https://github.com/ocaml/ocaml/issues/8805))
+    (Hannes Mehnert, review by Nicolás Ojeda Bär)
+  
+  - [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+    expressions.
+    (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
+    Gabriel Scherer)
+  
+   
 ---
 
 The release of OCaml version 4.14.2 is imminent.

--- a/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
+++ b/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
@@ -103,7 +103,7 @@ opam switch create 4.14.2~rc1
 The source code for the release candidate is available on
 
 - [GitHub](https://github.com/ocaml/ocaml/archive/4.14.2-rc1.tar.gz)
-- [Inria archives](https://caml.inria.fr/pub/distrib/ocaml-4.14/4.14.2-rc1.tar.gz)
+- [Inria archives](https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.2-rc1.tar.gz)
 
 ### Fine-Tuned Compiler Configuration
 

--- a/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
+++ b/data/changelog/ocaml/2024-03-07-ocaml-4.14.2.rc1.md
@@ -1,6 +1,6 @@
 ---
 title: OCaml 4.14.2 - Release Candidate
-description: Release Candidate of OCaml 4.12.1
+description: Release Candidate of OCaml 4.14.2
 tags: [ocaml]
 changelog: |
   ## Changes Since OCaml 4.14.1


### PR DESCRIPTION
This a changelog entry for the first release candidate, as usual it is probably better to wait for the opam package to be merged and propagated to the opam repository.