### PR TITLE
chore: set doc url to live, after voodoo upgrade

### DIFF
--- a/src/ocamlorg_package/lib/config.ml
+++ b/src/ocamlorg_package/lib/config.ml
@@ -5,7 +5,7 @@ let opam_polling =
 
 let documentation_url =
   Sys.getenv_opt "OCAMLORG_DOC_URL"
-  |> Option.value ~default:"https://docs-data.ocaml.org/current/"
+  |> Option.value ~default:"https://docs-data.ocaml.org/live/"
 
 let documentation_status_cache_ttl =
   env_with_default "OCAMLORG_DOC_STATUS_CACHE_TTL" "3600" |> float_of_string


### PR DESCRIPTION
https://github.com/ocaml/ocaml.org/pull/2300 set `OCAMLORG_DOC_URL` to point at `https://docs-data.ocaml.org/current/`.

This PR points `OCAMLORG_DOC_URL` back at `https://docs-data.ocaml.org/live/`.

This needs to merge after the documentation pipeline has set its `live` folder to point at the newest documentation build epoch.

--

This is part of the regular process when changes to voodoo require breaking changes on ocaml.org, due to how the documentation pipeline has two documentation "buckets": `live` and `current`.

During an upgrade, `live` contains the previous package documentation, while `current` contains the newly-built documentation.

In order to avoid service outage on ocaml.org, we apply a patch on ocaml.org that deals with the breaking changes and points ocaml.org to read documentation from the `current`. Then, on the documentation pipeline, we advance `live` to `current`, and after this, we can point ocaml.org at `live` again.