### PR TITLE
Explain why t-first works with labels 

### DIFF
--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -67,7 +67,7 @@ At parameter definition `~first` is the same as `~first:first`. Passing argument
 
 ### Passing Labelled Arguments Using the Pipe Operator
 
-However, labelled arguments can't be passed to the functions using the pipe operator (`|>`):
+Labelled arguments can't be applied to functions throught the pipe operator (`|>`):
 
 ```ocaml
 # let square ~a = a*a;;

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -72,7 +72,6 @@ val range : first:int -> last:int -> int list = <fun>
 
 At parameter definition `~first` is the same as `~first:first`. Passing argument `~last` is the same as `~last:last`.
 
-
 ## Passing Optional Arguments
 
 Optional arguments can be omitted. When passed, a tilde `~` or a question mark `?` must be used. They can be placed at any position and in any order.

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -32,6 +32,13 @@ Labelled arguments are passed using a tilde `~` and can be placed at any positio
 - : int = 42
 ```
 
+However, note that passing labelled arguments throught the pipe operator (`|>`) throws a syntax error:
+
+```ocaml
+# ~default:42 |> Option.value None;;
+Error: Syntax error
+```
+
 ## Labelling Parameters
 
 Here is how to name parameters in a function definition:
@@ -65,43 +72,6 @@ val range : first:int -> last:int -> int list = <fun>
 
 At parameter definition `~first` is the same as `~first:first`. Passing argument `~last` is the same as `~last:last`.
 
-### Passing Labelled Arguments Using the Pipe Operator
-
-Labelled arguments can't be applied to functions throught the pipe operator (`|>`):
-
-```ocaml
-# let square ~a = a*a;;
-val square : a:int -> int = <fun>
-
-# 4 |> square;;
-Warning 6 [labels-omitted]: label a was omitted in the application of this function.
-
-- : int = 16
-# ~a:4 |> square;;
-Error: Syntax error
-```
-To pass an argument to a function with labelled arguments, we should have at least one unlabelled argument. For instance,
-
-```ocaml
-# let double_only_unlabelled ~first second ~third = second*2;;
-val double_only_unlabelled : first:'a -> int -> third:'b -> int = <fun>
-
-# 2 |> double_only_unlabelled;;
-- : first:'a -> third:'b -> int = <fun>
-```
-This, in turn, makes it possible to declare a function with an unlabelled argument as the first one and still be sure, that only this unlabelled argument can be passed using the pipe operator.
-
-Declaring a function's unlabelled argument as the first one simplifies reading the function's type and does not prevent passing this argument using the pipe operator.
-
-Let's modify the `range` function previously defined by adding an additional parameter `step`.
-
-```ocaml
-# let rec range step ~first ~last = if first > last then [] else first :: range step ~first:(first + step) ~last;;
-val range : int -> first:int -> last:int -> int list = <fun>
-
-# 3 |> range ~last:10 ~first:1;;
-- : int list = [1; 4; 7; 10]
-```
 
 ## Passing Optional Arguments
 
@@ -244,6 +214,29 @@ The only difference between the two versions is the order in which the parameter
 Most often, `concat` is needed. Therefore a function's last declared parameter shouldn't be optional. The warning suggests turning `concat_warn` into `concat`. Disregarding it exposes a function with an optional parameter that must be provided, which is contradictory.
 
 **Note**: Optional parameters make it difficult for the compiler to know if a function is partially applied or not. This is why at least one positional parameter is required after the optional ones. If present at application, it means the function is fully applied, if missing, it means the function is partially applied.
+
+
+### Passing Labelled Arguments Using the Pipe Operator
+
+Labelled arguments can't be applied to functions throught the pipe operator (`|>`):
+
+```ocaml
+# ~default:42 |> Option.value None;;
+Error: Syntax error
+```
+
+Declaring a function's unlabelled argument as the first one simplifies reading the function's type and does not prevent passing this argument using the pipe operator.
+
+Let's modify the `range` function previously defined by adding an additional parameter `step`.
+
+```ocaml
+# let rec range step ~first ~last = if first > last then [] else first :: range step ~first:(first + step) ~last;;
+val range : int -> first:int -> last:int -> int list = <fun>
+
+# 3 |> range ~last:10 ~first:1;;
+- : int list = [1; 4; 7; 10]
+```
+
 
 ## Function with Only Optional Arguments
 

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -236,7 +236,6 @@ val range : int -> first:int -> last:int -> int list = <fun>
 - : int list = [1; 4; 7; 10]
 ```
 
-
 ## Function with Only Optional Arguments
 
 When all parameters of a function need to be optional, a dummy, positional and occurring last parameter must be added. The unit `()` value comes in handy for this. This is what is done here.

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -91,7 +91,9 @@ val double_only_unlabelled : first:'a -> int -> third:'b -> int = <fun>
 ```
 This, in turn, makes it possible to declare a function with an unlabelled argument as the first one and still be sure, that only this unlabelled argument can be passed using the pipe operator.
 
