### PR TITLE
Create new Events page with routing under Community

### DIFF
--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -34,6 +34,7 @@ end
 
 let sitemap = "/sitemap.xml"
 let community = "/community"
+let events = "/events"
 let success_story v = "/success-stories/" ^ v
 let industrial_users = "/industrial-users"
 let academic_users = "/academic-users"

--- a/src/ocamlorg_frontend/components/footer.eml
+++ b/src/ocamlorg_frontend/components/footer.eml
@@ -22,6 +22,7 @@ let resources = [
 let ecosystem = [
   (Url.packages, "Packages");
   (Url.community, "Community");
+  (Url.events, "Events");
   (Url.blog, "Blog");
   (Url.jobs, "Jobs");
   ]

--- a/src/ocamlorg_frontend/dune
+++ b/src/ocamlorg_frontend/dune
@@ -94,6 +94,10 @@
   (action
    (run %{bin:dream_eml} %{dep:community.eml} --workspace %{workspace_root})))
  (rule
+  (target events.ml)
+  (action
+   (run %{bin:dream_eml} %{dep:events.eml} --workspace %{workspace_root})))
+ (rule
   (target workshop.ml)
   (action
    (run %{bin:dream_eml} %{dep:workshop.eml} --workspace %{workspace_root})))

--- a/src/ocamlorg_frontend/layouts/community_layout.eml
+++ b/src/ocamlorg_frontend/layouts/community_layout.eml
@@ -1,18 +1,21 @@
 type section =
   | Overview
   | Jobs
+  | Events
 
 let tabs
 ~current =
   let url_of_section = function
     | Overview -> Url.community
     | Jobs -> Url.jobs
+    | Events -> Url.events
   in
   let title_of_section = function
     | Overview -> "Overview"
     | Jobs -> "Jobs"
+    | Events -> "Events"
   in
-  Layout.subnav_tabs ~title:"Community" ~current ~sections:[Overview; Jobs] ~url_of_section ~title_of_section
+  Layout.subnav_tabs ~title:"Community" ~current ~sections:[Overview; Jobs; Events] ~url_of_section ~title_of_section
 
 let single_column_layout
 ?use_swiper

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -13,6 +13,7 @@ let changelog = Changelog.render
 let changelog_entry = Changelog_entry.render
 let books = Books.render
 let community = Community.render
+let events = Events.render
 let home = Home.render
 let install = Install.render
 let industrial_users = Industrial_users.render

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -212,6 +212,7 @@ Community_layout.single_column_layout
       </div>
   </div>
 </div>
+<!--
 <div class="w-full section-blue-gradient dark:bg-none">
   <div class="container-fluid py-9">
     <p class="uppercase text-sm text-white tracking-widest opacity-60 font-medium mb-2">events</p>
@@ -271,3 +272,4 @@ Community_layout.single_column_layout
       </div>
     </div>
 <% ); %>
+-->

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -1,4 +1,4 @@
-let render ~upcoming_workshops ~old_workshops ~recurring_events ~upcoming_events =
+let render ~upcoming_workshops ~old_workshops ~upcoming_events =
 Community_layout.single_column_layout
 ~title:"The OCaml Community"
 ~description:"Looking to interact with people who are also interested in OCaml? Find out about upcoming events, read up on blogs from the community, sign up for OCaml mailing lists, and discover even more places to engage with people from the community!"
@@ -107,6 +107,41 @@ Community_layout.single_column_layout
       </div>
   </div>
 </div>
+<% if List.length upcoming_events > 0 then ( %>
+<div class="w-full">
+  <div class="container-fluid pt-6 pb-12">
+      <p class="uppercase text-sm text-content dark:text-dark-content tracking-widest font-medium mb-2">events</p>
+      <h2 class="font-bold text-2xl text-title dark:text-dark-title mb-2">Upcoming Events</h2>
+      <div class="grid lg:grid-cols-3 md:grid-cols-2 gap-8">
+          <% upcoming_events |> List.iter (fun (event : Data.Event.t) -> %>
+          <a href="<%s event.url %>" class="card dark:dark-card p-5 rounded-xl">
+            <p class="font-bold text-title dark:text-dark-title mb-2"><%s event.title %></p>
+            <div class="flex items-center space-x-2 mb-3">
+              <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
+              <p class="text-content dark:text-dark-content"><%s event.textual_location %></p>
+            </div>
+            <div class="flex items-center space-x-2 mt-2">
+              <%s! Icons.calendar "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
+              <p class="text-content dark:text-dark-content">
+                <%s event.starts.yyyy_mm_dd %>
+                <%s event.starts.utc_hh_mm |> Option.map (fun s -> s ^ " UTC") |> Option.value ~default:"" %>
+              </p>
+            </div>
+            <% (match event.ends with | None -> () | Some ends -> ( %>
+            <div class="flex items-center space-x-2 mt-2">
+              <p class="ml-9 text-content dark:text-dark-content">
+                to
+                <%s ends.yyyy_mm_dd %>
+                <%s ends.utc_hh_mm |> Option.map (fun s -> s ^ " UTC") |> Option.value ~default:"" %>
+              </p>
+            </div>
+            <% )); %>
+          </a>
+          <% ); %>
+      </div>
+  </div>
+</div>
+<% ); %>
 <div class="w-full border-b">
   <div class="container-fluid pt-6 pb-12">
     <p class="uppercase text-sm text-content dark:text-dark-content tracking-widest font-medium mb-2">workshop</p>
