### PR TITLE
Revert "Filter OCaml Planet Blog posts for "caml" keyword"

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -1,15 +1,12 @@
 - id: practicalocaml
   name: Practical OCaml
   url: https://practicalocaml.com/rss/
-  scrape_all: true
 - id: ocamlpro
   name: OCamlPro
   url: https://ocamlpro.com/blog/feed
-  scrape_all: true
 - id: ahrefs
   name: Ahrefs
   url: https://medium.com/feed/ahrefs/tagged/ocaml
-  scrape_all: true
 - id: tarides
   name: Tarides
   url: https://tarides.com/feed.xml
@@ -22,58 +19,48 @@
 - id: watch-ocaml
   name: Watch OCaml
   url: https://watch.ocaml.org/feeds/videos.xml
-  scrape_all: true
 - id: cwn
   name: Caml Weekly News
   url: https://alan.petitepomme.net/cwn/cwn.rss
-  scrape_all: true
 - id: andrej
   name: Andrej Bauer
   url: http://math.andrej.com/feed.xml
 - id: ujamjar
   name: Andy Ray
   url: http://www.ujamjar.com/ocaml.xml
-  scrape_all: true
 - id: ashishagarwal
   name: Ashish Agarwal
   url: http://ashishagarwal.org/tag/ocaml/feed/
-  scrape_all: true
 - id: cameleon
   name: Cameleon news
   url: http://www.blogger.com/feeds/7617521785419311079/posts/default
 - id: inria
   name: Caml INRIA
   url: http://caml.inria.fr/news.en.rss
-  scrape_all: true
 - id: coherentpdf
   name: Coherent Graphics
   url: https://coherentpdf.com/blog/?tag=ocaml&feed=rss2
-  scrape_all: true
 - id: coq
   name: Coq
   url: https://coq.inria.fr/rss.xml
 - id: cburnout
   name: Cranial Burnout
   url: http://www.blogger.com/feeds/9108979482982930820/posts/default/-/OCaml
-  scrape_all: true
 - id: erratique
   name: Daniel Bünzli
   url: https://erratique.ch/feeds/news.atom
 - id: dbaelde
   name: David Baelde
   url: http://www.blogger.com/feeds/17133288/posts/default/-/ocaml
-  scrape_all: true
 - id: dutherenverseauborddelatable
   name: David Teller
   url: https://dutherenverseauborddelatable.wordpress.com/category/ocaml/feed/
-  scrape_all: true
 - id: mega-nerd
   name: Erik de Castro Lopo
   url: http://www.mega-nerd.com/erikd/Blog/index.rss20
 - id: emillon
   name: Etienne Millon
   url: http://blog.emillon.org/feeds/ocaml.xml
-  scrape_all: true
 - id: frama-c
   name: Frama-C
   url: http://frama-c.com/rss.xml
@@ -84,7 +71,6 @@
   name: Gaius Hammond
   url: https://gaius.tech/category/ocaml/feed/
   disabled: true
-  scrape_all: true
 - id: reynard
   name: Gemma Gordon (OCaml Labs)
   url: http://reynard.io/feed.xml
@@ -92,7 +78,6 @@
 - id: camlcity
   name: Gerd Stolpmann
   url: http://blog.camlcity.org/blog/rss
-  scrape_all: true
 - id: hongboz
   name: Hong bo Zhang
   url: https://hongboz.wordpress.com/feed/
@@ -102,111 +87,90 @@
 - id: kcsrk
   name: KC Sivaramakrishnan
   url: https://kcsrk.info/atom-ocaml.xml
-  scrape_all: true
 - id: lpw25
   name: Leo White
   url: http://lpw25.net/rss.xml
 - id: skjegstad
   name: Magnus Skjegstad
   url: http://www.skjegstad.com/feeds/ocaml.tag.atom.xml
-  scrape_all: true
 - id: 0branch
   name: Marc Simpson
   url: https://blog.0branch.com/rss.xml
 - id: syntaxexclamation
   name: Matthias Puech
   url: https://syntaxexclamation.wordpress.com/tag/ocaml/feed/
-  scrape_all: true
 - id: mgiovannini
   name: Matías Giovannini
   url: http://www.blogger.com/feeds/5888658295182480819/posts/default
 - id: mlin
   name: Mike Lin
   url: http://www.blogger.com/feeds/3693082774051755513/posts/default/-/OCaml
-  scrape_all: true
 - id: mcclurmc
   name: Mike McClurg
   url: https://mcclurmc.wordpress.com/feed/
 - id: mirage
   name: MirageOS
   url: https://mirage.io/feed.xml
