### PR TITLE
Add event_type field to Events, and render tag in Event cards

### DIFF
--- a/data/events/2024-02-09-oups.md
+++ b/data/events/2024-02-09-oups.md
@@ -1,5 +1,6 @@
 ---
 title: "OCaml Users in Paris (OUPS)"
+event_type: meetup
 textual_location: Paris, France
 location:
   lat: 48.8566

--- a/data/events/2024-03-08-s-repls.md
+++ b/data/events/2024-03-08-s-repls.md
@@ -1,5 +1,6 @@
 ---
 title: "S-REPLS 14"
+event_type: seminar
 textual_location: "London, United Kingdom"
 url: https://www.cl.cam.ac.uk/events/s-repls14/
 recurring_event_slug: s-repls-programming-languages-seminar

--- a/data/events/2024-03-10-ocaml-retreat-auroville.md
+++ b/data/events/2024-03-10-ocaml-retreat-auroville.md
@@ -1,5 +1,6 @@
 ---
 title: "OCaml Retreat"
+event_type: retreat
 textual_location: "Auroville, India"
 url: https://ocamlretreat.org/
 recurring_event_slug: ocaml-retreat

--- a/data/events/2024-04-04-ocaml-manila.md
+++ b/data/events/2024-04-04-ocaml-manila.md
@@ -1,5 +1,6 @@
 ---
 title: "OCaml Manila: Inaugural Hackathon Night"
+event_type: meetup
 textual_location: Manila, Philippines
 url: https://www.meetup.com/ocaml-manila/events/299786391/
 recurring_event_slug: ocaml-manila-meetup

--- a/data/events/2024-04-22-mirageos-retreat.md
+++ b/data/events/2024-04-22-mirageos-retreat.md
@@ -1,5 +1,6 @@
 ---
 title: "MirageOS hack retreat"
+event_type: retreat
 textual_location: "Marrakesh, Morocco"
 location:
   lat: 31.628674

--- a/data/events/2024-04-25-oups.md
+++ b/data/events/2024-04-25-oups.md
@@ -1,5 +1,6 @@
 ---
 title: "OCaml Users in Paris (OUPS)"
+event_type: meetup
 textual_location: Paris, France
 location:
   lat: 48.8566

--- a/data/events/2024-09-07-ocaml-workshop.md
+++ b/data/events/2024-09-07-ocaml-workshop.md
@@ -1,5 +1,6 @@
 ---
 title: "OCaml Users and Developers Workshop 2024"
+event_type: conference
 textual_location: "Milan, Italy"
 url: https://icfp24.sigplan.org/home/ocaml-2024#Call-for-Papers
 starts:

--- a/data/events/recurring.yml
+++ b/data/events/recurring.yml
@@ -1,6 +1,7 @@
 recurring:
   - title: "OCaml Users in Paris (OUPS)"
     slug: "ocaml-users-paris-oups"
+    event_type: meetup
     textual_location: Paris, France
     location:
       lat: 48.8566
@@ -8,6 +9,7 @@ recurring:
     url: https://www.meetup.com/ocaml-paris/
   - title: "NYC OCaml Meetup"
     slug: "nyc-ocaml-meetup"
+    event_type: meetup
     textual_location: New York City, New York, USA
     location:
       lat: 40.7128
@@ -15,6 +17,7 @@ recurring:
     url: https://www.meetup.com/NYC-OCaml
   - title: "Silicon Valley OCaml Meetup"
     slug: "silicon-valley-ocaml-meetup"
+    event_type: meetup
     textual_location: San Francisco, California, USA
     location:
       lat: 37.7749
@@ -22,6 +25,7 @@ recurring:
     url: https://www.meetup.com/sv-ocaml/
   - title: "Cambridge NonDysFunctional Programmers"
     slug: "cambridge-nondysfunctional-programmers"
+    event_type: meetup
     textual_location: Cambridge, United Kingdom
     location:
       lat: 52.2053
@@ -29,6 +33,7 @@ recurring:
     url: https://www.meetup.com/Cambridge-NonDysFunctional-Programmers/
   - title: "MirageOS hack retreat"
     slug: "mirageos-hack-retreat"
+    event_type: retreat
     textual_location: "Marrakesh, Morocco"
     location:
       lat: 31.628674
@@ -36,17 +41,21 @@ recurring:
     url: https://retreat.mirage.io/
   - title: "South of England Regional Programming Language Seminar"
     slug: "s-repls-programming-languages-seminar"
+    event_type: seminar
     textual_location: "London, United Kingdom"
     url: https://srepls.github.io/
   - title: "OCaml Retreat"
     slug: "ocaml-retreat"
