### PR TITLE
Fix 002_tail_penultimate Exercise 

### DIFF
--- a/data/exercises/002_tail_penultimate.md
+++ b/data/exercises/002_tail_penultimate.md
@@ -19,7 +19,7 @@ val last_two : 'a list -> ('a * 'a) option = <fun>
 
 # Statement
 
-Find the last but one (last and penultimate) elements of a list.
+Find the last two (last and penultimate) elements of a list.
 
 ```ocaml
 # last_two ["a"; "b"; "c"; "d"];;


### PR DESCRIPTION
### Issue
Exercise 002_tail_penultimate on ocaml.org/exercises has a minor wording issue that changes the meaning of the problem. 

### Fix
Update the problem statement to correctly reflect the problem (last two, not "last but one").