-  scrape_all: true
 - id: ocaml-book
   name: OCaml Book
   url: http://ocaml-book.com/blog?format=rss
-  scrape_all: true
 - id: ocamllabs
   name: OCaml Labs compiler hacking
   url: http://ocamllabs.io/compiler-hacking/rss.xml
-  scrape_all: true
 - id: ocamlcore
   name: OCamlCore.com
   url: http://www.ocamlcore.com/wp/feed/?amp;language=en&language=en
-  scrape_all: true
 - id: ocsigen
   name: Ocsigen project
   url: https://ocsigen.org/feed.xml
-  scrape_all: true
 - id: orbitz
   name: Orbitz
   url: http://functional-orbitz.blogspot.com/feeds/posts/default/-/planetocaml?alt=rss
-  scrape_all: true
 - id: pdonadeo
   name: Paolo Donadeo
   url: http://www.donadeo.net/facets/programming-languages/objective-caml/feed/
-  scrape_all: true
 - id: psellos
   name: Psellos
   url: http://psellos.com/atom.xml
 - id: rjones
   name: Richard Jones
   url: https://rwmj.wordpress.com/tag/ocaml/feed/
-  scrape_all: true
 - id: rgrinberg
   name: Rudi Grinberg
   url: http://rgrinberg.com/blog/atom.xml
 - id: smondet
   name: Sebastien Mondet
   url: https://seb.mondet.org/b/OCaml.rss
-  scrape_all: true
 - id: sfletcher
   name: Shayne Fletcher
   url: http://blog.shaynefletcher.org/feeds/posts/default/-/OCaml
-  scrape_all: true
 - id: szacchiroli
   name: Stefano Zacchiroli
   url: https://upsilon.cc/~zack/tags/ocaml/index.rss
-  scrape_all: true
 - id: talex5
   name: Thomas Leonard
   url: http://roscidus.com/blog/blog/categories/ocaml/atom.xml
-  scrape_all: true
 - id: tvaroquaux
   name: Till Varoquaux
   url: http://www.blogger.com/feeds/6115529230232389198/posts/default
 - id: yansnotes
   name: Yan Shvartzshnaider
   url: http://yansnotes.blogspot.com/feeds/posts/default/-/ocaml
-  scrape_all: true
 - id: ocamljava
   name: OCaml-Java
   url: http://www.ocamljava.org/feed.xml
-  scrape_all: true
 - id: typeocaml
   name: Xinuo Chen
   url: http://typeocaml.com/rss/
-  scrape_all: true
 - id: drup
   name: Gabriel Radanne
   url: http://drup.github.io/feed-ocaml.xml
-  scrape_all: true
 - id: bap
   name: The BAP Blog
   url: https://binaryanalysisplatform.github.io/feed.xml
 - id: baturin
   name: Daniil Baturin
   url: https://baturin.org/blog/atom-ocaml.xml
-  scrape_all: true
 - id: signalsandthreads
   name: Signals and Threads
   url: https://feeds.simplecast.com/L9810DOa
@@ -219,11 +183,6 @@
 - id: emilpriver
   name: Emil Privér
   url: https://priver.dev/tags/ocaml/index.xml
-  scrape_all: true
 - id: melange
   name: Melange Blog
   url: https://melange.re/blog/feed.rss
-  scrape_all: true
-- id: chshersh
-  name: Dmitrii Kovanikov
-  url: https://dev.to/feed/chshersh

