### PR TITLE
fix: write directory instead of folder

### DIFF
--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -87,7 +87,7 @@ let () = print_endline "Hello, World!"
 
 The project-wide metadata is available in the `dune-project` file. It contains information about the project name, dependencies, and global setup.
 
-Each folder containing source files that need to be built must contain a `dune` file describing how.
+Each directory containing source files that need to be built must contain a `dune` file describing how.
 
 This builds the project:
 ```shell
@@ -173,7 +173,7 @@ module Hello : sig val v : string end
 
 Now exit `utop` with `Ctrl-D` or enter `#quit;;` before going to the next section.
 
-**Note**: If you add a file named `hello.ml` in the `lib` folder, Dune will consider this the whole `Hello` module and it will make `En` unreachable. If you want your module `En` to be visible, you need to add this in your `hello.ml` file:
+**Note**: If you add a file named `hello.ml` in the `lib` directory, Dune will consider this the whole `Hello` module and it will make `En` unreachable. If you want your module `En` to be visible, you need to add this in your `hello.ml` file:
 ```ocaml
 module En = En
 ```
@@ -339,9 +339,9 @@ $ opam exec -- dune exec hello
 
 ## A Sneak-Peek at Dune as a One-Stop Shop
 
-This section explains the purpose of the files and folders created by `dune proj init` which haven't been mentioned earlier.
+This section explains the purpose of the files and directories created by `dune proj init` which haven't been mentioned earlier.
 
-Along the history of OCaml, several build systems have been used. As of writing this tutorial (Summer 2023), Dune is the mainstream one, which is why it is used in the tutorial. Dune automatically extracts the dependencies between the modules from the files and compiles them in a compatible order. It only needs one `dune` file per folder where there is something to build. The three folders created by `dune proj init` have the following purposes:
+Along the history of OCaml, several build systems have been used. As of writing this tutorial (Summer 2023), Dune is the mainstream one, which is why it is used in the tutorial. Dune automatically extracts the dependencies between the modules from the files and compiles them in a compatible order. It only needs one `dune` file per directory where there is something to build. The three directories created by `dune proj init` have the following purposes:
 - `bin`: executable programs
 - `lib`: libraries
 - `test`: tests
@@ -352,11 +352,11 @@ There will be a tutorial dedicated to Dune. This tutorial will present the many 
 - Producing packaging metadata (here in `hello.opam`)
 - Creating arbitrary files using all-purpose rules
 
-The `_build` folder is where Dune stores all the files it generates. It can be deleted at any time, but subsequent builds will recreate it.
+The `_build` directory is where Dune stores all the files it generates. It can be deleted at any time, but subsequent builds will recreate it.
 
 ## Minimum Setup
 
-In this last section, let's create a bare minimum project, highlighting what's really needed for Dune to work. We begin by creating a fresh project folder:
+In this last section, let's create a bare minimum project, highlighting what's really needed for Dune to work. We begin by creating a fresh project directory:
 ```shell
 $ cd ..
 $ mkdir minimo

--- a/data/tutorials/language/1ms_00_modules.md
+++ b/data/tutorials/language/1ms_00_modules.md
@@ -47,7 +47,7 @@ configuration files are required:
   (lang dune 3.7)
   ```
 * The `dune` file contains actual build directives. A project may have several
-  `dune` files, one per folder containing things to build. This single line is
+  `dune` files, one per directory containing things to build. This single line is
   sufficient in this example:
   ```lisp
   (executable (name berlin))

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -18,7 +18,7 @@ As suggested by the name, a _functor_ is almost like a function. However, while 
 
 ## Project Setup
 
-This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have installed version 3.7 or later. We start by creating a fresh project. We need a folder named `funkt` with files `dune-project`, `dune`, and `funkt.ml`.
+This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have installed version 3.7 or later. We start by creating a fresh project. We need a directory named `funkt` with files `dune-project`, `dune`, and `funkt.ml`.
 
 ```shell
 $ mkdir funkt; cd funkt

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -39,7 +39,7 @@ This file contains the global project configuration. It's kept almost to the min
   (public_name nube))
 ```
 
-Each folder that requires some sort of build must contain a `dune` file. The `executable` stanza means an executable program is built.
+Each directory that requires some sort of build must contain a `dune` file. The `executable` stanza means an executable program is built.
 - The `name cloud` stanza means the file `cloud.ml` contains the executable.
 - The `public_name nube` stanza means the executable is made available using the name `nube`.
 
@@ -69,7 +69,7 @@ Cumulonimbus (Cb)
 ```
 
 