@@ -212,64 +247,3 @@ Community_layout.single_column_layout
       </div>
   </div>
 </div>
-<!--
-<div class="w-full section-blue-gradient dark:bg-none">
-  <div class="container-fluid py-9">
-    <p class="uppercase text-sm text-white tracking-widest opacity-60 font-medium mb-2">events</p>
-    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2">Recurring Events</h2>
-    <div class="grid lg:grid-cols-3 gap-8 lg:gap-10 mt-12">
-      <% recurring_events |> List.iter (fun (recurring_event : Data.Event.RecurringEvent.t) -> %>
-      <a href="<%s recurring_event.url %>" class="card dark:dark-card p-5 rounded-xl">
-          <p class="font-bold text-lg text-title dark:text-dark-title mb-3">
-              <%s recurring_event.title %>
-          </p>
-          <div class="flex items-center space-x-2">
-            <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary" %>
-            <p class="text-content dark:text-dark-content">
-                <%s recurring_event.textual_location %>
-            </p class="text-content dark:text-dark-content">
-          </div>
-      </a>
-      <% ); %>
-    </div>
-    <p class="text-white dark:text-dark-content my-6">
-      If you want to contribute a recurring event, check out the <a class="text-white underline hover:no-underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-recurring-event" target="_blank">Contributing Guide</a> on GitHub.
-    </p>
-  </div>
-</div>
-<% if List.length upcoming_events > 0 then ( %>
-    <div class="w-full">
-      <div class="container-fluid pt-6 pb-12">
-          <p class="uppercase text-sm text-content dark:text-dark-content tracking-widest font-medium mb-2">events</p>
-          <h2 class="font-bold text-2xl text-title dark:text-dark-title mb-2">Upcoming Events</h2>
-          <div class="grid lg:grid-cols-3 md:grid-cols-2 gap-8">
-              <% upcoming_events |> List.iter (fun (event : Data.Event.t) -> %>
-              <a href="<%s event.url %>" class="card dark:dark-card p-5 rounded-xl">
-                <p class="font-bold text-title dark:text-dark-title mb-2"><%s event.title %></p>
-                <div class="flex items-center space-x-2 mb-3">
-                  <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
-                  <p class="text-content dark:text-dark-content"><%s event.textual_location %></p>
-                </div>
-                <div class="flex items-center space-x-2 mt-2">
-                  <%s! Icons.calendar "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
-                  <p class="text-content dark:text-dark-content">
-                    <%s event.starts.yyyy_mm_dd %>
-                    <%s event.starts.utc_hh_mm |> Option.map (fun s -> s ^ " UTC") |> Option.value ~default:"" %>
-                  </p>
-                </div>
-                <% (match event.ends with | None -> () | Some ends -> ( %>
-                <div class="flex items-center space-x-2 mt-2">
-                  <p class="ml-9 text-content dark:text-dark-content">
-                    to
-                    <%s ends.yyyy_mm_dd %>
-                    <%s ends.utc_hh_mm |> Option.map (fun s -> s ^ " UTC") |> Option.value ~default:"" %>
-                  </p>
-                </div>
-                <% )); %>
-              </a>
-              <% ); %>
-          </div>
-      </div>
-    </div>
-<% ); %>
--->

--- a/src/ocamlorg_frontend/pages/events.eml
+++ b/src/ocamlorg_frontend/pages/events.eml
@@ -4,31 +4,9 @@ Community_layout.single_column_layout
 ~description:"The Events page!"
 ~canonical:Url.events
 ~active_top_nav_item:Header.Community
-~current:Overview @@
+~current:Events @@
 <div class="w-full section-blue-gradient dark:bg-none">
   <div class="container-fluid py-9">
