### PR TITLE
OCaml 4.14.2: fix release year

### DIFF
--- a/data/releases/4.14.2.md
+++ b/data/releases/4.14.2.md
@@ -5,7 +5,7 @@ date: 2024-03-15
 is_lts: true
 intro: |
   This page describes OCaml version **4.14.2**, released on
-  Mar 14, 2022. Go [here](/releases) for a list of all releases.
+  Mar 14, 2024. Go [here](/releases) for a list of all releases.
 
   This is a bug-fix release of [OCaml 4.14.1](/releases/4.14.1).
 


### PR DESCRIPTION
4.14.0 got released on 2022-03-28, therefore 4.14.2 can't have been
  released on 2022-03-24.

Fix year to match the date elsewhere in this file, it is 2024.

There is also a slight mismatch on the release day (14th vs 15th), but that is fine, the release was tagged on the 14th:
https://github.com/ocaml/ocaml/releases/tag/4.14.2 
And it was announced on the 15th: https://discuss.ocaml.org/t/ocaml-4-14-2-released/14308

Fixes: 96417f33 ("OCaml 4.14.2 release and changeloge pages (#2225)")