+    event_type: retreat
     textual_location: "Auroville, India"
     url: https://ocamlretreat.org/
   - title: "OCaml Manila Meetup"
     slug: "ocaml-manila-meetup"
+    event_type: meetup
     textual_location: "Manila, Philippines"
     url: https://www.meetup.com/ocaml-manila/
   - title: "ReasonSTHLM Meetup"
     slug: "reason-stockholm-meetup"
+    event_type: meetup
     textual_location: "Stockholm, Sweden"
     url: https://www.meetup.com/ReasonSTHLM/

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -452,6 +452,7 @@ module Is_ocaml_yet : sig
 end
 
 module Event : sig
+  type event_type = Meetup | Conference | Seminar | Hackathon | Retreat
   type location = { lat : float; long : float }
 
   module RecurringEvent : sig
@@ -461,6 +462,7 @@ module Event : sig
       url : string;
       textual_location : string;
       location : location option;
+      event_type : event_type;
     }
 
     val all : t list
@@ -480,6 +482,7 @@ module Event : sig
     body_md : string;
     body_html : string;
     recurring_event : RecurringEvent.t option;
+    event_type : event_type;
   }
 
   val all : t list

--- a/src/ocamlorg_frontend/pages/events.eml
+++ b/src/ocamlorg_frontend/pages/events.eml
@@ -1,3 +1,17 @@
+let string_from_event_type = function
+  | Data.Event.Meetup -> "Meetup"
+  | Conference -> "Conference"
+  | Seminar -> "Seminar"
+  | Hackathon -> "Hackathon"
+  | Retreat -> "Retreat"
+
+let color_for_event_type = function
+  | Data.Event.Meetup -> "bg-avatar-6"
+  | Conference -> "bg-avatar-0"
+  | Seminar -> "bg-avatar-11"
+  | Hackathon -> "bg-avatar-8"
+  | Retreat -> "bg-avatar-9"
+
 let render ~recurring_events ~upcoming_events =
 Community_layout.single_column_layout
 ~title:"The Events"
@@ -16,6 +30,9 @@ Community_layout.single_column_layout
               <% upcoming_events |> List.iter (fun (event : Data.Event.t) -> %>
               <a href="<%s event.url %>" class="card dark:dark-card p-5 rounded-xl">
                 <p class="font-bold text-title dark:text-dark-title mb-2"><%s event.title %></p>
+                <div class="px-3 mb-2 inline-block <%s color_for_event_type event.event_type %> rounded-3xl font-mono text-sm text-center text-white">
+                  <%s string_from_event_type event.event_type %>
+                </div>
                 <div class="flex items-center space-x-2 mb-3">
                   <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary mr-2" %>
                   <p class="text-content dark:text-dark-content"><%s event.textual_location %></p>
@@ -50,6 +67,9 @@ Community_layout.single_column_layout
           <p class="font-bold text-lg text-title dark:text-dark-title mb-3">
               <%s recurring_event.title %>
           </p>
+          <div class="px-3 mb-2 inline-block <%s color_for_event_type recurring_event.event_type %> rounded-3xl font-mono text-sm text-center text-white">
+            <%s string_from_event_type recurring_event.event_type %>
+          </div>
           <div class="flex items-center space-x-2">
             <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary" %>
             <p class="text-content dark:text-dark-content">


### PR DESCRIPTION
Addresses #2361. This PR:

- adds a new `event_type` field to the types `t` and `RecurringEvent.t` (and their respective metadata types) in `tool/ood-gen/lib/event.ml`,
- updates the `Event` module signature in `src/ocamlorg_data/data.mli`,
- adds an `event_type` value to the entries in `data/events/recurring.yml` and the `data/events/*.md` files, and
- makes a first attempt at rendering a tag in Event cards (for both upcoming and recurring events) on the Events page:
  <details><summary>(expand image)</summary>
  <img src="https://github.com/ocaml/ocaml.org/assets/59682192/87957496-e6be-4db2-839f-aa4b0185baa8" width=100%>
  </details>

Some notes:

- Entries in `recurring.yml` must always specify an `event_type` value. `*.md` files can omit them, but only if they have a linked recurring event.
- An upcoming event's `event_type` value is populated from either its `*.md` metadata, or its linked recurring event (if there is one). If these two sources specify different event types, or if neither specifies one, it is an error (and an exception is raised in `tool/ood-gen/lib/event.ml` when that happens).
- The event type tags in `src/ocamlorg_frontend/pages/events.eml` use the tag colors from [the Community pages design draft](https://www.figma.com/file/7hmoWkQP9PgLTfZCqiZMWa/OCaml-Community-Pages?type=design&node-id=973-5423&mode=design&t=NSEmv1UycNyd52rF-4).
- Do we also want to render these tags in other pages, e.g. the Upcoming Events section of the Community landing page?
