### PR TITLE
404 on illegal package name

### DIFF
--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -1,6 +1,9 @@
 module Import = Import
 open Import
-module Name = OpamPackage.Name
+module Name = struct
+  include OpamPackage.Name
+  let of_string_opt str = try Some (of_string str) with _ -> None
+end
 module Version = OpamPackage.Version
 module Info = Info
 module Statistics = Packages_stats

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -1,9 +1,12 @@
 module Import = Import
 open Import
+
 module Name = struct
   include OpamPackage.Name
+
   let of_string_opt str = try Some (of_string str) with _ -> None
 end
+
 module Version = OpamPackage.Version
 module Info = Info
 module Statistics = Packages_stats

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -12,6 +12,7 @@ module Name : sig
   val compare : t -> t -> int
   val to_string : t -> string
   val of_string : string -> t
+  val of_string_opt : string -> t option
 
   module Map : OpamStd.MAP with type key := t
 end

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -796,7 +796,8 @@ let is_ocaml_yet t id req =
     |> List.concat_map (fun (category : Data.Is_ocaml_yet.category) ->
            category.packages)
     |> List.filter_map (fun (p : Data.Is_ocaml_yet.package) ->
-           let name = Ocamlorg_package.Name.of_string p.name in (* FIXME: Failure *)
+           let name = Ocamlorg_package.Name.of_string p.name in
+           (* FIXME: Failure *)
            match Ocamlorg_package.get_latest t name with
            | Some x -> Some x
            | None ->
@@ -913,7 +914,9 @@ let packages_autocomplete_fragment t req =
   | _ -> Dream.html ""
 
 let package_overview t kind req =
-  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
+  let</>? name =
+    Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name"
+  in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1043,7 +1046,9 @@ let package_overview t kind req =
        ~search_index_digest ~toc ~deps_and_conflicts frontend_package)
 
 let package_versions t _kind req =
-  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
+  let</>? name =
+    Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name"
+  in
   let version_from_url = Dream.param req "version" in
   let</>? _package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1051,7 +1056,9 @@ let package_versions t _kind req =
   Dream.html (Ocamlorg_frontend.package_versions frontend_package)
 
 let package_documentation t kind req =
-  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
+  let</>? name =
+    Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name"
+  in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1185,7 +1192,9 @@ let package_documentation t kind req =
            ~content:doc.content frontend_package)
 
 let package_file t kind req =
-  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
+  let</>? name =
+    Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name"
+  in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1210,7 +1219,9 @@ let package_file t kind req =
        ~search_index_digest ~content_title:path ~toc frontend_package)
 
 let package_search_index t kind req =
-  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
+  let</>? name =
+    Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name"
+  in
   let version_from_url = Dream.param req "version" in
   let</>? package, _ = Package_helper.of_name_version t name version_from_url in
   let open Lwt.Syntax in

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -913,7 +913,7 @@ let packages_autocomplete_fragment t req =
   | _ -> Dream.html ""
 
 let package_overview t kind req =
-  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let</>? name = try Some (Ocamlorg_package.Name.of_string @@ Dream.param req "name") with _ -> None in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -796,7 +796,7 @@ let is_ocaml_yet t id req =
     |> List.concat_map (fun (category : Data.Is_ocaml_yet.category) ->
            category.packages)
     |> List.filter_map (fun (p : Data.Is_ocaml_yet.package) ->
-           let name = Ocamlorg_package.Name.of_string p.name in
+           let name = Ocamlorg_package.Name.of_string p.name in (* FIXME: Failure *)
            match Ocamlorg_package.get_latest t name with
            | Some x -> Some x
            | None ->
@@ -913,7 +913,7 @@ let packages_autocomplete_fragment t req =
   | _ -> Dream.html ""
 
 let package_overview t kind req =
-  let</>? name = try Some (Ocamlorg_package.Name.of_string @@ Dream.param req "name") with _ -> None in
+  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1043,7 +1043,7 @@ let package_overview t kind req =
        ~search_index_digest ~toc ~deps_and_conflicts frontend_package)
 
 let package_versions t _kind req =
-  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
   let</>? _package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1051,7 +1051,7 @@ let package_versions t _kind req =
   Dream.html (Ocamlorg_frontend.package_versions frontend_package)
 
 let package_documentation t kind req =
-  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1185,7 +1185,7 @@ let package_documentation t kind req =
            ~content:doc.content frontend_package)
 
 let package_file t kind req =
-  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
   let</>? package, frontend_package =
     Package_helper.of_name_version t name version_from_url
@@ -1210,7 +1210,7 @@ let package_file t kind req =
        ~search_index_digest ~content_title:path ~toc frontend_package)
 
 let package_search_index t kind req =
-  let name = Ocamlorg_package.Name.of_string @@ Dream.param req "name" in
+  let</>? name = Ocamlorg_package.Name.of_string_opt @@ Dream.param req "name" in
   let version_from_url = Dream.param req "version" in
   let</>? package, _ = Package_helper.of_name_version t name version_from_url in
   let open Lwt.Syntax in


### PR DESCRIPTION
Here are a log showing what happens:
```
06.09.24 07:48:15.614    dream.logger  INFO REQ 7502 GET /p/tezosservicnd%20ion-colors%20hover:text-primary/latest 10.0.1.3:40688 Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Sa
fari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)
06.09.24 07:48:15.614    dream.logger  INFO REQ 7502 303 /p/tezosservicnd%20ion-colors%20hover%3Atext-primary/latest in 101 μs
06.09.24 07:48:16.139    dream.logger  INFO REQ 7503 GET /p/tezosservicnd%20ion-colors%20hover%3Atext-primary/latest 10.0.1.3:40688 Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)
06.09.24 07:48:16.139    dream.logger  WARN REQ 7503 Aborted by: Failure("Invalid character in package name \"tezosservicnd ion-colors hover:text-primary\"")
06.09.24 07:48:16.139    dream.logger  WARN Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
06.09.24 07:48:16.139    dream.logger  WARN Called from Ocamlorg_web__Handler.package_overview in file "src/ocamlorg_web/lib/handler.ml", line 916, characters 13-70
06.09.24 07:48:16.139    dream.logger  WARN Called from Dream_encoding.compress in file "lib/dream_encoding.ml", line 158, characters 21-32
06.09.24 07:48:16.139    dream.logger  WARN Called from Lwt.Sequence_associated_storage.with_value in file "src/core/lwt.ml", line 804, characters 19-23
06.09.24 07:48:16.139    dream.logger  WARN Re-raised at Lwt.Sequence_associated_storage.with_value in file "src/core/lwt.ml", line 809, characters 6-15
06.09.24 07:48:16.139    dream.logger  WARN Called from Lwt.Sequential_composition.try_bind in file "src/core/lwt.ml", line 2139, characters 10-14
06.09.24 07:48:16.139      dream.http ERROR REQ 7503 Failure("Invalid character in package name \"tezosservicnd ion-colors hover:text-primary\"")
06.09.24 07:48:16.139      dream.http ERROR REQ 7503 Raised at Stdlib__Map.Make.find in file "map.ml", line 141, characters 10-25
06.09.24 07:48:16.139      dream.http ERROR REQ 7503 Called from Logs.Tag.find in file "src/logs.ml", line 154, characters 14-32
```