### PR TITLE
Fixed typo in zip archive example

### DIFF
--- a/data/cookbook/create-zip-archive/00-camlzip.ml
+++ b/data/cookbook/create-zip-archive/00-camlzip.ml
@@ -18,7 +18,7 @@ let rec traverse_fs f directory =
     Sys.readdir directory
     |> Array.iter
          (fun entry ->
-            traverse
+            traverse_fs
               f (directory ^ "/" ^ entry))
   else
     f directory


### PR DESCRIPTION
Fixing a small typo I noticed while using the creating zip archive cookbook. The recursive call to the function `traverse_fs` was missing the `_fs`.