### PR TITLE
Handle lts, default and missing version in middleware

### DIFF
--- a/src/ocamlorg_data/data.ml
+++ b/src/ocamlorg_data/data.ml
@@ -168,7 +168,22 @@ module Release = struct
   include Release
 
   let get_by_version version =
-    List.find_opt (fun x -> String.equal version x.version) all
+    if version = "lts" then Some lts
+    else if version = "latest" then Some latest
+    else
+      match
+        List.filter (fun x -> String.starts_with ~prefix:version x.version) all
+      with
+      | [] -> None
+      | [ release ] -> Some release
+      | u :: v ->
+          let version r =
+            r.version |> String.split_on_char '.' |> List.map int_of_string
+          in
+          Some
+            (List.fold_left
+               (fun r1 r2 -> if version r1 > version r2 then r1 else r2)
+               u v)
 end
 
 module News = struct

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -9,7 +9,7 @@ let no_trailing_slash next_handler request =
   if Dream.target request = target then next_handler request
   else Dream.redirect request target
 
-let versioning next_handler request =
+let language_manual next_handler request =
   let init_path = request |> Dream.target |> String.split_on_char '/' in
   let path =
     let minor (release : Data.Release.t) = Ocamlorg.Url.minor release.version in

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -11,26 +11,15 @@ let no_trailing_slash next_handler request =
 
 let versioning next_handler request =
   let init_path = request |> Dream.target |> String.split_on_char '/' in
-  let expand_version = function
-    | "lts" -> Ocamlorg.Url.minor Data.Release.lts.version
-    | "latest" -> Ocamlorg.Url.minor Data.Release.latest.version
-    | s -> s
-  in
-  let path = init_path |> List.map expand_version in
   let path =
-    match path with
-    | "" :: "manual" :: something :: tl -> (
-        match
-          List.find_opt
-            (fun (x : Data.Release.t) ->
-              Ocamlorg.Url.minor x.version = something)
-            Data.Release.all
-        with
-        | Some _ -> path
+    match init_path with
+    | "" :: "manual" :: something :: tl ->
+        "" :: "manual"
+        ::
+        (match Data.Release.get_by_version something with
+        | Some release -> Ocamlorg.Url.minor release.version :: tl
         | None ->
-            "" :: "manual"
-            :: Ocamlorg.Url.minor Data.Release.latest.version
-            :: something :: tl)
+            Ocamlorg.Url.minor Data.Release.latest.version :: something :: tl)
     | u -> u
   in
   let target = String.concat "/" path in

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -9,19 +9,30 @@ let no_trailing_slash next_handler request =
   if Dream.target request = target then next_handler request
   else Dream.redirect request target
 
-
 let versioning next_handler request =
   let init_path = request |> Dream.target |> String.split_on_char '/' in
   let expand_version = function
     | "lts" -> Ocamlorg.Url.minor Data.Release.lts.version
     | "latest" -> Ocamlorg.Url.minor Data.Release.latest.version
-    | s -> s in
+    | s -> s
+  in
   let path = init_path |> List.map expand_version in
-  let path = match path with
-  | "" :: "manual" :: something :: tl -> (match List.find_opt (fun (x : Data.Release.t) -> Ocamlorg.Url.minor x.version = something) Data.Release.all with
-   | Some _ -> path
-   | None -> "" :: "manual" :: Ocamlorg.Url.minor Data.Release.latest.version :: something :: tl)
-  | u -> u in
+  let path =
+    match path with
+    | "" :: "manual" :: something :: tl -> (
+        match
+          List.find_opt
+            (fun (x : Data.Release.t) ->
+              Ocamlorg.Url.minor x.version = something)
+            Data.Release.all
+        with
+        | Some _ -> path
+        | None ->
+            "" :: "manual"
+            :: Ocamlorg.Url.minor Data.Release.latest.version
+            :: something :: tl)
+    | u -> u
+  in
   let target = String.concat "/" path in
   if init_path = path then next_handler request
   else Dream.redirect request target

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -9,6 +9,23 @@ let no_trailing_slash next_handler request =
   if Dream.target request = target then next_handler request
   else Dream.redirect request target
 
