### PR TITLE
(docs) In "Libraries with Dune" tutorial: Add text on interface sharing using module type

### DIFF
--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -126,7 +126,7 @@ Dune creates libraries from folders. Let's look at an example. Here the folder i
 $ mkdir lib
 ```
 
-The `lib` folder is populated with the following files.
+The `lib` folder is populated with the following files:
 
 **`lib/dune`**
 ```lisp
@@ -264,9 +264,8 @@ Here `foo` is the project name and `foo.dir` is its container folder, the names 
 
 ## Remove Duplicated Interfaces
 
-In the previous stages, interfaces are duplicated. In the section
-[Libraries](#libraries) files `lib/cumulus.mli` and `lib/status.mli` are the
-same. In section [Include Subdirectories](#include-subdirectories) files
+In the previous stages, interfaces were duplicated. It's the same in the 
+[Libraries](#libraries) files `lib/cumulus.mli` and `lib/status.mli` section. In the [Include Subdirectories](#include-subdirectories) section, files
 `lib/cumulus/m.mli` and `lib/status/m.mli` are the same too.
 
 Here is a possible way to fix this using named module types (also known as

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -264,9 +264,8 @@ Here `foo` is the project name and `foo.dir` is its container folder, the names 
 
 ## Remove Duplicated Interfaces
 
-In the previous stages, interfaces were duplicated. It's the same in the 
-[Libraries](#libraries) files `lib/cumulus.mli` and `lib/status.mli` section. In the [Include Subdirectories](#include-subdirectories) section, files
-`lib/cumulus/m.mli` and `lib/status/m.mli` are the same too.
+In the previous stages, interfaces were duplicated. In the “[Libraries](#libraries)” section of this tutorial, two files are the same: `lib/cumulus.mli` and `lib/status.mli`
+Later, in the “[Include Subdirectories](#include-subdirectories)” section, the files `lib/cumulus/m.mli` and `lib/status/m.mli` are also the same.
 
 Here is a possible way to fix this using named module types (also known as
 signatures). First, delete the files `lib/cumulus/m.mli` and `lib/status/m.mli`.

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -262,6 +262,40 @@ This is sufficient for `dune build` to work. It will not build anything.
 Here `foo` is the project name and `foo.dir` is its container folder, the names don't have to be the same.
 -->
 
+## Remove Duplicated Interfaces
+
+In the previous stages, interfaces are duplicated. In the section
+[Libraries](#libraries) files `lib/cumulus.mli` and `lib/status.mli` are the
+same. In section [Include Subdirectories](#include-subdirectories) files
+`lib/cumulus/m.mli` and `lib/status/m.mli` are the same too.
+
+Here is a possible way to fix this using named module types (also known as
+signatures). First, delete the files `lib/cumulus/m.mli` and `lib/status/m.mli`.
+Then modify module `Wmo` interface and implementation.
+
+**`wmo.mli`**
+```ocaml
+module type Nimbus = sig
+  val nimbus : string
+end
+
+module Cumulus : Nimbus
+module Stratus : Nimbus
+```
+
+**`wmo.ml`**
+```ocaml
+module type Nimbus = sig
+  val nimbus : string
+end
+
+module Cumulus = Cumulus.M
+module Stratus = Stratus.M
+```
+
+This result is the same, except implementations `Cumulus.M` and `Stratus.M` are
+explicitly bound to the same interface, defined in module `Wmo`.
+
 ## Conclusion
 
 The OCaml module system allows organising a project in many ways. Dune provides several means to arrange modules into libraries.

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -264,7 +264,7 @@ Here `foo` is the project name and `foo.dir` is its container folder, the names 
 
 ## Remove Duplicated Interfaces
 
-In the previous stages, interfaces were duplicated. In the “[Libraries](#libraries)” section of this tutorial, two files are the same: `lib/cumulus.mli` and `lib/status.mli`
+In the previous stages, interfaces were duplicated. In the “[Libraries](#libraries)” section of this tutorial, two files are the same: `lib/cumulus.mli` and `lib/status.mli`.
 Later, in the “[Include Subdirectories](#include-subdirectories)” section, the files `lib/cumulus/m.mli` and `lib/status/m.mli` are also the same.
 
 Here is a possible way to fix this using named module types (also known as

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -264,8 +264,11 @@ Here `foo` is the project name and `foo.dir` is its container folder, the names 
 
 ## Remove Duplicated Interfaces
 
-In the previous stages, interfaces were duplicated. In the “[Libraries](#libraries)” section of this tutorial, two files are the same: `lib/cumulus.mli` and `lib/status.mli`.
-Later, in the “[Include Subdirectories](#include-subdirectories)” section, the files `lib/cumulus/m.mli` and `lib/status/m.mli` are also the same.
+In the previous stages, interfaces were duplicated. In the
+“[Libraries](#libraries)” section of this tutorial, two files are the same:
+`lib/cumulus.mli` and `lib/status.mli`. Later, in the “[Include
+Subdirectories](#include-subdirectories)” section, the files `lib/cumulus/m.mli`
+and `lib/status/m.mli` are also the same.
 
 Here is a possible way to fix this using named module types (also known as
 signatures). First, delete the files `lib/cumulus/m.mli` and `lib/status/m.mli`.


### PR DESCRIPTION
Add a section to the functor tutorial explaining how to share duplicated interfaces using module types