### PR TITLE
Extract markdown processing from PR #2410

### DIFF
--- a/tool/ood-gen/lib/academic_institution.ml
+++ b/tool/ood-gen/lib/academic_institution.ml
@@ -42,7 +42,7 @@ let decode (fpath, (head, body_md)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fpath)
   in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true body_md |> Cmarkit_html.of_doc ~safe:true
+    Markdown.Content.of_string body_md |> Markdown.Content.render
   in
   Result.map (of_metadata ~body_md ~body_html) metadata
 

--- a/tool/ood-gen/lib/industrial_user.ml
+++ b/tool/ood-gen/lib/industrial_user.ml
@@ -32,7 +32,7 @@ let decode (fpath, (head, body_md)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fpath)
   in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true body_md |> Cmarkit_html.of_doc ~safe:true
+    Markdown.Content.of_string body_md |> Markdown.Content.render
   in
   Result.map (of_metadata ~body_md ~body_html) metadata
 

--- a/tool/ood-gen/lib/is_ocaml_yet.ml
+++ b/tool/ood-gen/lib/is_ocaml_yet.ml
@@ -47,13 +47,12 @@ let decode (fpath, (head, body_md)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fpath)
   in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true body_md |> Cmarkit_html.of_doc ~safe:true
+    Markdown.Content.of_string body_md |> Markdown.Content.render
   in
   let modify_categories u =
     let modify_description description =