--- a/data/planet/signalsandthreads/a-poets-guide-to-product-management-with-peter-bogart-johnson.md
+++ b/data/planet/signalsandthreads/a-poets-guide-to-product-management-with-peter-bogart-johnson.md
@@ -1,0 +1,13 @@
+---
+title: A Poet's Guide to Product Management with Peter Bogart-Johnson
+description:
+url: https://signals-threads.simplecast.com/episodes/a-poets-guide-to-product-management-with-peter-bogart-johnson-_sAIFzsS
+date: 2023-08-15T13:42:13-00:00
+preview_image:
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Peter Bogart-Johnson was one of Jane Street&rsquo;s first program managers, and helped bring the art of PMing&mdash;where that &ldquo;P&rdquo; variously stands for &ldquo;project,&rdquo; &ldquo;product,&rdquo; or some blend of the two&mdash;to the company at large. He&rsquo;s also a poet and the editor of a literary magazine. In this episode, Peter and Ron discuss the challenge of gaining trust as an outsider: how do you teach teams a new way of doing things while preserving what&rsquo;s already working? The key, Peter says, is you listen; a good PM is an anthropologist. They also discuss how paying down technical debt isn&rsquo;t something you do instead of serving customers; what Jane Street looks for in PM candidates; and how to help teams coordinate in times of great change.</p><p>You can find the transcript for this episode &nbsp;on our <a href="https://signalsandthreads.com/a-poets-guide-to-product-management" target="_blank">website.</a></p><p>Some links to topics that came up in the discussion:</p><ul><li><a href="https://lit-magazine.blogspot.com/">LIT Magazine</a> (more recently <a href="https://www.litmagazine.org/">here</a>)</li><li><a href="https://staysaasy.com/product/2023/03/12/pm-engineers-dont-hate.html">How to be a PM that engineers don&rsquo;t hate</a> and <a href="https://staysaasy.com/engineering/2023/06/18/how-to-be-an-engineer-pms-down-hate.html">How to be an engineer that PMs don&rsquo;t hate</a></li></ul>
+

--- a/data/planet/signalsandthreads/an-inside-look-at-jane-streets-tech-internship-with-jeanne-van-briesen-matt-else-and-grace-zhang.md
+++ b/data/planet/signalsandthreads/an-inside-look-at-jane-streets-tech-internship-with-jeanne-van-briesen-matt-else-and-grace-zhang.md
@@ -1,0 +1,14 @@
+---
+title: An inside look at Jane Street's tech internship with Jeanne Van Briesen, Matt
+  Else, and Grace Zhang
+description:
+url: https://signalsandthreads.com
+date: 2020-11-06T17:00:00-00:00
+preview_image: https://signalsandthreads.com/static/images/twitter/signals_threads.png
+authors:
+- Signals and Threads
+source:
+---
+
+<p>In this week's episode, the season 1 finale, Ron speaks with Jeanne, Matt, and Grace, three former tech interns at Jane Street who have returned as full-timers. They talk about the experience of being an intern at Jane Street, the types of projects that interns work on, and how they've found the transition to full-time work.</p><p>You can find the transcript for this episode along with links to things we discussed on our <a href="https://signalsandthreads.com/multicast-and-the-markets">website</a>.</p>
+

--- a/data/planet/signalsandthreads/build-systems-with-andrey-mokhov.md
+++ b/data/planet/signalsandthreads/build-systems-with-andrey-mokhov.md
@@ -1,0 +1,13 @@
+---
+title: Build systems with Andrey Mokhov
+description:
+url: https://signalsandthreads.com/build-systems/
+date: 2020-09-16T15:55:47-00:00
+preview_image: https://signalsandthreads.com/static/images/twitter/build_systems.png
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Most software engineers only think about their build system when it breaks; and yet, this often unloved piece of software forms the backbone of every serious project. This week, Ron has a conversation with Andrey Mokhov about build systems, from the venerable Make to Bazel and beyond. Andrey has a lot of experience in this field, including significant contributions to <a href="https://gitlab.haskell.org/ghc/ghc/-/wikis/building/hadrian">the replacement</a> for the Glasgow Haskell Compiler&rsquo;s Make-based system and <a href="https://www.cambridge.org/core/journals/journal-of-functional-programming/article/build-systems-a-la-carte-theory-and-practice/097CE52C750E69BD16B78C318754C7A4">Build Systems &agrave; la carte</a>, a paper that untangles the complex ecosystem of existing build systems. Ron and Andrey muse on questions like why every language community seems to have its own purpose-built system and, closer to home, where Andrey and the rest of the build systems team at Jane Street are focusing their efforts.</p><p>You can find the transcript for this episode along with links to related work on our <a href="https://signalsandthreads.com/build-systems">website</a>.</p>
+

--- a/data/planet/signalsandthreads/clock-synchronization-with-chris-perl.md
+++ b/data/planet/signalsandthreads/clock-synchronization-with-chris-perl.md
@@ -1,0 +1,13 @@
+---
+title: Clock synchronization with Chris Perl
+description:
+url: https://signalsandthreads.com/clock-synchronization/
+date: 2020-10-14T16:00:00-00:00
+preview_image: https://signalsandthreads.com/static/images/twitter/clock_synchronization.png
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Clock synchronization, keeping all of the clocks on your network set to the &ldquo;correct&rdquo; time, sounds straightforward: our smartphones sure don&rsquo;t seem to have trouble with it. Next, keep them all accurate to within 100 microseconds, and prove that you did -- now things start to get tricky. In this episode, Ron talks with Chris Perl, a systems engineer at Jane Street about the fundamental difficulty of solving this problem at scale and how we solved it.</p><p>You can find the transcript for this episode along with links to things we discussed on our <a href="https://signalsandthreads.com/multicast-and-the-markets">website</a>.</p>
+

