### PR TITLE
Remove /manual/lts URL, fix broken route for /manual/latest

### DIFF
--- a/data/news/multicore/multicore-2020-03.md
+++ b/data/news/multicore/multicore-2020-03.md
@@ -29,7 +29,7 @@ Onto the details! The various ongoing and completed tasks for Multicore OCaml ar
 * [ocaml-multicore/ocaml-multicore#240](https://github.com/ocaml-multicore/ocaml-multicore/pull/240)
   Proposed implementation of threads in terms of Domain and Atomic
 
-  A new implementation of the `Threads` library (for use with the new `Domain` and [`Atomic`](/manual/lts/api/Atomic.html) modules in Multicore OCaml) has been proposed. This builds Dune 2.4.0, which in turn makes it useful to build other packages. This PR is open for review.
+  A new implementation of the `Threads` library (for use with the new `Domain` and [`Atomic`](/manual/latest/api/Atomic.html) modules in Multicore OCaml) has been proposed. This builds Dune 2.4.0, which in turn makes it useful to build other packages. This PR is open for review.
 
 * [ocaml-multicore/safepoints-cmm-mach](https://github.com/anmolsahoo25/ocaml-multicore/tree/safepoints-cmm-mach)
   Better safe points for OCaml

--- a/data/tutorials/guides/1wf_01_debugging.md
+++ b/data/tutorials/guides/1wf_01_debugging.md
@@ -498,7 +498,7 @@ happening in parallel and prints a back trace for both:
 
 Looking again at our program, we realize that these two writes are in
 fact not coordinated. One possible fix is to replace our mutable
-record field with an [`Atomic`](/manual/lts/api/Atomic.html) that guarantees each
+record field with an [`Atomic`](/manual/latest/api/Atomic.html) that guarantees each
 such write to happen fully, one after the other:
 
 ```ocaml

--- a/data/tutorials/guides/1wf_02_error_handling.md
+++ b/data/tutorials/guides/1wf_02_error_handling.md
@@ -85,7 +85,7 @@ raise this exception. Now, how do we handle exceptions? The construct is `try
 ### Predefined Exceptions
 
 The standard library predefines several exceptions, see
-[`Stdlib`](/manual/lts/api/Stdlib.html). Here are a few examples:
+[`Stdlib`](/manual/latest/api/Stdlib.html). Here are a few examples:
 
 ```ocaml
 # 1 / 0;;
@@ -918,8 +918,8 @@ fine, so it's a balance.
 # External Resources
 
 - [“Exceptions”](/manual/coreexamples.html#s%3Aexceptions) in ”The OCaml Manual, The Core Language”, chapter 1, section 6, December 2022
-- [Module **`option`**](/manual/lts/api/Option.html) in OCaml Library
-- [Module **`result`**](/manual/lts/api/Result.html) in Ocaml Library
+- [Module **`option`**](/manual/latest/api/Option.html) in OCaml Library
+- [Module **`result`**](/manual/latest/api/Result.html) in Ocaml Library
 - [“Error Handling”](https://dev.realworldocaml.org/error-handling.html) in “Real World OCaml”, part 7, Yaron Minsky and Anil Madhavapeddy, 2ⁿᵈ edition, Cambridge University Press, October 2022
 - “Add "finally" function to Pervasives”, Marcello Seri, GitHub PR, [ocaml/ocaml/pull/1855](https://github.com/ocaml/ocaml/pull/1855)
 - “A guide to recover from interrupts”, Guillaume Munch-Maccagnoni, parf the [`memprof-limits`](https://gitlab.com/gadmm/memprof-limits/) documentation

--- a/data/tutorials/guides/1wf_04_multicore_ready.md
+++ b/data/tutorials/guides/1wf_04_multicore_ready.md
@@ -339,7 +339,7 @@ simple test runner, one `Domain` may complete before the second has
 even started up yet! This is problematic, as there will be no apparent
 parallelism for TSan to observe and check. In the above example, the
 calls to `Unix.sleepf` help ensure that the test runner is indeed
-parallel. A useful alternative trick is to coordinate on an [`Atomic`](/manual/lts/api/Atomic.html)
+parallel. A useful alternative trick is to coordinate on an [`Atomic`](/manual/latest/api/Atomic.html)
 to make sure both `Domain`s are up and running before the parallel
 test code proceeds. To do so, we can adapt our parallel test runner as
 follows:

--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -13,7 +13,7 @@ case, _n_ is the number of valid elements in the container.
 Note that the big-O cost given for some operations reflects the current
 implementation but is not guaranteed by the official documentation.
 Hopefully it will not become worse. Anyway, if you want more details,
-you can read the [documentation](/manual/lts/api/index.html) about each of the modules or the OCaml [source code](https://github.com/ocaml/ocaml/tree/trunk/stdlib). Often, it
+you can read the [documentation](/manual/latest/api/index.html) about each of the modules or the OCaml [source code](https://github.com/ocaml/ocaml/tree/trunk/stdlib). Often, it
 is also instructive to read the corresponding implementation.
 
 ## Lists: Immutable Singly-Linked Lists

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -38,9 +38,9 @@ The `int` type is the default and basic integer type in OCaml. When you enter a 
 - : int = 42
 ```
 
-The `int` type represents platform-dependent signed integers. This means `int` does not always have same the number of bits. It depends on underlying platform characteristics, such as processor architecture or operating system. Operations on `int` values are provided by the [`Stdlib`](/manual/lts/api/Stdlib.html) and the [`Int`](/manual/lts/api/Int.html) modules.
+The `int` type represents platform-dependent signed integers. This means `int` does not always have same the number of bits. It depends on underlying platform characteristics, such as processor architecture or operating system. Operations on `int` values are provided by the [`Stdlib`](/manual/latest/api/Stdlib.html) and the [`Int`](/manual/latest/api/Int.html) modules.
 
-Usually, `int` has 31 bits in 32-bit architectures and 63 in 64-bit architectures, because one bit is reserved for OCaml's runtime operation. The standard library also provides [`Int32`](/manual/lts/api/Int32.html) and [`Int64`](/manual/lts/api/Int64.html) modules, which support platform-independent operations on 32- and 64-bit signed integers. These modules are not detailed in this tutorial.
+Usually, `int` has 31 bits in 32-bit architectures and 63 in 64-bit architectures, because one bit is reserved for OCaml's runtime operation. The standard library also provides [`Int32`](/manual/latest/api/Int32.html) and [`Int64`](/manual/latest/api/Int64.html) modules, which support platform-independent operations on 32- and 64-bit signed integers. These modules are not detailed in this tutorial.
 
 There are no dedicated types for unsigned integers in OCaml. Bitwise operations on `int` treat the sign bit the same as other bits. Binary operators use standard symbols. The signed remainder operator is written `mod`. Integers in OCaml have no predefined power operator.
 
@@ -64,7 +64,7 @@ Error: This expression has type int but an expression was expected of type
 Error: This expression has type float but an expression was expected of type
          int
 ```
-Operations on `float` are provided by the [`Stdlib`](/manual/lts/api/Stdlib.html) and the [`Float`](/manual/lts/api/Float.html) modules.
+Operations on `float` are provided by the [`Stdlib`](/manual/latest/api/Stdlib.html) and the [`Float`](/manual/latest/api/Float.html) modules.
 
 #### Booleans
 
@@ -80,7 +80,7 @@ Boolean values are represented by the type `bool`.
 - : bool = true
 ```
 
-Operations on `bool` are provided by the [`Stdlib`](/manual/lts/api/Stdlib.html) and the [`Bool`](/manual/lts/api/Bool.html) modules. The conjunction “and” is written `&&` and disjunction “or” is written `||`. Both are short-circuited, meaning that they don't evaluate the argument on the right if the left one's value is sufficient to decide the whole expression's value.
+Operations on `bool` are provided by the [`Stdlib`](/manual/latest/api/Stdlib.html) and the [`Bool`](/manual/latest/api/Bool.html) modules. The conjunction “and” is written `&&` and disjunction “or” is written `||`. Both are short-circuited, meaning that they don't evaluate the argument on the right if the left one's value is sufficient to decide the whole expression's value.
 
 In OCaml, `if … then … else …` is a _conditional expression_. It has the same type as its branches.
 ```ocaml
@@ -103,9 +103,9 @@ Values of type `char` correspond to the 256 symbols of the Latin-1 set. Characte
 # 'd';;
 - : char = 'd'
 ```
-Operations on `char` values are provided by the [`Stdlib`](/manual/lts/api/Stdlib.html) and the [`Char`](/manual/lts/api/Char.html) modules.
+Operations on `char` values are provided by the [`Stdlib`](/manual/latest/api/Stdlib.html) and the [`Char`](/manual/latest/api/Char.html) modules.
 
-The module [`Uchar`](/manual/lts/api/Uchar.html) provides support for Unicode characters.
+The module [`Uchar`](/manual/latest/api/Uchar.html) provides support for Unicode characters.
 
 ### Strings & Byte Sequences
 
@@ -131,7 +131,7 @@ Indexed access to string characters is possible using the following syntax:
 # "buenos dias".[4];;
 - : char : 'o'
 ```
-Operations on `string` values are provided by the [`Stdlib`](/manual/lts/api/Stdlib.html) and the [`String`](/manual/lts/api/String.html) modules.
+Operations on `string` values are provided by the [`Stdlib`](/manual/latest/api/Stdlib.html) and the [`String`](/manual/latest/api/String.html) modules.
 
 #### Byte Sequences
 
@@ -145,7 +145,7 @@ Moved intro pp to after example, as it contains the definition. Perhaps a short 
 ```
 Like strings, byte sequences are finite and fixed-sized. Each individual byte is represented by a `char` value. Like arrays, byte sequences are mutable, meaning they can't be extended or shortened, but each component byte may be updated. Essentially, a byte sequence (type `bytes`) is a mutable string that can't be printed. There is no way to write `bytes` literally, so they must be produced by a function.
 
-Operations on `bytes` values are provided by the [`Stdlib`](/manual/lts/api/Stdlib.html) and the [`Bytes`](/manual/lts/api/Bytes.html) modules. Only the function `Bytes.get` allows direct access to the characters contained in a byte sequence. Unlike arrays, there is no direct access operator on byte sequences. 
+Operations on `bytes` values are provided by the [`Stdlib`](/manual/latest/api/Stdlib.html) and the [`Bytes`](/manual/latest/api/Bytes.html) modules. Only the function `Bytes.get` allows direct access to the characters contained in a byte sequence. Unlike arrays, there is no direct access operator on byte sequences. 
 
 The memory representation of `bytes` is four times more compact that `char array`.
 ### Arrays & Lists
@@ -191,7 +191,7 @@ val letter : char array = [|'v'; 'x'; 'y'; 'z'|]
 
 The left-arrow `<-` is the array update operator. Above, it means the cell at index 2 is set to value `'F'`. It is the same as writing `Array.set letter 2 'F'`. Array update is a side effect, and the unit value is returned.
 
-Operations on arrays are provided by the [`Array`](/manual/lts/api/Array.html) module. There is a dedicated tutorial on [Arrays](/docs/arrays).
+Operations on arrays are provided by the [`Array`](/manual/latest/api/Array.html) module. There is a dedicated tutorial on [Arrays](/docs/arrays).
 
 #### Lists
 
@@ -209,7 +209,7 @@ As literals, lists are very much like arrays. Here are the same previous example
 
 Like arrays, lists are finite sequences of values of the same type. They are polymorphic, too. However, lists are extensible, immutable, and don't support direct access to all the values they contain. Lists play a central role in functional programming, so they have a [dedicated tutorial](/docs/lists).
 
-Operations on lists are provided by the [`List`](/manual/lts/api/List.html) module. The `List.append` function concatenates two lists. It can be used as an operator with the symbol `@`.
+Operations on lists are provided by the [`List`](/manual/latest/api/List.html) module. The `List.append` function concatenates two lists. It can be used as an operator with the symbol `@`.
 
 There are symbols of special importance with respect to lists:
 - The empty list is written `[]`, has type `'a list'`, and is pronounced “nil.”
@@ -265,7 +265,7 @@ Here is an example of pattern matching on an option value:
 - : int = 42
 ```
 
-Operations on options are provided by the [`Option`](/manual/lts/api/Option.html) module. Options are discussed in the [Error Handling](/docs/error-handling) guide.
+Operations on options are provided by the [`Option`](/manual/latest/api/Option.html) module. Options are discussed in the [Error Handling](/docs/error-handling) guide.
 
 #### Results
 
@@ -278,7 +278,7 @@ The `result` type can be used to express that a function's outcome can be either
 - : ('a, string) result = Error "Sorry"
 ```
 
-Operations on results are provided by the [`Result`](/manual/lts/api/Result.html) module. Results are discussed in the [Error Handling](/docs/error-handling) guide.
+Operations on results are provided by the [`Result`](/manual/latest/api/Result.html) module. Results are discussed in the [Error Handling](/docs/error-handling) guide.
 
 ### Tuples
 

--- a/data/tutorials/language/0it_02_loops_and_recursion.md
+++ b/data/tutorials/language/0it_02_loops_and_recursion.md
@@ -908,8 +908,8 @@ slow for some types of operation. For example, getting the head of a
 list, or iterating over a list to perform some operation on each element,
 is reasonably fast. However, when jumping to the n<sup>th</sup> element of a
 list or trying to randomly access a list, you'll find that both are slow operations.
-The OCaml [`Array`](/manual/lts/api/Array.html) type is a real array, so random access is fast, but
-insertion and deletion of elements is slow. [`Array`](/manual/lts/api/Array.html)s are also mutable, so
+The OCaml [`Array`](/manual/latest/api/Array.html) type is a real array, so random access is fast, but
+insertion and deletion of elements is slow. [`Array`](/manual/latest/api/Array.html)s are also mutable, so
 you can randomly change elements, too.
 
 The basics of arrays are simple:

--- a/data/tutorials/language/0it_03_lists.md
+++ b/data/tutorials/language/0it_03_lists.md
@@ -128,13 +128,13 @@ course. Here are two examples showing the `map` function in use:
 
 ## The Standard Library `List` Module
 
-The standard library [List](/manual/lts/api/List.html) module contains a
+The standard library [List](/manual/latest/api/List.html) module contains a
 wide range of useful utility functions, including pre-written versions of many
 of the functions we have written in this tutorial. A version of the module with
 labelled functions is available as part of
-[StdLabels](/manual/lts/api/StdLabels.html).
+[StdLabels](/manual/latest/api/StdLabels.html).
 
-In the [List](/manual/lts/api/List.html) module documentation, functions
+In the [List](/manual/latest/api/List.html) module documentation, functions
 which can raise an exception are marked. Such exceptions are usually the result
 of lists which are empty (and therefore have neither a head nor a tail) or
 lists of mismatched length.
@@ -142,7 +142,7 @@ lists of mismatched length.
 ### Maps and Iterators
 
 We have already written a `map` function from scratch, and it is no surprise
-that one is included in the [List](/manual/lts/api/List.html) module.
+that one is included in the [List](/manual/latest/api/List.html) module.
 There is also a variant for two lists:
 
 ```ocaml
@@ -151,8 +151,8 @@ There is also a variant for two lists:
 ```
 
 In addition, we have an imperative analogue to
-[`map`](/manual/lts/api/List.html#VALmap), called
-[`iter`](/manual/lts/api/List.html#VALiter). It takes an imperative
+[`map`](/manual/latest/api/List.html#VALmap), called
+[`iter`](/manual/latest/api/List.html#VALiter). It takes an imperative
 function of type `'a -> unit` and an `'a list` and applies the function to each
 element in turn. A suitable function might be `print_endline`:
 
@@ -164,7 +164,7 @@ mary
 - : unit = ()
 ```
 
-There is a variant [`iter2`](/manual/lts/api/List.html#VALiter2) for two
+There is a variant [`iter2`](/manual/latest/api/List.html#VALiter2) for two
 lists too:
 
 ```ocaml
@@ -178,8 +178,8 @@ mary jones
 - : unit = ()
 ```
 
-Notice that [`map2`](/manual/lts/api/List.html#VALmap2) and
-[`iter2`](/manual/lts/api/List.html#VALiter2) will fail if the lists are
+Notice that [`map2`](/manual/latest/api/List.html#VALmap2) and
+[`iter2`](/manual/latest/api/List.html#VALiter2) will fail if the lists are
 of unequal length:
 
 ```ocaml
@@ -189,7 +189,7 @@ Exception: Invalid_argument "List.map2".
 
 ### List Scanning
 
-The useful function [`mem`](/manual/lts/api/List.html#VALmem) checks
+The useful function [`mem`](/manual/latest/api/List.html#VALmem) checks
 whether a given element is a member of a list by scanning its contents:
 
 ```ocaml
@@ -214,8 +214,8 @@ val any : bool = true
 ```
 
 This is rather clumsy, though. The standard library provides two useful
-functions [`for_all`](/manual/lts/api/List.html#VALfor_all) and
-[`exists`](/manual/lts/api/List.html#VALexists) for this common problem:
+functions [`for_all`](/manual/latest/api/List.html#VALfor_all) and
+[`exists`](/manual/latest/api/List.html#VALexists) for this common problem:
 
 ```ocaml
 # List.for_all (fun x -> x mod 2 = 0) [2; 4; 6; 8];;
@@ -229,7 +229,7 @@ pieces of frequently-used code are turned into useful general functions.
 
 ### List Searching
 
-The function [`find`](/manual/lts/api/List.html#VALfind) returns the
+The function [`find`](/manual/latest/api/List.html#VALfind) returns the
 first element of a list matching a given predicate (a predicate is a testing
 function which returns either true or false when given an element). It raises
 an exception if such an element is not found:
@@ -242,7 +242,7 @@ an exception if such an element is not found:
 Exception: Not_found.
 ```
 
-The [`filter`](/manual/lts/api/List.html#VALfilter) function again takes
+The [`filter`](/manual/latest/api/List.html#VALfilter) function again takes
 a predicate and tests it against each element in the list, but this time
 returns the list of all elements which test true:
 
@@ -252,7 +252,7 @@ returns the list of all elements which test true:
 ```
 
 If we wish to know also which elements did not test true, we can use
-[`partition`](/manual/lts/api/List.html#VALpartition) which returns a
+[`partition`](/manual/latest/api/List.html#VALpartition) which returns a
 pair of lists: the first being the list of elements for which the predicate is
 true, the second those for which it is false.
 
@@ -262,8 +262,8 @@ true, the second those for which it is false.
 ```
 
 Note that the documentation for
-[`filter`](/manual/lts/api/List.html#VALfilter)  and
-[`partition`](/manual/lts/api/List.html#VALpartition) tells us that the
+[`filter`](/manual/latest/api/List.html#VALfilter)  and
+[`partition`](/manual/latest/api/List.html#VALpartition) tells us that the
 order of the input is preserved in the output. Where this is not stated it the
 documentation, it cannot be assumed.
 
@@ -272,8 +272,8 @@ documentation, it cannot be assumed.
 Association lists are a simple (and simplistic) way of implementing the
 dictionary data structure: that is to say, a group of keys each with an
 associated value. For large dictionaries, for efficiency, we would use the
-standard library's [Map](/manual/lts/api/Map.html) or
-[Hashtbl](/manual/lts/api/Hashtbl.html) modules. But these functions from
+standard library's [Map](/manual/latest/api/Map.html) or
+[Hashtbl](/manual/latest/api/Hashtbl.html) modules. But these functions from
 the List module are useful for lists which are generally small, and have other
 advantages: since they are just lists of pairs, they can be built and modified
 easily. They are also easily printed in the toplevel.
@@ -287,9 +287,9 @@ easily. They are also easily printed in the toplevel.
 
 When using association lists, and for other purposes, it is sometimes useful to
 be able to make a list of pairs from a pair of lists and vice versa. The
-[`List`](/manual/lts/api/List.html) module provides the functions
-[`split`](/manual/lts/api/List.html#VALsplit) and
-[`combine`](/manual/lts/api/List.html#VALcombine) for this purpose:
+[`List`](/manual/latest/api/List.html) module provides the functions
+[`split`](/manual/latest/api/List.html#VALsplit) and
+[`combine`](/manual/latest/api/List.html#VALcombine) for this purpose:
 
 ```ocaml
 # List.split [(3, "three"); (1, "one"); (4, "four")];;
@@ -300,12 +300,12 @@ be able to make a list of pairs from a pair of lists and vice versa. The
 
 ### Sorting Lists
 
-The function [`List.sort`](/manual/lts/api/List.html#VALsort), given a
+The function [`List.sort`](/manual/latest/api/List.html#VALsort), given a
 comparison function of type `'a -> 'a -> int` (zero if equal, negative if first
 smaller, positive if second smaller) and an input list of type `'a list`,
 returns the list sorted according to the comparison function. Typically, we use
 the built-in comparison function
-[`compare`](/manual/lts/api/Stdlib.html#VALcompare) which can compare any
+[`compare`](/manual/latest/api/Stdlib.html#VALcompare) which can compare any
 two values of like type (with the exception of functions which are incomparable).
 
 ```ocaml
@@ -323,18 +323,18 @@ two values of like type (with the exception of functions which are incomparable)
 - : (int * int) list = [(1, 3); (1, 2); (2, 3); (2, 2)]
 ```
 
-The function [`Fun.flip`](/manual/lts/api/Fun.html#VALflip) reverses a binary function parameter order.
+The function [`Fun.flip`](/manual/latest/api/Fun.html#VALflip) reverses a binary function parameter order.
 
 ### Folds
 
 There are two interestingly-named functions in the List module,
-[`fold_left`](/manual/lts/api/List.html#VALfold_left) and
-[`fold_right`](/manual/lts/api/List.html#VALfold_right). Their job is
+[`fold_left`](/manual/latest/api/List.html#VALfold_left) and
+[`fold_right`](/manual/latest/api/List.html#VALfold_right). Their job is
 to combine the elements of a list together, using a given function,
 accumulating an answer which is then returned. The answer returned depends upon
 the function given, the elements of the list, and the initial value of the
 accumulator supplied. So you can imagine these are very general functions.
-Let's explore [`fold_left`](/manual/lts/api/List.html#VALfold_left)
+Let's explore [`fold_left`](/manual/latest/api/List.html#VALfold_left)
 first.
 
 In this example, we supply the addition function and an initial
@@ -356,7 +356,7 @@ our initial accumulator
 ```
 
 The largest number in the list is found. Let's look at the type of the
-[`fold_left`](/manual/lts/api/List.html#VALfold_left) function:
+[`fold_left`](/manual/latest/api/List.html#VALfold_left) function:
 
 ```ocaml
 # List.fold_left;;
@@ -371,10 +371,10 @@ have type `'a`. Of course, in both of our examples, `'a` and `'b` are the same
 as one another. But this is not always so.
 
 Consider the following definition of `append` which uses
-[`fold_right`](/manual/lts/api/List.html#VALfold_right)
-([`fold_left`](/manual/lts/api/List.html#VALfold_left) considers the
+[`fold_right`](/manual/latest/api/List.html#VALfold_right)
+([`fold_left`](/manual/latest/api/List.html#VALfold_left) considers the
 elements from the left,
-[`fold_right`](/manual/lts/api/List.html#VALfold_right) from the right):
+[`fold_right`](/manual/latest/api/List.html#VALfold_right) from the right):
 
 ```ocaml
 # let append x y =
@@ -393,7 +393,7 @@ fold right parameters is a little different:
 
 The function comes first, then the list of elements, then the initial
 accumulator value. We can use
-[`fold_right`](/manual/lts/api/List.html#VALfold_right) to define our
+[`fold_right`](/manual/latest/api/List.html#VALfold_right) to define our
 usual `map` function:
 
 ```ocaml
@@ -403,7 +403,7 @@ val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 ```
 
 But care is needed. If we try that with
-[`List.concat`](/manual/lts/api/List.html#VALconcat), which turns a
+[`List.concat`](/manual/latest/api/List.html#VALconcat), which turns a
 list of lists into a list by concatenating the lists together, we produce this:
 
 ```ocaml
@@ -414,14 +414,14 @@ val concat : 'a list list -> 'a list = <fun>
 Unfortunately, the order of evaluation here is such that larger and larger
 items are passed to the `@` operator as its first argument, and so the function
 has a worse running time than
-[`List.concat`](/manual/lts/api/List.html#VALconcat). You can read more
+[`List.concat`](/manual/latest/api/List.html#VALconcat). You can read more
 about the time and space efficiency of lists and other common OCaml data
 structures in the [comparison of standard
 containers](/docs/data-structures-comparison).
 
 Here are some more redefinitions of familiar functions in terms of
-[`fold_left`](/manual/lts/api/List.html#VALfold_left) or
-[`fold_right`](/manual/lts/api/List.html#VALfold_right). Can you work
+[`fold_left`](/manual/latest/api/List.html#VALfold_left) or
+[`fold_right`](/manual/latest/api/List.html#VALfold_right). Can you work
 out how they operate?
 
 ```ocaml

--- a/data/tutorials/language/0it_05_imperative.md
+++ b/data/tutorials/language/0it_05_imperative.md
@@ -677,7 +677,7 @@ A module may expose or encapsulate a state in several different ways:
 1. It depends: only expose state initialisation, which implies there only is a single state
 1. Bad: mutable state with no explicit initialisation function or no name referring to the mutable state
 
-For example, the [`Hashtbl`](/manual/lts/api/Hashtbl.html) module provides an interface of the first kind. It has the type `Hashtbl.t` representing mutable data. It also exposes `create`, `clear`, and `reset` functions. The `clear` and `reset` functions return `unit`. This strongly signals the reader that they perform the side-effect of updating the mutable data.
+For example, the [`Hashtbl`](/manual/latest/api/Hashtbl.html) module provides an interface of the first kind. It has the type `Hashtbl.t` representing mutable data. It also exposes `create`, `clear`, and `reset` functions. The `clear` and `reset` functions return `unit`. This strongly signals the reader that they perform the side-effect of updating the mutable data.
 ```ocaml
 # #show Hashtbl.t;;
 type ('a, 'b) t = ('a, 'b) Hashtbl.t
@@ -751,7 +751,7 @@ Error: Unbound module Analytics
 
 **Note:** This code will not run because there is no module called `Analytics`. [Analytics](https://en.wikipedia.org/wiki/Web_analytics) are remote monitoring libraries.
 
-A module called `Array` is defined; it shadows and includes the [`Stdlib.Array`](/manual/lts/api/Array.html) module. See the [Module Inclusion](docs/modules#module-inclusion) part of the [Modules](docs/modules) tutorial for details about this pattern.
+A module called `Array` is defined; it shadows and includes the [`Stdlib.Array`](/manual/latest/api/Array.html) module. See the [Module Inclusion](docs/modules#module-inclusion) part of the [Modules](docs/modules) tutorial for details about this pattern.
 
 To understand why this code is bad, figure out that `Analytics.collect` is a function that makes a network connection to transmit data to a remote server.
 

--- a/data/tutorials/language/1ms_00_modules.md
+++ b/data/tutorials/language/1ms_00_modules.md
@@ -87,7 +87,7 @@ let () = hello ()
 ```
 
 Using `open` is optional. Usually, we don't open a module like `List` because it
-provides names other modules also provide, such as [`Array`](/manual/lts/api/Array.html) or `Option`. Modules
+provides names other modules also provide, such as [`Array`](/manual/latest/api/Array.html) or `Option`. Modules
 like `Printf` provide names that aren't subject to conflicts, such as `printf`.
 Placing `open Printf` at the top of a file avoids writing `Printf.printf` repeatedly.
 ```ocaml

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -42,9 +42,9 @@ Check that this works using the `opam exec -- dune exec funkt` command. It shoul
 
 ## Using an Existing Functor: `Set.Make`
 
-The standard library contains a [`Set`](/manual/lts/api/Set.html) module which is designed to handle sets. This module enables you to perform operations such as union, intersection, and difference on sets. You may check the [Set](/docs/sets) tutorial to learn more about this module, but it is not required to follow the present tutorial.
+The standard library contains a [`Set`](/manual/latest/api/Set.html) module which is designed to handle sets. This module enables you to perform operations such as union, intersection, and difference on sets. You may check the [Set](/docs/sets) tutorial to learn more about this module, but it is not required to follow the present tutorial.
 
-To create a set module for a given element type (which allows you to use the provided type and its associated [functions](/manual/lts/api/Set.S.html)), it's necessary to use the functor `Set.Make` provided by the `Set` module. Here is a simplified version of `Set`'s interface:
+To create a set module for a given element type (which allows you to use the provided type and its associated [functions](/manual/latest/api/Set.S.html)), it's necessary to use the functor `Set.Make` provided by the `Set` module. Here is a simplified version of `Set`'s interface:
 ```ocaml
 module type OrderedType = sig
   type t
@@ -57,7 +57,7 @@ module Make : functor (Ord : OrderedType) -> Set.S
 Here is how this reads (starting from the bottom, then going up):
 * Like a function (indicated by the arrow `->`), the functor `Set.Make`
   - takes a module with signature `OrderedType` and
-  - returns a module with signature [`Set.S`](/manual/lts/api/Set.S.html)
+  - returns a module with signature [`Set.S`](/manual/latest/api/Set.S.html)
 * The module type `OrderedType` requires a type `t` and a function `compare`, which are used to perform the comparisons between elements of the set.
 
 **Note**: Most set operations need to compare elements to check if they are the same. To allow using a user-defined comparison algorithm, the `Set.Make` functor takes a module that specifies both the element type `t` and the `compare` function. Passing the comparison function as a higher-order parameter, as done in `Array.sort`, for example, would add a lot of boilerplate code. Providing set operations as a functor allows specifying the comparison function only once.
@@ -184,9 +184,9 @@ end
 ```
 
 The functors  `Set.Make`, `Map.Make`, and `Hashtbl.Make` return modules satisfying the interfaces `Set.S`, `Map.S`, and `Hashtbl.S` (respectively), which all contain an abstract type `t` and associated functions. Refer to the documentation for the details about what they provide:
-* [`Set.S`](/manual/lts/api/Set.S.html)
-* [`Map.S`](/manual/lts/api/Map.S.html)
-* [`Hashtbl.S`](/manual/lts/api/Hashtbl.S.html)
+* [`Set.S`](/manual/latest/api/Set.S.html)
+* [`Map.S`](/manual/latest/api/Map.S.html)
+* [`Hashtbl.S`](/manual/latest/api/Hashtbl.S.html)
 
 ### Writing Your Own Functors
 
@@ -352,7 +352,7 @@ The dependency `List` is _injected_ when compiling the module `Funkt`. Observe t
 
 **Replacing a Dependency**
 
-Now, replacing the implementation of `iter` inside `IterListPrint` is no longer a refactoring; it is another functor application with another dependency. Here, [`Array`](/manual/lts/api/Array.html) replaces `List`:
+Now, replacing the implementation of `iter` inside `IterListPrint` is no longer a refactoring; it is another functor application with another dependency. Here, [`Array`](/manual/latest/api/Array.html) replaces `List`:
 
 **`funkt.ml`**
 ```ocaml
@@ -420,7 +420,7 @@ In the example above, `t` from `with type` takes precedence over the local `t`, 
 
 In this section, we define a functor to extend several modules in the same way. This is the same idea as in the [Extending a Module with a Standard Library Functor](#extending-a-module-with-a-standard-library-functor), except we write the functor ourselves.
 
-In this example, we extend `List` and [`Array`](/manual/lts/api/Array.html) modules with a function `scan_left`. It does almost the same as `fold_left`, except it returns all the intermediate values, not the last one as `fold_left` does.
+In this example, we extend `List` and [`Array`](/manual/latest/api/Array.html) modules with a function `scan_left`. It does almost the same as `fold_left`, except it returns all the intermediate values, not the last one as `fold_left` does.
 
 Create a fresh directory with the following files:
 

--- a/data/tutorials/language/3ds_00_options.md
+++ b/data/tutorials/language/3ds_00_options.md
@@ -45,7 +45,7 @@ See [Error Handling](/docs/error-handling) for a longer discussion on error hand
 
 ## The Standard Library `Option` Module
 
-Most of the functions in this section, as well as other useful ones, are provided by the OCaml standard library in the [`Stdlib.Option`](/manual/lts/api/Option.html) module.
+Most of the functions in this section, as well as other useful ones, are provided by the OCaml standard library in the [`Stdlib.Option`](/manual/latest/api/Option.html) module.
 
 ### Map Over an Option
 

--- a/data/tutorials/language/3ds_01_arrays.md
+++ b/data/tutorials/language/3ds_01_arrays.md
@@ -10,7 +10,7 @@ category: "Data Structures"
 
 In OCaml, arrays are collections of elements of one type. Unlike lists, arrays can be mutated by replacing their elements with other values of the same type, but cannot be resized. Arrays also allow efficient access to elements at any position.
 
-Despite these differences, many of the functions readily available on arrays are similar to the ones available for lists. Please refer to the [List tutorial](https://ocaml.org/docs/lists) and [documentation](/manual/lts/api/List.html) for more details about these functions.
+Despite these differences, many of the functions readily available on arrays are similar to the ones available for lists. Please refer to the [List tutorial](https://ocaml.org/docs/lists) and [documentation](/manual/latest/api/List.html) for more details about these functions.
 
 This tutorial aims to introduce the subject of arrays in OCaml and showcase the most useful functions and use cases.
 
@@ -63,7 +63,7 @@ To modify an element in an array, we simply assign a new value to it using the i
 
 Note that this operation returns `unit`, not the modified array. `even_numbers` is modified in place as a side effect.
 
-## The Standard Library [`Array`](/manual/lts/api/Array.html) Module
+## The Standard Library [`Array`](/manual/latest/api/Array.html) Module
 
 OCaml provides several useful functions for working with arrays. Here are some of the most common ones:
 
@@ -176,4 +176,4 @@ This copies two elements of `zeroes`, starting at index `1` into the last part o
 
 ## Conclusion
 
-In this tutorial, we covered the basics of arrays in OCaml, including how to create and manipulate them, as well as some of the most useful functions and use cases. Please refer to the [standard library documentation](/manual/lts/api/Array.html) to browse the complete list of functions of the [`Array`](/manual/lts/api/Array.html) module.
+In this tutorial, we covered the basics of arrays in OCaml, including how to create and manipulate them, as well as some of the most useful functions and use cases. Please refer to the [standard library documentation](/manual/latest/api/Array.html) to browse the complete list of functions of the [`Array`](/manual/latest/api/Array.html) module.

--- a/data/tutorials/language/3ds_02_maps.md
+++ b/data/tutorials/language/3ds_02_maps.md
@@ -8,7 +8,7 @@ category: "Data Structures"
 
 ## Introduction
 
-The [`Map`](/manual/lts/api/Map.html) module lets you create _immutable_ key-value [association
+The [`Map`](/manual/latest/api/Map.html) module lets you create _immutable_ key-value [association
 tables](https://en.wikipedia.org/wiki/Associative_array) for your types. Such
 maps are never modified, and every operation returns a new map instead.
 
@@ -16,7 +16,7 @@ maps are never modified, and every operation returns a new map instead.
 functions such as `List.map`, `Array.map`, `Option.map`, and others. The maps
 described in this tutorial are also called dictionaries or associative tables.
 
-To use `Map`, we first have to use the [`Map.Make`](/manual/lts/api/Map.Make.html) functor to create our custom
+To use `Map`, we first have to use the [`Map.Make`](/manual/latest/api/Map.Make.html) functor to create our custom
 map module. Refer to the [Functors](/docs/functors) for more information on
 functors. This functor has a module parameter that defines the keys' type to
 be used in the maps, and a function for comparing them.
@@ -317,5 +317,5 @@ end
 This was an overview of OCaml's `Map` module. Maps are reasonably efficient and
 can be an alternative to the imperative `Hashtbl` module.
 
-For more information, refer to [Map](/manual/lts/api/Map.html) in the Standard Library
+For more information, refer to [Map](/manual/latest/api/Map.html) in the Standard Library
 documentation.

--- a/data/tutorials/language/3ds_03_sets.md
+++ b/data/tutorials/language/3ds_03_sets.md
@@ -215,5 +215,5 @@ end);;
 
 ## Conclusion
 
-We gave an overview of OCaml's `Set` module by creating a `StringSet` module using the `Set.Make` functor. Further, we looked at how to create sets based on a custom comparison function. For more information, refer to [Set](/manual/lts/api/Set.Make.html) in the Standard Library documentation.
+We gave an overview of OCaml's `Set` module by creating a `StringSet` module using the `Set.Make` functor. Further, we looked at how to create sets based on a custom comparison function. For more information, refer to [Set](/manual/latest/api/Set.Make.html) in the Standard Library documentation.
 

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -176,7 +176,7 @@ instance:
 * `Seq.map`
 * `Seq.fold_left`
 
-All those are also available for [`Array`](/manual/lts/api/Array.html), `List`, and `Set` and behave
+All those are also available for [`Array`](/manual/latest/api/Array.html), `List`, and `Set` and behave
 essentially the same. Observe that there is no `fold_right` function. Since
 OCaml 4.11, there is something which isn't (yet) available on other types:
 `unfold`. Here is how it is implemented:

--- a/data/tutorials/language/4ad_00_metaprogramming.md
+++ b/data/tutorials/language/4ad_00_metaprogramming.md
@@ -179,7 +179,7 @@ need to understand what this Parsetree is.
 During the compilation phase, OCaml's compiler will parse the input file into an
 internal representation of it, called the Parsetree. The program is represented
 as a tree, with a complex OCaml type that you can find in the [`Parsetree`
-module](/manual/lts/api/compilerlibref/Parsetree.html).
+module](/manual/latest/api/compilerlibref/Parsetree.html).
 
 Let's look at a few properties of this tree:
 - Each node in the AST has a type corresponding to a different role, such as
@@ -190,7 +190,7 @@ Let's look at a few properties of this tree:
 
 There are several complementary ways of getting a grasp on the Parsetree type.
 One is to read the [API
-documentation](/manual/lts/api/compilerlibref/Parsetree.html), which
+documentation](/manual/latest/api/compilerlibref/Parsetree.html), which
 includes examples of what each type and value represent. Another is to
 examine the Parsetree value of crafted OCaml code. This can be achieved using
 the external tool [astexplorer](https://astexplorer.net/), our OCaml
@@ -509,7 +509,7 @@ questions, especially in the presence of multiple PPX rewriters.
 - How can I write a PPX easily if I have to deal with parsing or demarshalling
   an AST?
 - How can I deal with such a [long and complex
-  type](/manual/lts/api/compilerlibref/Parsetree.html) as in Parsetree?
+  type](/manual/latest/api/compilerlibref/Parsetree.html) as in Parsetree?
 - How can I solve the problem that new OCaml versions tend to add new features
   to the language and therefore need to enrich and break the Parsetree types?
 

--- a/data/tutorials/language/4ad_01_operators.md
+++ b/data/tutorials/language/4ad_01_operators.md
@@ -169,7 +169,7 @@ In both cases, values are passed to `@^` before `&^`. Therefore, it is said that
 1. Left associative: `%` `*` `/`
 1. Left associative: `#`
 
-The complete list of precedence is longer because it includes the predefined operators that are not allowed to be used as custom operators. The OCaml Manual has a [table](/manual/lts/api/Ocaml_operators.html) that sums up the operator associativity rules.
+The complete list of precedence is longer because it includes the predefined operators that are not allowed to be used as custom operators. The OCaml Manual has a [table](/manual/latest/api/Ocaml_operators.html) that sums up the operator associativity rules.
 
 ## Binding Operators
 

--- a/data/tutorials/language/5rt_00_memory_representation.md
+++ b/data/tutorials/language/5rt_00_memory_representation.md
@@ -179,7 +179,7 @@ collection process described earlier.
 The `size` field records the length of the block in memory words. This is 22
 bits on 32-bit platforms, which is the reason OCaml strings are limited to 16
 MB on that architecture. If you need bigger strings, either switch to a
-64-bit host, or use the [`Bigarray`](/manual/lts/api/Bigarray.html) module.
+64-bit host, or use the [`Bigarray`](/manual/latest/api/Bigarray.html) module.
 
 The 2-bit `color` field is used by the GC to keep track of its state during
 mark-and-sweep collection.
@@ -551,7 +551,7 @@ libraries use it for general-purpose I/O:
 
 `Bigstring`
 : The `Bigstring` module provides a `String`-like interface that uses
-  [`Bigarray`](/manual/lts/api/Bigarray.html) internally. The `Bigbuffer` collects these into extensible
+  [`Bigarray`](/manual/latest/api/Bigarray.html) internally. The `Bigbuffer` collects these into extensible
   string buffers that can operate entirely on external system memory.
 
 The [Lacaml](http://mmottl.github.io/lacaml/) library isn't part of Core but

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -125,11 +125,9 @@ let router t =
       Dream.scope ""
         [ Dream_encoding.compress ]
         [
-          Dream.get "/manual/**" (Dream.static Config.manual_path);
           Dream.get "/manual/latest/**"
             (Dream.static (Config.manual_path ^ "/5.2"));
-          Dream.get "/manual/lts/**"
-            (Dream.static (Config.manual_path ^ "/4.14"));
+          Dream.get "/manual/**" (Dream.static Config.manual_path);
         ];
       Dream.scope ""
         [ Dream_encoding.compress ]


### PR DESCRIPTION
- order of routes was wrong, the catchall route prevented the /latest route to be served
- /manual/lts URL probably not necessary, removing

Links to manual and stdlib from docs should now work.