### PR TITLE
Changelog entry for OCaml 5.2.0~rc1

### DIFF
--- a/data/changelog/ocaml/2024-05-02-ocaml-5.2.0.rc1.md
+++ b/data/changelog/ocaml/2024-05-02-ocaml-5.2.0.rc1.md
@@ -1,0 +1,54 @@
+---
+title: OCaml 5.2.0 - First Release Candidate
+description: First Release Candidate of OCaml 5.2.0
+tags: [ocaml]
+changelog: |
+  ## Changes since the second beta
+  
+  - [#13130](https://github.com/ocaml/ocaml/issues/13130): minor fixes to pprintast for raw identifiers and local module open
+    syntax for types.
+    (Chet Murthy, review by Gabriel Scherer)
+  
+  - [#13100](https://github.com/ocaml/ocaml/issues/13100) Fix detection of zstd when compiling with musl-gcc
+    (David Allsopp, review by  Samuel Hym)
+---
+
+
+The release of OCaml 5.2.0 is imminent.
+As a final step, we are publishing a release candidate to check that everything is in order before the release in the upcoming week(s).
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+Compared to the beta release, this release contains one safe runtime fix and two configuration tweaks.
+
+The full change log for OCaml 5.2.0 is available [on
+GitHub](https://github.com/ocaml/ocaml/blob/5.2/Changes). A short summary of the
+changes since the second beta release is also available below.
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1 and later:
+```bash
+opam update
+opam switch create 5.2.0~rc1
+```
+
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0-rc1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0~rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.2.0~rc1+options <option_list>
+```
+where `<option_list>` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.2.0~rc1+flambda+nffa ocaml-variants.5.2.0~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.

--- a/data/changelog/ocaml/2024-05-02-ocaml-5.2.0.rc1.md
+++ b/data/changelog/ocaml/2024-05-02-ocaml-5.2.0.rc1.md
@@ -19,7 +19,7 @@ As a final step, we are publishing a release candidate to check that everything 
 
 If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
 
-Compared to the beta release, this release contains one safe runtime fix and two configuration tweaks.
+Compared to the second beta, this release contains one small compiler-libs printer fix and one configuration tweak.
 
 The full change log for OCaml 5.2.0 is available [on
 GitHub](https://github.com/ocaml/ocaml/blob/5.2/Changes). A short summary of the

--- a/data/changelog/ocaml/2024-05-02-ocaml-5.2.0.rc1.md
+++ b/data/changelog/ocaml/2024-05-02-ocaml-5.2.0.rc1.md
@@ -5,12 +5,12 @@ tags: [ocaml]
 changelog: |
   ## Changes since the second beta
   
-  - [#13130](https://github.com/ocaml/ocaml/issues/13130): minor fixes to pprintast for raw identifiers and local module open
+  - [#13130](https://github.com/ocaml/ocaml/issues/13130): Minor fixes to `pprintast` for raw identifiers and local module open
     syntax for types.
     (Chet Murthy, review by Gabriel Scherer)
   
-  - [#13100](https://github.com/ocaml/ocaml/issues/13100) Fix detection of zstd when compiling with musl-gcc
-    (David Allsopp, review by  Samuel Hym)
+  - [#13100](https://github.com/ocaml/ocaml/issues/13100) Fix detection of `zstd` when compiling with `musl-gcc`
+    (David Allsopp, review by Samuel Hym)
 ---
 
 


### PR DESCRIPTION
This PR adds a changelog entry for the first release candidate of OCaml 5.2.0 .