### PR TITLE
docs: fix mistake in explanation of boolean list

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -353,7 +353,7 @@ Lists may be the most common data type in OCaml. They are ordered collections of
 The examples above read the following way:
 1. The empty list, nil
 1. A list containing the numbers 1, 2, and 3
-1. A list containing the Booleans `false`, `true`, and `false`. Repetitions are allowed.
+1. A list containing the Booleans `false`, `false`, and `true`. Repetitions are allowed.
 1. A list of lists
 
 Lists are defined as being either empty, written `[]`, or being an element `x` added at the front of another list `u`, which is written `x :: u` (the double colon operator is pronounced “cons”).


### PR DESCRIPTION
In  `1_01_a_tour_of_ocaml.md` there is an incorrect explanation of the example of the boolean list.

Closes #2664. 