### PR TITLE
Fix opam switch activation instruction on Windows

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -108,7 +108,7 @@ or from PowerShell:
 (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }
 ```
 
-Opam is now installed and configured!
+Opam initialisation may take several minutes. While waiting its installation and configuration to complete, start reading [A Tour of OCaml](tour-of-ocaml).
 
 **Note**: opam can manage something called _switches_. This is key when switching between several OCaml projects. However, in this “getting started” series of tutorials, switches are not needed. If interested, you can read an introduction to [opam switches here](/docs/opam-switch-introduction).
 

--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -108,7 +108,7 @@ or from PowerShell:
 (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }
 ```
 
-Opam initialisation may take several minutes. While waiting its installation and configuration to complete, start reading [A Tour of OCaml](tour-of-ocaml).
+Opam initialisation may take several minutes. While waiting for its installation and configuration to complete, start reading [A Tour of OCaml](tour-of-ocaml).
 
 **Note**: opam can manage something called _switches_. This is key when switching between several OCaml projects. However, in this “getting started” series of tutorials, switches are not needed. If interested, you can read an introduction to [opam switches here](/docs/opam-switch-introduction).
 

--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -99,7 +99,7 @@ $ eval $(opam env)
 on Unix, and from the Windows Command Prompt:
 
 ```
-for /f\"tokens=*\" %i in ('opam env') do @%i
+for /f \"tokens=*\" %i in ('opam env') do @%i
 ```
 
 or from PowerShell:

--- a/src/ocamlorg_frontend/pages/install.eml
+++ b/src/ocamlorg_frontend/pages/install.eml
@@ -167,7 +167,7 @@ Layout.render
 
               or on PowerShell
 
-              <%s! Copy_to_clipboard.small_code_snippet ~id:"powershell-activate" "(& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $_ }" %>
+              <%s! Copy_to_clipboard.small_code_snippet ~id:"powershell-activate" "(& opam env) -split '\\r?\\n' | ForEach-Object { Invoke-Expression $_ }" %>
             </p>
           </li>
         </ol>

--- a/src/ocamlorg_frontend/pages/install.eml
+++ b/src/ocamlorg_frontend/pages/install.eml
@@ -163,7 +163,7 @@ Layout.render
             <p>
               You need to activate the opam switch by running on cmd
 
-              <%s! Copy_to_clipboard.small_code_snippet ~id:"cmd-activate" "for /f\"tokens=*\" %i in ('opam env') do @%i" %>
+              <%s! Copy_to_clipboard.small_code_snippet ~id:"cmd-activate" "for /f \"tokens=*\" %i in ('opam env') do @%i" %>
 
               or on PowerShell
 

--- a/src/ocamlorg_frontend/pages/install.eml
+++ b/src/ocamlorg_frontend/pages/install.eml
@@ -168,6 +168,8 @@ Layout.render
               or on PowerShell
 
               <%s! Copy_to_clipboard.small_code_snippet ~id:"powershell-activate" "(& opam env) -split '\\r?\\n' | ForEach-Object { Invoke-Expression $_ }" %>
+
+              Opam initialisation may take several minutes. Start <a href="<%s Url.tutorial "tour-of-ocaml" %>">A Tour of OCaml</a> while waiting.
             </p>
           </li>
         </ol>


### PR DESCRIPTION
Fix #2707 
* [X] Missing space (typo)
* [X] Endline code (escape sequence)
* [X] Antivirus (add "takes minutes" text)