### PR TITLE
Correctly invert text on "Is OCaml Web" page

### DIFF
--- a/src/ocamlorg_frontend/pages/is_ocaml_yet.eml
+++ b/src/ocamlorg_frontend/pages/is_ocaml_yet.eml
@@ -22,9 +22,10 @@ Learn_layout.three_column_layout
 ~current:Learn_layout.Guides
 ~left_sidebar_html:(Some(left_sidebar ~current_tutorial:(Some (Printf.sprintf "is-ocaml-%s-yet" meta.id)) ~tutorials))
 ~right_sidebar_html:(Some (Toc.render toc)) @@
-<h1 class="font-bold mb-8"><%s meta.question %></h1>
-<p class="mt-6 text-xl leading-8"><%s meta.answer %></p>
-<div class="mt-10 prose prose-orange max-w-3xl">
+<div class="prose prose-orange dark:prose-invert max-w-3xl">
+  <h1 class="mb-8"><%s meta.question %></h1>
+  <p class="mt-6 text-xl leading-8"><%s meta.answer %></p>
+
  <%s! meta.body_html %>
 
   <ul class="mt-8 px-0 font-light leading-8 text-neutral-800 text-lg flex flex-wrap gap-x-4 gap-y-1">


### PR DESCRIPTION
The "Is OCaml Xyz Yet?" pages (currently only [Is OCaml Web Yet?](https://ocaml.org/docs/is-ocaml-web-yet#lower-web-stack)) are not correctly styled in dark mode, leading to hard to read text.

![A screenshot of 'Is OCaml Web Yet?' The page background is in black (dark mode being enabled), but the body still uses the light-mode theme (also being dark), making it unreadable.](https://github.com/ocaml/ocaml.org/assets/4346137/5758a1af-e8dd-4c96-bdfb-8bedf3c46147)

This commit adds the missing tag `dark:prose-invert` class to the page - a rudimentary search shows that this is the only page missing it. In order for the heading and tagline to also be styled, I've moved them inside the prose tag (following `tutorial.eml`, which is used for most pages in the "Guides" section).

This does slightly change the layout of the page (the header is slightly smaller), but this is more consistent with other pages in this section, so feels like a win. Happy to revert this if preferred though!

![A screenshot of 'Is OCaml Web Yet?' with this commit applied. Once again, the page is in dark mode, but now the text is white and thus readable!](https://github.com/ocaml/ocaml.org/assets/4346137/e277562e-1b40-45c2-90fc-e4f97fdd9324)
