### PR TITLE
jobs: remove XenServer positions

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -137,20 +137,6 @@ jobs:
     publication_date: 2023-03-06
     company: IRIF, Université Paris-Cité
     company_logo: https://www.irif.fr/_media/irif_horizontal_noborder.svg
-  - title: XenServer Toolstack - Software Engineer
-    link: https://careers.cloud.com/jobs/software-engineer-xenserver-toolstack-cambridge-cambridgeshire-united-kingdom
-    locations:
-      - Cambridge, United-Kingdom
-    publication_date: 2024-01-04
-    company: XenServer, Cloud Software Group
-    company_logo: https://www.xenserver.com/content/dam/xenserver/images/xenserver-full-color-rgb.svg
-  - title: XenServer Toolstack - Senior Software Engineer
-    link: https://careers.cloud.com/jobs/senior-software-engineer-xenserver-toolstack-cambridge-cambridgeshire-united-kingdom
-    locations:
-      - Cambridge, United-Kingdom
-    publication_date: 2024-01-04
-    company: XenServer, Cloud Software Group
-    company_logo: https://www.xenserver.com/content/dam/xenserver/images/xenserver-full-color-rgb.svg
   - title: Software Engineer
     link: https://base.routine.co/jobs/positions/backend-software-engineer
     locations:


### PR DESCRIPTION
The positions have been filled and the job links are now 404. We may have other positions in the future, but meanwhile remove the broken links.