### PR TITLE
Performance: cache search index digest until ocaml-docs-ci computes it

### DIFF
--- a/src/ocamlorg_package/lib/config.ml
+++ b/src/ocamlorg_package/lib/config.ml
@@ -7,8 +7,8 @@ let documentation_url =
   Sys.getenv_opt "OCAMLORG_DOC_URL"
   |> Option.value ~default:"https://docs-data.ocaml.org/live/"
 
-let documentation_status_cache_ttl =
-  env_with_default "OCAMLORG_DOC_STATUS_CACHE_TTL" "3600" |> float_of_string
+let package_caches_ttl =
+  env_with_default "OCAMLORG_PACKAGE_CACHES_TTL" "3600" |> float_of_string
 
 let default_cache_dir =
   match Sys.os_type with

--- a/src/ocamlorg_package/lib/config.mli
+++ b/src/ocamlorg_package/lib/config.mli
@@ -2,6 +2,6 @@
 
 val opam_polling : int
 val documentation_url : string
-val documentation_status_cache_ttl : float
+val package_caches_ttl : float
 val opam_repository_path : Fpath.t
 val package_state_path : Fpath.t

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -151,6 +151,10 @@ val search_index :
   kind:[< `Package | `Universe of string ] -> t -> string option Lwt.t
 (** Retrieve the search index of a given package. *)
 
+val search_index_digest :
+  kind:[< `Package | `Universe of string ] -> state -> t -> string option Lwt.t
+(** Retrieve the hash digest of the search index of a given package. *)
+
 val init : ?disable_polling:bool -> unit -> state
 (** [init ()] initialises the opam-repository state. By default
     [disable_polling] is set to [false], but can be disabled for tests. *)

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -597,6 +597,13 @@ module Package_helper = struct
                publication = v.publication;
              })
 
+  let search_index_digest ~kind state name =
+    let open Lwt.Syntax in
+    let* search_index_digest =
+      Ocamlorg_package.search_index_digest ~kind state name
+    in
+    search_index_digest |> Option.map Dream.to_base64url |> Lwt.return
+
   let frontend_package ?on_latest_url ?documentation_status state
       (package : Ocamlorg_package.t) : Ocamlorg_frontend.Package.package =
     let name = Ocamlorg_package.name package
@@ -816,11 +823,8 @@ let package_overview t kind req =
   in
   let* sidebar_data = Package_helper.package_sidebar_data ~kind t package in
 
-  let* maybe_search_index = Ocamlorg_package.search_index ~kind package in
-  let search_index_digest =
-    Option.map
-      (fun idx -> idx |> Digest.string |> Dream.to_base64url)
-      maybe_search_index
+  let* search_index_digest =
+    Package_helper.search_index_digest ~kind t package
   in
 
   let package_info = Ocamlorg_package.info package in
@@ -1025,11 +1029,8 @@ let package_documentation t kind req =
                  { title; href; kind = Library; children })
       in
       let* module_map = Ocamlorg_package.module_map ~kind package in
-      let* maybe_search_index = Ocamlorg_package.search_index ~kind package in
-      let search_index_digest =
-        Option.map
-          (fun idx -> idx |> Digest.string |> Dream.to_base64url)
-          maybe_search_index
+      let* search_index_digest =
+        Package_helper.search_index_digest ~kind t package
       in
       let toc = Package_helper.frontend_toc doc.toc in
       let (maptoc : Ocamlorg_frontend.Navmap.toc list) =
@@ -1094,11 +1095,8 @@ let package_file t kind req =
   in
   let path = (Dream.path [@ocaml.warning "-3"]) req |> String.concat "/" in
   let* sidebar_data = Package_helper.package_sidebar_data ~kind t package in
-  let* maybe_search_index = Ocamlorg_package.search_index ~kind package in
-  let search_index_digest =
-    Option.map
-      (fun idx -> idx |> Digest.string |> Dream.to_base64url)
-      maybe_search_index
+  let* search_index_digest =
+    Package_helper.search_index_digest ~kind t package
   in
   let* maybe_doc = Ocamlorg_package.file ~kind package path in
   let</>? doc = maybe_doc in


### PR DESCRIPTION
Mitigates https://github.com/ocaml/ocaml.org/issues/2619 until ocaml-docs-ci generates digests for the search indexes as part of `status.json`.