### PR TITLE
Set the cutoff date for the OCaml Planet RSS feed to 90 days

### DIFF
--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -337,7 +337,7 @@ module GlobalFeed = struct
     let title : Syndic.Atom.title = Text "The OCaml Planet" in
     let now = Ptime.of_float_s (Unix.gettimeofday ()) |> Option.get in
     let cutoff_date =
-      Ptime.sub_span now (Ptime.Span.v (365, 0L)) |> Option.get
+      Ptime.sub_span now (Ptime.Span.v (90, 0L)) |> Option.get
     in
 
     let entries =


### PR DESCRIPTION
Since dlvr.it will not poll RSS feeds larger than 1,5MB, I am reducing the size of the RSS feed by showing only posts from the last 90 days here. Could possibly be reduced further in the future if need arises.