### PR TITLE
OCaml 4.14.2 release and changelog pages

### DIFF
--- a/data/changelog/ocaml/2024-03-15-ocaml-4.14.2.md
+++ b/data/changelog/ocaml/2024-03-15-ocaml-4.14.2.md
@@ -1,0 +1,110 @@
+---
+title: Release of OCaml 4.14.2
+description: Release of OCaml 4.14.2
+tags: [ocaml]
+changelog: |
+  ## Changes in OCaml 4.14.2 (14 March 2024)
+
+  ### Runtime system:
+  
+  - [#11764](https://github.com/ocaml/ocaml/issues/11764), [#12577](https://github.com/ocaml/ocaml/issues/12577): Add prototypes to old-style C function definitions
+     and declarations.
+    (Antonin Décimo, review by Xavier Leroy and Nick Barnes)
+  
+  - [#11763](https://github.com/ocaml/ocaml/issues/11763), [#11759](https://github.com/ocaml/ocaml/issues/11759), [#11861](https://github.com/ocaml/ocaml/issues/11861), [#12509](https://github.com/ocaml/ocaml/issues/12509), [#12577](https://github.com/ocaml/ocaml/issues/12577): Use strict prototypes on primitives.
+    (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
+     Hinderer and Nick Barnes)
+  
+  * (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): do not use `-flat-namespace` linking for macOS.
+    (Carlo Cabrera, review by Damien Doligez)
+  
+  - [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+    (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+  
+  ### Build system:
+  
+  - [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces.
+    (Élie Brami, review by Sébastien Hinderer and David Allsopp)
+  
+  - [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+    so that code sections remain readable, as needed for closure marshaling.
+    (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+    Sébastien Hinderer)
+  
+  - [#12903](https://github.com/ocaml/ocaml/issues/12903): Disable control flow integrity on OpenBSD >= 7.4 to avoid
+    illegal instruction errors on certain CPUs.
+    (Michael Hendricks, review by Miod Vallat)
+  
+  ### Bug fixes:
+  
+  - [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): don't add inconsistent equalities when computing
+    high-level error messages for functor applications and inclusions.
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#12878](https://github.com/ocaml/ocaml/issues/12878): fix incorrect treatment of injectivity for private recursive types.
+    (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
+  
+  - [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+    invalid programs forming recursive types.
+    (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+  
+  - [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix compact_allocate to avoid a pathological case
+    that causes very slow compaction.
+    (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
+  
+  - [#12513](https://github.com/ocaml/ocaml/issues/12513), [#12518](https://github.com/ocaml/ocaml/issues/12518): Automatically enable emulated `fma` for Visual Studio 2019+
+    to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
+    in VirtualBox. Restores parity with the other Windows ports, which don't
+    require explicit `--enable-imprecise-c99-float-ops`.
+    (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
+     Sébastien Hinderer)
+  
+  - [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): bugfix in caml_unregister_frametable
+    (Frédéric Recoules, review by Gabriel Scherer)
+  
+  - [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialization of I/O mutexes after a fork()
+    (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
+  
+  * (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
+    (emitted for Linux in [#8805](https://github.com/ocaml/ocaml/issues/8805))
+    (Hannes Mehnert, review by Nicolás Ojeda Bär)
+  
+  - [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+    expressions.
+    (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
+    Gabriel Scherer)
+  
+  - [#12116](https://github.com/ocaml/ocaml/issues/12116), [#12993](https://github.com/ocaml/ocaml/issues/12993): explicitly build non PIE executables on x86 32bits
+    architectures
+    (Florian Angeletti, review by David Allsopp)
+  
+  - [#13018](https://github.com/ocaml/ocaml/issues/13018): Don't pass duplicate libraries to the linker when compiling ocamlc.opt
+    and when using systhreads (new versions of lld emit a warning).
+    (David Allsopp, review by Nicolás Ojeda Bär)
+---
+
+We have the pleasure of celebrating the birthday of Grace Chisholm Young by announcing the release of OCaml version 4.14.2.
+
+This release is a collection of safe bug fixes, cherry-picked from the OCaml 5 branch.
+If you are still using OCaml 4.14 and cannot yet upgrade to OCaml 5, this release is for you.
+
+The 4.14 branch is expected to receive updates for at least one year, while the OCaml 5 branch is stabilising.
+
+Thus don't hesitate to report any bugs on the [OCaml issue tracker](https://github.com/ocaml/ocaml/issues).
+
+See the list of changes below for more details.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+
+```bash
+opam update
+opam switch create 4.14.2
+```
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz)
+* [Inria archive](https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.2.tar.gz)

--- a/data/releases/4.14.2.md
+++ b/data/releases/4.14.2.md
@@ -1,0 +1,157 @@
+---
+kind: compiler
+version: 4.14.2
+date: 2024-03-15
+is_lts: true
+intro: |
+  This page describes OCaml version **4.14.2**, released on
+  Mar 14, 2022. Go [here](/releases) for a list of all releases.
+
+  This is a bug-fix release of [OCaml 4.14.1](/releases/4.14.1).
+
+  As the last version of OCaml 4, the 4.14 branch of OCaml will be maintained during the transition period for OCaml 5.
+  During this period, OCaml 4.14 will receive episodic bugfix updates as a long term support branch until at least 2024.
+highlights: |
+  - Bug fixes for 4.14.1
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 4.14.2
+```
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: sets OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: compiles OCaml without the native-code compiler
+- `ocaml-option-flambda`: sets OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: sets OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: sets OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: sets OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-32bit`: sets OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts
+- `ocaml-option-nnp`: sets OCaml to be compiled with `--disable-naked-pointers`
+- `ocaml-option-nnpchecker`: set OCaml to be compiled with `--enable-naked-pointers-checker`
+- `ocaml-option-fp`: sets OCaml to be compiled with frame-pointers enabled
+
+For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with:
+
+
+```
+opam switch create 4.14.2+flambda+nnpchecker ocaml-variants.4.14.2+options ocaml-option-flambda ocaml-option-nnpchecker
+```
+
+---
+
+Source Distribution
+-------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.14.2.zip)
+  format.
+- [opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://v2.ocaml.org/releases/4.14/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions. See also the [Windows release
+notes](https://v2.ocaml.org/releases/4.14/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+---
+
+## Changes in OCaml 4.14.2 (14 March 2024)
+
+This is the
+[changelog](https://v2.ocaml.org/releases/4.14/notes/Changes).
+
+
+### Runtime system:
+
+- [#11764](https://github.com/ocaml/ocaml/issues/11764), [#12577](https://github.com/ocaml/ocaml/issues/12577): Add prototypes to old-style C function definitions
+   and declarations.
+  (Antonin Décimo, review by Xavier Leroy and Nick Barnes)
+
+- [#11763](https://github.com/ocaml/ocaml/issues/11763), [#11759](https://github.com/ocaml/ocaml/issues/11759), [#11861](https://github.com/ocaml/ocaml/issues/11861), [#12509](https://github.com/ocaml/ocaml/issues/12509), [#12577](https://github.com/ocaml/ocaml/issues/12577): Use strict prototypes on primitives.
+  (Antonin Décimo, review by Xavier Leroy, David Allsopp, Sébastien
+   Hinderer and Nick Barnes)
+
+* (*breaking change*) [#10723](https://github.com/ocaml/ocaml/issues/10723): do not use `-flat-namespace` linking for macOS.
+  (Carlo Cabrera, review by Damien Doligez)
+
+- [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+  (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+
+### Build system:
+
+- [#11590](https://github.com/ocaml/ocaml/issues/11590): Allow installing to a destination path containing spaces.
+  (Élie Brami, review by Sébastien Hinderer and David Allsopp)
+
+- [#12372](https://github.com/ocaml/ocaml/issues/12372): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  so that code sections remain readable, as needed for closure marshaling.
+  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+  Sébastien Hinderer)
+
+- [#12903](https://github.com/ocaml/ocaml/issues/12903): Disable control flow integrity on OpenBSD >= 7.4 to avoid
+  illegal instruction errors on certain CPUs.
+  (Michael Hendricks, review by Miod Vallat)
+
+### Bug fixes:
+
+- [#12061](https://github.com/ocaml/ocaml/issues/12061), [#12063](https://github.com/ocaml/ocaml/issues/12063): don't add inconsistent equalities when computing
+  high-level error messages for functor applications and inclusions.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#12878](https://github.com/ocaml/ocaml/issues/12878): fix incorrect treatment of injectivity for private recursive types.
+  (Jeremy Yallop, review by Gabriel Scherer and Jacques Garrigue)
+
+- [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+  invalid programs forming recursive types.
+  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+
+- [#12264](https://github.com/ocaml/ocaml/issues/12264), [#12289](https://github.com/ocaml/ocaml/issues/12289): Fix compact_allocate to avoid a pathological case
+  that causes very slow compaction.
+  (Damien Doligez, report by Arseniy Alekseyev, review by Sadiq Jaffer)
+
+- [#12513](https://github.com/ocaml/ocaml/issues/12513), [#12518](https://github.com/ocaml/ocaml/issues/12518): Automatically enable emulated `fma` for Visual Studio 2019+
+  to allow configuration with either pre-Haswell/pre-Piledriver CPUs or running
+  in VirtualBox. Restores parity with the other Windows ports, which don't
+  require explicit `--enable-imprecise-c99-float-ops`.
+  (David Allsopp, report by Jonah Beckford and Kate Deplaix, review by
+   Sébastien Hinderer)
+
+- [#11633](https://github.com/ocaml/ocaml/issues/11633), [#11636](https://github.com/ocaml/ocaml/issues/11636): bugfix in caml_unregister_frametable
+  (Frédéric Recoules, review by Gabriel Scherer)
+
+- [#12636](https://github.com/ocaml/ocaml/issues/12636), [#12646](https://github.com/ocaml/ocaml/issues/12646): More prudent reinitialization of I/O mutexes after a fork()
+  (Xavier Leroy, report by Zach Baylin, review by Enguerrand Decorne)
+
+* (*breaking change*) [#10845](https://github.com/ocaml/ocaml/issues/10845) Emit frametable size on amd64 BSD (OpenBSD, FreeBSD, NetBSD) systems
+  (emitted for Linux in [#8805](https://github.com/ocaml/ocaml/issues/8805))
+  (Hannes Mehnert, review by Nicolás Ojeda Bär)
+
+- [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+  expressions.
+  (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
+  Gabriel Scherer)
+
+- [#12116](https://github.com/ocaml/ocaml/issues/12116), [#12993](https://github.com/ocaml/ocaml/issues/12993): explicitly build non PIE executables on x86 32bits
+  architectures
+  (Florian Angeletti, review by David Allsopp)
+
+- [#13018](https://github.com/ocaml/ocaml/issues/13018): Don't pass duplicate libraries to the linker when compiling ocamlc.opt
+  and when using systhreads (new versions of lld emit a warning).
+  (David Allsopp, review by Nicolás Ojeda Bär)


### PR DESCRIPTION
This PR adds the changelog news and the release entry for the freshly released OCaml 4.14.2 .