### PR TITLE
Sort exercises by slug before emitting template

### DIFF
--- a/tool/ood-gen/lib/exercise.ml
+++ b/tool/ood-gen/lib/exercise.ml
@@ -74,16 +74,8 @@ let decode (fpath, (head, body)) : (t, [> `Msg of string ]) result =
   Ok (metadata |> of_metadata ~statement ~solution)
 
 let compare_by_slug =
-  let parse_int s = s |> int_of_string_opt |> Option.value ~default:0 in
   let key exercise : int * string =
-    let slug = exercise.slug in
-    let len = String.length slug in
-    if len = 0 then (0, "")
-    else
-      match slug.[len - 1] with
-      | 'A' .. 'Z' as c ->
-          (parse_int (String.sub slug 0 (len - 1)), String.make 1 c)
-      | _ -> (parse_int slug, "")
+    Scanf.sscanf exercise.slug "%d%[A-Z]" (fun s c -> (s, c))
   in
   fun (x : t) (y : t) -> compare (key x) (key y)
 

--- a/tool/ood-gen/lib/exercise.ml
+++ b/tool/ood-gen/lib/exercise.ml
@@ -73,7 +73,22 @@ let decode (fpath, (head, body)) : (t, [> `Msg of string ]) result =
   in
   Ok (metadata |> of_metadata ~statement ~solution)
 
-let all () = Utils.map_files decode "exercises/*.md"
+let compare_by_slug =
+  let parse_int s = s |> int_of_string_opt |> Option.value ~default:0 in
+  let key exercise : int * string =
+    let slug = exercise.slug in
+    let len = String.length slug in
+    if len = 0 then (0, "")
+    else
+      match slug.[len - 1] with
+      | 'A' .. 'Z' as c ->
+          (parse_int (String.sub slug 0 (len - 1)), String.make 1 c)
+      | _ -> (parse_int slug, "")
+  in
+  fun (x : t) (y : t) -> compare (key x) (key y)
+
+let all () =
+  Utils.map_files decode "exercises/*.md" |> List.sort compare_by_slug
 
 let template () =
   Format.asprintf


### PR DESCRIPTION
Should fix #2149.

Note that comparing slugs lexicographically doesn't work because it yields `"10" < "2"`, etc. Here we parse each slug into its numeric part (defaulting to 0) and its rightmost letter (if present) before comparing them as `int * string` tuples.
Maybe the letter could be instead parsed as a `char option` or directly as an `int`, but I hope it's not too convoluted overall.