-    <p class="uppercase text-sm text-white tracking-widest opacity-60 font-medium mb-2">events</p>
-    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2">Recurring Events</h2>
-    <div class="grid lg:grid-cols-3 gap-8 lg:gap-10 mt-12">
-      <% recurring_events |> List.iter (fun (recurring_event : Data.Event.RecurringEvent.t) -> %>
-      <a href="<%s recurring_event.url %>" class="card dark:dark-card p-5 rounded-xl">
-          <p class="font-bold text-lg text-title dark:text-dark-title mb-3">
-              <%s recurring_event.title %>
-          </p>
-          <div class="flex items-center space-x-2">
-            <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary" %>
-            <p class="text-content dark:text-dark-content">
-                <%s recurring_event.textual_location %>
-            </p class="text-content dark:text-dark-content">
-          </div>
-      </a>
-      <% ); %>
-    </div>
-    <p class="text-white dark:text-dark-content my-6">
-      If you want to contribute a recurring event, check out the <a class="text-white underline hover:no-underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-recurring-event" target="_blank">Contributing Guide</a> on GitHub.
-    </p>
-  </div>
-</div>
 <% if List.length upcoming_events > 0 then ( %>
     <div class="w-full">
       <div class="container-fluid pt-6 pb-12">
@@ -64,3 +42,25 @@ Community_layout.single_column_layout
       </div>
     </div>
 <% ); %>
+    <p class="uppercase text-sm text-white tracking-widest opacity-60 font-medium mb-2">events</p>
+    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2">Recurring Events</h2>
+    <div class="grid lg:grid-cols-3 gap-8 lg:gap-10 mt-12">
+      <% recurring_events |> List.iter (fun (recurring_event : Data.Event.RecurringEvent.t) -> %>
+      <a href="<%s recurring_event.url %>" class="card dark:dark-card p-5 rounded-xl">
+          <p class="font-bold text-lg text-title dark:text-dark-title mb-3">
+              <%s recurring_event.title %>
+          </p>
+          <div class="flex items-center space-x-2">
+            <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary" %>
+            <p class="text-content dark:text-dark-content">
+                <%s recurring_event.textual_location %>
+            </p class="text-content dark:text-dark-content">
+          </div>
+      </a>
+      <% ); %>
+    </div>
+    <p class="text-white dark:text-dark-content my-6">
+      If you want to contribute a recurring event, check out the <a class="text-white underline hover:no-underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-recurring-event" target="_blank">Contributing Guide</a> on GitHub.
+    </p>
+  </div>
+</div>

--- a/src/ocamlorg_frontend/pages/events.eml
+++ b/src/ocamlorg_frontend/pages/events.eml
@@ -1,0 +1,66 @@
+let render ~recurring_events ~upcoming_events =
+Community_layout.single_column_layout
+~title:"The Events"
+~description:"The Events page!"
+~canonical:Url.events
+~active_top_nav_item:Header.Community
+~current:Overview @@
+<div class="w-full section-blue-gradient dark:bg-none">
+  <div class="container-fluid py-9">
+    <p class="uppercase text-sm text-white tracking-widest opacity-60 font-medium mb-2">events</p>
+    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2">Recurring Events</h2>
+    <div class="grid lg:grid-cols-3 gap-8 lg:gap-10 mt-12">
+      <% recurring_events |> List.iter (fun (recurring_event : Data.Event.RecurringEvent.t) -> %>
+      <a href="<%s recurring_event.url %>" class="card dark:dark-card p-5 rounded-xl">
+          <p class="font-bold text-lg text-title dark:text-dark-title mb-3">
+              <%s recurring_event.title %>
+          </p>
+          <div class="flex items-center space-x-2">
+            <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary" %>
+            <p class="text-content dark:text-dark-content">
+                <%s recurring_event.textual_location %>
+            </p class="text-content dark:text-dark-content">
+          </div>
+      </a>
+      <% ); %>
+    </div>
+    <p class="text-white dark:text-dark-content my-6">
+      If you want to contribute a recurring event, check out the <a class="text-white underline hover:no-underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-recurring-event" target="_blank">Contributing Guide</a> on GitHub.
+    </p>
+  </div>
+</div>
+<% if List.length upcoming_events > 0 then ( %>
+    <div class="w-full">
+      <div class="container-fluid pt-6 pb-12">
+          <p class="uppercase text-sm text-content dark:text-dark-content tracking-widest font-medium mb-2">events</p>
+          <h2 class="font-bold text-2xl text-title dark:text-dark-title mb-2">Upcoming Events</h2>
+          <div class="grid lg:grid-cols-3 md:grid-cols-2 gap-8">
+              <% upcoming_events |> List.iter (fun (event : Data.Event.t) -> %>
+              <a href="<%s event.url %>" class="card dark:dark-card p-5 rounded-xl">
+                <p class="font-bold text-title dark:text-dark-title mb-2"><%s event.title %></p>
+                <div class="flex items-center space-x-2 mb-3">
+                  <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
+                  <p class="text-content dark:text-dark-content"><%s event.textual_location %></p>
+                </div>
+                <div class="flex items-center space-x-2 mt-2">
+                  <%s! Icons.calendar "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
+                  <p class="text-content dark:text-dark-content">
+                    <%s event.starts.yyyy_mm_dd %>
+                    <%s event.starts.utc_hh_mm |> Option.map (fun s -> s ^ " UTC") |> Option.value ~default:"" %>
+                  </p>
+                </div>
+                <% (match event.ends with | None -> () | Some ends -> ( %>
+                <div class="flex items-center space-x-2 mt-2">
+                  <p class="ml-9 text-content dark:text-dark-content">
+                    to
+                    <%s ends.yyyy_mm_dd %>
+                    <%s ends.utc_hh_mm |> Option.map (fun s -> s ^ " UTC") |> Option.value ~default:"" %>
+                  </p>
+                </div>
+                <% )); %>
+              </a>
+              <% ); %>
+          </div>
+      </div>
+    </div>
+<% ); %>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -83,6 +83,28 @@ let community _req =
     (Ocamlorg_frontend.community ~old_workshops ~upcoming_workshops
        ~recurring_events ~upcoming_events)
 