-      Cmarkit.Doc.of_string ~strict:true (String.trim description)
-      |> Hilite.Md.transform
-      |> Cmarkit_html.of_doc ~safe:false
+      String.trim description |> Markdown.Content.of_string
+      |> Markdown.Content.render
     in
     List.map
       (fun cat ->

--- a/tool/ood-gen/lib/markdown.ml
+++ b/tool/ood-gen/lib/markdown.ml
@@ -1,0 +1,75 @@
+open Ocamlorg.Import
+
+module Toc = struct
+  type t = { title : string; href : string; children : t list }
+  [@@deriving show { with_path = false }]
+
+  let id_to_href id =
+    match id with
+    | None -> "#"
+    | Some (`Auto id) -> "#" ^ id
+    | Some (`Id id) -> "#" ^ id
+
+  let rec create_toc ~max_level level
+      (headings : Cmarkit.Block.Heading.t Cmarkit.node list) : t list =
+    match headings with
+    | [] -> []
+    | (h, _) :: rest when Cmarkit.Block.Heading.level h > max_level ->
+        create_toc ~max_level level rest
+    | (h, _) :: rest when Cmarkit.Block.Heading.level h = level ->
+        let l = Cmarkit.Block.Heading.level h in
+        let child_headings, remaining_headings =
+          collect_children ~max_level (l + 1) rest []
+        in
+        let children = create_toc ~max_level (l + 1) child_headings in
+        let title =
+          Cmarkit.Inline.to_plain_text ~break_on_soft:false
+            (Cmarkit.Block.Heading.inline h)
+        in
+        {
+          title = String.concat "\n" (List.map (String.concat "") title);
+          href = id_to_href (Cmarkit.Block.Heading.id h);
+          children;
+        }
+        :: create_toc ~max_level level remaining_headings
+    | (h, _) :: _ when Cmarkit.Block.Heading.level h > level ->
+        create_toc ~max_level (level + 1) headings
+    | _ :: rest -> create_toc ~max_level level rest
+
+  and collect_children ~max_level level
+      (headings : Cmarkit.Block.Heading.t Cmarkit.node list) acc =
+    match headings with
+    | [] -> (acc, [])
+    | (h, _) :: rest when Cmarkit.Block.Heading.level h > max_level ->
+        collect_children ~max_level level rest acc
+    | (h, _) :: _ when Cmarkit.Block.Heading.level h < level -> (acc, headings)
+    | heading :: rest ->
+        collect_children level ~max_level rest (acc @ [ heading ])
+
+  let headers (doc : Cmarkit.Doc.t) : Cmarkit.Block.Heading.t Cmarkit.node list
+      =
+    let rec headers_from_block (block : Cmarkit.Block.t) =
+      match block with
+      | Cmarkit.Block.Heading h -> [ h ]
+      | Cmarkit.Block.Blocks (blocks, _) ->
+          List.map headers_from_block blocks |> List.concat
+      | _ -> []
+    in
+
+    Cmarkit.Doc.block doc |> headers_from_block
+
+  let generate ?(start_level = 1) ?(max_level = 2) doc =
+    if max_level <= start_level then
+      invalid_arg "t: ~max_level must be >= ~start_level";
+    create_toc ~max_level start_level (headers doc)
+end
+
+module Content = struct
+  let of_string content =
+    Cmarkit.Doc.of_string ~strict:true ~heading_auto_ids:true content
+
+  let render ?(syntax_highlighting = false) doc =
+    if syntax_highlighting then
+      Hilite.Md.transform doc |> Cmarkit_html.of_doc ~safe:false
+    else doc |> Cmarkit_html.of_doc ~safe:false
+end

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -29,9 +29,8 @@ let decode (fname, (head, body)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fname)
   in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true (String.trim body)
-    |> Hilite.Md.transform
-    |> Cmarkit_html.of_doc ~safe:false
+    body |> Markdown.Content.of_string
+    |> Markdown.Content.render ~syntax_highlighting:true
   in
   Result.map (of_metadata ~slug ~body_html) metadata
 

--- a/tool/ood-gen/lib/outreachy.ml
+++ b/tool/ood-gen/lib/outreachy.ml
@@ -23,7 +23,7 @@ let modify_projects (v : project list) : project list =
       {
         title = p.title;
         description =
-          Cmarkit.Doc.of_string p.description |> Cmarkit_html.of_doc ~safe:true;
+          p.description |> Markdown.Content.of_string |> Markdown.Content.render;
         mentee = p.mentee;
         blog = p.blog;
         source = p.source;

--- a/tool/ood-gen/lib/page.ml
+++ b/tool/ood-gen/lib/page.ml
@@ -22,9 +22,8 @@ type t = {
 let decode (file, (head, body_md)) =
   let metadata = metadata_of_yaml head |> Result.map_error (Utils.where file) in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true body_md
-    |> Hilite.Md.transform
-    |> Cmarkit_html.of_doc ~safe:false
+    body_md |> Markdown.Content.of_string
+    |> Markdown.Content.render ~syntax_highlighting:true
   in
   let slug =
     file |> Filename.basename |> Filename.remove_extension

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -88,14 +88,13 @@ module Local = struct
         body_html;
       }
 
-    let decode (fpath, (head, body)) =
+    let decode (fpath, (head, body_md)) =
       let metadata =
         metadata_of_yaml head |> Result.map_error (Utils.where fpath)
       in
       let body_html =
-        Cmarkit.Doc.of_string ~strict:true (String.trim body)
-        |> Hilite.Md.transform
-        |> Cmarkit_html.of_doc ~safe:false
+        body_md |> Markdown.Content.of_string
+        |> Markdown.Content.render ~syntax_highlighting:true
       in
       let source, slug =
         match Str.split (Str.regexp_string "/") fpath with
@@ -213,13 +212,13 @@ module External = struct
         (metadata_to_yaml v |> Yaml.to_string
         |> Result.get_ok ~error:(fun (`Msg m) -> Exn.Decode_error m))
 
-    let decode (fpath, (head, body)) =
+    let decode (fpath, (head, body_md)) =
       let metadata =
         metadata_of_yaml head |> Result.map_error (Utils.where fpath)
       in
       let body_html =
-        Cmarkit.Doc.of_string ~strict:true (String.trim body)
-        |> Cmarkit_html.of_doc ~safe:true
+        body_md |> Markdown.Content.of_string
+        |> Markdown.Content.render ~syntax_highlighting:true
       in
       let source =
         match Str.split (Str.regexp_string "/") fpath with

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -44,13 +44,11 @@ type t = {
 let of_metadata m =
   of_metadata m ~intro_md:m.intro
     ~intro_html:
-      (Cmarkit.Doc.of_string ~strict:true m.intro
-      |> Cmarkit_html.of_doc ~safe:true)
+      (m.intro |> Markdown.Content.of_string |> Markdown.Content.render)
     ~highlights_md:m.highlights
     ~highlights_html:
-      (Cmarkit.Doc.of_string ~strict:true m.highlights
-      |> Hilite.Md.transform
-      |> Cmarkit_html.of_doc ~safe:false)
+      (m.highlights |> Markdown.Content.of_string
+      |> Markdown.Content.render ~syntax_highlighting:true)
     ~modify_is_latest:(Option.value ~default:false)
     ~modify_is_lts:(Option.value ~default:false)
 
@@ -63,9 +61,8 @@ let decode (fpath, (head, body_md)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fpath)
   in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true body_md
-    |> Hilite.Md.transform
-    |> Cmarkit_html.of_doc ~safe:false
+    body_md |> Markdown.Content.of_string
+    |> Markdown.Content.render ~syntax_highlighting:true
   in
   Result.map (of_metadata ~body_md ~body_html) metadata
 

--- a/tool/ood-gen/lib/search.ml
+++ b/tool/ood-gen/lib/search.ml
@@ -1,0 +1,110 @@
+open Ocamlorg.Import
+
+type section = { title : string; id : string }
+[@@deriving show { with_path = false }]
+
+type t = {
+  title : string;
+  category : string;
+  section : section option;
+  content : string;
+  slug : string;
+}
+[@@deriving show { with_path = false }]
+
+let id_to_href id =
+  match id with
+  | None -> "#"
+  | Some (`Auto id) -> "#" ^ id
+  | Some (`Id id) -> "#" ^ id
+
+let rec flatten_block (block : Cmarkit.Block.t) : Cmarkit.Block.t list =
+  match block with
+  | Cmarkit.Block.Blocks (blocks, _) ->
+      blocks |> List.map flatten_block |> List.flatten (*flatten the blocks *)
+  | x -> [ x ]
+
+let rec collect_blocks_until_heading (block : Cmarkit.Block.t list) acc =
+  match block with
+  | [] -> (acc, [])
+  | Cmarkit.Block.Heading (_, _) :: _ -> (acc, block)
+  | Cmarkit.Block.Blocks (blocks, _) :: _ ->
+      blocks |> collect_blocks_until_heading []
+  | h :: t -> collect_blocks_until_heading t (h :: acc)
+
+(* collects a section by its heading and content *)
+let collect_section (blocks : Cmarkit.Block.t list) :
+    ( (section option * Cmarkit.Block.t list) * Cmarkit.Block.t list,
+      [> `Msg of string ] )
+    result =
+  match blocks with
+  | Cmarkit.Block.Heading (h, _) :: t ->
+      let collected_blocks, remaining_blocks =
+        collect_blocks_until_heading t []
+      in
+      Ok
+        ( ( Some
+              {
+                title =
+                  Cmarkit.Block.Heading.inline h
+                  |> Cmarkit.Inline.to_plain_text ~break_on_soft:false
+                  |> List.flatten |> String.concat "\n";
+                id = id_to_href (Cmarkit.Block.Heading.id h);
+              },
+            collected_blocks ),
+          remaining_blocks )
+  | _ :: t ->
+      let collected_blocks, remaining_blocks =
+        collect_blocks_until_heading t []
+      in
+      Ok ((None, collected_blocks), remaining_blocks)
+  | [] -> Error (`Msg "empty list in the document")
+
+let rec block_to_string (block : Cmarkit.Block.t) : string =
+  match block with
+  | Cmarkit.Block.Blank_line _ -> ""
+  | Cmarkit.Block.Block_quote (p, _) ->
+      Cmarkit.Block.Block_quote.block p |> block_to_string
+  | Cmarkit.Block.Code_block _ -> ""
+  | Cmarkit.Block.Heading (h, _) ->
+      Cmarkit.Block.Heading.inline h
+      |> Cmarkit.Inline.to_plain_text ~break_on_soft:false
+      |> List.flatten |> String.concat "\n"
+  | Cmarkit.Block.Html_block (block_lines, _) ->
+      let rec block_lines_to_string (block_lines : Cmarkit.Block_line.t list) :
+          string =
+        match block_lines with
+        | [] -> ""
+        | h :: t ->
+            Cmarkit.Block_line.to_string h ^ "\n" ^ block_lines_to_string t
+      in
+      block_lines_to_string block_lines
+  | Cmarkit.Block.List (l, _) ->
+      let items =
+        Cmarkit.Block.List'.items l |> List.map (fun (item, _) -> item)
+      in
+      items
+      |> List.map Cmarkit.Block.List_item.block
+      |> List.map block_to_string |> String.concat "\n"
+  | Cmarkit.Block.Link_reference_definition (l, _) ->
+      Cmarkit.Link_definition.label l
+      |> Option.map Cmarkit.Label.text
+      |> Option.value ~default:[]
+      |> List.map Cmarkit.Block_line.tight_to_string
+      |> String.concat " "
+  | Cmarkit.Block.Paragraph (p, _) ->
+      Cmarkit.Block.Paragraph.inline p
+      |> Cmarkit.Inline.to_plain_text ~break_on_soft:false
+      |> List.flatten |> String.concat "\n"
+  | Cmarkit.Block.Blocks (blocks, _) ->
+      blocks |> List.map block_to_string |> String.concat "\n"
+  | Cmarkit.Block.Thematic_break _ -> ""
+  | _ -> ""
+
+let rec collect_all_sections (section_blocks : Cmarkit.Block.t list) =
+  match collect_section section_blocks with
+  | Ok (section, remaining_blocks) ->
+      if remaining_blocks <> [] then
+        section :: collect_all_sections remaining_blocks
+      else [ section ]
+  | Error (`Msg msg) -> failwith msg

--- a/tool/ood-gen/lib/success_story.ml
+++ b/tool/ood-gen/lib/success_story.ml
@@ -30,7 +30,7 @@ let decode (fpath, (head, body_md)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fpath)
   in
   let body_html =
-    Cmarkit.Doc.of_string ~strict:true body_md |> Cmarkit_html.of_doc ~safe:true
+    body_md |> Markdown.Content.of_string |> Markdown.Content.render
   in
   Result.map (of_metadata ~body_md ~body_html) metadata
 

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -37,7 +37,7 @@ type t = {
 
 let of_metadata m =
   of_metadata m ~slug:(Utils.slugify m.name) ~modify_description:(fun v ->
-      Cmarkit.Doc.of_string ~strict:true v |> Cmarkit_html.of_doc ~safe:true)
+      v |> Markdown.Content.of_string |> Markdown.Content.render)
 
 let decode s = Result.map of_metadata (metadata_of_yaml s)
 let all () = Utils.yaml_sequence_file decode "tools.yml"

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -46,18 +46,6 @@ type metadata = {
 }
 [@@deriving of_yaml]
 
-type search_document_section = { title : string; id : string }
-[@@deriving show { with_path = false }]
-
-type search_document = {
-  title : string;
-  category : string;
-  section : search_document_section option;
-  content : string;
-  slug : string;
-}
-[@@deriving show { with_path = false }]
-
 type t = {
   title : string;
   short_title : string;
@@ -67,7 +55,7 @@ type t = {
   section : Section.t;
   category : string;
   external_tutorial : external_tutorial option;
-  toc : toc list;
+  toc : Markdown.Toc.t list;
   body_md : string;
   body_html : string;
   recommended_next_tutorials : recommended_next_tutorials;
@@ -84,198 +72,6 @@ let of_metadata m =
     ~modify_recommended_next_tutorials:(function None -> [] | Some u -> u)
     ~modify_prerequisite_tutorials:(function None -> [] | Some u -> u)
     ~modify_short_title:(function None -> m.title | Some u -> u)
-
-module Toc = struct
-  let id_to_href id =
-    match id with
-    | None -> "#"
-    | Some (`Auto id) -> "#" ^ id
-    | Some (`Id id) -> "#" ^ id
-
-  let rec create_toc ~max_level level
-      (headings : Cmarkit.Block.Heading.t Cmarkit.node list) : toc list =
-    match headings with
-    | [] -> []
-    | (h, _) :: rest when Cmarkit.Block.Heading.level h > max_level ->
-        create_toc ~max_level level rest
-    | (h, _) :: rest when Cmarkit.Block.Heading.level h = level ->
-        let l = Cmarkit.Block.Heading.level h in
-        let child_headings, remaining_headings =
-          collect_children ~max_level (l + 1) rest []
-        in
-        let children = create_toc ~max_level (l + 1) child_headings in
-        let title =
-          Cmarkit.Inline.to_plain_text ~break_on_soft:false
-            (Cmarkit.Block.Heading.inline h)
-        in
-        {
-          title = String.concat "\n" (List.map (String.concat "") title);
-          href = id_to_href (Cmarkit.Block.Heading.id h);
-          children;
-        }
-        :: create_toc ~max_level level remaining_headings
-    | (h, _) :: _ when Cmarkit.Block.Heading.level h > level ->
-        create_toc ~max_level (level + 1) headings
-    | _ :: rest -> create_toc ~max_level level rest
-
-  and collect_children ~max_level level
-      (headings : Cmarkit.Block.Heading.t Cmarkit.node list) acc =
-    match headings with
-    | [] -> (acc, [])
-    | (h, _) :: rest when Cmarkit.Block.Heading.level h > max_level ->
-        collect_children ~max_level level rest acc
-    | (h, _) :: _ when Cmarkit.Block.Heading.level h < level -> (acc, headings)
-    | heading :: rest ->
-        collect_children level ~max_level rest (acc @ [ heading ])
-
-  let headers (doc : Cmarkit.Doc.t) : Cmarkit.Block.Heading.t Cmarkit.node list
-      =
-    let rec headers_from_block (block : Cmarkit.Block.t) =
-      match block with
-      | Cmarkit.Block.Heading h -> [ h ]
-      | Cmarkit.Block.Blocks (blocks, _) ->
-          List.map headers_from_block blocks |> List.concat
-      | _ -> []
-    in
-
-    Cmarkit.Doc.block doc |> headers_from_block
-
-  let generate ?(start_level = 1) ?(max_level = 2) doc =
-    if max_level <= start_level then
-      invalid_arg "toc: ~max_level must be >= ~start_level";
-    create_toc ~max_level start_level (headers doc)
-end
-
-module Search = struct
-  let id_to_href id =
-    match id with
-    | None -> "#"
-    | Some (`Auto id) -> "#" ^ id
-    | Some (`Id id) -> "#" ^ id
-
-  let rec flatten_block (block : Cmarkit.Block.t) : Cmarkit.Block.t list =
-    match block with
-    | Cmarkit.Block.Blocks (blocks, _) ->
-        blocks |> List.map flatten_block |> List.flatten (*flatten the blocks *)
-    | x -> [ x ]
-
-  let rec collect_blocks_until_heading (block : Cmarkit.Block.t list) acc =
-    match block with
-    | [] -> (acc, [])
-    | Cmarkit.Block.Heading (_, _) :: _ -> (acc, block)
-    | Cmarkit.Block.Blocks (blocks, _) :: _ ->
-        blocks |> collect_blocks_until_heading []
-    | h :: t -> collect_blocks_until_heading t (h :: acc)
-
-  (* collects a section by its heading and content *)
-  let collect_section (blocks : Cmarkit.Block.t list) :
-      ( (search_document_section option * Cmarkit.Block.t list)
-        * Cmarkit.Block.t list,
-        [> `Msg of string ] )
-      result =
-    match blocks with
-    | Cmarkit.Block.Heading (h, _) :: t ->
-        let collected_blocks, remaining_blocks =
-          collect_blocks_until_heading t []
-        in
-        Ok
-          ( ( Some
-                {
-                  title =
-                    Cmarkit.Block.Heading.inline h
-                    |> Cmarkit.Inline.to_plain_text ~break_on_soft:false
-                    |> List.flatten |> String.concat "\n";
-                  id = id_to_href (Cmarkit.Block.Heading.id h);
-                },
-              collected_blocks ),
-            remaining_blocks )
-    | _ :: t ->
-        let collected_blocks, remaining_blocks =
-          collect_blocks_until_heading t []
-        in
-        Ok ((None, collected_blocks), remaining_blocks)
-    | [] -> Error (`Msg "empty list in the document")
-
-  let rec block_to_string (block : Cmarkit.Block.t) : string =
-    match block with
-    | Cmarkit.Block.Blank_line _ -> ""
-    | Cmarkit.Block.Block_quote (p, _) ->
-        Cmarkit.Block.Block_quote.block p |> block_to_string
-    | Cmarkit.Block.Code_block _ -> ""
-    | Cmarkit.Block.Heading (h, _) ->
-        Cmarkit.Block.Heading.inline h
-        |> Cmarkit.Inline.to_plain_text ~break_on_soft:false
-        |> List.flatten |> String.concat "\n"
-    | Cmarkit.Block.Html_block (block_lines, _) ->
-        let rec block_lines_to_string (block_lines : Cmarkit.Block_line.t list)
-            : string =
-          match block_lines with
-          | [] -> ""
-          | h :: t ->
-              Cmarkit.Block_line.to_string h ^ "\n" ^ block_lines_to_string t
-        in
-        block_lines_to_string block_lines
-    | Cmarkit.Block.List (l, _) ->
-        let items =
-          Cmarkit.Block.List'.items l |> List.map (fun (item, _) -> item)
-        in
-        items
-        |> List.map Cmarkit.Block.List_item.block
-        |> List.map block_to_string |> String.concat "\n"
-    | Cmarkit.Block.Link_reference_definition (l, _) ->
-        Cmarkit.Link_definition.label l
-        |> Option.map Cmarkit.Label.text
-        |> Option.value ~default:[]
-        |> List.map Cmarkit.Block_line.tight_to_string
-        |> String.concat " "
-    | Cmarkit.Block.Paragraph (p, _) ->
-        Cmarkit.Block.Paragraph.inline p
-        |> Cmarkit.Inline.to_plain_text ~break_on_soft:false
-        |> List.flatten |> String.concat "\n"
-    | Cmarkit.Block.Blocks (blocks, _) ->
-        blocks |> List.map block_to_string |> String.concat "\n"
-    | Cmarkit.Block.Thematic_break _ -> ""
-    | _ -> ""
-
-  let rec collect_all_sections (section_blocks : Cmarkit.Block.t list) =
-    match collect_section section_blocks with
-    | Ok (section, remaining_blocks) ->
-        if remaining_blocks <> [] then
-          section :: collect_all_sections remaining_blocks
-        else [ section ]
-    | Error (`Msg msg) -> failwith msg
-
-  let document_from_section
-      ( (section : search_document_section option),
-        (content : Cmarkit.Block.t list) ) ~(metadata : metadata) :
-      search_document =
-    let section_document =
-      {
-        title = metadata.title;
-        category = metadata.category;
-        section;
-        content = content |> List.map block_to_string |> String.concat "\n";
-        slug = metadata.id;
-      }
-    in
-    section_document
-
-  let decode_search_document (_fpath, (head, body_md)) :
-      (search_document list, [> `Msg of string ]) result =
-    match metadata_of_yaml head with
-    | Ok metadata ->
-        let content_blocks =
-          body_md
-          |> Cmarkit.Doc.of_string ~heading_auto_ids:true
-          |> Cmarkit.Doc.block
-        in
-        let document =
-          content_blocks |> flatten_block |> collect_all_sections
-          |> List.map (document_from_section ~metadata)
-        in
-        Ok document
-    | Error msg -> Error msg
-end
 
 exception Missing_Tutorial of string
 
@@ -307,18 +103,65 @@ let decode (fpath, (head, body_md)) =
     |> Result.get_ok ~error:(fun (`Msg msg) ->
            Exn.Decode_error (fpath ^ ":" ^ msg))
   in
-  let doc = Cmarkit.Doc.of_string ~strict:true ~heading_auto_ids:true body_md in
-  let toc = Toc.generate ~start_level:2 ~max_level:4 doc in
-  let body_html = Hilite.Md.transform doc |> Cmarkit_html.of_doc ~safe:false in
+  let doc = Markdown.Content.of_string body_md in
+  let toc = Markdown.Toc.generate ~start_level:2 ~max_level:4 doc in
+  let body_html = Markdown.Content.render ~syntax_highlighting:true doc in
   Result.map (of_metadata ~fpath ~section ~toc ~body_md ~body_html) metadata
 
 let all () =
   Utils.map_files decode "tutorials/*/*.md"
   |> List.sort (fun t1 t2 -> String.compare t1.fpath t2.fpath)
 
-let all_search_documents () : search_document list =
-  Utils.map_files Search.decode_search_document "tutorials/*/*.md"
-  |> List.flatten
+module TutorialSearch = struct
+  type search_document_section = { title : string; id : string }
+  [@@deriving show { with_path = false }]
+
+  type search_document = {
+    title : string;
+    category : string;
+    section : search_document_section option;
+    content : string;
+    slug : string;
+  }
+  [@@deriving show { with_path = false }]
+
+  let document_from_section
+      ((section : Search.section option), (content : Cmarkit.Block.t list))
+      ~(metadata : metadata) : search_document =
+    let section_document =
+      {
+        title = metadata.title;
+        category = metadata.category;
+        section =
+          section
+          |> Option.map (fun (s : Search.section) ->
+                 { title = s.title; id = s.id });
+        content =
+          content |> List.map Search.block_to_string |> String.concat "\n";
+        slug = metadata.id;
+      }
+    in
+    section_document
+
+  let decode_search_document (_fpath, (head, body_md)) :
+      (search_document list, [> `Msg of string ]) result =
+    match metadata_of_yaml head with
+    | Ok metadata ->
+        let content_blocks =
+          body_md
+          |> Cmarkit.Doc.of_string ~heading_auto_ids:true
+          |> Cmarkit.Doc.block
+        in
+        let document =
+          content_blocks |> Search.flatten_block |> Search.collect_all_sections
+          |> List.map (document_from_section ~metadata)
+        in
+        Ok document
+    | Error msg -> Error msg
+
+  let all () : search_document list =
+    Utils.map_files decode_search_document "tutorials/*/*.md" |> List.flatten
+end
 
 let template () =
   let _ = check_tutorial_references @@ all () in
@@ -384,5 +227,5 @@ let all_search_documents = %a
 |}
     (Fmt.brackets (Fmt.list pp ~sep:Fmt.semi))
     (all ())
-    (Fmt.brackets (Fmt.list pp_search_document ~sep:Fmt.semi))
-    (all_search_documents ())
+    (Fmt.brackets (Fmt.list TutorialSearch.pp_search_document ~sep:Fmt.semi))
+    (TutorialSearch.all ())

--- a/tool/ood-gen/lib/workshop.ml
+++ b/tool/ood-gen/lib/workshop.ml
@@ -86,8 +86,9 @@ let decode (fpath, (head, body_md)) =
   let metadata =
     metadata_of_yaml head |> Result.map_error (Utils.where fpath)
   in
-  let doc = Cmarkit.Doc.of_string body_md in
-  let body_html = Cmarkit_html.of_doc ~safe:true doc in
+  let body_html =
+    body_md |> Markdown.Content.of_string |> Markdown.Content.render
+  in
   Result.map (of_metadata ~body_md ~body_html) metadata
 
 let all () =


### PR DESCRIPTION
Only contains files and changes from PR #2410, untouched, allowing rebasing it clean once this is merged. 