--- a/data/planet/signalsandthreads/compiler-optimization-with-greta-yorsh.md
+++ b/data/planet/signalsandthreads/compiler-optimization-with-greta-yorsh.md
@@ -1,0 +1,13 @@
+---
+title: Compiler optimization with Greta Yorsh
+description:
+url: https://signalsandthreads.com/compiler-optimization/
+date: 2020-09-30T16:00:00-00:00
+preview_image: https://signalsandthreads.com/static/images/twitter/compiler_optimization.png
+authors:
+- Signals and Threads
+source:
+---
+
+<p>It&rsquo;s a software engineer&rsquo;s dream: A compiler that can take idiomatic high-level code and output maximally efficient instructions. Ron&rsquo;s guest this week is Greta Yorsh, who has worked on just that problem in a career spanning both industry and academia. Ron and Greta talk about some&nbsp; of the tricks that compilers use to make our software faster, ranging from feedback-directed optimization and super-optimization to formal analysis.</p><p>You can find the transcript for this episode along with links to things we discussed on our <a href="https://signalsandthreads.com/multicast-and-the-markets">website</a>.</p>
+

--- a/data/planet/signalsandthreads/introducing-signals--threads.md
+++ b/data/planet/signalsandthreads/introducing-signals--threads.md
@@ -1,0 +1,13 @@
+---
+title: Introducing Signals & Threads
+description:
+url: https://signals-threads.simplecast.com/episodes/introducing-signals-threads-zLlapP9a
+date: 2020-08-24T01:25:54-00:00
+preview_image:
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Listen in on Jane Street&rsquo;s Ron Minsky as he has conversations with engineers working on everything from clock synchronization to reliable multicast, build systems to reconfigurable hardware. Get a peek at how Jane Street approaches problems, and how those ideas relate to tech more broadly.</p>
+

--- a/data/planet/signalsandthreads/more-signals--threads-coming-soon.md
+++ b/data/planet/signalsandthreads/more-signals--threads-coming-soon.md
@@ -1,0 +1,13 @@
+---
+title: More Signals & Threads coming soon!
+description:
+url: https://signals-threads.simplecast.com/episodes/more-signals-and-threads-coming-soon-bZXFSWKN
+date: 2021-08-24T13:36:17-00:00
+preview_image:
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Signals &amp; Threads is back, and we have a fun season of topics lined up, including: Building better abstractions for design and user interfaces, the role of writing in a technical organization, the approach that different languages take to memory management...and more. We hope you&rsquo;ll join us. The first episode drops September 1st.</p>
+

--- a/data/planet/signalsandthreads/multicast-and-the-markets-with-brian-nigito.md
+++ b/data/planet/signalsandthreads/multicast-and-the-markets-with-brian-nigito.md
@@ -1,0 +1,13 @@
+---
+title: Multicast and the markets with Brian Nigito
+description:
+url: https://signalsandthreads.com/multicast-and-the-markets/
+date: 2020-09-23T16:00:09-00:00
+preview_image: https://signalsandthreads.com/static/images/twitter/multicast_markets.png
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Electronic exchanges like Nasdaq need to handle a staggering number of transactions every second. To keep up, they rely on two deceptively simple-sounding concepts: single-threaded programs and multicast networking. In this episode, Ron speaks with Brian Nigito, a 20-year industry veteran who helped build some of the earliest electronic exchanges, about the tradeoffs that led to the architecture we have today, and how modern exchanges use these straightforward building blocks to achieve blindingly fast performance at scale.</p><p>You can find the transcript for this episode along with links to things we discussed on our <a href="https://signalsandthreads.com/multicast-and-the-markets">website</a>.</p>
+

