### PR TITLE
Linking Bigarray references

### DIFF
--- a/data/tutorials/language/5rt_00_memory_representation.md
+++ b/data/tutorials/language/5rt_00_memory_representation.md
@@ -179,7 +179,7 @@ collection process described earlier.
 The `size` field records the length of the block in memory words. This is 22
 bits on 32-bit platforms, which is the reason OCaml strings are limited to 16
 MB on that architecture. If you need bigger strings, either switch to a
-64-bit host, or use the `Bigarray` module.
+64-bit host, or use the [`Bigarray`](/api/Bigarray.html) module.
 
 The 2-bit `color` field is used by the GC to keep track of its state during
 mark-and-sweep collection.
@@ -551,7 +551,7 @@ libraries use it for general-purpose I/O:
 
 `Bigstring`
 : The `Bigstring` module provides a `String`-like interface that uses
-  `Bigarray` internally. The `Bigbuffer` collects these into extensible
+  [`Bigarray`](/api/Bigarray.html) internally. The `Bigbuffer` collects these into extensible
   string buffers that can operate entirely on external system memory.
 
 The [Lacaml](http://mmottl.github.io/lacaml/) library isn't part of Core but


### PR DESCRIPTION
This should partially fix https://github.com/ocaml/ocaml.org/issues/2088

I found some references to Bigarray in the following files:
news/ocaml/ocaml-2022-02.md
releases/4.07.0.md

It didn't seem like I should update them because they're release notes and news, so I left them as is. But I can update them if that's desired.

@cuihtlauac @SaySayo How does this look?