### PR TITLE
Single data type definition for Academic_Institution

### DIFF
--- a/src/ocamlorg_data/data.ml
+++ b/src/ocamlorg_data/data.ml
@@ -1,4 +1,5 @@
 module Academic_institution = struct
+  include Data_intf.Academic_institution
   include Academic_institution
 
   let get_by_slug slug = List.find_opt (fun x -> String.equal slug x.slug) all

--- a/src/ocamlorg_data/data.mli
+++ b/src/ocamlorg_data/data.mli
@@ -1,24 +1,5 @@
 module Academic_institution : sig
-  type location = { lat : float; long : float }
-
-  type course = {
-    name : string;
-    acronym : string option;
-    online_resource : string option;
-  }
-
-  type t = {
-    name : string;
-    slug : string;
-    description : string;
-    url : string;
-    logo : string option;
-    continent : string;
-    courses : course list;
-    location : location option;
-    body_md : string;
-    body_html : string;
-  }
+  include module type of Data_intf.Academic_institution
 
   val all : t list
   val get_by_slug : string -> t option

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -1,0 +1,24 @@
+module Academic_institution = struct
+  type location = { lat : float; long : float } [@@deriving of_yaml, show]
+
+  type course = {
+    name : string;
+    acronym : string option;
+    online_resource : string option;
+  }
+  [@@deriving of_yaml, show]
+
+  type t = {
+    name : string;
+    slug : string;
+    description : string;
+    url : string;
+    logo : string option;
+    continent : string;
+    courses : course list;
+    location : location option;
+    body_md : string;
+    body_html : string;
+  }
+  [@@deriving show]
+end

--- a/src/ocamlorg_data/dune
+++ b/src/ocamlorg_data/dune
@@ -1,6 +1,17 @@
 (library
+ (name data_intf)
+ (public_name ocamlorg.data_intf)
+ (modules data_intf)
+ (libraries ppx_show.runtime)
+ (preprocess
+  (pps ppx_deriving_yaml ppx_show)))
+
+(library
  (name data)
- (public_name ocamlorg.data))
+ (public_name ocamlorg.data)
+ (libraries ocamlorg.data_intf)
+ (modules
+  (:standard \ data_intf)))
 
 (rule
  (target academic_institution.ml)

--- a/tool/ood-gen/lib/academic_institution.ml
+++ b/tool/ood-gen/lib/academic_institution.ml
@@ -1,12 +1,4 @@
-type location = { lat : float; long : float }
-[@@deriving of_yaml, show { with_path = false }]
-
-type course = {
-  name : string;
-  acronym : string option;
-  online_resource : string option;
-}
-[@@deriving of_yaml, show { with_path = false }]
+open Data_intf.Academic_institution
 
 type metadata = {
   name : string;
@@ -17,25 +9,9 @@ type metadata = {
   courses : course list;
   location : location option;
 }
-[@@deriving of_yaml]
+[@@deriving of_yaml, stable_record ~version:t ~add:[ body_md; body_html; slug ]]
 
-type t = {
-  name : string;
-  slug : string;
-  description : string;
-  url : string;
-  logo : string option;
-  continent : string;
-  courses : course list;
-  location : location option;
-  body_md : string;
-  body_html : string;
-}
-[@@deriving
-  stable_record ~version:metadata ~remove:[ body_md; body_html; slug ],
-    show { with_path = false }]
-
-let of_metadata m = of_metadata m ~slug:(Utils.slugify m.name)
+let of_metadata m = metadata_to_t m ~slug:(Utils.slugify m.name)
 
 let decode (fpath, (head, body_md)) =
   let metadata =
@@ -49,29 +25,7 @@ let decode (fpath, (head, body_md)) =
 let all () = Utils.map_files decode "academic_institutions/*.md"
 
 let template () =
-  Format.asprintf
-    {|
-type location = { lat : float; long : float }
-
-type course =
-  { name : string
-  ; acronym : string option
-  ; online_resource : string option
-  }
-
-type t =
-  { name : string
-  ; slug : string
-  ; description : string
-  ; url : string
-  ; logo : string option
-  ; continent : string
-  ; courses : course list
-  ; location : location option
-  ; body_md : string
-  ; body_html : string
-  }
-
+  Format.asprintf {|
 let all = %a
 |}
     (Fmt.brackets (Fmt.list pp ~sep:Fmt.semi))

--- a/tool/ood-gen/lib/dune
+++ b/tool/ood-gen/lib/dune
@@ -3,6 +3,7 @@
  (libraries
   bos
   ocamlorg.global
+  ocamlorg.data_intf
   cmarkit
   yaml
   unix


### PR DESCRIPTION
Use the same type in `ocamlorg` and `ood` for `Academic_Institution`, without duplicate definitions
* It's defined in `src/ocamorg_data/data_intf.ml`
* `src/ocamlorg_data` defines two libraries
  - `Data_intf`, which is used both by `ood` and `ocamlorg`
  - `Data`, which is only used by `ocamlorg` but includes `Data_intf`
* Should have no impact on ocamlorg source or behaviour (no file touched)
* Removes code in `tool/ood-gen/lib/academic_institution.ml`
* Type definition is moved from `data.mli` into `data_intf.mli`, like in the intf hack, except it's compiled.