### PR TITLE
Fixed issue in ex.ml of practice/008

### DIFF
--- a/practice/008/ex.ml
+++ b/practice/008/ex.ml
@@ -12,7 +12,7 @@ module Make(Tested: Testable) : sig val v : test end = struct
     "empty list" >:: (fun _ -> assert_equal [] (Tested.compress []));
   ]
 
-  let tests = "Remove Duplicates" >::: [ tests ]
+  let v = "Remove Duplicates" >::: [ tests ]
 end
 
 module Work : Testable = Work.Impl


### PR DESCRIPTION
This is to fix error in practice/005/ex.ml 
Changed ```tests``` to ```v```
Partly addresses issue #2287 

@divyankachaudhari kindly review.
Thanks