### PR TITLE
Changelog entry for OCaml 5.2.0~beta1

### DIFF
--- a/data/changelog/ocaml/2024-03-25-ocaml-5.2.0-beta1.md
+++ b/data/changelog/ocaml/2024-03-25-ocaml-5.2.0-beta1.md
@@ -1,0 +1,149 @@
+---
+title: OCaml 5.2.0 - First Beta
+description: First Beta Release of OCaml 5.2.0
+tags: [ocaml]
+changelog: |
+  ### Runtime System Fixes
+  
+  - [#12875](https://github.com/ocaml/ocaml/issues/12875), [#12879](https://github.com/ocaml/ocaml/issues/12879), [#12882](https://github.com/ocaml/ocaml/issues/12882): Execute preemptive systhread switching as a
+    delayed pending action. This ensures that one can reason within the
+    FFI that no mutation happens on the same domain when allocating on
+    the OCaml heap from C, consistently with OCaml 4. This also fixes
+    further bugs with the multicore systhreads implementation.
+    (Guillaume Munch-Maccagnoni, bug reports and suggestion by Mark
+     Shinwell, review by Nick Barnes and Stephen Dolan)
+ 
+  - [#12876](https://github.com/ocaml/ocaml/issues/12876): Port ThreadSanitizer support to Linux on POWER
+    (Miod Vallat, review by Tim McGilchrist)
+  
+  - [#12678](https://github.com/ocaml/ocaml/issues/12678), [#12898](https://github.com/ocaml/ocaml/issues/12898): free channel buffers on close rather than on finalization
+    (Damien Doligez, review by Jan Midtgaard and Gabriel Scherer, report
+     by Jan Midtgaard)
+  
+  - [#12915](https://github.com/ocaml/ocaml/issues/12915): Port ThreadSanitizer support to Linux on s390x
+    (Miod Vallat, review by Tim McGilchrist)
+  
+  - [#12914](https://github.com/ocaml/ocaml/issues/12914): Slightly change the s390x assembly dialect in order to build with
+    Clang's integrated assembler.
+    (Miod Vallat, review by Gabriel Scherer)
+  
+  - [#12897](https://github.com/ocaml/ocaml/issues/12897): fix locking bugs in Runtime_events
+    (Gabriel Scherer and Thomas Leonard,
+     review by Olivier Nicole, Vincent Laviron and Damien Doligez,
+     report by Thomas Leonard)
+  
+  - [#12860](https://github.com/ocaml/ocaml/issues/12860): Fix an assertion that wasn't taking into account the possibility of an
+    ephemeron pointing at static data.
+    (Mark Shinwell, review by Gabriel Scherer and KC Sivaramakrishnan)
+  
+  - [#11040](https://github.com/ocaml/ocaml/issues/11040), [#12894](https://github.com/ocaml/ocaml/issues/12894): Silence false data race observed between caml_shared_try_alloc
+    and oldify. Introduces macros to call tsan annotations which help annotate
+    a ``happens before'' relationship.
+    (Hari Hara Naveen S and Olivier Nicole,
+     review by Gabriel Scherer and Miod Vallat)
+  
+  - [#12919](https://github.com/ocaml/ocaml/issues/12919): Fix register corruption in caml_callback2_asm on s390x.
+    (Miod Vallat, review by Gabriel Scherer)
+  
+  - [#12969](https://github.com/ocaml/ocaml/issues/12969): Fix a data race in caml_darken_cont
+    (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer and Miod Vallat)
+  
+  ### Standard Library Fix
+  
+  - [#12677](https://github.com/ocaml/ocaml/issues/12677), [#12889](https://github.com/ocaml/ocaml/issues/12889): make Domain.DLS thread-safe
+    (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
+     report by Vesa Karvonen)
+  
+  ### Type System Fix
+  
+  - [#12924](https://github.com/ocaml/ocaml/issues/12924), [#12930](https://github.com/ocaml/ocaml/issues/12930): Rework package constraint checking to improve interaction with
+    immediacy
+    (Chris Casinghino and Florian Angeletti, review by Florian Angeletti and
+     Richard Eisenberg)
+  
+  ### Compiler User-Interface Fix
+  
+  - [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+    invalid programs forming recursive types.
+    (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+  
+  ### Build System Fixes
+  
+  - [#12198](https://github.com/ocaml/ocaml/issues/12198), [#12321](https://github.com/ocaml/ocaml/issues/12321), [#12586](https://github.com/ocaml/ocaml/issues/12586), [#12616](https://github.com/ocaml/ocaml/issues/12616), [#12706](https://github.com/ocaml/ocaml/issues/12706), +[#13048](https://github.com/ocaml/ocaml/issues/13048): continue the merge of the
+     sub-makefiles into the root Makefile started with [#11243](https://github.com/ocaml/ocaml/issues/11243), [#11248](https://github.com/ocaml/ocaml/issues/11248),
+     [#11268](https://github.com/ocaml/ocaml/issues/11268), [#11420](https://github.com/ocaml/ocaml/issues/11420) and [#11675](https://github.com/ocaml/ocaml/issues/11675).
+     (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
+  
+  - [#12768](https://github.com/ocaml/ocaml/issues/12768), +[#13030](https://github.com/ocaml/ocaml/issues/13030): Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
+     and fix C compiler feature detection on macOS.
+     (Antonin Décimo, review by Miod Vallat and Sébastien Hinderer)
+  
+  - [#13019](https://github.com/ocaml/ocaml/issues/13019): Remove linking instructions for the Unix library from threads.cma
+    (this was done for threads.cmxa in OCaml 3.11). Eliminates warnings from
+    new lld when using threads.cma of duplicated libraries.
+    (David Allsopp, review by Nicolás Ojeda Bär)
+  
+  - [#12758](https://github.com/ocaml/ocaml/issues/12758), +[#12998](https://github.com/ocaml/ocaml/issues/12998): Remove the `Marshal.Compression` flag to the
+     `Marshal.to_*` functions.  The compilers are still able to use
+     ZSTD compression for compilation artefacts.
+     This is a forward port and clean-up of the emergency fix that was introduced
+  
+  ### Compiler Internals Fix
+  
+  - [#12389](https://github.com/ocaml/ocaml/issues/12389), [#12544](https://github.com/ocaml/ocaml/issues/12544), [#12984](https://github.com/ocaml/ocaml/issues/12984), +[#12987](https://github.com/ocaml/ocaml/issues/12987): centralize the handling of metadata for
+    compilation units and artifacts in preparation for better unicode support for
+    OCaml source files.
+    (Florian Angeletti, review by Vincent Laviron and Gabriel Scherer)
+
+ ---
+
+Nearly two months after the first alpha release, the release of OCaml 5.2.0 is drawing near.
+
+We have thus released a first beta version of OCaml 5.2.0 to help you update your softwares and libraries ahead of the release (see below for the installation instructions).
+
+Compared to the alpha release, this beta contains a majority of runtime system fixes, and a handful of other fixes across many subsystems.
+
+Overall, the opam ecosystem looks in a good shape for the first beta release.
+Most core development tools support OCaml 5.2.0, and you can follow the last remaining wrinkles on the
+[opam readiness for 5.2.0 meta-issue](https://github.com/ocaml/opam-repository/issues/25182).
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+Currently, the release is planned for the end of April or the beginning of May.
+
+If you are interested in full list of features and bug fixes of the new OCaml version, the
+updated change log for OCaml 5.2.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.2/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1:
+
+```bash
+opam update
+opam switch create 5.2.0~beta1
+```
+
+The source code for the alpha is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-beta1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~beta1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.2.0~beta1+options <option_list>
+```
+
+where `option_list` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+
+```bash
+opam switch create 5.2.0~beta1+flambda+nffa ocaml-variants.5.2.0~beta1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This PR adds a changelog entry for the upcoming first beta of OCaml 5.2.0 .
As previously, this PR is dependent upon the PR on the opam side:  https://github.com/ocaml/opam-repository/pull/25578 .