-Here is the folder contents:
+Here is the directory contents:
 ```shell
 $ tree
 .
@@ -79,7 +79,7 @@ $ tree
 └── wmo.ml
 ```
 
-Dune stores the files it creates in a folder named `_build`. In a project managed using Git, the `_build` folder should be ignored
+Dune stores the files it creates in a directory named `_build`. In a project managed using Git, the `_build` directory should be ignored
 ```shell
 $ echo _build >> .gitignore
 ```
@@ -121,12 +121,12 @@ The `dune describe` command allows having a look at the project's module structu
 <!--This contrasts with the `struct ... end` syntax where modules are aggregated top-down by nesting submodules into container modules. -->
 In OCaml, a library is a collection of modules. By default, when Dune builds a library, it wraps the bundled modules into a module. This allows having several modules with the same name, inside different libraries, in the same project. That feature is known as [_namespaces_](https://en.wikipedia.org/wiki/Namespace) for module names. This is similar to what module do for definitions; they avoid name clashes.
 
-Dune creates libraries from folders. Let's look at an example. Here the folder is `lib`:
+Dune creates libraries from directories. Let's look at an example. Here the directory is `lib`:
 ```shell
 $ mkdir lib
 ```
 
-The `lib` folder is populated with the following files:
+The `lib` directory is populated with the following files:
 
 **`lib/dune`**
 ```lisp
@@ -153,7 +153,7 @@ val nimbus : string
 let nimbus = "Nimbostratus (Ns)"
 ```
 
-All the modules found in the `lib` folder are bundled into the `Wmo` module. This module is the same as what we had in the `wmo.ml` file. To avoid redundancy, we delete it:
+All the modules found in the `lib` directory are bundled into the `Wmo` module. This module is the same as what we had in the `wmo.ml` file. To avoid redundancy, we delete it:
 ```shell
 $ rm wmo.ml
 ```
@@ -169,8 +169,8 @@ We update the `dune` file building the executable to use the library as a depend
 ```
 
 **Observations**:
-* Dune creates a module `Wmo` from the contents of folder `lib`.
-* The folder's name (here `lib`) is irrelevant.
+* Dune creates a module `Wmo` from the contents of directory `lib`.
+* The directory's name (here `lib`) is irrelevant.
 * The library name appears uncapitalised (`wmo`) in `dune` files:
   - In its definition, in `lib/dune`
   - When used as a dependency in `dune`
@@ -194,7 +194,7 @@ Here is how to make sense of these module definitions:
 
 Run `dune exec nube` to see that the behaviour of the program is the same as in the previous section.
 
-When a library folder contains a wrapper module (here `wmo.ml`), it is the only one exposed. All other file-based modules from that folder that do not appear in the wrapper module are private.
+When a library directory contains a wrapper module (here `wmo.ml`), it is the only one exposed. All other file-based modules from that directory that do not appear in the wrapper module are private.
 
 Using a wrapper file makes several things possible:
 - Have different public and internal names, `module CumulusCloud = Cumulus`
@@ -205,7 +205,7 @@ Using a wrapper file makes several things possible:
 
 ## Include Subdirectories
 
-By default, Dune builds a library from the modules found in the same folder as the `dune` file, but it doesn't look into subfolders. It is possible to change this behaviour.
+By default, Dune builds a library from the modules found in the same directory as the `dune` file, but it doesn't look into subdirectories. It is possible to change this behaviour.
 
 In this example, we create subdirectories and move files there.
 ```shell
@@ -234,14 +234,14 @@ module Stratus = Stratus.M
 
 Run `dune exec nube` to see that the behaviour of the program is the same as in the two previous sections.
 
-The `include_subdirs qualified` stanza works recursively, except on subfolders containing a `dune` file. See the [Dune](https://dune.readthedocs.io/en/stable/dune-files.html#include-subdirs) [documentation](https://github.com/ocaml/dune/issues/1084) for [more](https://discuss.ocaml.org/t/upcoming-dune-feature-include-subdirs-qualified) on this [topic](https://github.com/ocaml/dune/tree/main/test/blackbox-tests/test-cases/include-qualified).
+The `include_subdirs qualified` stanza works recursively, except on subdirectories containing a `dune` file. See the [Dune](https://dune.readthedocs.io/en/stable/dune-files.html#include-subdirs) [documentation](https://github.com/ocaml/dune/issues/1084) for [more](https://discuss.ocaml.org/t/upcoming-dune-feature-include-subdirs-qualified) on this [topic](https://github.com/ocaml/dune/tree/main/test/blackbox-tests/test-cases/include-qualified).
 
 <!--
 ## Starting a Project from a Single File
 
 It is possible to start an empty Dune project from a single file.
 
-Create a fresh folder.
+Create a fresh directory.
 ```shell
 $ mkdir foo.dir; cd foo.dir
 ```
@@ -259,7 +259,7 @@ This is sufficient for `dune build` to work. It will not build anything.
 - `(package (name foo) (allow_empty))` this means we're creating an Opam package named `foo` and we allow it to be empty
 - `(generate_opam_files)` we ask Dune to setup the opam configuration automatically
 
-Here `foo` is the project name and `foo.dir` is its container folder, the names don't have to be the same.
+Here `foo` is the project name and `foo.dir` is its container directory, the names don't have to be the same.
 -->
 
 ## Remove Duplicated Interfaces

--- a/data/tutorials/platform/0_09_opam_path.md
+++ b/data/tutorials/platform/0_09_opam_path.md
@@ -73,7 +73,7 @@ Now, whenever you navigate to your OCaml project directory, `direnv` will automa
 
 6. Example
 
-Suppose you have an OCaml project in folder `disco` and local opam switch is associated to it, and a `.envrc` file in that folder containing the following:
+Suppose you have an OCaml project in directory `disco` and local opam switch is associated to it, and a `.envrc` file in that directory containing the following:
 ```bash
 eval $(opam env)
 ```
@@ -81,7 +81,7 @@ After running `direnv allow`, `direnv` will handle the opam switch activation fo
 
 7. Messages from `direnv`
 
-Whenever entering or leaving a `direnv` managed folder, you will be informed of the the actions performed.
+Whenever entering or leaving a `direnv` managed directory, you will be informed of the the actions performed.
 
 On entrance:
 ```

--- a/data/tutorials/platform/2_08_odoc.md
+++ b/data/tutorials/platform/2_08_odoc.md
@@ -40,7 +40,7 @@ include this stanza:
  (package name-of-your-package))
 ```
 
-A common place to put `.mld` files is a folder named `doc` or `docs`.
+A common place to put `.mld` files is a directory named `doc` or `docs`.
 
 For more information on how to write documentation pages for `odoc`,
 see the [`odoc` for authors documentation](https://ocaml.github.io/odoc/odoc_for_authors.html#doc-pages).


### PR DESCRIPTION
fixes #2569

This PR replaces all occurrences of "folder" with "directory" in the following files:

- [X] 6 <kbd>[data/tutorials/getting-started/1_02_your_first_ocaml_program.md](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/getting-started/1_02_your_first_ocaml_program.md)</kbd>
- [X] 1 <kbd>[data/tutorials/language/1ms_00_modules.md](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/language/1ms_00_modules.md)</kbd>
- [X] 1 <kbd>[data/tutorials/language/1ms_01_functors.md](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/language/1ms_01_functors.md)</kbd>
- [X] 13 <kbd>[data/tutorials/language/1ms_02_dune.md](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/language/1ms_02_dune.md)</kbd>
- [X] 2 <kbd>[data/tutorials/platform/0_09_opam_path.md](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/platform/0_09_opam_path.md)</kbd>
- [X] 1 <kbd>[data/tutorials/platform/2_08_odoc.md](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/platform/2_08_odoc.md)</kbd>