### PR TITLE
OCaml 5.2.0-beta2 changelog entry

### DIFF
--- a/data/changelog/ocaml/2024-04-16-ocaml-5.2.0-beta2.md
+++ b/data/changelog/ocaml/2024-04-16-ocaml-5.2.0-beta2.md
@@ -70,7 +70,7 @@ opam update
 opam switch create 5.2.0~beta2
 ```
 
-The source code for the alpha is also available at these addresses:
+The source code for the beta is also available at these addresses:
 
 * [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-beta2.tar.gz)
 * [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~beta2.tar.gz)

--- a/data/changelog/ocaml/2024-04-16-ocaml-5.2.0-beta2.md
+++ b/data/changelog/ocaml/2024-04-16-ocaml-5.2.0-beta2.md
@@ -67,13 +67,13 @@ on opam 2.1:
 
 ```bash
 opam update
-opam switch create 5.2.0~beta1
+opam switch create 5.2.0~beta2
 ```
 
 The source code for the alpha is also available at these addresses:
 
-* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-beta1.tar.gz)
-* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~beta1.tar.gz)
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-beta2.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~beta2.tar.gz)
 
 ### Fine-Tuned Compiler Configuration
 
@@ -81,13 +81,13 @@ If you want to tweak the configuration of the compiler, you can switch to the op
 
 ```bash
 opam update
-opam switch create <switch_name> ocaml-variants.5.2.0~beta1+options <option_list>
+opam switch create <switch_name> ocaml-variants.5.2.0~beta2+options <option_list>
 ```
 
 where `option_list` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
 
 ```bash
-opam switch create 5.2.0~beta1+flambda+nffa ocaml-variants.5.2.0~beta1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+opam switch create 5.2.0~beta2+flambda+nffa ocaml-variants.5.2.0~beta2+options ocaml-option-flambda ocaml-option-no-flat-float-array
 ```
 
 All available options can be listed with `opam search ocaml-option`.

--- a/data/changelog/ocaml/2024-04-16-ocaml-5.2.0-beta2.md
+++ b/data/changelog/ocaml/2024-04-16-ocaml-5.2.0-beta2.md
@@ -1,0 +1,93 @@
+---
+title: OCaml 5.2.0 - Second Beta
+description: Second Beta Release of OCaml 5.2.0
+tags: [ocaml]
+changelog: |
+  ### Compiler-libs API Changes
+  
+  - [#13001](https://github.com/ocaml/ocaml/issues/13001): do not read_back entire shapes to get aliases' uids when building the
+    usages index
+    (Ulysse Gérard, review by Gabriel Scherer and Nathanaëlle Courant)
+  
+  ### Bug Fixes
+  
+  - [#13058](https://github.com/ocaml/ocaml/issues/13058): Add TSan instrumentation to caml_call_gc(), since it may raise
+    exceptions.
+    (Fabrice Buoro, Olivier Nicole, Gabriel Scherer and Miod Vallat)
+  
+  - [#13079](https://github.com/ocaml/ocaml/issues/13079): Save and restore frame pointer across Iextcall on ARM64
+    (Tim McGilchrist, review by KC Sivaramakrishnan and Miod Vallat)
+  
+  - [#13094](https://github.com/ocaml/ocaml/issues/13094): Fix undefined behavior of left-shifting a negative number.
+    (Antonin Décimo, review by Miod Vallat and Nicolás Ojeda Bär)
+  
+  ### Documentation Updates
+  
+  - [#13078](https://github.com/ocaml/ocaml/issues/13078): update Format tutorial on structural boxes to mention alignment
+    questions.
+    (Edwin Török, review by Florian Angeletti)
+  
+  - [#13092](https://github.com/ocaml/ocaml/issues/13092): document the existence of the `[@@poll error]` built-in attribute
+    (Florian Angeletti, review by Gabriel Scherer)
+
+  - [#13066](https://github.com/ocaml/ocaml/issues/13066), update OCAMLRUNPARAM documentation for the stack size parameter l
+    (Florian Angeletti, review by Nicolás Ojeda Bär, Tim McGilchrist, and
+     Miod Vallat)
+ ---
+
+Last week, we merged an update to the compiler-libs "shape" API for querying definition information from the compiler.
+
+Unfortunately, this small change of API breaks compatibility with at least odoc.
+Generally, we try to avoid this kind of changes during the beta releases of the
+compiler. However, after discussions we concluded that it will be easier on the
+long term to fix the API right now in order to avoid multiplying the number of
+supported versions of the shape API in the various OCaml developer tools .
+
+We have thus released a second beta version of OCaml 5.2.0 to give the time to developer tools to update their 5.2.0 version ahead of the release (see below for the installation instructions).
+
+Beyond this changes of API, the new beta contains three more bug fixes and three
+documentation updates, which is a good sign in term of stability.
+
+As usual, you can follow the last remaining compatibility slags on the
+[opam readiness for 5.2.0 meta-issue](https://github.com/ocaml/opam-repository/issues/25182).
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+Currently, the release is planned for the beginning of May.
+
+If you are interested in full list of features and bug fixes of the new OCaml version, the
+updated change log for OCaml 5.2.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.2/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1:
+
+```bash
+opam update
+opam switch create 5.2.0~beta1
+```
+
+The source code for the alpha is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-beta1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~beta1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.2.0~beta1+options <option_list>
+```
+
+where `option_list` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+
+```bash
+opam switch create 5.2.0~beta1+flambda+nffa ocaml-variants.5.2.0~beta1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This PR adds the changelog entry for the upcoming beta2 release of OCaml 5.2.0 (which should happen tomorrow).