### PR TITLE
Fix Example referencing Type not yet Defined

### DIFF
--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -162,8 +162,8 @@ Single-case pattern matching can also be used for parameter declaration.
 
 Here is an example with tuples:
 ```ocaml
-# let get_country ((country, { first; last }) : citizen) = country;;
-val get_country : citizen -> string = <fun>
+# let get_balance ((balance, { first; last }) : int * name) = balance;;
+val get_balance : int * string -> int = <fun>
 ```
 
 Here is an example with the `name` record:

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -162,8 +162,8 @@ Single-case pattern matching can also be used for parameter declaration.
 
 Here is an example with tuples:
 ```ocaml
-# let get_balance ((balance, { first; last }) : int * name) = balance;;
-val get_balance : int * string -> int = <fun>
+# let get_country ((country, { first; last }) : string * name) = country;;
+val get_country : string * name -> string = <fun>
 ```
 
 Here is an example with the `name` record:


### PR DESCRIPTION
Fix an example that used a type that was not yet defined.

This caused me some headache when going through the tutorials thinking I had missed something but it turned out the example was using a type that was defined in a below section.