### PR TITLE
OCaml 5.2.0 announce and release page

### DIFF
--- a/data/changelog/ocaml/2024-05-13-ocaml-5.2.0.md
+++ b/data/changelog/ocaml/2024-05-13-ocaml-5.2.0.md
@@ -1,0 +1,962 @@
+---
+title: Release of OCaml 5.2.0
+description: Release of OCaml 5.2.0
+tags: [ocaml]
+changelog: |
+  
+  (Changes that can break existing programs are marked with a "*")
+  
+  ### Restored and new backends:
+  
+  - [#12276](https://github.com/ocaml/ocaml/issues/12276), [#12601](https://github.com/ocaml/ocaml/issues/12601): native-code compilation for POWER (64 bits, little-endian)
+    (Xavier Leroy, review by KC Sivaramakrishnan, Anil Madhavapeddy,
+     and Stephen Dolan)
+  
+  - [#12667](https://github.com/ocaml/ocaml/issues/12667): extend the latter to POWER 64 bits, big-endian, ELFv2 ABI
+    (A. Wilcox, review by Xavier Leroy)
+  
+  ### Runtime system:
+  
+  - [#12193](https://github.com/ocaml/ocaml/issues/12193): Re-introduce GC compaction for shared pools
+    Adds a parallel compactor for the shared pools (which contain major heap
+    blocks sized less than 128 words). Explicit only for now, on calls to
+    `Gc.compact`.
+    (Sadiq Jaffer, Nick Barnes, review by Anil Madhavapeddy, Damien Doligez,
+     David Allsopp, Miod Vallat, Artem Pianykh, Stephen Dolan, Mark Shinwell
+     and KC Sivaramakrishnan)
+  
+  - [#12114](https://github.com/ocaml/ocaml/issues/12114): Add ThreadSanitizer support
+    (Fabrice Buoro and Olivier Nicole, based on an initial work by Anmol Sahoo,
+     review by Damien Doligez, Sébastien Hinderer, Jacques-Henri Jourdan, Luc
+     Maranget, Guillaume Munch-Maccagnoni, Gabriel Scherer)
+  
+  
+  - [#12850](https://github.com/ocaml/ocaml/issues/12850): Update Gc.quick_stat data at the end of major cycles and compaction
+    This PR adds an additional caml_collect_gc_stats_sample_stw to the major heap
+    cycling stw. This means that Gc.quick_stat now actually reflects the state of
+    the heap after a major cycle or compaction.
+    (Sadiq Jaffer, review by Miod Vallat and Gabriel Scherer)
+  
+  - [#12859](https://github.com/ocaml/ocaml/issues/12859): Ensure Gc.compact does a full major before the compactor runs
+    (Sadiq Jaffer, review by Leo White, Mark Shinwell, Gabriel Scherer,
+     Josh Berdine, David Allsopp and KC Sivaramakrishnan)
+  
+  - [#10111](https://github.com/ocaml/ocaml/issues/10111): Increase the detail of location information for debugging events to
+    allow the end line number and character offset to be reported.
+    (David Allsopp, review by Nick Barnes, Enguerrand Decorne and Stephen Dolan)
+  
+  - [#10403](https://github.com/ocaml/ocaml/issues/10403), [#12202](https://github.com/ocaml/ocaml/issues/12202): introduce `caml_ext_table_add_noexc` that does not
+    raise `Out_of_memory` exceptions and use it inside the blocking sections
+    of `caml_read_directory`.  Also, check for overflows in ext table sizes.
+    (Xavier Leroy, report by Arseniy Alekseyev, review by Gabriel Scherer)
+  
+  - [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+    (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+  
+  - [#12772](https://github.com/ocaml/ocaml/issues/12772), [#12787](https://github.com/ocaml/ocaml/issues/12787): Avoid using _Bool in public headers for the sake of C++
+    compatibility
+    (Guillaume Munch-Maccagnoni, report by KC Sivaramakrishnan, review
+    by Xavier Leroy and KC Sivaramakrishnan)
+  
+  - [#12223](https://github.com/ocaml/ocaml/issues/12223): Constify constructors and flags tables in C code. Now these
+    tables will go in the readonly segment, where they belong.
+    (Antonin Décimo, review by Gabriel Scherer and Xavier Leroy)
+  
+  - [#12234](https://github.com/ocaml/ocaml/issues/12234): make instrumented time calculation more thread-safe on macOS.
+    (Anil Madhavapeddy, review by Daniel Bünzli and Xavier Leroy)
+  
+  - [#12235](https://github.com/ocaml/ocaml/issues/12235), [#12468](https://github.com/ocaml/ocaml/issues/12468): introduce and use the `CAMLnoret` macro as
+    a lighter alternative to `CAMLnoreturn_start` / `CAMLnoreturn_end`.
+    Implement it so as to conform with C11, C23, C++11, C++17.
+    (Xavier Leroy and Dhruv Maroo, with help from Antonin Décimo, review by
+     Gabriel Scherer and David Allsopp)
+  
+  - [#12275](https://github.com/ocaml/ocaml/issues/12275): caml/stack.h: more abstract macros to describe OCaml stacks and
+    how to traverse them, supporting more stack layouts.
+    (Xavier Leroy, review by KC Sivaramakrishnan and Fabrice Buoro)
+  
+  - [#12268](https://github.com/ocaml/ocaml/issues/12268): deliver `Out_of_memory` exception if domain creation fails
+    due to memory resource exhaustion.  It was previous always a `Failure`.
+    (Anil Madhavapeddy, review by David Allsopp)
+  
+  - [#12300](https://github.com/ocaml/ocaml/issues/12300), [#12314](https://github.com/ocaml/ocaml/issues/12314): Discard out_channel buffered data on permanent I/O error
+    (Xavier Leroy, report by Török Edwin, review by Anil Madhavapeddy
+    and Nicolás Ojeda Bär)
+  
+  - [#11386](https://github.com/ocaml/ocaml/issues/11386): Simplifications and fixes to multicore systhreads implementation.
+    (Guillaume Munch-Maccagnoni, review by Anil Madhavapeddy and KC
+     Sivaramakrishnan)
+  
+  - [#12875](https://github.com/ocaml/ocaml/issues/12875), [#12879](https://github.com/ocaml/ocaml/issues/12879), [#12882](https://github.com/ocaml/ocaml/issues/12882): Execute preemptive systhread switching as a
+    delayed pending action. This ensures that one can reason within the
+    FFI that no mutation happens on the same domain when allocating on
+    the OCaml heap from C, consistently with OCaml 4. This also fixes
+    further bugs with the multicore systhreads implementation.
+    (Guillaume Munch-Maccagnoni, bug reports and suggestion by Mark
+     Shinwell, review by Nick Barnes and Stephen Dolan)
+  
+  - [#12408](https://github.com/ocaml/ocaml/issues/12408): `Domain.spawn` no longer leaks its functional argument for
+    the whole duration of the children domain lifetime.
+    (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+  
+  - [#12409](https://github.com/ocaml/ocaml/issues/12409): Fix unsafety and deadlocks should an asynchronous exception
+    arise at specific locations during domain creation and shutdown.
+    (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+  
+  - [#11911](https://github.com/ocaml/ocaml/issues/11911), [#12381](https://github.com/ocaml/ocaml/issues/12381): Restore statmemprof functionality in part, with
+    some API changes in Gc.Memprof.
+    (Nick Barnes, review by Jacques-Henri Jourdan
+     and Guillaume Munch-Maccagnoni).
+  
+  - [#12430](https://github.com/ocaml/ocaml/issues/12430): Simplify dynamic bytecode loading in Meta.reify_bytecode
+    (Stephen Dolan, review by Sébastien Hinderer, Vincent Laviron and Xavier
+     Leroy)
+  
+  - [#12489](https://github.com/ocaml/ocaml/issues/12489): Fix an error-handling bug in caml_alloc_sprintf
+    (Stephen Dolan, report by Chris Casinghino, review by Jeremy Yallop
+     and Xavier Leroy)
+  
+  - [#11307](https://github.com/ocaml/ocaml/issues/11307): Finish adapting the implementation of asynchronous actions for
+    multicore: soundness, liveness, and performance issues.
+    Do not crash if a signal handler is called from an unregistered C
+    thread, and other possible soundness issues. Prevent issues where join
+    on other domains could make the toplevel unresponsible to Ctrl-C. Avoid
+    needless repeated polling in C code when callbacks cannot run
+    immediately.
+    (Guillaume Munch-Maccagnoni, review by Enguerrand Decorne, Xavier
+    Leroy, and KC Sivaramakrishnan)
+  
+  - [#12634](https://github.com/ocaml/ocaml/issues/12634): Simplify TSan backtrace bookkeeping upon raise
+    (Olivier Nicole and Fabrice Buoro, review by Gabriel Scherer)
+  
+  * (*breaking change*) [#12686](https://github.com/ocaml/ocaml/issues/12686): Some primitives had the wrong types to be callable from the bytecode
+    interpreter.  Either fix their types, mark them as `CAMLexport` instead of
+    `CAMLprim`, or remove them entirely if no longer used.
+    (Xavier Leroy, review by David Allsopp)
+  
+  - [#12700](https://github.com/ocaml/ocaml/issues/12700), continuing [#11763](https://github.com/ocaml/ocaml/issues/11763) and trying to address [#12660](https://github.com/ocaml/ocaml/issues/12660):
+    Use the correct types for primitives when generating the table of primitives
+    used by ocamlrun.
+    (Xavier Leroy, motivation, review and improvements by Antonin Décimo)
+  
+  - [#12345](https://github.com/ocaml/ocaml/issues/12345), [#12710](https://github.com/ocaml/ocaml/issues/12710): Fix issues with finaliser orphaning at domain termination
+    (KC Sivaramakrishnan, report by Gabriel Scherer, review by Gabriel Scherer,
+    Sadiq Jaffer and Fabrice Buoro)
+  
+  - [#12599](https://github.com/ocaml/ocaml/issues/12599): Refactor Dynlink startup to avoid parsing bytecode sections twice
+    (Stephen Dolan, review by David Allsopp, Hugo Heuzard, Damien Doligez and
+     Xavier Leroy)
+  
+  - [#12678](https://github.com/ocaml/ocaml/issues/12678), [#12898](https://github.com/ocaml/ocaml/issues/12898): free channel buffers on close rather than on finalization
+    (Damien Doligez, review by Jan Midtgaard and Gabriel Scherer, report
+     by Jan Midtgaard)
+  
+  - [#12681](https://github.com/ocaml/ocaml/issues/12681): Fix TSan false positives due to volatile write handling
+    (Olivier Nicole, Fabrice Buoro and Anmol Sahoo, review by Luc Maranget,
+     Gabriel Scherer, Hernan Ponce de Leon and Xavier Leroy)
+  
+  - [#12743](https://github.com/ocaml/ocaml/issues/12743): Use pthread_sigmask instead of sigprocmask
+    Updates usage of sigprocmask to pthread_sigmask in otherlibs/unix.
+    (Max Slater, review by Miod Vallat and Xavier Leroy)
+  
+  - [#12769](https://github.com/ocaml/ocaml/issues/12769): Unify MSVC and MinGW-w64 code paths, by always using WinAPI
+    directly.
+    (David Allsopp, Antonin Décimo, and Samuel Hym, review by Nicolas
+     Ojeda Bar)
+  
+  - [#11911](https://github.com/ocaml/ocaml/issues/11911), [#12382](https://github.com/ocaml/ocaml/issues/12382), [#12383](https://github.com/ocaml/ocaml/issues/12383): Restore statmemprof functionality in part
+    (backtrace buffers, per-thread and per-domain data structures,
+    GC/allocation interface). (Nick Barnes, review by Gabriel Scherer,
+    Fabrice Buoro, Sadiq Jaffer, Guillaume Munch-Maccagnoni, and
+    Jacques-Henri Jourdan).
+  
+  - [#12735](https://github.com/ocaml/ocaml/issues/12735): Store both ends of the stack chain in continuations
+    (Leo White, review by Miod Vallat and KC Sivaramakrishnan)
+  
+  - [#12746](https://github.com/ocaml/ocaml/issues/12746): Simplify and clean up TSan annotations
+    (Olivier Nicole, review by Miod Vallat and Fabrice Buoro)
+  
+  - [#12809](https://github.com/ocaml/ocaml/issues/12809): Add ThreadSanitizer support to FreeBSD/amd64
+    (Miod Vallat, review by Gabriel Scherer)
+  
+  - [#12810](https://github.com/ocaml/ocaml/issues/12810): Port ThreadSanitizer support to Linux and macOS on arm64
+    (Miod Vallat, review by Tim McGilchrist)
+  
+  - [#12811](https://github.com/ocaml/ocaml/issues/12811): Define and use the CAMLthread_local macro for TLS variables.
+    (Antonin Décimo and Samuel Hym, review by Miod Vallat and Xavier Leroy)
+  
+  - [#12814](https://github.com/ocaml/ocaml/issues/12814): More detailed failure messages from `input_value` and `Marshal.from_*`
+    (Xavier Leroy, review by Stephen Dolan and Anil Madhavapeddy)
+  
+  - [#12815](https://github.com/ocaml/ocaml/issues/12815): Correctly format multi-line locations in exception backtraces, in the
+    style that the compiler driver uses.
+    (David Allsopp, review by Gabriel Scherer)
+  
+  - [#12773](https://github.com/ocaml/ocaml/issues/12773), [#12830](https://github.com/ocaml/ocaml/issues/12830), [#12834](https://github.com/ocaml/ocaml/issues/12834): Rewrite `caml_c_thread_(un)register` to fix
+    various bugs.
+    (Guillaume Munch-Maccagnoni, reported by Miod Vallat, suggested by
+     Hari Hara Naveen S, reviewed by Fabrice Buoro, Gabriel Scherer and
+     Miod Vallat)
+  
+  - [#12876](https://github.com/ocaml/ocaml/issues/12876): Port ThreadSanitizer support to Linux on POWER
+    (Miod Vallat, review by Tim McGilchrist)
+  
+  - [#12886](https://github.com/ocaml/ocaml/issues/12886): Reinitialize IO mutexes after fork
+    (Max Slater, review by Guillaume Munch-Maccagnoni and Xavier Leroy)
+  
+  - [#12907](https://github.com/ocaml/ocaml/issues/12907): Port ThreadSanitizer support to Linux on RiscV
+    (Miod Vallat, review by Nicolás Ojeda Bär and Fabrice Buoro)
+  
+  - [#12915](https://github.com/ocaml/ocaml/issues/12915): Port ThreadSanitizer support to Linux on s390x
+    (Miod Vallat, review by Tim McGilchrist)
+  
+  - [#12934](https://github.com/ocaml/ocaml/issues/12934): Fix data races between marking and sweeping functions
+    (Olivier Nicole, suggested by Stephen Dolan, review by Gabriel Scherer,
+     Miod Vallat and Damien Doligez)
+  
+  ### Language features:
+  
+  - [#12295](https://github.com/ocaml/ocaml/issues/12295), [#12568](https://github.com/ocaml/ocaml/issues/12568): Give `while true' a polymorphic type, similarly to
+    `assert false'
+    (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer,
+    suggestion by Rodolphe Lepigre and John Whitington)
+  
+  - [#12044](https://github.com/ocaml/ocaml/issues/12044): Add local module open syntax for types.
+    ```
+      module A = struct
+        type t = int
+        type r = unit
+        type s = string
+      end
+  
+      type example = A.(t * r * s)
+    ```
+    (Alistair O'Brien, review by Gabriel Scherer, Nicolás Ojeda Bär
+     and Florian Angeletti)
+  
+  - [#11252](https://github.com/ocaml/ocaml/issues/11252), RFC 27: Support raw identifier syntax \#foo
+    (Stephen Dolan, review by David Allsopp, Gabriel Scherer and Olivier Nicole)
+  
+  
+  - [#12315](https://github.com/ocaml/ocaml/issues/12315): Use type annotations from arguments in let rec
+    (Stephen Dolan, review by Gabriel Scherer)
+  
+  - [#12375](https://github.com/ocaml/ocaml/issues/12375): allow use of [@untagged] for all immediate types like char, bool,
+    and variant with only constant constructors.
+    (Christophe Raffalli, review by Gabriel Scherer)
+  
+  * (*breaking change*) [#12502](https://github.com/ocaml/ocaml/issues/12502): the compiler now normalizes the newline sequence \r\n to
+    a single \n character during lexing, to guarantee that the semantics
+    of newlines in string literals is not modified by Windows tools
+    transforming \n into \r\n in source files.
+    Warning 29 [eol-in-string] is not emitted anymore, as the normalization
+    gives a more robust semantics to newlines in string literals.
+    (Gabriel Scherer and Damien Doligez, review by Daniel Bünzli, David
+     Allsopp, Andreas Rossberg, Xavier Leroy, report by Andreas Rossberg)
+  
+  ### Standard library:
+  
+  - [#11563](https://github.com/ocaml/ocaml/issues/11563): Add the Dynarray module to the stdlib. Dynamic arrays are
+    arrays whose length can be changed by adding or removing elements at
+    the end, similar to 'vectors' in C++ or Rust.
+    (Gabriel Scherer, Simon Cruanes and Florian Angeletti, review by
+     Daniel Bünzli, Guillaume Munch-Maccagnoni, Clément Allain,
+     Damien Doligez, Wiktor Kuchta and Pieter Goetschalckx)
+  
+  
+  - [#12716](https://github.com/ocaml/ocaml/issues/12716): Add `Format.pp_print_nothing` function.
+    (Léo Andrès, review by Gabriel Scherer and Nicolás Ojeda Bär)
+  
+  * (*breaking change*) [#6732](https://github.com/ocaml/ocaml/issues/6732), [#12423](https://github.com/ocaml/ocaml/issues/12423): Make Buffer.add_substitute surjective and fix its
+    documentation.
+    (Damien Doligez, review by Antonin Décimo)
+  
+  * (*breaking change*) [#10775](https://github.com/ocaml/ocaml/issues/10775), [#12499](https://github.com/ocaml/ocaml/issues/12499): Half-precision floating-point elements in Bigarray.
+    (Anton Yabchinskiy, review by Xavier Leroy and Nicolás Ojeda Bär)
+  
+  - [#11517](https://github.com/ocaml/ocaml/issues/11517), [#12477](https://github.com/ocaml/ocaml/issues/12477): Expose pp_infinity in interface of the format module, and
+    check that margin is less than pp_infinity when setting or checking geometry.
+    (Janith Petangoda, reported by Simmo Saan, reviewed by Florian Angeletti,
+    Simmo Saan, Josh Berdine and Gabriel Scherer)
+  
+  - [#12217](https://github.com/ocaml/ocaml/issues/12217): Add `Array.shuffle`.
+    (Daniel Bünzli, review by Nicolás Ojeda Bär, David Allsopp and Alain Frisch)
+  
+  - [#12212](https://github.com/ocaml/ocaml/issues/12212): Add cache-aligned constructor for atomics. The patch ensures that
+    all allocations (of the right size) in the shared heap are aligned.
+    (Bartosz Modelski with Gabriel Scherer, Guillaume Munch-Maccagnoni,
+     Xavier Leroy, review by Alain Frisch, Anil Madhavapeddy, Gabriel Scherer,
+     Guillaume Munch-Maccagnoni, KC Sivaramakrishnan, Stefan Muenzel,
+     Xavier Leroy)
+  
+  - [#12307](https://github.com/ocaml/ocaml/issues/12307): Add BLAKE2b hashing and an MD5 submodule to the Digest module.
+    (Xavier Leroy, review by Olivier Nicole, Gabriel Scherer, Wiktor Kuchta,
+     Daniel Bünzli, David Allsopp)
+  
+  - [#12365](https://github.com/ocaml/ocaml/issues/12365): Add In_channel.input_bigarray, In_channel.really_input_bigarray,
+    Out_channel.output_bigarray, Unix.read_bigarray, Unix.write_bigarray,
+    Unix.single_write_bigarray.
+    (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer,
+     David Allsopp)
+  
+  - [#12455](https://github.com/ocaml/ocaml/issues/12455): Add `Array.init_matrix`, `Float.Array.make_matrix`,
+    `Float.Array.init_matrix`.
+    (Glen Mével, review by Xavier Leroy, Gabriel Scherer, Jeremy Yallop,
+    Nicolas Ojeda Bar)
+  
+  * (*breaking change*) [#12455](https://github.com/ocaml/ocaml/issues/12455): `Array.make_matrix dimx dimy f` now raises `Invalid_argument`
+    when `dimx = 0 && dimy < 0` This was already specified but not enforced.
+    (Glen Mével, report by Jeremy Yallop, review by Nicolas Ojeda Bar)
+  
+  - [#12459](https://github.com/ocaml/ocaml/issues/12459): Add `Random.int_in_range`, `Random.int32_in_range`,
+    `Random.int64_in_range`, `Random.nativeint_in_range`,
+    and their counterpart in `Random.State`.
+    (Glen Mével and Xavier Leroy, review by Gabriel Scherer, Xavier Leroy,
+     Florian Angeletti)
+  
+  - [#12459](https://github.com/ocaml/ocaml/issues/12459): `Random`: restore compatibility between 32-bit integers (JavaScript)
+    and 63-bit integers (64-bit OCaml).
+    For `Random.full_int` this was guaranteed in 4.14 but wrongly removed in 5.0.
+    (Xavier Leroy, review by Glen Mével)
+  
+  - [#12511](https://github.com/ocaml/ocaml/issues/12511): Minor performance improvements and cleanups in the implementation
+    of modules Int32, Int64, and Nativeint
+    (Xavier Leroy, review by Gabriel Scherer and Daniel Bünzli)
+  
+  - [#12558](https://github.com/ocaml/ocaml/issues/12558): Adapt GC alarms for multicore and fix their documentation.
+    (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan
+     and Gabriel Scherer)
+  
+  - [#12625](https://github.com/ocaml/ocaml/issues/12625): Remove the Closure module from Obj
+    (Vincent Laviron, review by Xavier Leroy)
+  
+  - [#12758](https://github.com/ocaml/ocaml/issues/12758), [#12998](https://github.com/ocaml/ocaml/issues/12998): Remove the `Marshal.Compression` flag to the
+    `Marshal.to_*` functions.  The compilers are still able to use
+    ZSTD compression for compilation artefacts.
+    This is a forward port and clean-up of the emergency fix that was introduced
+    in OCaml 5.1.1 by [#12734](https://github.com/ocaml/ocaml/issues/12734).
+    (Xavier Leroy, review by Damien Doligez)
+  
+  - [#12784](https://github.com/ocaml/ocaml/issues/12784): Fix computation of minor-heap allocation in Gc.counters()
+    and Gc.allocated_bytes(). (Nick Barnes, review by Gabriel Scherer)
+  
+  - [#12770](https://github.com/ocaml/ocaml/issues/12770): Add `Fun.compose`.
+    (Justin Frank, review by Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
+  
+  - [#12845](https://github.com/ocaml/ocaml/issues/12845): Add `{In,Out}_channel.is_binary_mode` as the dual of
+    `set_binary_mode`. This function was previously only available in the internal
+    C API.
+    (David Allsopp, review by Nicolás Ojeda Bär and Xavier Leroy)
+  
+  ### Type system:
+  
+  - [#12313](https://github.com/ocaml/ocaml/issues/12313), [#11799](https://github.com/ocaml/ocaml/issues/11799): Do not re-build as-pattern type when a ground type annotation
+    is given. This allows to work around problems with GADTs in as-patterns.
+    (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
+  
+  ### Code generation and optimizations:
+  
+  - [#11239](https://github.com/ocaml/ocaml/issues/11239): on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.
+    This reduces stack usage.  It's only C stacks that require 16-alignment.
+    (Xavier Leroy, review by Gabriel Scherer and Stephen Dolan)
+  
+  - [#12311](https://github.com/ocaml/ocaml/issues/12311): on POWER, 32-bit FP numbers stored in memory (e.g. in bigarrays)
+    were not correctly rounded sometimes.
+    (Xavier Leroy, review by Anil Madhavapeddy and Tim McGilchrist)
+  
+  - [#12551](https://github.com/ocaml/ocaml/issues/12551), [#12608](https://github.com/ocaml/ocaml/issues/12608), [#12782](https://github.com/ocaml/ocaml/issues/12782), [#12596](https://github.com/ocaml/ocaml/issues/12596): Overhaul of recursive value compilation.
+    Non-function recursive bindings are now forbidden from Lambda onwards,
+    and compiled using a new Value_rec_compiler module.
+    (Vincent Laviron and Lunia Ayanides, review by Gabriel Scherer,
+     Stefan Muenzel and Nathanaëlle Courant)
+  
+  - [#1809](https://github.com/ocaml/ocaml/issues/1809), [#12181](https://github.com/ocaml/ocaml/issues/12181): rewrite `compare x y op 0` to `x op y` when values are integers
+    (Xavier Clerc, Stefan Muenzel, review by Gabriel Scherer and Vincent Laviron)
+  
+  - [#12825](https://github.com/ocaml/ocaml/issues/12825): disable common subexpression elimination for atomic loads... again.
+    (Gabriel Scherer, review by KC Sivaramakrishnan, Xavier Leroy
+     and Vincent Laviron, report by Vesa Karvonen)
+  
+  ### Other libraries:
+  
+  - [#12213](https://github.com/ocaml/ocaml/issues/12213): Dynlink library, improve legibility of error messages
+    (Samuel Hym, review by Gabriel Scherer and Nicolás Ojeda Bär)
+  
+  * (*breaking change*) [#12686](https://github.com/ocaml/ocaml/issues/12686): Runtime_events library, C API: define
+    `caml_runtime_events_{start,pause,resume}` as returning `void`
+    instead of `value`.
+    (Xavier Leroy, review by David Allsopp)
+  
+  ### Compiler user-interface and warnings:
+  
+  - [#11989](https://github.com/ocaml/ocaml/issues/11989), [#12246](https://github.com/ocaml/ocaml/issues/12246), RFC 31: New flag, -H, to allow for transitive dependencies
+    without including them in the initial environment.
+    (Chris Casinghino, François Bobot, and Gabriel Scherer, review by Leo White
+     and Stefan Muenzel, RFC by François Bobot)
+  
+  
+  * (*breaking change*) [#10613](https://github.com/ocaml/ocaml/issues/10613), [#12405](https://github.com/ocaml/ocaml/issues/12405): Simplify the values used for the system variable (`system:` in
+    `ocamlopt -config` or the `Config.system` constant). In particular, s390x and
+    ppc64 now report "linux" instead of "elf"; all variants of 32-bit ARM on Linux
+    now report "linux"; OpenBSD now reports "openbsd" instead of "bsd" for 32-bit
+    ARM; FreeBSD, NetBSD and OpenBSD now report the same value for both x86_64 and
+    x86_32; x86_32 systems matching *bsd but not freebsd*, netbsd* or openbsd*
+    are no longer identified (as on x86_64); x86_32 Linux now reports "linux"
+    instead of "linux_elf".
+    (David Allsopp, request by Kate Deplaix, review by Sébastien Hinderer and
+    Xavier Leroy)
+  
+  - [#12247](https://github.com/ocaml/ocaml/issues/12247): configure: --disable-ocamldebug can now be used instead
+    of --disable-debugger (which remains available for compatibility)
+    (Gabriel Scherer, review by Damien Doligez and Sébastien Hinderer)
+  
+  - [#12199](https://github.com/ocaml/ocaml/issues/12199): improve the error message for non-overriding `inherit!`
+    (Florian Angeletti, review by Jules Aguillon)
+  
+  - [#12210](https://github.com/ocaml/ocaml/issues/12210): uniform style for inline code in compiler messages
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  * (*breaking change*) [#12278](https://github.com/ocaml/ocaml/issues/12278), #:12325: Remove the OCAML_FLEXLINK environment variable from the
+    compiler drivers. This environment variable was previously used as part of the
+    FlexDLL bootstrap procedure and existed solely for that purpose. Its removal
+    greatly simplifies both the build system and testsuite machinery.
+    (David Allsopp, review by Sébastien Hinderer)
+  
+  - [#12347](https://github.com/ocaml/ocaml/issues/12347): error messages: always report missing polyvariant tags
+    (Florian Angeletti, report by Tianbo Hao, review by Gabriel Scherer)
+  
+  - [#12224](https://github.com/ocaml/ocaml/issues/12224), specialized error message when trying to apply non-functor
+    module (e.g `module M = Int(Int)`)
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#12451](https://github.com/ocaml/ocaml/issues/12451): Warning 53 (misplaced attributes) now works for all attributes.
+    (Chris Casinghino, review by Florian Angeletti)
+  
+  - [#12622](https://github.com/ocaml/ocaml/issues/12622): Give hints about existential types appearing in error messages
+    (Leo White, review by Gabriel Scherer and Florian Angeletti)
+  
+  - [#12671](https://github.com/ocaml/ocaml/issues/12671): When a class type parameter or class parameter does not match,
+    identify which parameter in the error message, instead of saying
+    "A type parameter" or "A parameter".
+    (Stefan Muenzel, review by Gabriel Scherer)
+  
+  - [#12679](https://github.com/ocaml/ocaml/issues/12679): Add more detail to the error message and manual in case of
+    invalid module type substitutions.
+    (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
+  
+  - [#12750](https://github.com/ocaml/ocaml/issues/12750): Display the command executed to extract primitives in
+    `ocamlc -verbose`.
+    (David Allsopp, review by Nicolás Ojeda Bär)
+  
+  - [#12777](https://github.com/ocaml/ocaml/issues/12777): Add details about the actual and expected method types to the method
+    mismatch error messages.
+    (Javier Chávarri, review by Gabriel Scherer and Florian Angeletti)
+  
+  * (*breaking change*) [#12942](https://github.com/ocaml/ocaml/issues/12942): Fix an line ordering in some module inclusion error messages
+    (Nick Roberts, review by Florian Angeletti, report by Carl Eastlund)
+  ### Manual and documentation:
+  
+  - [#12338](https://github.com/ocaml/ocaml/issues/12338): clarification of the documentation of process related function in
+    the unix module regarding the first element of args and shell's pid.
+    (Christophe Raffalli, review by Florian Angeletti)
+  
+  - [#12473](https://github.com/ocaml/ocaml/issues/12473): Document in runtime/memory.c our current understanding of
+    accesses to the OCaml heap from the C runtime code -- the problem
+    of hybrid programs mixing two memory models.
+    (Gabriel Scherer and Guillaume Munch-Maccagnoni, review by Olivier
+     Nicole and Xavier Leroy)
+  
+  - [#12456](https://github.com/ocaml/ocaml/issues/12456): Document the incompatibility between effects on the one
+    hand, and `caml_callback` and asynchronous callbacks (signal
+    handlers, finalisers, memprof callbacks...) on the other hand.
+    (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan)
+  
+  - [#12694](https://github.com/ocaml/ocaml/issues/12694): Document in runtime/tsan.c the TSan instrumentation choices and the
+    consequences with regard to the memory model.
+    (Olivier Nicole, review by Miod Vallat, Gabriel Scherer, Guillaume
+     Munch-Maccagnoni and Fabrice Buoro)
+  
+  - [#12802](https://github.com/ocaml/ocaml/issues/12802): Add manual chapter about ThreadSanitizer support
+    (Olivier Nicole, review by Miod Vallat, Sebastien Hinderer, Fabrice Buoro,
+     Gabriel Scherer and KC Sivaramakrishnan)
+  
+  - [#12819](https://github.com/ocaml/ocaml/issues/12819): Clarify which runtime interactions are allowed in custom ops
+    (Basile Clément, review by Guillaume Munch-Maccagnoni and Xavier Leroy)
+  
+  - [#12840](https://github.com/ocaml/ocaml/issues/12840): manual: update runtime tracing chapter for custom events (ex [#12335](https://github.com/ocaml/ocaml/issues/12335))
+    (Lucas Pluvinage, Sadiq Jaffer and Olivier Nicole, review by Gabriel Scherer,
+     David Allsopp, Tim McGilchrist and Thomas Leonard)
+  
+  - [#13066](https://github.com/ocaml/ocaml/issues/13066), update OCAMLRUNPARAM documentation for the stack size parameter l
+    (Florian Angeletti, review by Nicolás Ojeda Bär, Tim McGilchrist, and
+     Miod Vallat)
+  
+  - [#13078](https://github.com/ocaml/ocaml/issues/13078): update Format tutorial on structural boxes to mention alignment
+    questions.
+    (Edwin Török, review by Florian Angeletti)
+  
+  - [#13092](https://github.com/ocaml/ocaml/issues/13092): document the existence of the `[@@poll error]` built-in attribute
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  ### Tools:
+  
+  - [#12340](https://github.com/ocaml/ocaml/issues/12340): testsuite: collect known issues with current -short-paths
+    implementation for existential types
+    (Florian Angeletti, Samuel Hym, review by Florian Angeletti and Thomas Refis)
+  
+  - [#12147](https://github.com/ocaml/ocaml/issues/12147): ocamllex: Allow carriage returns at the end of line directives.
+    (SeungCheol Jung, review by Nicolás Ojeda Bär)
+  
+  - [#12260](https://github.com/ocaml/ocaml/issues/12260): Fix invalid_argument on some external or module aliases in ocamlnat
+    (Fabian Hemmer, review by Vincent Laviron)
+  
+  - [#12185](https://github.com/ocaml/ocaml/issues/12185): New script language for ocamltest.
+    (Damien Doligez with Florian Angeletti, Sébastien Hinderer, Gabriel Scherer,
+     review by Sébastien Hinderer and Gabriel Scherer)
+  
+  - [#12371](https://github.com/ocaml/ocaml/issues/12371): ocamltest: fix recursive expansion of variables.
+    (Antonin Décimo, Damien Doligez, review by Sébastien Hinderer,
+     Damien Doligez, Gabriel Scherer, and Xavier Leroy)
+  
+  * (*breaking change*) [#12497](https://github.com/ocaml/ocaml/issues/12497), [#12613](https://github.com/ocaml/ocaml/issues/12613): Make ocamlc/ocamlopt fail with an error when no
+    input files are specified to build an executable.
+    (Antonin Décimo, review by Sébastien Hinderer)
+  
+  - [#12576](https://github.com/ocaml/ocaml/issues/12576): ocamldep: various refactors.
+    (Antonin Décimo, review by Florian Angeletti, Gabriel Scherer, and Léo Andrès)
+  
+  - [#12615](https://github.com/ocaml/ocaml/issues/12615): ocamldoc: get rid of the odoc_literate and odoc_todo generators.
+    (Sébaistien Hinderer, review by Gabriel Scherer and Florian Angeletti)
+  
+  - [#12624](https://github.com/ocaml/ocaml/issues/12624): Use $XDG_CONFIG_DIRS in addition to $XDG_CONFIG_HOME when searching
+    for init.ml and use this to extend init.ml support to the toplevel when
+    running on Windows.
+    (David Allsopp, report by Jonah Beckford, review by Nicolás Ojeda Bär and
+     Antonin Décimo)
+  
+  - [#12688](https://github.com/ocaml/ocaml/issues/12688): Setting the env variable `NO_COLOR` with an empty value no longer
+    has effects. Previously, setting `NO_COLOR` with any value, including
+    the empty value, would disable colors (unless `OCAML_COLOR` is also set).
+    After this change, the user must set `NO_COLOR` with an non-empty value
+    to disable colors. This reflects a specification clarification/change
+    from the upstream website at https://no-color.org.
+    (Favonia, review by Gabriel Scherer)
+  
+  - [#12744](https://github.com/ocaml/ocaml/issues/12744): ocamltest: run tests in recursive subdirs more eagerly
+    (Nick Roberts, review by Nicolás Ojeda Bär)
+  
+  - [#12901](https://github.com/ocaml/ocaml/issues/12901), 12908: ocamllex: add overflow checks to prevent generating incorrect
+    lexers; use unsigned numbers in the table encoding when possible.
+    (Vincent Laviron, report by Edwin Török, review by Xavier Leroy)
+  
+  ### Internal/compiler-libs changes:
+  
+  - [#12508](https://github.com/ocaml/ocaml/issues/12508) : Add compiler-side support for project-wide occurrences in Merlin, by
+    generating index tables of all identifier occurrences. This extra data in .cmt
+    files is only added when the new flag -bin-annot-occurrences is passed.
+    (Ulysse Gérard, Nathanaëlle Courant, suggestions by Gabriel Scherer and Thomas
+    Refis, review by Florian Angeletti, Gabriel Scherer and Thomas Refis)
+  
+  - [#12236](https://github.com/ocaml/ocaml/issues/12236), [#12386](https://github.com/ocaml/ocaml/issues/12386), [#12391](https://github.com/ocaml/ocaml/issues/12391), [#12496](https://github.com/ocaml/ocaml/issues/12496), [#12673](https://github.com/ocaml/ocaml/issues/12673): Use syntax as sole determiner of arity
+    This changes function arity to be based solely on the source program's
+    parsetree. Previously, the heuristic for arity had more subtle heuristics
+    that involved type information about patterns.  Function arity is important
+    because it determines when a pattern match's effects run and is an input
+    into the fast path for function application.
+  
+    This change affects tooling: it changes the function constructs in parsetree
+    and typedtree.
+  
+    See https://github.com/ocaml/RFCs/pull/32 for the original RFC.
+  
+    (Nick Roberts; review by Richard Eisenberg, Leo White, and Gabriel Scherer;
+    RFC by Stephen Dolan)
+  
+  
+  - [#12639](https://github.com/ocaml/ocaml/issues/12639): parsing: Attach a location to the RHS of Ptyp_alias
+    and improve the 'alias type mismatch' error message.
+    (Jules Aguillon, review by Florian Angeletti)
+  
+  - [#12447](https://github.com/ocaml/ocaml/issues/12447): Remove 32-bit targets from X86_proc.system
+    (Masanori Ogino, review by David Allsopp)
+  
+  - [#12216](https://github.com/ocaml/ocaml/issues/12216), [#12248](https://github.com/ocaml/ocaml/issues/12248): Prevent reordering of atomic loads during instruction
+    scheduling.  This is for reference, as instruction scheduling is currently
+    unused in OCaml 5.
+    (Xavier Leroy, report by Luc Maranget and KC Sivaramakrishnan,
+     review by Nicolás Ojeda Bär)
+  
+  - [#12025](https://github.com/ocaml/ocaml/issues/12025): Split Typecore.unify_pat_types into two
+    to avoid unnecessary references to the environment in type_pat
+    (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
+  
+  - [#12031](https://github.com/ocaml/ocaml/issues/12031): Use dedicated types to represent names of compilation units
+    and predefined exceptions in CMO files.
+    (Sébastien Hinderer, review by Florian Angeletti, Thomas Refis,
+    Gabriel Scherer, Vincent Laviron, Pierre Chambart, Luke Maurer,
+    Hugo Heuzard, Xavier Leroy and Damien Doligez)
+  
+  - [#12109](https://github.com/ocaml/ocaml/issues/12109): Pack parameters to unification in unification_environment
+    (Takafumi Saikawa and Jacques Garrigue, review by Richard Eisenberg)
+  
+  - [#12331](https://github.com/ocaml/ocaml/issues/12331), [#12361](https://github.com/ocaml/ocaml/issues/12361): Pack the unification data for pattern checking in Typecore
+    (Takafumi Saikawa and Jacques Garrigue,
+     review by Gabriel Scherer, Thomas Refis and Florian Angeletti)
+  
+  - [#12229](https://github.com/ocaml/ocaml/issues/12229): Remove global mutable state for typechecking patterns
+    in Typecore in favor of local mutable state.
+    (Nick Roberts, review by Takafumi Saikawa)
+  
+  - [#12542](https://github.com/ocaml/ocaml/issues/12542): Minor bugfix to [#12236](https://github.com/ocaml/ocaml/issues/12236): restore dropped call to `instance`
+    (Nick Roberts, review by Jacques Garrigue)
+  
+  - [#12242](https://github.com/ocaml/ocaml/issues/12242): Move the computation of stack frame parameters to a separate
+    `Stackframe` module, and save the parameters in the results of the
+    `Linearize` pass
+    (Xavier Leroy, review by KC Sivaramakrishnan and Mark Shinwell)
+  
+  - [#12442](https://github.com/ocaml/ocaml/issues/12442): document jump summaries in the pattern-matching compiler
+    (Gabriel Scherer and Thomas Refis, review by Florian Angeletti
+     and Vincent Laviron)
+  
+  - [#12446](https://github.com/ocaml/ocaml/issues/12446), [#12792](https://github.com/ocaml/ocaml/issues/12792): remove the hooks machinery around channel locking
+    in runtime/io.c
+    (Gabriel Scherer, review by Xavier Leroy)
+  
+  - [#12389](https://github.com/ocaml/ocaml/issues/12389), [#12544](https://github.com/ocaml/ocaml/issues/12544), [#12984](https://github.com/ocaml/ocaml/issues/12984), [#12987](https://github.com/ocaml/ocaml/issues/12987): centralize the handling of metadata for
+    compilation units and artifacts in preparation for better unicode support for
+    OCaml source files.
+    (Florian Angeletti, review by Vincent Laviron and Gabriel Scherer)
+  
+  - [#12532](https://github.com/ocaml/ocaml/issues/12532), [#12553](https://github.com/ocaml/ocaml/issues/12553): improve readability of the pattern-matching debug output
+    (Gabriel Scherer, review by Thomas Refis)
+  
+  - [#12537](https://github.com/ocaml/ocaml/issues/12537): Use C11/C++11 standard static assertion.
+    (Antonin Décimo, review by Sebastien Hinderer, Xavier Leroy,
+     and KC Sivaramakrishnan)
+  
+  - [#12169](https://github.com/ocaml/ocaml/issues/12169): runtime: document and enforce naming conventions around STW sections.
+    (Gabriel Scherer, review by Enguerrand Decorne, Miod Vallat, B. Szilvasy
+     and Nick Barnes, report by KC Sivaramakrishnan)
+  
+  - [#12669](https://github.com/ocaml/ocaml/issues/12669) : Clean up some global state handling in schedgen
+    (Stefan Muenzel, review by Miod Vallat and Gabriel Scherer)
+  
+  - [#12640](https://github.com/ocaml/ocaml/issues/12640): Make the module separator used in symbol names configurable
+    (Miod Vallat, review by Hugo Heuzard and Xavier Leroy)
+  
+  - [#12691](https://github.com/ocaml/ocaml/issues/12691) : Clean up Ctype.expand_abbrev_gen and
+    rename Env.add_local_type to add_local_constraint
+    (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
+  
+  - [#12786](https://github.com/ocaml/ocaml/issues/12786) : Clean up the algorithm of Ctype.limited_generalize
+    (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer)
+  
+  - [#10691](https://github.com/ocaml/ocaml/issues/10691): Ast_mapper, Ast_iterator: add functions directive_argument,
+    toplevel_directive and toplevel_phrase.
+    (Guillaume Petiot, review by Gabriel Scherer and Kate Deplaix)
+  
+  - [#12764](https://github.com/ocaml/ocaml/issues/12764): Move all installable headers in `caml/` sub-directories.
+    (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
+  
+  - [#12914](https://github.com/ocaml/ocaml/issues/12914): Slightly change the s390x assembly dialect in order to build with
+    Clang's integrated assembler.
+    (Miod Vallat, review by Gabriel Scherer)
+  
+  - [#13001](https://github.com/ocaml/ocaml/issues/13001): do not read_back entire shapes to get aliases' uids when building the
+    usages index
+    (Ulysse Gérard, review by Gabriel Scherer and Nathanaëlle Courant)
+  
+  ### Build system:
+  
+  - [#12198](https://github.com/ocaml/ocaml/issues/12198), [#12321](https://github.com/ocaml/ocaml/issues/12321), [#12586](https://github.com/ocaml/ocaml/issues/12586), [#12616](https://github.com/ocaml/ocaml/issues/12616), [#12706](https://github.com/ocaml/ocaml/issues/12706), [#13048](https://github.com/ocaml/ocaml/issues/13048): continue the merge of the
+    sub-makefiles into the root Makefile started with [#11243](https://github.com/ocaml/ocaml/issues/11243), [#11248](https://github.com/ocaml/ocaml/issues/11248),
+    [#11268](https://github.com/ocaml/ocaml/issues/11268), [#11420](https://github.com/ocaml/ocaml/issues/11420) and [#11675](https://github.com/ocaml/ocaml/issues/11675).
+    (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
+  
+  - [#12569](https://github.com/ocaml/ocaml/issues/12569), [#12570](https://github.com/ocaml/ocaml/issues/12570): remove 'otherlibraries' as a prerequisite for 'runtop';
+    use 'runtop-with-otherlibs' to use a library from otherlibs/
+    (Gabriel Scherer, review by Sébastien Hinderer, suggestion by David Allsopp)
+  
+  - [#12652](https://github.com/ocaml/ocaml/issues/12652): Make magic numbers easier to bump and duplicate.
+    (Sébastien Hinderer, review by Antonin Décimo, David Allsopp and Florian
+    Angeletti)
+  
+  * (*breaking change*) [#12751](https://github.com/ocaml/ocaml/issues/12751): --with-target-bindir configure option implemented. This option
+    refers to the location of the runtime binaries on the target system for a
+    cross-compiler and is embedded in executables produced by ocamlc. It does
+    not affect the bytecode executables installed as part of the build. The old
+    mechanism `make TARGET_BINDIR=..` no longer works.
+    (David Allsopp, review by Damien Doligez, Xavier Leroy and Olivier Nicole)
+  
+  - [#12768](https://github.com/ocaml/ocaml/issues/12768), [#13030](https://github.com/ocaml/ocaml/issues/13030): Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
+    and fix C compiler feature detection on macOS.
+    (Antonin Décimo, review by Miod Vallat and Sébastien Hinderer)
+  
+  ### Bug fixes:
+  
+  - [#10652](https://github.com/ocaml/ocaml/issues/10652), [#12720](https://github.com/ocaml/ocaml/issues/12720): fix evaluation order in presence of optional arguments
+    (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
+  
+  - [#12595](https://github.com/ocaml/ocaml/issues/12595), [#12597](https://github.com/ocaml/ocaml/issues/12597): fix a race in `caml_clear_gc_stats_sample`
+    (Gabriel Scherer, review by B. Szilvasy, report by B. Szilvasy)
+  
+  - [#12580](https://github.com/ocaml/ocaml/issues/12580): Fix location of alias pattern variables.
+    (Chris Casinghino, review Gabriel Scherer, report by Milo Davis)
+  
+  - [#12583](https://github.com/ocaml/ocaml/issues/12583): Add a closing event for when `EV_MAJOR_EPHE_MARK` is complete
+    (Sudha Parimala, review by Gabriel Scherer)
+  
+  - [#12566](https://github.com/ocaml/ocaml/issues/12566): caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
+    instead of `malloc` since 4.06, breaking (in pooled mode) user code
+    that uses `free` on the result. Symmetrically,
+    caml_input_value_from_malloc should use `free`.
+    (Gabriel Scherer, review by Xavier Leroy and Enguerrand Decorne,
+     report by Ido Yariv)
+  
+  - [#12490](https://github.com/ocaml/ocaml/issues/12490): Unix: protect the popen_processes hashtable with a mutex
+    (Gabriel Scherer, report by Olivier Nicole, review by Xavier Leroy)
+  
+  - [#11931](https://github.com/ocaml/ocaml/issues/11931): Fix tricky typing bug with type substitutions
+    (Stephen Dolan, review by Leo White and Jacques Garrigue)
+  
+  - [#12037](https://github.com/ocaml/ocaml/issues/12037), [#12171](https://github.com/ocaml/ocaml/issues/12171): Fix get_extern_state potential NULL dereference.
+    (Alexander Skvortsov, report by Török Edwin,
+     design by Gabriel Scherer, Xavier Leroy)
+  
+  - [#12635](https://github.com/ocaml/ocaml/issues/12635): Fix get_intern_state potential NULL dereference.
+    (Antonin Décimo, review by KC Sivaramakrishnan)
+  
+  - [#12032](https://github.com/ocaml/ocaml/issues/12032), [#12059](https://github.com/ocaml/ocaml/issues/12059): Bug fixes related to compilation of recursive definitions
+    (Vincent Laviron, report by Victoire Noizet, review by Gabriel Scherer)
+  
+  * (*breaking change*) [#12145](https://github.com/ocaml/ocaml/issues/12145): Loopy constraints cause ocamlc to loop.
+    Fixed by completely removing the call to `update_type` in
+    `Typedecl.transl_type_decl`, as the expansion is already checked by
+    `check_regularity`. As a result, recursion is more polymorphic,
+    which may cause some (essentially wrong) type declarations to have
+    unbound type variables, and some constraints unrelated to the concrete
+    type to be ignored (see tests/typing-misc/constraints.ml).
+    (Jacques Garrigue, report by Richard Eisenberg, review by Leo White)
+  
+  - [#12207](https://github.com/ocaml/ocaml/issues/12207), [#12222](https://github.com/ocaml/ocaml/issues/12222): Make closure computation linear in the number of recursive
+    functions instead of quadratic
+    (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
+    and Gabriel Scherer)
+  
+  - [#11040](https://github.com/ocaml/ocaml/issues/11040), [#12591](https://github.com/ocaml/ocaml/issues/12591): fix a data race in major_gc.c
+    (Gabriel Scherer, review by Guillaume Munch-Maccagnoni
+     and KC Sivaramakrishnan, report by Sadiq Jaffer)
+  
+  - [#12238](https://github.com/ocaml/ocaml/issues/12238), [#12403](https://github.com/ocaml/ocaml/issues/12403), [#12698](https://github.com/ocaml/ocaml/issues/12698): read input files in one go to avoid source reprinting
+    issues.
+    (Gabriel Scherer, report by Mike Spivey and Vincent Laviron, review by
+     Nicolás Ojeda Bär, Xavier Leroy and Jeremy Yallop)
+  
+  - [#12334](https://github.com/ocaml/ocaml/issues/12334), [#12368](https://github.com/ocaml/ocaml/issues/12368): Bad error message with mutually recursive abbreviations
+    (Jacques Garrigue, report by Richard Eisenberg, review by Gabriel Scherer
+     and Richard Eisenberg)
+  
+  - [#12401](https://github.com/ocaml/ocaml/issues/12401): `seek_in` and `seek_out` sometimes returned normally when given
+    negative offsets, instead of failing. Now both functions should consistently
+    raise `Sys_error` in this case.
+    (Nicolás Ojeda Bär, review by Gabriel Scherer)
+  
+  - [#12267](https://github.com/ocaml/ocaml/issues/12267): Fix stack alignment computation
+    (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
+  
+  - [#12395](https://github.com/ocaml/ocaml/issues/12395), [#12404](https://github.com/ocaml/ocaml/issues/12404): Fix thread-unsafety in the fallback implementation of
+    `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
+    (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
+  
+  - [#12949](https://github.com/ocaml/ocaml/issues/12949): open shadowing mistriggers
+    (Gabriel Scherer, review by Florian Angeletti, report by Andreas Rossberg)
+  
+  - [#12526](https://github.com/ocaml/ocaml/issues/12526): Honor `ocaml.inline always` attribute on functions with
+    optional arguments and default values in the Closure backend
+    (Alain Frisch, review by Vincent Laviron)
+  
+  - [#12677](https://github.com/ocaml/ocaml/issues/12677), [#12889](https://github.com/ocaml/ocaml/issues/12889): make Domain.DLS thread-safe
+    (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
+     report by Vesa Karvonen)
+  
+  - [#12561](https://github.com/ocaml/ocaml/issues/12561): Fix crash when combining TSan and frame-pointers
+    (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard, review by Miod
+    Vallat and Gabriel Scherer)
+  
+  - [#12482](https://github.com/ocaml/ocaml/issues/12482): Rework bounds checking code in the POWER backend
+    (Miod Vallat and Xavier Leroy, report by Jan Midtgaard, review by
+     KC Sivaramakrishnan)
+  
+  - [#12528](https://github.com/ocaml/ocaml/issues/12528), [#12703](https://github.com/ocaml/ocaml/issues/12703): Avoid pointer arithmetic overflow in Tag_val macro
+    (very likely harmless, but can trigger alarms)
+    (Xavier Leroy, report by Sam Goldman, review by Guillaume Munch-Maccagnoni)
+  
+  - [#12593](https://github.com/ocaml/ocaml/issues/12593): TSan should handle Effect.Unhandled correctly
+    (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard and Miod Vallat,
+     review by Gabriel Scherer)
+  
+  - [#12684](https://github.com/ocaml/ocaml/issues/12684): fix locations filename in AST produced by the `-pp` option
+    (Gabriel Scherer, review by Florian Angeletti)
+  
+  - [#12714](https://github.com/ocaml/ocaml/issues/12714): check whether macros are defined before using them to ensure
+    that the headers can always be used in code which turns on -Wundef
+    (or equivalent).
+    (Antonin Décimo, review by Miod Vallat, Gabriel Scherer,
+     Xavier Leroy, and David Allsopp)
+  
+  - [#12726](https://github.com/ocaml/ocaml/issues/12726): fix segmentation fault under Windows when executing a bytecode file if
+    the runtime (`ocamlrun.exe`) cannot be found.
+    (Vadim Zborovskii, Nicolás Ojeda Bär, report by Vadim Zborovskii, review by
+    David Allsopp)
+  
+  - [#12727](https://github.com/ocaml/ocaml/issues/12727), [#12730](https://github.com/ocaml/ocaml/issues/12730): fix bug with value let-rec and labelled applications
+    (Vincent Laviron, review by Gabriel Scherer)
+  
+  * (*breaking change*) [#12751](https://github.com/ocaml/ocaml/issues/12751): Always keep within the 128 character limit for shebang lines. Previous
+    fix in [#8622](https://github.com/ocaml/ocaml/issues/8622) handled building the compiler with a long prefix; this patch
+    extends this to the bytecode executables emitted by that compiler.
+    (David Allsopp, review by Damien Doligez, Xavier Leroy and Olivier Nicole)
+  
+  - [#12755](https://github.com/ocaml/ocaml/issues/12755): Fix data race on global pools arrays of pool_freelist
+    (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer)
+  
+  - [#12796](https://github.com/ocaml/ocaml/issues/12796), [#12801](https://github.com/ocaml/ocaml/issues/12801): Fix memory corruption in caml_unix_alloc_sockaddr
+    (Thomas Leonard, review by Nicolás Ojeda Bär)
+  
+  - [#12737](https://github.com/ocaml/ocaml/issues/12737): Fix data races in minor_gc.c and caml_natdynlink_open
+    (Olivier Nicole, review by Stefan Muenzel, Miod Vallat, Guillaume
+     Munch-Maccagnoni, Gabriel Scherer and Xavier Leroy)
+  
+  - [#12831](https://github.com/ocaml/ocaml/issues/12831): Fix call to caml_call_realloc_stack for s390x in PIC mode
+    (Vincent Laviron, report by Jerry James, review by Miod Vallat)
+  
+  * (*breaking change*) [#12837](https://github.com/ocaml/ocaml/issues/12837): Show non-generalizable type parameters in type definitions
+    Changes type of type parameters in outcometree.mli.
+    (Jacques Garrigue, review by Richard Eisenberg)
+  
+  - [#12897](https://github.com/ocaml/ocaml/issues/12897): fix locking bugs in Runtime_events
+    (Gabriel Scherer and Thomas Leonard,
+     review by Olivier Nicole, Vincent Laviron and Damien Doligez,
+     report by Thomas Leonard)
+  
+  - [#12851](https://github.com/ocaml/ocaml/issues/12851): Fix race between runtime events teardown and event emission
+    (Olivier Nicole, review by Miod Vallat and Gabriel Scherer)
+  
+  - [#12860](https://github.com/ocaml/ocaml/issues/12860): Fix an assertion that wasn't taking into account the possibility of an
+    ephemeron pointing at static data.
+    (Mark Shinwell, review by Gabriel Scherer and KC Sivaramakrishnan)
+  
+  - [#12861](https://github.com/ocaml/ocaml/issues/12861): Fix a possible crash in the `threads` library.
+    (Mark Shinwell, review by Gabriel Scherer and KC Sivaramakrishnan)
+  
+  - [#11040](https://github.com/ocaml/ocaml/issues/11040), [#12894](https://github.com/ocaml/ocaml/issues/12894): Silence false data race observed between caml_shared_try_alloc
+    and oldify. Introduces macros to call tsan annotations which help annotate
+    a ``happens before'' relationship.
+    (Hari Hara Naveen S and Olivier Nicole,
+     review by Gabriel Scherer and Miod Vallat)
+  
+  - [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+    expressions.
+    (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
+    Gabriel Scherer)
+  
+  - [#12919](https://github.com/ocaml/ocaml/issues/12919): Fix register corruption in caml_callback2_asm on s390x.
+    (Miod Vallat, review by Gabriel Scherer)
+  
+  - [#12924](https://github.com/ocaml/ocaml/issues/12924), [#12930](https://github.com/ocaml/ocaml/issues/12930): Rework package constraint checking to improve interaction with
+    immediacy
+    (Chris Casinghino and Florian Angeletti, review by Florian Angeletti and
+     Richard Eisenberg)
+  
+  - [#12969](https://github.com/ocaml/ocaml/issues/12969): Fix a data race in caml_darken_cont
+    (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer and Miod Vallat)
+  
+  - [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+    invalid programs forming recursive types.
+    (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+  
+  - [#13019](https://github.com/ocaml/ocaml/issues/13019): Remove linking instructions for the Unix library from threads.cma
+    (this was done for threads.cmxa in OCaml 3.11). Eliminates warnings from
+    new lld when using threads.cma of duplicated libraries.
+    (David Allsopp, review by Nicolás Ojeda Bär)
+  
+  - [#13058](https://github.com/ocaml/ocaml/issues/13058): Add TSan instrumentation to caml_call_gc(), since it may raise
+    exceptions.
+    (Fabrice Buoro, Olivier Nicole, Gabriel Scherer and Miod Vallat)
+  
+  - [#13079](https://github.com/ocaml/ocaml/issues/13079): Save and restore frame pointer across Iextcall on ARM64
+    (Tim McGilchrist, review by KC Sivaramakrishnan and Miod Vallat)
+  
+  - [#13094](https://github.com/ocaml/ocaml/issues/13094): Fix undefined behavior of left-shifting a negative number.
+    (Antonin Décimo, review by Miod Vallat and Nicolás Ojeda Bär)
+  
+  - [#13130](https://github.com/ocaml/ocaml/issues/13130): minor fixes to pprintast for raw identifiers and local module open
+    syntax for types.
+    (Chet Murthy, review by Gabriel Scherer)
+  
+---
+
+We have the pleasure of celebrating the birthday of Inge Lehmann by announcing the
+release of OCaml version 5.2.0.
+
+Some of the highlights in OCaml 5.2.0 are:
+- Re-introduced GC compaction
+- Restored native backend for POWER 64 bits
+- Thread sanitizer support
+- New Dynarray module
+- New -H flag for hidden include directories
+- Project-wide occurence metadata support for developer tools
+- Raw identifiers
+- Local open in type expressions
+
+And a lot of incremental changes:
+- Around 20 new functions in the standard library
+- Many fixes and improvements in the runtime
+- Many bug fixes
+
+OCaml 5.2.0 is still a somewhat experimental release compared to the OCaml
+4.14 branch. In particular
+
+   - The Windows MSVC port is still unavailable.
+   - Ephemeron performances need to be investigated.
+   - `statmemprof` is being tested in the developer branch.
+   - There are a number of known runtime concurrency or GC performance bugs
+     (that trigger under rare circumstances).
+
+Since the Windows MSVC port and statmemprof are still missing, the maintenance
+support for OCaml 4.14 will be extended until at least the end of the year.
+
+Please report any unexpected behaviours on the [OCaml issue tracker](https://github.com/ocaml/ocaml/issues)
+and post any questions or comments you might have on our
+[discussion forums](https://discuss.ocaml.org).
+
+
+The full list of changes can be found in the changelog below.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 5.2.0
+```
+
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.2.0+options <option_list>
+```
+where `<option_list>` is a comma-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.2.0+flambda+nffa ocaml-variants.5.0.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```

--- a/data/changelog/ocaml/2024-05-13-ocaml-5.2.0.md
+++ b/data/changelog/ocaml/2024-05-13-ocaml-5.2.0.md
@@ -956,7 +956,7 @@ If you want to tweak the configuration of the compiler, you can switch to the op
 opam update
 opam switch create <switch_name> ocaml-variants.5.2.0+options <option_list>
 ```
-where `<option_list>` is a comma-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+where `<option_list>` is a space separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
 ```bash
 opam switch create 5.2.0+flambda+nffa ocaml-variants.5.0.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
 ```

--- a/data/releases/5.1.1.md
+++ b/data/releases/5.1.1.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 5.1.1
 date: 2023-12-08
-is_latest: true
+is_latest: false
 intro: |
   This page describes OCaml version **5.1.1**, released on
   Dec 8, 2023. Go [here](/releases) for a list of all releases.

--- a/data/releases/5.2.0.md
+++ b/data/releases/5.2.0.md
@@ -9,19 +9,17 @@ intro: |
 
   This release is available as an [opam](/p/ocaml/5.2.0) package.
 highlights: |
-
-- Re-introduced GC compaction
-- Restored native backend for POWER 64 bits
-- Thread sanitizer support
-- New Dynarray module
-- New -H flag for hidden include directories
-- Project-wide occurence metadata support for developer tools
-- Raw identifiers
-- Local open in type expressions
-- Around 20 new functions in the standard library
-- Many fixes and improvements in the runtime
-- Many bug fixes
-
+  - Re-introduced GC compaction
+  - Restored native backend for POWER 64 bits
+  - Thread sanitizer support
+  - New Dynarray module
+  - New -H flag for hidden include directories
+  - Project-wide occurence metadata support for developer tools
+  - Raw identifiers
+  - Local open in type expressions
+  - Around 20 new functions in the standard library
+  - Many fixes and improvements in the runtime
+  - Many bug fixes
 ---
 
 ## What's New

--- a/data/releases/5.2.0.md
+++ b/data/releases/5.2.0.md
@@ -1,0 +1,1043 @@
+---
+kind: compiler
+version: 5.2.0
+date: 2024-05-13
+is_latest: true
+intro: |
+  This page describes OCaml version **5.2.0**, released on
+  2024-05-13. Go [here](/releases) for a list of all releases.
+
+  This release is available as an [opam](/p/ocaml/5.2.0) package.
+highlights: |
+
+- Re-introduced GC compaction
+- Restored native backend for POWER 64 bits
+- Thread sanitizer support
+- New Dynarray module
+- New -H flag for hidden include directories
+- Project-wide occurence metadata support for developer tools
+- Raw identifiers
+- Local open in type expressions
+- Around 20 new functions in the standard library
+- Many fixes and improvements in the runtime
+- Many bug fixes
+
+---
+
+## What's New
+
+Some of the highlights in OCaml 5.2.0 are:
+- Re-introduced GC compaction
+- Restored native backend for POWER 64 bits
+- Thread sanitizer support
+- New Dynarray module
+- New -H flag for hidden include directories
+- Project-wide occurence metadata support for developer tools
+- Raw identifiers
+- Local open in type expressions
+
+And a lot of incremental changes:
+- Around 20 new functions in the standard library
+- Many fixes and improvements in the runtime
+- Many bug fixes
+
+
+OCaml 5.2.0 is still a somewhat experimental release compared to the OCaml
+4.14 branch. In particular
+
+   - The Windows MSVC port is still unavailable.
+   - Ephemeron performances need to be investigated.
+   - `statmemprof` is being tested in the developer branch.
+   - There are a number of known runtime concurrency or GC performance bugs
+     (that trigger under rare circumstances).
+
+For a comprehensive list of changes and details on all new features,
+bug fixes, optimizations, etc., please consult the
+[changelog](#Changes).
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 5.2.0
+```
+
+The source code for OCaml 5.2.0 is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.2.0.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.0.tar.gz)
+
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: set OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: compile OCaml without the native-code compiler
+- `ocaml-option-flambda`: set OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: set OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: set OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: set OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-tsan` : set OCaml to be compiled with thread sanitiser support
+- `ocaml-option-address-sanitizer`: set OCaml to be compiled with address sanitiser
+- `ocaml-option-leak-sanitizer`: set OCaml to be compiled with leak sanitiser
+- `ocaml-option-fp`: set OCaml to be compiled with frame pointers
+
+For instance, one can install a switch with both `flambda` and the `--disable-flat-float-array` option with
+
+
+```
+opam switch create 5.2.0+flambda+nffa ocaml-variants.5.2.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+
+Source Distribution
+-------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/5.2.0.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin)
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/5.2.0.zip)
+  format
+- [Opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://v2.ocaml.org/releases/5.2/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions — see also the [Windows release
+notes](https://v2.ocaml.org/releases/5.2/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+Alternative Compilers
+---------------------
+
+Additionally, the following projects allow you to compile OCaml code to
+targets traditionally associated with other languages:
+
+* [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
+  to JavaScript compiler.
+
+User Manual
+-------------
+
+The user manual for OCaml can be:
+
+- [Browsed
+  online](https://ocaml.org/releases/5.2/manual/index.html),
+- Downloaded as a single
+  [PDF](https://ocaml.org/releases/5.2/ocaml-5.2-refman.pdf),
+  or [plain
+  text](https://ocaml.org/releases/5.2/ocaml-5.2-refman.txt)
+  document,
+- Downloaded as a single
+  [TAR](https://ocaml.org/releases/5.2/ocaml-5.2-refman-html.tar.gz)
+  or
+  [ZIP](https://ocaml.org/releases/5.2/ocaml-5.2-refman-html.zip)
+  archive of HTML files,
+- Downloaded as a single
+  [tarball](https://ocaml.org/releases/5.2/ocaml-5.2-refman.info.tar.gz)
+  of Emacs info files,
+
+
+## Changes 
+
+(Changes that can break existing programs are marked with a  "breaking change" warning)
+
+### Restored and new backends:
+
+- [#12276](https://github.com/ocaml/ocaml/issues/12276), [#12601](https://github.com/ocaml/ocaml/issues/12601): native-code compilation for POWER (64 bits, little-endian)
+  (Xavier Leroy, review by KC Sivaramakrishnan, Anil Madhavapeddy,
+   and Stephen Dolan)
+
+- [#12667](https://github.com/ocaml/ocaml/issues/12667): extend the latter to POWER 64 bits, big-endian, ELFv2 ABI
+  (A. Wilcox, review by Xavier Leroy)
+
+### Runtime system:
+
+- [#12193](https://github.com/ocaml/ocaml/issues/12193): Re-introduce GC compaction for shared pools
+  Adds a parallel compactor for the shared pools (which contain major heap
+  blocks sized less than 128 words). Explicit only for now, on calls to
+  `Gc.compact`.
+  (Sadiq Jaffer, Nick Barnes, review by Anil Madhavapeddy, Damien Doligez,
+   David Allsopp, Miod Vallat, Artem Pianykh, Stephen Dolan, Mark Shinwell
+   and KC Sivaramakrishnan)
+
+- [#12114](https://github.com/ocaml/ocaml/issues/12114): Add ThreadSanitizer support
+  (Fabrice Buoro and Olivier Nicole, based on an initial work by Anmol Sahoo,
+   review by Damien Doligez, Sébastien Hinderer, Jacques-Henri Jourdan, Luc
+   Maranget, Guillaume Munch-Maccagnoni, Gabriel Scherer)
+
+
+- [#12850](https://github.com/ocaml/ocaml/issues/12850): Update Gc.quick_stat data at the end of major cycles and compaction
+  This PR adds an additional caml_collect_gc_stats_sample_stw to the major heap
+  cycling stw. This means that Gc.quick_stat now actually reflects the state of
+  the heap after a major cycle or compaction.
+  (Sadiq Jaffer, review by Miod Vallat and Gabriel Scherer)
+
+- [#12859](https://github.com/ocaml/ocaml/issues/12859): Ensure Gc.compact does a full major before the compactor runs
+  (Sadiq Jaffer, review by Leo White, Mark Shinwell, Gabriel Scherer,
+   Josh Berdine, David Allsopp and KC Sivaramakrishnan)
+
+- [#10111](https://github.com/ocaml/ocaml/issues/10111): Increase the detail of location information for debugging events to
+  allow the end line number and character offset to be reported.
+  (David Allsopp, review by Nick Barnes, Enguerrand Decorne and Stephen Dolan)
+
+- [#10403](https://github.com/ocaml/ocaml/issues/10403), [#12202](https://github.com/ocaml/ocaml/issues/12202): introduce `caml_ext_table_add_noexc` that does not
+  raise `Out_of_memory` exceptions and use it inside the blocking sections
+  of `caml_read_directory`.  Also, check for overflows in ext table sizes.
+  (Xavier Leroy, report by Arseniy Alekseyev, review by Gabriel Scherer)
+
+- [#11332](https://github.com/ocaml/ocaml/issues/11332), [#12702](https://github.com/ocaml/ocaml/issues/12702): make sure `Bool_val(v)` has type `bool` in C++
+  (Xavier Leroy, report by ygrek, review by Gabriel Scherer)
+
+- [#12772](https://github.com/ocaml/ocaml/issues/12772), [#12787](https://github.com/ocaml/ocaml/issues/12787): Avoid using _Bool in public headers for the sake of C++
+  compatibility
+  (Guillaume Munch-Maccagnoni, report by KC Sivaramakrishnan, review
+  by Xavier Leroy and KC Sivaramakrishnan)
+
+- [#12223](https://github.com/ocaml/ocaml/issues/12223): Constify constructors and flags tables in C code. Now these
+  tables will go in the readonly segment, where they belong.
+  (Antonin Décimo, review by Gabriel Scherer and Xavier Leroy)
+
+- [#12234](https://github.com/ocaml/ocaml/issues/12234): make instrumented time calculation more thread-safe on macOS.
+  (Anil Madhavapeddy, review by Daniel Bünzli and Xavier Leroy)
+
+- [#12235](https://github.com/ocaml/ocaml/issues/12235), [#12468](https://github.com/ocaml/ocaml/issues/12468): introduce and use the `CAMLnoret` macro as
+  a lighter alternative to `CAMLnoreturn_start` / `CAMLnoreturn_end`.
+  Implement it so as to conform with C11, C23, C++11, C++17.
+  (Xavier Leroy and Dhruv Maroo, with help from Antonin Décimo, review by
+   Gabriel Scherer and David Allsopp)
+
+- [#12275](https://github.com/ocaml/ocaml/issues/12275): caml/stack.h: more abstract macros to describe OCaml stacks and
+  how to traverse them, supporting more stack layouts.
+  (Xavier Leroy, review by KC Sivaramakrishnan and Fabrice Buoro)
+
+- [#12268](https://github.com/ocaml/ocaml/issues/12268): deliver `Out_of_memory` exception if domain creation fails
+  due to memory resource exhaustion.  It was previous always a `Failure`.
+  (Anil Madhavapeddy, review by David Allsopp)
+
+- [#12300](https://github.com/ocaml/ocaml/issues/12300), [#12314](https://github.com/ocaml/ocaml/issues/12314): Discard out_channel buffered data on permanent I/O error
+  (Xavier Leroy, report by Török Edwin, review by Anil Madhavapeddy
+  and Nicolás Ojeda Bär)
+
+- [#11386](https://github.com/ocaml/ocaml/issues/11386): Simplifications and fixes to multicore systhreads implementation.
+  (Guillaume Munch-Maccagnoni, review by Anil Madhavapeddy and KC
+   Sivaramakrishnan)
+
+- [#12875](https://github.com/ocaml/ocaml/issues/12875), [#12879](https://github.com/ocaml/ocaml/issues/12879), [#12882](https://github.com/ocaml/ocaml/issues/12882): Execute preemptive systhread switching as a
+  delayed pending action. This ensures that one can reason within the
+  FFI that no mutation happens on the same domain when allocating on
+  the OCaml heap from C, consistently with OCaml 4. This also fixes
+  further bugs with the multicore systhreads implementation.
+  (Guillaume Munch-Maccagnoni, bug reports and suggestion by Mark
+   Shinwell, review by Nick Barnes and Stephen Dolan)
+
+- [#12408](https://github.com/ocaml/ocaml/issues/12408): `Domain.spawn` no longer leaks its functional argument for
+  the whole duration of the children domain lifetime.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+
+- [#12409](https://github.com/ocaml/ocaml/issues/12409): Fix unsafety and deadlocks should an asynchronous exception
+  arise at specific locations during domain creation and shutdown.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer)
+
+- [#11911](https://github.com/ocaml/ocaml/issues/11911), [#12381](https://github.com/ocaml/ocaml/issues/12381): Restore statmemprof functionality in part, with
+  some API changes in Gc.Memprof.
+  (Nick Barnes, review by Jacques-Henri Jourdan
+   and Guillaume Munch-Maccagnoni).
+
+- [#12430](https://github.com/ocaml/ocaml/issues/12430): Simplify dynamic bytecode loading in Meta.reify_bytecode
+  (Stephen Dolan, review by Sébastien Hinderer, Vincent Laviron and Xavier
+   Leroy)
+
+- [#12489](https://github.com/ocaml/ocaml/issues/12489): Fix an error-handling bug in caml_alloc_sprintf
+  (Stephen Dolan, report by Chris Casinghino, review by Jeremy Yallop
+   and Xavier Leroy)
+
+- [#11307](https://github.com/ocaml/ocaml/issues/11307): Finish adapting the implementation of asynchronous actions for
+  multicore: soundness, liveness, and performance issues.
+  Do not crash if a signal handler is called from an unregistered C
+  thread, and other possible soundness issues. Prevent issues where join
+  on other domains could make the toplevel unresponsible to Ctrl-C. Avoid
+  needless repeated polling in C code when callbacks cannot run
+  immediately.
+  (Guillaume Munch-Maccagnoni, review by Enguerrand Decorne, Xavier
+  Leroy, and KC Sivaramakrishnan)
+
+- [#12634](https://github.com/ocaml/ocaml/issues/12634): Simplify TSan backtrace bookkeeping upon raise
+  (Olivier Nicole and Fabrice Buoro, review by Gabriel Scherer)
+
+* (*breaking change*) [#12686](https://github.com/ocaml/ocaml/issues/12686): Some primitives had the wrong types to be callable from the bytecode
+  interpreter.  Either fix their types, mark them as `CAMLexport` instead of
+  `CAMLprim`, or remove them entirely if no longer used.
+  (Xavier Leroy, review by David Allsopp)
+
+- [#12700](https://github.com/ocaml/ocaml/issues/12700), continuing [#11763](https://github.com/ocaml/ocaml/issues/11763) and trying to address [#12660](https://github.com/ocaml/ocaml/issues/12660):
+  Use the correct types for primitives when generating the table of primitives
+  used by ocamlrun.
+  (Xavier Leroy, motivation, review and improvements by Antonin Décimo)
+
+- [#12345](https://github.com/ocaml/ocaml/issues/12345), [#12710](https://github.com/ocaml/ocaml/issues/12710): Fix issues with finaliser orphaning at domain termination
+  (KC Sivaramakrishnan, report by Gabriel Scherer, review by Gabriel Scherer,
+  Sadiq Jaffer and Fabrice Buoro)
+
+- [#12599](https://github.com/ocaml/ocaml/issues/12599): Refactor Dynlink startup to avoid parsing bytecode sections twice
+  (Stephen Dolan, review by David Allsopp, Hugo Heuzard, Damien Doligez and
+   Xavier Leroy)
+
+- [#12678](https://github.com/ocaml/ocaml/issues/12678), [#12898](https://github.com/ocaml/ocaml/issues/12898): free channel buffers on close rather than on finalization
+  (Damien Doligez, review by Jan Midtgaard and Gabriel Scherer, report
+   by Jan Midtgaard)
+
+- [#12681](https://github.com/ocaml/ocaml/issues/12681): Fix TSan false positives due to volatile write handling
+  (Olivier Nicole, Fabrice Buoro and Anmol Sahoo, review by Luc Maranget,
+   Gabriel Scherer, Hernan Ponce de Leon and Xavier Leroy)
+
+- [#12743](https://github.com/ocaml/ocaml/issues/12743): Use pthread_sigmask instead of sigprocmask
+  Updates usage of sigprocmask to pthread_sigmask in otherlibs/unix.
+  (Max Slater, review by Miod Vallat and Xavier Leroy)
+
+- [#12769](https://github.com/ocaml/ocaml/issues/12769): Unify MSVC and MinGW-w64 code paths, by always using WinAPI
+  directly.
+  (David Allsopp, Antonin Décimo, and Samuel Hym, review by Nicolas
+   Ojeda Bar)
+
+- [#11911](https://github.com/ocaml/ocaml/issues/11911), [#12382](https://github.com/ocaml/ocaml/issues/12382), [#12383](https://github.com/ocaml/ocaml/issues/12383): Restore statmemprof functionality in part
+  (backtrace buffers, per-thread and per-domain data structures,
+  GC/allocation interface). (Nick Barnes, review by Gabriel Scherer,
+  Fabrice Buoro, Sadiq Jaffer, Guillaume Munch-Maccagnoni, and
+  Jacques-Henri Jourdan).
+
+- [#12735](https://github.com/ocaml/ocaml/issues/12735): Store both ends of the stack chain in continuations
+  (Leo White, review by Miod Vallat and KC Sivaramakrishnan)
+
+- [#12746](https://github.com/ocaml/ocaml/issues/12746): Simplify and clean up TSan annotations
+  (Olivier Nicole, review by Miod Vallat and Fabrice Buoro)
+
+- [#12809](https://github.com/ocaml/ocaml/issues/12809): Add ThreadSanitizer support to FreeBSD/amd64
+  (Miod Vallat, review by Gabriel Scherer)
+
+- [#12810](https://github.com/ocaml/ocaml/issues/12810): Port ThreadSanitizer support to Linux and macOS on arm64
+  (Miod Vallat, review by Tim McGilchrist)
+
+- [#12811](https://github.com/ocaml/ocaml/issues/12811): Define and use the CAMLthread_local macro for TLS variables.
+  (Antonin Décimo and Samuel Hym, review by Miod Vallat and Xavier Leroy)
+
+- [#12814](https://github.com/ocaml/ocaml/issues/12814): More detailed failure messages from `input_value` and `Marshal.from_*`
+  (Xavier Leroy, review by Stephen Dolan and Anil Madhavapeddy)
+
+- [#12815](https://github.com/ocaml/ocaml/issues/12815): Correctly format multi-line locations in exception backtraces, in the
+  style that the compiler driver uses.
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#12773](https://github.com/ocaml/ocaml/issues/12773), [#12830](https://github.com/ocaml/ocaml/issues/12830), [#12834](https://github.com/ocaml/ocaml/issues/12834): Rewrite `caml_c_thread_(un)register` to fix
+  various bugs.
+  (Guillaume Munch-Maccagnoni, reported by Miod Vallat, suggested by
+   Hari Hara Naveen S, reviewed by Fabrice Buoro, Gabriel Scherer and
+   Miod Vallat)
+
+- [#12876](https://github.com/ocaml/ocaml/issues/12876): Port ThreadSanitizer support to Linux on POWER
+  (Miod Vallat, review by Tim McGilchrist)
+
+- [#12886](https://github.com/ocaml/ocaml/issues/12886): Reinitialize IO mutexes after fork
+  (Max Slater, review by Guillaume Munch-Maccagnoni and Xavier Leroy)
+
+- [#12907](https://github.com/ocaml/ocaml/issues/12907): Port ThreadSanitizer support to Linux on RiscV
+  (Miod Vallat, review by Nicolás Ojeda Bär and Fabrice Buoro)
+
+- [#12915](https://github.com/ocaml/ocaml/issues/12915): Port ThreadSanitizer support to Linux on s390x
+  (Miod Vallat, review by Tim McGilchrist)
+
+- [#12934](https://github.com/ocaml/ocaml/issues/12934): Fix data races between marking and sweeping functions
+  (Olivier Nicole, suggested by Stephen Dolan, review by Gabriel Scherer,
+   Miod Vallat and Damien Doligez)
+
+### Language features:
+
+- [#12295](https://github.com/ocaml/ocaml/issues/12295), [#12568](https://github.com/ocaml/ocaml/issues/12568): Give `while true' a polymorphic type, similarly to
+  `assert false'
+  (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer,
+  suggestion by Rodolphe Lepigre and John Whitington)
+
+- [#12044](https://github.com/ocaml/ocaml/issues/12044): Add local module open syntax for types.
+  ```
+    module A = struct
+      type t = int
+      type r = unit
+      type s = string
+    end
+
+    type example = A.(t * r * s)
+  ```
+  (Alistair O'Brien, review by Gabriel Scherer, Nicolás Ojeda Bär
+   and Florian Angeletti)
+
+- [#11252](https://github.com/ocaml/ocaml/issues/11252), RFC 27: Support raw identifier syntax \#foo
+  (Stephen Dolan, review by David Allsopp, Gabriel Scherer and Olivier Nicole)
+
+
+- [#12315](https://github.com/ocaml/ocaml/issues/12315): Use type annotations from arguments in let rec
+  (Stephen Dolan, review by Gabriel Scherer)
+
+- [#12375](https://github.com/ocaml/ocaml/issues/12375): allow use of [@untagged] for all immediate types like char, bool,
+  and variant with only constant constructors.
+  (Christophe Raffalli, review by Gabriel Scherer)
+
+* (*breaking change*) [#12502](https://github.com/ocaml/ocaml/issues/12502): the compiler now normalizes the newline sequence \r\n to
+  a single \n character during lexing, to guarantee that the semantics
+  of newlines in string literals is not modified by Windows tools
+  transforming \n into \r\n in source files.
+  Warning 29 [eol-in-string] is not emitted anymore, as the normalization
+  gives a more robust semantics to newlines in string literals.
+  (Gabriel Scherer and Damien Doligez, review by Daniel Bünzli, David
+   Allsopp, Andreas Rossberg, Xavier Leroy, report by Andreas Rossberg)
+
+### Standard library:
+
+- [#11563](https://github.com/ocaml/ocaml/issues/11563): Add the Dynarray module to the stdlib. Dynamic arrays are
+  arrays whose length can be changed by adding or removing elements at
+  the end, similar to 'vectors' in C++ or Rust.
+  (Gabriel Scherer, Simon Cruanes and Florian Angeletti, review by
+   Daniel Bünzli, Guillaume Munch-Maccagnoni, Clément Allain,
+   Damien Doligez, Wiktor Kuchta and Pieter Goetschalckx)
+
+
+- [#12716](https://github.com/ocaml/ocaml/issues/12716): Add `Format.pp_print_nothing` function.
+  (Léo Andrès, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
+* (*breaking change*) [#6732](https://github.com/ocaml/ocaml/issues/6732), [#12423](https://github.com/ocaml/ocaml/issues/12423): Make Buffer.add_substitute surjective and fix its
+  documentation.
+  (Damien Doligez, review by Antonin Décimo)
+
+* (*breaking change*) [#10775](https://github.com/ocaml/ocaml/issues/10775), [#12499](https://github.com/ocaml/ocaml/issues/12499): Half-precision floating-point elements in Bigarray.
+  (Anton Yabchinskiy, review by Xavier Leroy and Nicolás Ojeda Bär)
+
+- [#11517](https://github.com/ocaml/ocaml/issues/11517), [#12477](https://github.com/ocaml/ocaml/issues/12477): Expose pp_infinity in interface of the format module, and
+  check that margin is less than pp_infinity when setting or checking geometry.
+  (Janith Petangoda, reported by Simmo Saan, reviewed by Florian Angeletti,
+  Simmo Saan, Josh Berdine and Gabriel Scherer)
+
+- [#12217](https://github.com/ocaml/ocaml/issues/12217): Add `Array.shuffle`.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär, David Allsopp and Alain Frisch)
+
+- [#12212](https://github.com/ocaml/ocaml/issues/12212): Add cache-aligned constructor for atomics. The patch ensures that
+  all allocations (of the right size) in the shared heap are aligned.
+  (Bartosz Modelski with Gabriel Scherer, Guillaume Munch-Maccagnoni,
+   Xavier Leroy, review by Alain Frisch, Anil Madhavapeddy, Gabriel Scherer,
+   Guillaume Munch-Maccagnoni, KC Sivaramakrishnan, Stefan Muenzel,
+   Xavier Leroy)
+
+- [#12307](https://github.com/ocaml/ocaml/issues/12307): Add BLAKE2b hashing and an MD5 submodule to the Digest module.
+  (Xavier Leroy, review by Olivier Nicole, Gabriel Scherer, Wiktor Kuchta,
+   Daniel Bünzli, David Allsopp)
+
+- [#12365](https://github.com/ocaml/ocaml/issues/12365): Add In_channel.input_bigarray, In_channel.really_input_bigarray,
+  Out_channel.output_bigarray, Unix.read_bigarray, Unix.write_bigarray,
+  Unix.single_write_bigarray.
+  (Nicolás Ojeda Bär, review by Jeremy Yallop, Xavier Leroy, Gabriel Scherer,
+   David Allsopp)
+
+- [#12455](https://github.com/ocaml/ocaml/issues/12455): Add `Array.init_matrix`, `Float.Array.make_matrix`,
+  `Float.Array.init_matrix`.
+  (Glen Mével, review by Xavier Leroy, Gabriel Scherer, Jeremy Yallop,
+  Nicolas Ojeda Bar)
+
+* (*breaking change*) [#12455](https://github.com/ocaml/ocaml/issues/12455): `Array.make_matrix dimx dimy f` now raises `Invalid_argument`
+  when `dimx = 0 && dimy < 0` This was already specified but not enforced.
+  (Glen Mével, report by Jeremy Yallop, review by Nicolas Ojeda Bar)
+
+- [#12459](https://github.com/ocaml/ocaml/issues/12459): Add `Random.int_in_range`, `Random.int32_in_range`,
+  `Random.int64_in_range`, `Random.nativeint_in_range`,
+  and their counterpart in `Random.State`.
+  (Glen Mével and Xavier Leroy, review by Gabriel Scherer, Xavier Leroy,
+   Florian Angeletti)
+
+- [#12459](https://github.com/ocaml/ocaml/issues/12459): `Random`: restore compatibility between 32-bit integers (JavaScript)
+  and 63-bit integers (64-bit OCaml).
+  For `Random.full_int` this was guaranteed in 4.14 but wrongly removed in 5.0.
+  (Xavier Leroy, review by Glen Mével)
+
+- [#12511](https://github.com/ocaml/ocaml/issues/12511): Minor performance improvements and cleanups in the implementation
+  of modules Int32, Int64, and Nativeint
+  (Xavier Leroy, review by Gabriel Scherer and Daniel Bünzli)
+
+- [#12558](https://github.com/ocaml/ocaml/issues/12558): Adapt GC alarms for multicore and fix their documentation.
+  (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan
+   and Gabriel Scherer)
+
+- [#12625](https://github.com/ocaml/ocaml/issues/12625): Remove the Closure module from Obj
+  (Vincent Laviron, review by Xavier Leroy)
+
+- [#12758](https://github.com/ocaml/ocaml/issues/12758), [#12998](https://github.com/ocaml/ocaml/issues/12998): Remove the `Marshal.Compression` flag to the
+  `Marshal.to_*` functions.  The compilers are still able to use
+  ZSTD compression for compilation artefacts.
+  This is a forward port and clean-up of the emergency fix that was introduced
+  in OCaml 5.1.1 by [#12734](https://github.com/ocaml/ocaml/issues/12734).
+  (Xavier Leroy, review by Damien Doligez)
+
+- [#12784](https://github.com/ocaml/ocaml/issues/12784): Fix computation of minor-heap allocation in Gc.counters()
+  and Gc.allocated_bytes(). (Nick Barnes, review by Gabriel Scherer)
+
+- [#12770](https://github.com/ocaml/ocaml/issues/12770): Add `Fun.compose`.
+  (Justin Frank, review by Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
+
+- [#12845](https://github.com/ocaml/ocaml/issues/12845): Add `{In,Out}_channel.is_binary_mode` as the dual of
+  `set_binary_mode`. This function was previously only available in the internal
+  C API.
+  (David Allsopp, review by Nicolás Ojeda Bär and Xavier Leroy)
+
+### Type system:
+
+- [#12313](https://github.com/ocaml/ocaml/issues/12313), [#11799](https://github.com/ocaml/ocaml/issues/11799): Do not re-build as-pattern type when a ground type annotation
+  is given. This allows to work around problems with GADTs in as-patterns.
+  (Jacques Garrigue, report by Leo White, review by Gabriel Scherer)
+
+### Code generation and optimizations:
+
+- [#11239](https://github.com/ocaml/ocaml/issues/11239): on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.
+  This reduces stack usage.  It's only C stacks that require 16-alignment.
+  (Xavier Leroy, review by Gabriel Scherer and Stephen Dolan)
+
+- [#12311](https://github.com/ocaml/ocaml/issues/12311): on POWER, 32-bit FP numbers stored in memory (e.g. in bigarrays)
+  were not correctly rounded sometimes.
+  (Xavier Leroy, review by Anil Madhavapeddy and Tim McGilchrist)
+
+- [#12551](https://github.com/ocaml/ocaml/issues/12551), [#12608](https://github.com/ocaml/ocaml/issues/12608), [#12782](https://github.com/ocaml/ocaml/issues/12782), [#12596](https://github.com/ocaml/ocaml/issues/12596): Overhaul of recursive value compilation.
+  Non-function recursive bindings are now forbidden from Lambda onwards,
+  and compiled using a new Value_rec_compiler module.
+  (Vincent Laviron and Lunia Ayanides, review by Gabriel Scherer,
+   Stefan Muenzel and Nathanaëlle Courant)
+
+- [#1809](https://github.com/ocaml/ocaml/issues/1809), [#12181](https://github.com/ocaml/ocaml/issues/12181): rewrite `compare x y op 0` to `x op y` when values are integers
+  (Xavier Clerc, Stefan Muenzel, review by Gabriel Scherer and Vincent Laviron)
+
+- [#12825](https://github.com/ocaml/ocaml/issues/12825): disable common subexpression elimination for atomic loads... again.
+  (Gabriel Scherer, review by KC Sivaramakrishnan, Xavier Leroy
+   and Vincent Laviron, report by Vesa Karvonen)
+
+### Other libraries:
+
+- [#12213](https://github.com/ocaml/ocaml/issues/12213): Dynlink library, improve legibility of error messages
+  (Samuel Hym, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
+* (*breaking change*) [#12686](https://github.com/ocaml/ocaml/issues/12686): Runtime_events library, C API: define
+  `caml_runtime_events_{start,pause,resume}` as returning `void`
+  instead of `value`.
+  (Xavier Leroy, review by David Allsopp)
+
+### Compiler user-interface and warnings:
+
+- [#11989](https://github.com/ocaml/ocaml/issues/11989), [#12246](https://github.com/ocaml/ocaml/issues/12246), RFC 31: New flag, -H, to allow for transitive dependencies
+  without including them in the initial environment.
+  (Chris Casinghino, François Bobot, and Gabriel Scherer, review by Leo White
+   and Stefan Muenzel, RFC by François Bobot)
+
+
+* (*breaking change*) [#10613](https://github.com/ocaml/ocaml/issues/10613), [#12405](https://github.com/ocaml/ocaml/issues/12405): Simplify the values used for the system variable (`system:` in
+  `ocamlopt -config` or the `Config.system` constant). In particular, s390x and
+  ppc64 now report "linux" instead of "elf"; all variants of 32-bit ARM on Linux
+  now report "linux"; OpenBSD now reports "openbsd" instead of "bsd" for 32-bit
+  ARM; FreeBSD, NetBSD and OpenBSD now report the same value for both x86_64 and
+  x86_32; x86_32 systems matching *bsd but not freebsd*, netbsd* or openbsd*
+  are no longer identified (as on x86_64); x86_32 Linux now reports "linux"
+  instead of "linux_elf".
+  (David Allsopp, request by Kate Deplaix, review by Sébastien Hinderer and
+  Xavier Leroy)
+
+- [#12247](https://github.com/ocaml/ocaml/issues/12247): configure: --disable-ocamldebug can now be used instead
+  of --disable-debugger (which remains available for compatibility)
+  (Gabriel Scherer, review by Damien Doligez and Sébastien Hinderer)
+
+- [#12199](https://github.com/ocaml/ocaml/issues/12199): improve the error message for non-overriding `inherit!`
+  (Florian Angeletti, review by Jules Aguillon)
+
+- [#12210](https://github.com/ocaml/ocaml/issues/12210): uniform style for inline code in compiler messages
+  (Florian Angeletti, review by Gabriel Scherer)
+
+* (*breaking change*) [#12278](https://github.com/ocaml/ocaml/issues/12278), #:12325: Remove the OCAML_FLEXLINK environment variable from the
+  compiler drivers. This environment variable was previously used as part of the
+  FlexDLL bootstrap procedure and existed solely for that purpose. Its removal
+  greatly simplifies both the build system and testsuite machinery.
+  (David Allsopp, review by Sébastien Hinderer)
+
+- [#12347](https://github.com/ocaml/ocaml/issues/12347): error messages: always report missing polyvariant tags
+  (Florian Angeletti, report by Tianbo Hao, review by Gabriel Scherer)
+
+- [#12224](https://github.com/ocaml/ocaml/issues/12224), specialized error message when trying to apply non-functor
+  module (e.g `module M = Int(Int)`)
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#12451](https://github.com/ocaml/ocaml/issues/12451): Warning 53 (misplaced attributes) now works for all attributes.
+  (Chris Casinghino, review by Florian Angeletti)
+
+- [#12622](https://github.com/ocaml/ocaml/issues/12622): Give hints about existential types appearing in error messages
+  (Leo White, review by Gabriel Scherer and Florian Angeletti)
+
+- [#12671](https://github.com/ocaml/ocaml/issues/12671): When a class type parameter or class parameter does not match,
+  identify which parameter in the error message, instead of saying
+  "A type parameter" or "A parameter".
+  (Stefan Muenzel, review by Gabriel Scherer)
+
+- [#12679](https://github.com/ocaml/ocaml/issues/12679): Add more detail to the error message and manual in case of
+  invalid module type substitutions.
+  (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
+
+- [#12750](https://github.com/ocaml/ocaml/issues/12750): Display the command executed to extract primitives in
+  `ocamlc -verbose`.
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
+- [#12777](https://github.com/ocaml/ocaml/issues/12777): Add details about the actual and expected method types to the method
+  mismatch error messages.
+  (Javier Chávarri, review by Gabriel Scherer and Florian Angeletti)
+
+* (*breaking change*) [#12942](https://github.com/ocaml/ocaml/issues/12942): Fix an line ordering in some module inclusion error messages
+  (Nick Roberts, review by Florian Angeletti, report by Carl Eastlund)
+### Manual and documentation:
+
+- [#12338](https://github.com/ocaml/ocaml/issues/12338): clarification of the documentation of process related function in
+  the unix module regarding the first element of args and shell's pid.
+  (Christophe Raffalli, review by Florian Angeletti)
+
+- [#12473](https://github.com/ocaml/ocaml/issues/12473): Document in runtime/memory.c our current understanding of
+  accesses to the OCaml heap from the C runtime code -- the problem
+  of hybrid programs mixing two memory models.
+  (Gabriel Scherer and Guillaume Munch-Maccagnoni, review by Olivier
+   Nicole and Xavier Leroy)
+
+- [#12456](https://github.com/ocaml/ocaml/issues/12456): Document the incompatibility between effects on the one
+  hand, and `caml_callback` and asynchronous callbacks (signal
+  handlers, finalisers, memprof callbacks...) on the other hand.
+  (Guillaume Munch-Maccagnoni, review by KC Sivaramakrishnan)
+
+- [#12694](https://github.com/ocaml/ocaml/issues/12694): Document in runtime/tsan.c the TSan instrumentation choices and the
+  consequences with regard to the memory model.
+  (Olivier Nicole, review by Miod Vallat, Gabriel Scherer, Guillaume
+   Munch-Maccagnoni and Fabrice Buoro)
+
+- [#12802](https://github.com/ocaml/ocaml/issues/12802): Add manual chapter about ThreadSanitizer support
+  (Olivier Nicole, review by Miod Vallat, Sebastien Hinderer, Fabrice Buoro,
+   Gabriel Scherer and KC Sivaramakrishnan)
+
+- [#12819](https://github.com/ocaml/ocaml/issues/12819): Clarify which runtime interactions are allowed in custom ops
+  (Basile Clément, review by Guillaume Munch-Maccagnoni and Xavier Leroy)
+
+- [#12840](https://github.com/ocaml/ocaml/issues/12840): manual: update runtime tracing chapter for custom events (ex [#12335](https://github.com/ocaml/ocaml/issues/12335))
+  (Lucas Pluvinage, Sadiq Jaffer and Olivier Nicole, review by Gabriel Scherer,
+   David Allsopp, Tim McGilchrist and Thomas Leonard)
+
+- [#13066](https://github.com/ocaml/ocaml/issues/13066), update OCAMLRUNPARAM documentation for the stack size parameter l
+  (Florian Angeletti, review by Nicolás Ojeda Bär, Tim McGilchrist, and
+   Miod Vallat)
+
+- [#13078](https://github.com/ocaml/ocaml/issues/13078): update Format tutorial on structural boxes to mention alignment
+  questions.
+  (Edwin Török, review by Florian Angeletti)
+
+- [#13092](https://github.com/ocaml/ocaml/issues/13092): document the existence of the `[@@poll error]` built-in attribute
+  (Florian Angeletti, review by Gabriel Scherer)
+
+### Tools:
+
+- [#12340](https://github.com/ocaml/ocaml/issues/12340): testsuite: collect known issues with current -short-paths
+  implementation for existential types
+  (Florian Angeletti, Samuel Hym, review by Florian Angeletti and Thomas Refis)
+
+- [#12147](https://github.com/ocaml/ocaml/issues/12147): ocamllex: Allow carriage returns at the end of line directives.
+  (SeungCheol Jung, review by Nicolás Ojeda Bär)
+
+- [#12260](https://github.com/ocaml/ocaml/issues/12260): Fix invalid_argument on some external or module aliases in ocamlnat
+  (Fabian Hemmer, review by Vincent Laviron)
+
+- [#12185](https://github.com/ocaml/ocaml/issues/12185): New script language for ocamltest.
+  (Damien Doligez with Florian Angeletti, Sébastien Hinderer, Gabriel Scherer,
+   review by Sébastien Hinderer and Gabriel Scherer)
+
+- [#12371](https://github.com/ocaml/ocaml/issues/12371): ocamltest: fix recursive expansion of variables.
+  (Antonin Décimo, Damien Doligez, review by Sébastien Hinderer,
+   Damien Doligez, Gabriel Scherer, and Xavier Leroy)
+
+* (*breaking change*) [#12497](https://github.com/ocaml/ocaml/issues/12497), [#12613](https://github.com/ocaml/ocaml/issues/12613): Make ocamlc/ocamlopt fail with an error when no
+  input files are specified to build an executable.
+  (Antonin Décimo, review by Sébastien Hinderer)
+
+- [#12576](https://github.com/ocaml/ocaml/issues/12576): ocamldep: various refactors.
+  (Antonin Décimo, review by Florian Angeletti, Gabriel Scherer, and Léo Andrès)
+
+- [#12615](https://github.com/ocaml/ocaml/issues/12615): ocamldoc: get rid of the odoc_literate and odoc_todo generators.
+  (Sébaistien Hinderer, review by Gabriel Scherer and Florian Angeletti)
+
+- [#12624](https://github.com/ocaml/ocaml/issues/12624): Use $XDG_CONFIG_DIRS in addition to $XDG_CONFIG_HOME when searching
+  for init.ml and use this to extend init.ml support to the toplevel when
+  running on Windows.
+  (David Allsopp, report by Jonah Beckford, review by Nicolás Ojeda Bär and
+   Antonin Décimo)
+
+- [#12688](https://github.com/ocaml/ocaml/issues/12688): Setting the env variable `NO_COLOR` with an empty value no longer
+  has effects. Previously, setting `NO_COLOR` with any value, including
+  the empty value, would disable colors (unless `OCAML_COLOR` is also set).
+  After this change, the user must set `NO_COLOR` with an non-empty value
+  to disable colors. This reflects a specification clarification/change
+  from the upstream website at https://no-color.org.
+  (Favonia, review by Gabriel Scherer)
+
+- [#12744](https://github.com/ocaml/ocaml/issues/12744): ocamltest: run tests in recursive subdirs more eagerly
+  (Nick Roberts, review by Nicolás Ojeda Bär)
+
+- [#12901](https://github.com/ocaml/ocaml/issues/12901), 12908: ocamllex: add overflow checks to prevent generating incorrect
+  lexers; use unsigned numbers in the table encoding when possible.
+  (Vincent Laviron, report by Edwin Török, review by Xavier Leroy)
+
+### Internal/compiler-libs changes:
+
+- [#12508](https://github.com/ocaml/ocaml/issues/12508) : Add compiler-side support for project-wide occurrences in Merlin, by
+  generating index tables of all identifier occurrences. This extra data in .cmt
+  files is only added when the new flag -bin-annot-occurrences is passed.
+  (Ulysse Gérard, Nathanaëlle Courant, suggestions by Gabriel Scherer and Thomas
+  Refis, review by Florian Angeletti, Gabriel Scherer and Thomas Refis)
+
+- [#12236](https://github.com/ocaml/ocaml/issues/12236), [#12386](https://github.com/ocaml/ocaml/issues/12386), [#12391](https://github.com/ocaml/ocaml/issues/12391), [#12496](https://github.com/ocaml/ocaml/issues/12496), [#12673](https://github.com/ocaml/ocaml/issues/12673): Use syntax as sole determiner of arity
+  This changes function arity to be based solely on the source program's
+  parsetree. Previously, the heuristic for arity had more subtle heuristics
+  that involved type information about patterns.  Function arity is important
+  because it determines when a pattern match's effects run and is an input
+  into the fast path for function application.
+
+  This change affects tooling: it changes the function constructs in parsetree
+  and typedtree.
+
+  See https://github.com/ocaml/RFCs/pull/32 for the original RFC.
+
+  (Nick Roberts; review by Richard Eisenberg, Leo White, and Gabriel Scherer;
+  RFC by Stephen Dolan)
+
+
+- [#12639](https://github.com/ocaml/ocaml/issues/12639): parsing: Attach a location to the RHS of Ptyp_alias
+  and improve the 'alias type mismatch' error message.
+  (Jules Aguillon, review by Florian Angeletti)
+
+- [#12447](https://github.com/ocaml/ocaml/issues/12447): Remove 32-bit targets from X86_proc.system
+  (Masanori Ogino, review by David Allsopp)
+
+- [#12216](https://github.com/ocaml/ocaml/issues/12216), [#12248](https://github.com/ocaml/ocaml/issues/12248): Prevent reordering of atomic loads during instruction
+  scheduling.  This is for reference, as instruction scheduling is currently
+  unused in OCaml 5.
+  (Xavier Leroy, report by Luc Maranget and KC Sivaramakrishnan,
+   review by Nicolás Ojeda Bär)
+
+- [#12025](https://github.com/ocaml/ocaml/issues/12025): Split Typecore.unify_pat_types into two
+  to avoid unnecessary references to the environment in type_pat
+  (Jacques Garrigue and Takafumi Saikawa, review by Gabriel Scherer)
+
+- [#12031](https://github.com/ocaml/ocaml/issues/12031): Use dedicated types to represent names of compilation units
+  and predefined exceptions in CMO files.
+  (Sébastien Hinderer, review by Florian Angeletti, Thomas Refis,
+  Gabriel Scherer, Vincent Laviron, Pierre Chambart, Luke Maurer,
+  Hugo Heuzard, Xavier Leroy and Damien Doligez)
+
+- [#12109](https://github.com/ocaml/ocaml/issues/12109): Pack parameters to unification in unification_environment
+  (Takafumi Saikawa and Jacques Garrigue, review by Richard Eisenberg)
+
+- [#12331](https://github.com/ocaml/ocaml/issues/12331), [#12361](https://github.com/ocaml/ocaml/issues/12361): Pack the unification data for pattern checking in Typecore
+  (Takafumi Saikawa and Jacques Garrigue,
+   review by Gabriel Scherer, Thomas Refis and Florian Angeletti)
+
+- [#12229](https://github.com/ocaml/ocaml/issues/12229): Remove global mutable state for typechecking patterns
+  in Typecore in favor of local mutable state.
+  (Nick Roberts, review by Takafumi Saikawa)
+
+- [#12542](https://github.com/ocaml/ocaml/issues/12542): Minor bugfix to [#12236](https://github.com/ocaml/ocaml/issues/12236): restore dropped call to `instance`
+  (Nick Roberts, review by Jacques Garrigue)
+
+- [#12242](https://github.com/ocaml/ocaml/issues/12242): Move the computation of stack frame parameters to a separate
+  `Stackframe` module, and save the parameters in the results of the
+  `Linearize` pass
+  (Xavier Leroy, review by KC Sivaramakrishnan and Mark Shinwell)
+
+- [#12442](https://github.com/ocaml/ocaml/issues/12442): document jump summaries in the pattern-matching compiler
+  (Gabriel Scherer and Thomas Refis, review by Florian Angeletti
+   and Vincent Laviron)
+
+- [#12446](https://github.com/ocaml/ocaml/issues/12446), [#12792](https://github.com/ocaml/ocaml/issues/12792): remove the hooks machinery around channel locking
+  in runtime/io.c
+  (Gabriel Scherer, review by Xavier Leroy)
+
+- [#12389](https://github.com/ocaml/ocaml/issues/12389), [#12544](https://github.com/ocaml/ocaml/issues/12544), [#12984](https://github.com/ocaml/ocaml/issues/12984), [#12987](https://github.com/ocaml/ocaml/issues/12987): centralize the handling of metadata for
+  compilation units and artifacts in preparation for better unicode support for
+  OCaml source files.
+  (Florian Angeletti, review by Vincent Laviron and Gabriel Scherer)
+
+- [#12532](https://github.com/ocaml/ocaml/issues/12532), [#12553](https://github.com/ocaml/ocaml/issues/12553): improve readability of the pattern-matching debug output
+  (Gabriel Scherer, review by Thomas Refis)
+
+- [#12537](https://github.com/ocaml/ocaml/issues/12537): Use C11/C++11 standard static assertion.
+  (Antonin Décimo, review by Sebastien Hinderer, Xavier Leroy,
+   and KC Sivaramakrishnan)
+
+- [#12169](https://github.com/ocaml/ocaml/issues/12169): runtime: document and enforce naming conventions around STW sections.
+  (Gabriel Scherer, review by Enguerrand Decorne, Miod Vallat, B. Szilvasy
+   and Nick Barnes, report by KC Sivaramakrishnan)
+
+- [#12669](https://github.com/ocaml/ocaml/issues/12669) : Clean up some global state handling in schedgen
+  (Stefan Muenzel, review by Miod Vallat and Gabriel Scherer)
+
+- [#12640](https://github.com/ocaml/ocaml/issues/12640): Make the module separator used in symbol names configurable
+  (Miod Vallat, review by Hugo Heuzard and Xavier Leroy)
+
+- [#12691](https://github.com/ocaml/ocaml/issues/12691) : Clean up Ctype.expand_abbrev_gen and
+  rename Env.add_local_type to add_local_constraint
+  (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
+
+- [#12786](https://github.com/ocaml/ocaml/issues/12786) : Clean up the algorithm of Ctype.limited_generalize
+  (Takafumi Saikawa and Jacques Garrigue, review by Gabriel Scherer)
+
+- [#10691](https://github.com/ocaml/ocaml/issues/10691): Ast_mapper, Ast_iterator: add functions directive_argument,
+  toplevel_directive and toplevel_phrase.
+  (Guillaume Petiot, review by Gabriel Scherer and Kate Deplaix)
+
+- [#12764](https://github.com/ocaml/ocaml/issues/12764): Move all installable headers in `caml/` sub-directories.
+  (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
+
+- [#12914](https://github.com/ocaml/ocaml/issues/12914): Slightly change the s390x assembly dialect in order to build with
+  Clang's integrated assembler.
+  (Miod Vallat, review by Gabriel Scherer)
+
+- [#13001](https://github.com/ocaml/ocaml/issues/13001): do not read_back entire shapes to get aliases' uids when building the
+  usages index
+  (Ulysse Gérard, review by Gabriel Scherer and Nathanaëlle Courant)
+
+### Build system:
+
+- [#12198](https://github.com/ocaml/ocaml/issues/12198), [#12321](https://github.com/ocaml/ocaml/issues/12321), [#12586](https://github.com/ocaml/ocaml/issues/12586), [#12616](https://github.com/ocaml/ocaml/issues/12616), [#12706](https://github.com/ocaml/ocaml/issues/12706), [#13048](https://github.com/ocaml/ocaml/issues/13048): continue the merge of the
+  sub-makefiles into the root Makefile started with [#11243](https://github.com/ocaml/ocaml/issues/11243), [#11248](https://github.com/ocaml/ocaml/issues/11248),
+  [#11268](https://github.com/ocaml/ocaml/issues/11268), [#11420](https://github.com/ocaml/ocaml/issues/11420) and [#11675](https://github.com/ocaml/ocaml/issues/11675).
+  (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
+
+- [#12569](https://github.com/ocaml/ocaml/issues/12569), [#12570](https://github.com/ocaml/ocaml/issues/12570): remove 'otherlibraries' as a prerequisite for 'runtop';
+  use 'runtop-with-otherlibs' to use a library from otherlibs/
+  (Gabriel Scherer, review by Sébastien Hinderer, suggestion by David Allsopp)
+
+- [#12652](https://github.com/ocaml/ocaml/issues/12652): Make magic numbers easier to bump and duplicate.
+  (Sébastien Hinderer, review by Antonin Décimo, David Allsopp and Florian
+  Angeletti)
+
+* (*breaking change*) [#12751](https://github.com/ocaml/ocaml/issues/12751): --with-target-bindir configure option implemented. This option
+  refers to the location of the runtime binaries on the target system for a
+  cross-compiler and is embedded in executables produced by ocamlc. It does
+  not affect the bytecode executables installed as part of the build. The old
+  mechanism `make TARGET_BINDIR=..` no longer works.
+  (David Allsopp, review by Damien Doligez, Xavier Leroy and Olivier Nicole)
+
+- [#12768](https://github.com/ocaml/ocaml/issues/12768), [#13030](https://github.com/ocaml/ocaml/issues/13030): Detect mingw-w64 coupling with GCC or LLVM, detect clang-cl,
+  and fix C compiler feature detection on macOS.
+  (Antonin Décimo, review by Miod Vallat and Sébastien Hinderer)
+
+### Bug fixes:
+
+- [#10652](https://github.com/ocaml/ocaml/issues/10652), [#12720](https://github.com/ocaml/ocaml/issues/12720): fix evaluation order in presence of optional arguments
+  (Jacques Garrigue, report by Leo White, review by Vincent Laviron)
+
+- [#12595](https://github.com/ocaml/ocaml/issues/12595), [#12597](https://github.com/ocaml/ocaml/issues/12597): fix a race in `caml_clear_gc_stats_sample`
+  (Gabriel Scherer, review by B. Szilvasy, report by B. Szilvasy)
+
+- [#12580](https://github.com/ocaml/ocaml/issues/12580): Fix location of alias pattern variables.
+  (Chris Casinghino, review Gabriel Scherer, report by Milo Davis)
+
+- [#12583](https://github.com/ocaml/ocaml/issues/12583): Add a closing event for when `EV_MAJOR_EPHE_MARK` is complete
+  (Sudha Parimala, review by Gabriel Scherer)
+
+- [#12566](https://github.com/ocaml/ocaml/issues/12566): caml_output_value_to_malloc wrongly uses `caml_stat_alloc`
+  instead of `malloc` since 4.06, breaking (in pooled mode) user code
+  that uses `free` on the result. Symmetrically,
+  caml_input_value_from_malloc should use `free`.
+  (Gabriel Scherer, review by Xavier Leroy and Enguerrand Decorne,
+   report by Ido Yariv)
+
+- [#12490](https://github.com/ocaml/ocaml/issues/12490): Unix: protect the popen_processes hashtable with a mutex
+  (Gabriel Scherer, report by Olivier Nicole, review by Xavier Leroy)
+
+- [#11931](https://github.com/ocaml/ocaml/issues/11931): Fix tricky typing bug with type substitutions
+  (Stephen Dolan, review by Leo White and Jacques Garrigue)
+
+- [#12037](https://github.com/ocaml/ocaml/issues/12037), [#12171](https://github.com/ocaml/ocaml/issues/12171): Fix get_extern_state potential NULL dereference.
+  (Alexander Skvortsov, report by Török Edwin,
+   design by Gabriel Scherer, Xavier Leroy)
+
+- [#12635](https://github.com/ocaml/ocaml/issues/12635): Fix get_intern_state potential NULL dereference.
+  (Antonin Décimo, review by KC Sivaramakrishnan)
+
+- [#12032](https://github.com/ocaml/ocaml/issues/12032), [#12059](https://github.com/ocaml/ocaml/issues/12059): Bug fixes related to compilation of recursive definitions
+  (Vincent Laviron, report by Victoire Noizet, review by Gabriel Scherer)
+
+* (*breaking change*) [#12145](https://github.com/ocaml/ocaml/issues/12145): Loopy constraints cause ocamlc to loop.
+  Fixed by completely removing the call to `update_type` in
+  `Typedecl.transl_type_decl`, as the expansion is already checked by
+  `check_regularity`. As a result, recursion is more polymorphic,
+  which may cause some (essentially wrong) type declarations to have
+  unbound type variables, and some constraints unrelated to the concrete
+  type to be ignored (see tests/typing-misc/constraints.ml).
+  (Jacques Garrigue, report by Richard Eisenberg, review by Leo White)
+
+- [#12207](https://github.com/ocaml/ocaml/issues/12207), [#12222](https://github.com/ocaml/ocaml/issues/12222): Make closure computation linear in the number of recursive
+  functions instead of quadratic
+  (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
+  and Gabriel Scherer)
+
+- [#11040](https://github.com/ocaml/ocaml/issues/11040), [#12591](https://github.com/ocaml/ocaml/issues/12591): fix a data race in major_gc.c
+  (Gabriel Scherer, review by Guillaume Munch-Maccagnoni
+   and KC Sivaramakrishnan, report by Sadiq Jaffer)
+
+- [#12238](https://github.com/ocaml/ocaml/issues/12238), [#12403](https://github.com/ocaml/ocaml/issues/12403), [#12698](https://github.com/ocaml/ocaml/issues/12698): read input files in one go to avoid source reprinting
+  issues.
+  (Gabriel Scherer, report by Mike Spivey and Vincent Laviron, review by
+   Nicolás Ojeda Bär, Xavier Leroy and Jeremy Yallop)
+
+- [#12334](https://github.com/ocaml/ocaml/issues/12334), [#12368](https://github.com/ocaml/ocaml/issues/12368): Bad error message with mutually recursive abbreviations
+  (Jacques Garrigue, report by Richard Eisenberg, review by Gabriel Scherer
+   and Richard Eisenberg)
+
+- [#12401](https://github.com/ocaml/ocaml/issues/12401): `seek_in` and `seek_out` sometimes returned normally when given
+  negative offsets, instead of failing. Now both functions should consistently
+  raise `Sys_error` in this case.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
+- [#12267](https://github.com/ocaml/ocaml/issues/12267): Fix stack alignment computation
+  (Miod Vallat, report by Jan Midtgaard, review by Gabriel Scherer)
+
+- [#12395](https://github.com/ocaml/ocaml/issues/12395), [#12404](https://github.com/ocaml/ocaml/issues/12404): Fix thread-unsafety in the fallback implementation of
+  `Unix.create_process` (the one used when `posix_spawnp` is unavailable)
+  (Xavier Leroy, report by Chris Vine, review by Nicolás Ojeda Bär)
+
+- [#12949](https://github.com/ocaml/ocaml/issues/12949): open shadowing mistriggers
+  (Gabriel Scherer, review by Florian Angeletti, report by Andreas Rossberg)
+
+- [#12526](https://github.com/ocaml/ocaml/issues/12526): Honor `ocaml.inline always` attribute on functions with
+  optional arguments and default values in the Closure backend
+  (Alain Frisch, review by Vincent Laviron)
+
+- [#12677](https://github.com/ocaml/ocaml/issues/12677), [#12889](https://github.com/ocaml/ocaml/issues/12889): make Domain.DLS thread-safe
+  (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
+   report by Vesa Karvonen)
+
+- [#12561](https://github.com/ocaml/ocaml/issues/12561): Fix crash when combining TSan and frame-pointers
+  (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard, review by Miod
+  Vallat and Gabriel Scherer)
+
+- [#12482](https://github.com/ocaml/ocaml/issues/12482): Rework bounds checking code in the POWER backend
+  (Miod Vallat and Xavier Leroy, report by Jan Midtgaard, review by
+   KC Sivaramakrishnan)
+
+- [#12528](https://github.com/ocaml/ocaml/issues/12528), [#12703](https://github.com/ocaml/ocaml/issues/12703): Avoid pointer arithmetic overflow in Tag_val macro
+  (very likely harmless, but can trigger alarms)
+  (Xavier Leroy, report by Sam Goldman, review by Guillaume Munch-Maccagnoni)
+
+- [#12593](https://github.com/ocaml/ocaml/issues/12593): TSan should handle Effect.Unhandled correctly
+  (Fabrice Buoro and Olivier Nicole, report by Jan Midtgaard and Miod Vallat,
+   review by Gabriel Scherer)
+
+- [#12684](https://github.com/ocaml/ocaml/issues/12684): fix locations filename in AST produced by the `-pp` option
+  (Gabriel Scherer, review by Florian Angeletti)
+
+- [#12714](https://github.com/ocaml/ocaml/issues/12714): check whether macros are defined before using them to ensure
+  that the headers can always be used in code which turns on -Wundef
+  (or equivalent).
+  (Antonin Décimo, review by Miod Vallat, Gabriel Scherer,
+   Xavier Leroy, and David Allsopp)
+
+- [#12726](https://github.com/ocaml/ocaml/issues/12726): fix segmentation fault under Windows when executing a bytecode file if
+  the runtime (`ocamlrun.exe`) cannot be found.
+  (Vadim Zborovskii, Nicolás Ojeda Bär, report by Vadim Zborovskii, review by
+  David Allsopp)
+
+- [#12727](https://github.com/ocaml/ocaml/issues/12727), [#12730](https://github.com/ocaml/ocaml/issues/12730): fix bug with value let-rec and labelled applications
+  (Vincent Laviron, review by Gabriel Scherer)
+
+* (*breaking change*) [#12751](https://github.com/ocaml/ocaml/issues/12751): Always keep within the 128 character limit for shebang lines. Previous
+  fix in [#8622](https://github.com/ocaml/ocaml/issues/8622) handled building the compiler with a long prefix; this patch
+  extends this to the bytecode executables emitted by that compiler.
+  (David Allsopp, review by Damien Doligez, Xavier Leroy and Olivier Nicole)
+
+- [#12755](https://github.com/ocaml/ocaml/issues/12755): Fix data race on global pools arrays of pool_freelist
+  (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer)
+
+- [#12796](https://github.com/ocaml/ocaml/issues/12796), [#12801](https://github.com/ocaml/ocaml/issues/12801): Fix memory corruption in caml_unix_alloc_sockaddr
+  (Thomas Leonard, review by Nicolás Ojeda Bär)
+
+- [#12737](https://github.com/ocaml/ocaml/issues/12737): Fix data races in minor_gc.c and caml_natdynlink_open
+  (Olivier Nicole, review by Stefan Muenzel, Miod Vallat, Guillaume
+   Munch-Maccagnoni, Gabriel Scherer and Xavier Leroy)
+
+- [#12831](https://github.com/ocaml/ocaml/issues/12831): Fix call to caml_call_realloc_stack for s390x in PIC mode
+  (Vincent Laviron, report by Jerry James, review by Miod Vallat)
+
+* (*breaking change*) [#12837](https://github.com/ocaml/ocaml/issues/12837): Show non-generalizable type parameters in type definitions
+  Changes type of type parameters in outcometree.mli.
+  (Jacques Garrigue, review by Richard Eisenberg)
+
+- [#12897](https://github.com/ocaml/ocaml/issues/12897): fix locking bugs in Runtime_events
+  (Gabriel Scherer and Thomas Leonard,
+   review by Olivier Nicole, Vincent Laviron and Damien Doligez,
+   report by Thomas Leonard)
+
+- [#12851](https://github.com/ocaml/ocaml/issues/12851): Fix race between runtime events teardown and event emission
+  (Olivier Nicole, review by Miod Vallat and Gabriel Scherer)
+
+- [#12860](https://github.com/ocaml/ocaml/issues/12860): Fix an assertion that wasn't taking into account the possibility of an
+  ephemeron pointing at static data.
+  (Mark Shinwell, review by Gabriel Scherer and KC Sivaramakrishnan)
+
+- [#12861](https://github.com/ocaml/ocaml/issues/12861): Fix a possible crash in the `threads` library.
+  (Mark Shinwell, review by Gabriel Scherer and KC Sivaramakrishnan)
+
+- [#11040](https://github.com/ocaml/ocaml/issues/11040), [#12894](https://github.com/ocaml/ocaml/issues/12894): Silence false data race observed between caml_shared_try_alloc
+  and oldify. Introduces macros to call tsan annotations which help annotate
+  a ``happens before'' relationship.
+  (Hari Hara Naveen S and Olivier Nicole,
+   review by Gabriel Scherer and Miod Vallat)
+
+- [#12958](https://github.com/ocaml/ocaml/issues/12958): Fix tail-modulo-cons compilation of try-with, && and ||
+  expressions.
+  (Gabriel Scherer and Nicolás Ojeda Bär, report by Sylvain Boilard, review by
+  Gabriel Scherer)
+
+- [#12919](https://github.com/ocaml/ocaml/issues/12919): Fix register corruption in caml_callback2_asm on s390x.
+  (Miod Vallat, review by Gabriel Scherer)
+
+- [#12924](https://github.com/ocaml/ocaml/issues/12924), [#12930](https://github.com/ocaml/ocaml/issues/12930): Rework package constraint checking to improve interaction with
+  immediacy
+  (Chris Casinghino and Florian Angeletti, review by Florian Angeletti and
+   Richard Eisenberg)
+
+- [#12969](https://github.com/ocaml/ocaml/issues/12969): Fix a data race in caml_darken_cont
+  (Fabrice Buoro and Olivier Nicole, review by Gabriel Scherer and Miod Vallat)
+
+- [#12971](https://github.com/ocaml/ocaml/issues/12971), [#12974](https://github.com/ocaml/ocaml/issues/12974): fix an uncaught Ctype.Escape exception on some
+  invalid programs forming recursive types.
+  (Gabriel Scherer, review by Florian Angeletti, report by Neven Villani)
+
+- [#13019](https://github.com/ocaml/ocaml/issues/13019): Remove linking instructions for the Unix library from threads.cma
+  (this was done for threads.cmxa in OCaml 3.11). Eliminates warnings from
+  new lld when using threads.cma of duplicated libraries.
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
+- [#13058](https://github.com/ocaml/ocaml/issues/13058): Add TSan instrumentation to caml_call_gc(), since it may raise
+  exceptions.
+  (Fabrice Buoro, Olivier Nicole, Gabriel Scherer and Miod Vallat)
+
+- [#13079](https://github.com/ocaml/ocaml/issues/13079): Save and restore frame pointer across Iextcall on ARM64
+  (Tim McGilchrist, review by KC Sivaramakrishnan and Miod Vallat)
+
+- [#13094](https://github.com/ocaml/ocaml/issues/13094): Fix undefined behavior of left-shifting a negative number.
+  (Antonin Décimo, review by Miod Vallat and Nicolás Ojeda Bär)
+
+- [#13130](https://github.com/ocaml/ocaml/issues/13130): minor fixes to pprintast for raw identifiers and local module open
+  syntax for types.
+  (Chet Murthy, review by Gabriel Scherer)


### PR DESCRIPTION
This PR adds the changelog entry and the release for OCaml 5.2.0 . The new release is already available on the opam repository, so the PR can be merged once copy-edited.