+let events _req =
+  let recurring_events = Data.Event.RecurringEvent.all in
+  let current_date =
+    let open Unix in
+    let tm = localtime (Unix.gettimeofday ()) in
+    Format.asprintf "%04d-%02d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)
+      tm.tm_mday
+  in
+  let upcoming_events =
+    List.filter
+      (fun (e : Data.Event.t) ->
+        e.starts.yyyy_mm_dd >= current_date
+        || Option.is_some e.ends
+           && e.ends
+              |> Option.map (fun (e : Data.Event.utc_datetime) -> e.yyyy_mm_dd)
+              |> Option.get >= current_date)
+      Data.Event.all
+    |> Ocamlorg.Import.List.take 6
+  in
+  Dream.html
+    (Ocamlorg_frontend.events ~recurring_events ~upcoming_events)
+
 let paginate ~req ~n items =
   let items_per_page = n in
   let page =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -51,7 +51,6 @@ let platform _req =
   Dream.html (Ocamlorg_frontend.platform ~tutorials tools)
 
 let community _req =
-  let recurring_events = Data.Event.RecurringEvent.all in
   let current_date =
     let open Unix in
     let tm = localtime (Unix.gettimeofday ()) in
@@ -81,7 +80,7 @@ let community _req =
   in
   Dream.html
     (Ocamlorg_frontend.community ~old_workshops ~upcoming_workshops
-       ~recurring_events ~upcoming_events)
+       ~upcoming_events)
 
 let events _req =
   let recurring_events = Data.Event.RecurringEvent.all in
@@ -102,8 +101,7 @@ let events _req =
       Data.Event.all
     |> Ocamlorg.Import.List.take 6
   in
-  Dream.html
-    (Ocamlorg_frontend.events ~recurring_events ~upcoming_events)
+  Dream.html (Ocamlorg_frontend.events ~recurring_events ~upcoming_events)
 
 let paginate ~req ~n items =
   let items_per_page = n in

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -31,6 +31,7 @@ let page_routes t =
       Dream.get Url.learn_guides Handler.learn_guides;
       Dream.get Url.platform Handler.platform;
       Dream.get Url.community Handler.community;
+      Dream.get Url.events Handler.events;
       Dream.get Url.changelog Handler.changelog;
       Dream.get (Url.changelog_entry ":id") Handler.changelog_entry;
       Dream.get (Url.success_story ":id") Handler.success_story;

--- a/src/ocamlorg_web/lib/sitemap.ml
+++ b/src/ocamlorg_web/lib/sitemap.ml
@@ -8,6 +8,7 @@ let urls =
     Url.packages;
     Url.packages_search;
     Url.community;
+    Url.events;
     Url.industrial_users;
     Url.academic_users;
     Url.about;


### PR DESCRIPTION
The events section in the Community page is now moved to a new `Events` page, and the routing has been updated accordingly.