-We modify our previous example adding a new parameter **step**.
+Declaring a function's unlabelled argument as the first one simplifies reading the function's type and does not prevent passing this argument using the pipe operator.
+
+Let's modify the `range` function previously defined by adding an additional parameter `step`.
 
 ```ocaml
 # let rec range step ~first ~last = if first > last then [] else first :: range step ~first:(first + step) ~last;;

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -65,7 +65,7 @@ val range : first:int -> last:int -> int list = <fun>
 
 At parameter definition `~first` is the same as `~first:first`. Passing argument `~last` is the same as `~last:last`.
 
-### Applying a function with labelled arguments using the pipe operator
+### Passing Labelled Arguments Using the Pipe Operator
 
 However, labelled arguments can't be passed to the functions using the pipe operator (`|>`):
 

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -65,6 +65,42 @@ val range : first:int -> last:int -> int list = <fun>
 
 At parameter definition `~first` is the same as `~first:first`. Passing argument `~last` is the same as `~last:last`.
 
+### Applying a function with labelled arguments using the pipe operator
+
+However, labelled arguments can't be passed to the functions using the pipe operator (`|>`):
+
+```ocaml
+# let square ~a = a*a;;
+val square : a:int -> int = <fun>
+
+# 4 |> square;;
+Warning 6 [labels-omitted]: label a was omitted in the application of this function.
+
+- : int = 16
+# ~a:4 |> square;;
+Error: Syntax error
+```
+To pass an argument to a function with labelled arguments, we should have at least one unlabelled argument. For instance,
+
+```ocaml
+# let double_only_unlabelled ~first second ~third = second*2;;
+val double_only_unlabelled : first:'a -> int -> third:'b -> int = <fun>
+
+# 2 |> double_only_unlabelled;;
+- : first:'a -> third:'b -> int = <fun>
+```
+This, in turn, makes it possible to declare a function with an unlabelled argument as the first one and still be sure, that only this unlabelled argument can be passed using the pipe operator.
+
+We modify our previous example adding a new parameter **step**.
+
+```ocaml
+# let rec range step ~first ~last = if first > last then [] else first :: range step ~first:(first + step) ~last;;
+val range : int -> first:int -> last:int -> int list = <fun>
+
+# 3 |> range ~last:10 ~first:1;;
+- : int list = [1; 4; 7; 10]
+```
+
 ## Passing Optional Arguments
 
 Optional arguments can be omitted. When passed, a tilde `~` or a question mark `?` must be used. They can be placed at any position and in any order.

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -32,7 +32,7 @@ Labelled arguments are passed using a tilde `~` and can be placed at any positio
 - : int = 42
 ```
 
-However, note that passing labelled arguments throught the pipe operator (`|>`) throws a syntax error:
+**Note**: Passing labelled arguments through the pipe operator (`|>`) throws a syntax error:
 
 ```ocaml
 # ~default:42 |> Option.value None;;

--- a/data/tutorials/language/0it_04_labels.md
+++ b/data/tutorials/language/0it_04_labels.md
@@ -217,13 +217,6 @@ Most often, `concat` is needed. Therefore a function's last declared parameter s
 
 ### Passing Labelled Arguments Using the Pipe Operator
 
-Labelled arguments can't be applied to functions throught the pipe operator (`|>`):
-
-```ocaml
-# ~default:42 |> Option.value None;;
-Error: Syntax error
-```
-
 Declaring a function's unlabelled argument as the first one simplifies reading the function's type and does not prevent passing this argument using the pipe operator.
 
 Let's modify the `range` function previously defined by adding an additional parameter `step`.


### PR DESCRIPTION
This change solves #2083 by adding the explanation with examples in the Labelled and Optional Arguments tutorial.