--- a/data/planet/signalsandthreads/state-machine-replication-and-why-you-should-care-with-doug-patti.md
+++ b/data/planet/signalsandthreads/state-machine-replication-and-why-you-should-care-with-doug-patti.md
@@ -1,0 +1,13 @@
+---
+title: State Machine Replication, and Why You Should Care with Doug Patti
+description:
+url: https://signals-threads.simplecast.com/episodes/state-machine-replication-and-why-you-should-care-with-doug-patti-ddqeDcTw
+date: 2022-04-20T16:00:00-00:00
+preview_image:
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Doug Patti is a developer in Jane Street&rsquo;s Client-Facing Tech team, where he works on a system called Concord that undergirds Jane Street&rsquo;s client offerings. In this episode, Doug and Ron discuss how Concord, which has state-machine replication as its core abstraction, helps Jane Street achieve the reliability, scalability, and speed that the client business demands. They&rsquo;ll also discuss Doug&rsquo;s involvement in building a successor system called Aria, which is designed to deliver those same benefits to a much wider audience.</p><p>You can find the transcript for this episode &nbsp;on our <a href="https://signalsandthreads.com/state-machine-replication-and-why-you-should-care" target="_blank">website</a>.</p><p>Some links to topics that came up in the discussion:</p><ul><li>Jane Street&rsquo;s <a href="https://www.janestreet.com/institutional-services/electronic-trading-platforms/">client-facing trading platforms</a></li><li>A Signals and Threads episode on <a href="https://signalsandthreads.com/multicast-and-the-markets/">market data and multicast</a> which discusses some of the history of state-machine replication in the markets.</li><li>The <a href="https://www.investopedia.com/terms/f/financial-information-exchange.asp">FIX protocol</a></li><li><a href="https://en.wikipedia.org/wiki/Multicast">UDP multicast</a></li><li><a href="https://en.wikipedia.org/wiki/Reliable_multicast#:~:text=A%20reliable%20multicast%20is%20any,as%20multi-receiver%20file%20transfer.">Reliable multicast</a></li><li><a href="https://kafka.apache.org/intro">Kafka</a></li></ul>
+

--- a/data/planet/signalsandthreads/swapping-the-engine-out-of-a-moving-race-car-with-ella-ehrlich.md
+++ b/data/planet/signalsandthreads/swapping-the-engine-out-of-a-moving-race-car-with-ella-ehrlich.md
@@ -1,0 +1,13 @@
+---
+title: Swapping the Engine Out of a Moving Race Car with Ella Ehrlich
+description:
+url: https://signals-threads.simplecast.com/episodes/swapping-the-engine-out-of-a-moving-race-car-with-ella-ehrlich-WWjYmqQI
+date: 2022-09-12T20:46:54-00:00
+preview_image:
+authors:
+- Signals and Threads
+source:
+---
+
+<p>Ella Ehrlich has been a developer at Jane Street for close to a decade. During much of that time, she&rsquo;s worked on Gord, one of Jane Street&rsquo;s oldest and most critical systems, which is responsible for normalizing and distributing the firm&rsquo;s trading data. Ella and Ron talk about how to grow and modernize a legacy system without compromising uptime, why game developers are the &ldquo;musicians of software,&rdquo; and some of the work Jane Street has done to try to hire a more diverse set of software engineers.</p><p>You can find the transcript for this episode &nbsp;on our <a href="https://signalsandthreads.com/swapping-the-engine-out-of-a-moving-race-car" target="_blank">website.</a></p><p>Some links to topics that came up in the discussion:</p><ul><li><a href="https://lol.fandom.com/wiki/Evil_Geniuses.NA">EG</a>, The League of Legends team that Ella is a huge fan of.</li><li><a href="https://kafka.apache.org/">Apache Kafka</a>, the message bus that Gord migrated to.</li><li>Some of the <a href="https://www.openfigi.com/">various</a> <a href="https://en.wikipedia.org/wiki/Reuters_Instrument_Code">sources</a> <a href="https://www.cmegroup.com/tools-information/vendorSymbol.html">of</a> <a href="https://www.isin.org/">symbology</a> you have to deal with when normalizing trading data. (Really, there are too many sources to list here!)</li><li>A list of Jane Street&rsquo;s recruiting <a href="https://www.janestreet.com/join-jane-street/programs-and-events/">Programs and Events</a>, including <a href="https://www.janestreet.com/join-jane-street/programs-and-events/insight/">INSIGHT</a>, which focuses on women, and <a href="https://www.janestreet.com/join-jane-street/programs-and-events/in-focus/">IN FOCUS</a>, which focuses on historically underrepresented ethnic or racial minorities.</li></ul>
+

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -388,7 +388,6 @@ module Planet = struct
     url : string;
     description : string;
     disabled : bool;
-    scrape_all : bool;
   }
   [@@deriving show]
 


### PR DESCRIPTION
Reverts ocaml/ocaml.org#2443

Not all useful blog posts contain the "caml" keyword, and we would be in a position to make a call on which blogs to pull all blog posts in from - maybe better to stay with the old behavior.