### PR TITLE
Build on OCaml 5 (river pin)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-ocaml-4.14
+FROM ocaml/opam:debian-ocaml-5.2
 
 # Branch freeze was opam-repo HEAD at the time of commit
 RUN cd ~/opam-repository && git checkout -b freeze c45f5bab71d3589f41f9603daca5acad14df0ab0 && opam update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - "4.14"
+          - "5.2"
 
     steps:
       - name: Checkout Repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine-3.20-ocaml-4.14 as build
+FROM ocaml/opam:alpine-3.20-ocaml-5.2 as build
 
 # Install system dependencies
 RUN sudo apk update && sudo apk add --update libev-dev openssl-dev gmp-dev oniguruma-dev inotify-tools curl-dev autoconf

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deps: create_switch ## Install development dependencies
 
 .PHONY: create_switch
 create_switch: ## Create switch and pinned opam repo
-	opam switch create . 4.14.2 --no-install --repos pin=git+https://github.com/ocaml/opam-repository#c45f5bab71d3589f41f9603daca5acad14df0ab0
+	opam switch create . 5.2.0 --no-install --repos pin=git+https://github.com/ocaml/opam-repository#c45f5bab71d3589f41f9603daca5acad14df0ab0
 
 .PHONY: switch
 switch: deps ## Create an opam switch and install development dependencies

--- a/dune-project
+++ b/dune-project
@@ -31,9 +31,7 @@
   "This repository contains the server that serves the official OCaml website at https://ocaml.org.")
  (depends
   (ocaml
-   (and
-    (>= 4.14.0)
-    (< 5.0.0)))
+   (>= 4.14.0))
   dune
   cohttp
   cohttp-lwt-unix

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,6 +1,11 @@
 (lang dune 3.15)
 
 (pin
+ (name ocamlnet)
+ (url "git+https://github.com/aantron/ocamlnet#7ef255a0a994ef2721f3359077b36bcdd0428ee4")
+ (package (name ocamlnet)))
+
+(pin
  (name tailwindcss)
  (url "git+https://github.com/tmattio/opam-tailwindcss#3e60fc32bbcf82525999d83ad0f395e16107026b")
  (package (name tailwindcss)))
@@ -11,4 +16,4 @@
  (package (name olinkcheck)))
 
 (lock_dir
- (pins tailwindcss olinkcheck))
+ (pins ocamlnet tailwindcss olinkcheck))

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,9 +1,9 @@
 (lang dune 3.15)
 
 (pin
- (name ocamlnet)
- (url "git+https://github.com/aantron/ocamlnet#7ef255a0a994ef2721f3359077b36bcdd0428ee4")
- (package (name ocamlnet)))
+ (name river)
+ (url "git+https://github.com/aantron/river#476dc945a908a69548bddd267f143a3e5d9c8a1a")
+ (package (name river)))
 
 (pin
  (name tailwindcss)
@@ -16,4 +16,4 @@
  (package (name olinkcheck)))
 
 (lock_dir
- (pins ocamlnet tailwindcss olinkcheck))
+ (pins river tailwindcss olinkcheck))

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -70,6 +70,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
+  ["river.dev" "git+https://github.com/aantron/river#476dc945a908a69548bddd267f143a3e5d9c8a1a"]
   ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
 ]

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/ocaml/ocaml.org"
 doc: "https://ocaml.github.io/ocaml.org/"
 bug-reports: "https://github.com/ocaml/ocaml.org/issues"
 depends: [
-  "ocaml" {>= "4.14.0" & < "5.0.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "3.15"}
   "cohttp"
   "cohttp-lwt-unix"
@@ -70,6 +70,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
+  # See https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/merge_requests/24
+  # See https://github.com/aantron/ocamlnet/commit/7ef255a0a994ef2721f3359077b36bcdd0428ee4
+  ["ocamlnet.dev" "git+https://github.com/aantron/ocamlnet#7ef255a0a994ef2721f3359077b36bcdd0428ee4"]
   ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
 ]

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -70,9 +70,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
-  # See https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/merge_requests/24
-  # See https://github.com/aantron/ocamlnet/commit/7ef255a0a994ef2721f3359077b36bcdd0428ee4
-  ["ocamlnet.dev" "git+https://github.com/aantron/ocamlnet#7ef255a0a994ef2721f3359077b36bcdd0428ee4"]
   ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
 ]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,4 +1,5 @@
 pin-depends: [
+  ["river.dev" "git+https://github.com/aantron/river#476dc945a908a69548bddd267f143a3e5d9c8a1a"]
   ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
   ["olinkcheck.~dev" "git+https://github.com/tarides/olinkcheck"]
 ]


### PR DESCRIPTION
With this PR, it is possible to build and run OCaml.org on OCaml 5 with

```
make deps
make start
```

<br>

The build was failing due to problems with a configuration script in [ocamlnet](https://gitlab.com/gerdstolpmann/lib-ocamlnet3), a transitive dependency of OCaml.org, through package [River](https://github.com/tarides/river). For details on the problem in ocamlnet, see https://github.com/aantron/ocamlnet/commit/7ef255a0a994ef2721f3359077b36bcdd0428ee4:


> Work around broken `HAVE_BYTES` detection
>
> `configure` uses `ocamlc -safe-string` to determine whether the compiler has the `bytes` type. However, on OCaml 5, this command, without input files, exits with a non-zero exit code and prints `No input files`. This causes `configure` to wrongly believe that `-safe-string` is not supported, which then triggers a multitude of compilation errors.
>
> This commit (in ocamlnet) changes the code to unconditionally assume that `bytes` is available. A better way is probably to adapt OASIS, or what generated the `configure` script.

The code in ocamlnet's `configure` script is [here](https://github.com/aantron/ocamlnet/blob/7ef255a0a994ef2721f3359077b36bcdd0428ee4/code/configure#L617-L634). cc @gerdstolpmann

<br>

This PR pins ocamlnet to a fork with the above workaround, until ocamlnet is fixed upstream and released. See the [OCaml 5 compatibility MR](https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/merge_requests/24) in ocamlnet.

<br>

This PR points package `ocamlnet` to my own fork on GitHub, which could become a problem for `git bisect` or other purposes in the future, if the fork were to become inaccessible. However, I see that OCaml.org already has dependencies pointed to other repos, so perhaps this is fine. Please let me know if you'd like me to put the ocamlnet patch somewhere else.