### PR TITLE
feat: Put 'Upcoming Events' on RSS feed weekly

### DIFF
--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -28,67 +28,85 @@ module GlobalFeed = struct
 
   let create_events_announcement_entry () =
     let now = Ptime.of_float_s (Unix.gettimeofday ()) |> Option.get in
-    let year, month, _ = now |> Ptime.to_date in
+    let year, month, day = now |> Ptime.to_date in
 
-    let start = Ptime.of_date (year, month, 1) |> Option.get in
-    let human_readable_date =
-      Format.sprintf "%s %d"
-        (Syndic.Date.month start |> Syndic.Date.string_of_month)
-        (Syndic.Date.year start)
+    let start =
+      Ptime.of_date (year, month, min 22 ((day / 7 * 7) + 1)) |> Option.get
+      (* choose a day between 1, 8, 15, 22 so that reminders are sent out four
+         times a month*)
     in
-    let cutoff =
-      Ptime.add_span start (Ptime.Span.v (90, 0L))
-      |> Option.get |> Ptime.to_rfc3339
-    in
-    let start = start |> Ptime.to_rfc3339 in
+    let start_rfc3999 = start |> Ptime.to_rfc3339 in
+
     let events =
+      let cutoff =
+        Ptime.add_span start (Ptime.Span.v (90, 0L))
+        |> Option.get |> Ptime.to_rfc3339
+      in
       Event.all ()
       |> List.filter (fun (e : Data_intf.Event.t) ->
-             String.compare e.starts.yyyy_mm_dd start > 0
+             String.compare e.starts.yyyy_mm_dd start_rfc3999 > 0
              && String.compare e.starts.yyyy_mm_dd cutoff < 0)
     in
-    let authors = (Syndic.Atom.author "OCaml Events", []) in
-    let render_single_event (event : Data_intf.Event.t) =
-      let textual_location = event.city ^ ", " ^ event.country in
-      let start_date_str =
-        event.starts.yyyy_mm_dd ^ "T"
-        ^ Option.value ~default:"00:00" event.starts.utc_hh_mm
-        ^ ":00Z"
-      in
-      let start_date = Syndic.Date.of_rfc3339 start_date_str in
-      let human_readable_date =
-        Format.sprintf "%s %d, %d"
-          (Syndic.Date.month start_date |> Syndic.Date.string_of_month)
-          (Syndic.Date.day start_date)
-          (Syndic.Date.year start_date)
-      in
-      let content =
-        Format.sprintf {|<li><a href="%s">%s // %s // %s</a></li>
-|} event.url
-          event.title textual_location human_readable_date
-      in
-      content
-    in
 
-    let content =
-      events
-      |> List.map render_single_event
-      |> String.concat "\n"
-      |> Format.sprintf {|<ul>%s</ul>|}
-    in
+    match events with
+    | [] -> None
+    | _ ->
+        let human_readable_date =
+          Format.sprintf "%s %d, %d"
+            (Syndic.Date.month start |> Syndic.Date.string_of_month)
+            (Syndic.Date.day start) (Syndic.Date.year start)
+        in
+        let authors = (Syndic.Atom.author "OCaml Events", []) in
+        let render_single_event (event : Data_intf.Event.t) =
+          let textual_location = event.city ^ ", " ^ event.country in
+          let start_date_str =
+            event.starts.yyyy_mm_dd ^ "T"
+            ^ Option.value ~default:"00:00" event.starts.utc_hh_mm
+            ^ ":00Z"
+          in
+          let start_date = Syndic.Date.of_rfc3339 start_date_str in
+          let human_readable_date =
+            Format.sprintf "%s %d, %d"
+              (Syndic.Date.month start_date |> Syndic.Date.string_of_month)
+              (Syndic.Date.day start_date)
+              (Syndic.Date.year start_date)
+          in
+          let content =
+            Format.sprintf {|<li><a href="%s">%s // %s // %s</a></li>
+|}
+              event.url event.title textual_location human_readable_date
+          in
+          content
+        in
 
-    let period_start = Syndic.Date.of_rfc3339 start in
+        let content =
+          events
+          |> List.map render_single_event
+          |> String.concat "\n"
+          |> Format.sprintf {|<ul>%s</ul>|}
+        in
 
-    let id = Uri.of_string "https://ocaml.org/events" in
-    Syndic.Atom.entry ~id ~authors
-      ~title:
-        (Syndic.Atom.Text
-           ("Upcoming OCaml Events (" ^ human_readable_date ^ " and onwards)"))
-      ~updated:period_start
-      ~links:[ Syndic.Atom.link (Uri.of_string "https://ocaml.org/events") ]
-      ~categories:[ Syndic.Atom.category "events" ]
-      ~content:(Syndic.Atom.Html (None, content))
-      ()
+        let id =
+          let id_date_str =
+            Format.sprintf "%s-%d-%d"
+              (Syndic.Date.month start |> Syndic.Date.string_of_month)
+              (Syndic.Date.day start) (Syndic.Date.year start)
+          in
+
+          Uri.of_string ("https://ocaml.org/events#" ^ id_date_str)
+        in
+        Some
+          (Syndic.Atom.entry ~id ~authors
+             ~title:
+               (Syndic.Atom.Text
+                  ("Upcoming OCaml Events (" ^ human_readable_date
+                 ^ " and onwards)"))
+             ~updated:start
+             ~links:
+               [ Syndic.Atom.link (Uri.of_string "https://ocaml.org/events") ]
+             ~categories:[ Syndic.Atom.category "events" ]
+             ~content:(Syndic.Atom.Html (None, content))
+             ())
 
   let entry_of_post (post : Data_intf.Blog.Post.t) =
     let content = Syndic.Atom.Html (None, post.body_html) in
@@ -140,9 +158,14 @@ module GlobalFeed = struct
   let create_feed () =
     let open Rss in
     let entries = all () |> create_entries ~create_entry ~days:90 in
-    let event_announcements = [ create_events_announcement_entry () ] in
 
-    entries @ event_announcements
-    |> entries_to_feed ~id:"planet.xml" ~title:"The OCaml Planet"
-    |> feed_to_string
+    match create_events_announcement_entry () with
+    | None ->
+        entries
+        |> entries_to_feed ~id:"planet.xml" ~title:"The OCaml Planet"
+        |> feed_to_string
+    | Some event_announcements ->
+        entries @ [ event_announcements ]
+        |> entries_to_feed ~id:"planet.xml" ~title:"The OCaml Planet"
+        |> feed_to_string
 end


### PR DESCRIPTION
- turns out we need to update the `id` every time we publish a new events announcement, so that the RSS feed to social media automation will pick it up
- now we publish the events announcement on a weekly bases, on days 1, 8, 15, 22 of the month