### PR TITLE
Revert "Remove useless include (#2493)"

### DIFF
--- a/src/ocamlorg_data/data.ml
+++ b/src/ocamlorg_data/data.ml
@@ -148,10 +148,14 @@ end
 module Planet = struct
   include Planet
 
-  module LocalBlog = struct
-    include LocalBlog
+  module Post = struct
+    include Planet.Post
+  end
 
-    let get_by_id id = List.find_opt (fun (x : t) -> String.equal x.source.id id) all
+  module LocalBlog = struct
+    include Planet.LocalBlog
+
+    let get_by_id id = List.find_opt (fun x -> String.equal x.source.id id) all
   end
 
   let local_posts =


### PR DESCRIPTION
This reverts commit 6695523d7e153b39b0d000efe31b65150bfd45fe.