+
+let versioning next_handler request =
+  let init_path = request |> Dream.target |> String.split_on_char '/' in
+  let expand_version = function
+    | "lts" -> Ocamlorg.Url.minor Data.Release.lts.version
+    | "latest" -> Ocamlorg.Url.minor Data.Release.latest.version
+    | s -> s in
+  let path = init_path |> List.map expand_version in
+  let path = match path with
+  | "" :: "manual" :: something :: tl -> (match List.find_opt (fun (x : Data.Release.t) -> Ocamlorg.Url.minor x.version = something) Data.Release.all with
+   | Some _ -> path
+   | None -> "" :: "manual" :: Ocamlorg.Url.minor Data.Release.latest.version :: something :: tl)
+  | u -> u in
+  let target = String.concat "/" path in
+  if init_path = path then next_handler request
+  else Dream.redirect request target
+
 let head handler request =
   match Dream.method_ request with
   | `HEAD ->

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -9,7 +9,7 @@ let no_trailing_slash next_handler request =
   if Dream.target request = target then next_handler request
   else Dream.redirect request target
 
-let language_manual next_handler request =
+let language_manual_version next_handler request =
   let init_path = request |> Dream.target |> String.split_on_char '/' in
   let path =
     let minor (release : Data.Release.t) = Ocamlorg.Url.minor release.version in

--- a/src/ocamlorg_web/lib/middleware.ml
+++ b/src/ocamlorg_web/lib/middleware.ml
@@ -12,14 +12,15 @@ let no_trailing_slash next_handler request =
 let versioning next_handler request =
   let init_path = request |> Dream.target |> String.split_on_char '/' in
   let path =
+    let minor (release : Data.Release.t) = Ocamlorg.Url.minor release.version in
     match init_path with
     | "" :: "manual" :: something :: tl ->
         "" :: "manual"
-        ::
-        (match Data.Release.get_by_version something with
-        | Some release -> Ocamlorg.Url.minor release.version :: tl
-        | None ->
-            Ocamlorg.Url.minor Data.Release.latest.version :: something :: tl)
+        :: Data.Release.(
+             Option.fold
+               ~none:(minor latest ^ "/" ^ something)
+               ~some:minor (get_by_version something))
+        :: tl
     | u -> u
   in
   let target = String.concat "/" path in

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -13,8 +13,8 @@ let run () =
   let state = Ocamlorg_package.init () in
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
-    @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.versioning
-    @@ Middleware.head @@ Router.router state
+    @@ Dream.logger @@ Middleware.no_trailing_slash
+    @@ Middleware.language_manual @@ Middleware.head @@ Router.router state
   with
   | Unix.Unix_error (err, fn, _) ->
       Format.eprintf "%S failed: %s@." fn (Unix.error_message err);

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -13,8 +13,8 @@ let run () =
   let state = Ocamlorg_package.init () in
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
-    @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.versioning @@ Middleware.head
-    @@ Router.router state
+    @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.versioning
+    @@ Middleware.head @@ Router.router state
   with
   | Unix.Unix_error (err, fn, _) ->
       Format.eprintf "%S failed: %s@." fn (Unix.error_message err);

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -14,7 +14,8 @@ let run () =
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
     @@ Dream.logger @@ Middleware.no_trailing_slash
-    @@ Middleware.language_manual_version @@ Middleware.head @@ Router.router state
+    @@ Middleware.language_manual_version @@ Middleware.head
+    @@ Router.router state
   with
   | Unix.Unix_error (err, fn, _) ->
       Format.eprintf "%S failed: %s@." fn (Unix.error_message err);

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -14,7 +14,7 @@ let run () =
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
     @@ Dream.logger @@ Middleware.no_trailing_slash
-    @@ Middleware.language_manual @@ Middleware.head @@ Router.router state
+    @@ Middleware.language_manual_version @@ Middleware.head @@ Router.router state
   with
   | Unix.Unix_error (err, fn, _) ->
       Format.eprintf "%S failed: %s@." fn (Unix.error_message err);

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -13,7 +13,7 @@ let run () =
   let state = Ocamlorg_package.init () in
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port
-    @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.head
+    @@ Dream.logger @@ Middleware.no_trailing_slash @@ Middleware.versioning @@ Middleware.head
     @@ Router.router state
   with
   | Unix.Unix_error (err, fn, _) ->

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -124,9 +124,7 @@ let router t =
       sitemap_routes;
       Dream.scope ""
         [ Dream_encoding.compress ]
-        [
-          Dream.get "/manual/**" (Dream.static Config.manual_path);
-        ];
+        [ Dream.get "/manual/**" (Dream.static Config.manual_path) ];
       Dream.scope ""
         [ Dream_encoding.compress ]
         [ Dream.get "/media/**" (Dream.static ~loader:media_loader "") ];

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -125,8 +125,6 @@ let router t =
       Dream.scope ""
         [ Dream_encoding.compress ]
         [
-          Dream.get "/manual/latest/**"
-            (Dream.static (Config.manual_path ^ "/5.2"));
           Dream.get "/manual/**" (Dream.static Config.manual_path);
         ];
       Dream.scope ""


### PR DESCRIPTION
Fix Issue #2357

New redirects also introduced
* X into X.max
* X.Y.Z into X.Y