### PR TITLE
feat: list the upcoming events of the current month and going forward…

### DIFF
--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -93,8 +93,8 @@ module ChangelogFeed = struct
   let create_feed () =
     let open Rss in
     () |> all
-    |> create_feed ~id:"changelog.xml" ~title:"OCaml Changelog" ~create_entry
-         ~span:365
+    |> create_entries ~create_entry ~days:365
+    |> entries_to_feed ~id:"changelog.xml" ~title:"OCaml Changelog"
     |> feed_to_string
 end
 

--- a/tool/ood-gen/lib/event.ml
+++ b/tool/ood-gen/lib/event.ml
@@ -114,7 +114,8 @@ module EventsFeed = struct
   let create_feed () =
     let open Rss in
     () |> all
-    |> create_feed ~id:"events.xml" ~title:"OCaml Events" ~create_entry
+    |> create_entries ~create_entry
+    |> entries_to_feed ~id:"events.xml" ~title:"OCaml Events"
     |> feed_to_string
 end
 

--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -1,15 +1,18 @@
-let create_feed ~id ~title ~create_entry ?span u =
-  let id = Uri.of_string ("https://ocaml.org/" ^ id) in
-  let title : Syndic.Atom.title = Text title in
+let create_entries ~create_entry ?days u =
   let is_fresh =
-    let some span (entry : Syndic.Atom.entry) =
+    let some days (entry : Syndic.Atom.entry) =
       let now = Ptime.of_float_s (Unix.gettimeofday ()) |> Option.get in
-      let than = Ptime.sub_span now (Ptime.Span.v (span, 0L)) |> Option.get in
+      let than = Ptime.sub_span now (Ptime.Span.v (days, 0L)) |> Option.get in
       if Ptime.is_later entry.updated ~than then Some entry else None
     in
-    Option.fold ~none:Option.some ~some span
+    Option.fold ~none:Option.some ~some days
   in
   let entries = u |> List.filter_map (fun x -> x |> create_entry |> is_fresh) in
+  entries
+
+let entries_to_feed ~id ~title (entries : Syndic.Atom.entry list) =
+  let id = Uri.of_string ("https://ocaml.org/" ^ id) in
+  let title : Syndic.Atom.title = Text title in
   let updated = (List.hd entries).updated in
   Syndic.Atom.feed ~id ~title ~updated entries
 

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -35,7 +35,8 @@ let create_entry (v : t) =
 let create_feed () =
   let open Rss in
   () |> all
-  |> create_feed ~id:"video.xml" ~title:"OCaml Videos" ~create_entry ~span:3653
+  |> create_entries ~create_entry ~days:365
+  |> entries_to_feed ~id:"video.xml" ~title:"OCaml Videos"
   |> feed_to_string
 
 let scrape () =


### PR DESCRIPTION
… on the OCaml Planet RSS feed

Purpose: We want to announce events via the RSS feed so that the social media accounts linked to the RSS feed automatically publish monthly announcements for upcoming events.