### PR TITLE
changelog: alpha1 for OCaml 5.3.0

### DIFF
--- a/data/changelog/ocaml/2024-09-20-ocaml-5.3.0.alpha1.md
+++ b/data/changelog/ocaml/2024-09-20-ocaml-5.3.0.alpha1.md
@@ -1,0 +1,64 @@
+---
+title: OCaml 5.3.0 - First Alpha
+description: First Alpha Release of OCaml 5.3.0
+tags: [ocaml]
+---
+
+Four months after the release of OCaml 5.2.0, the set of new features for the
+future version 5.3.0 of OCaml has been frozen. We are thus happy to announce the
+first alpha release for OCaml 5.3.0.
+
+This alpha version is here to help fellow hackers join us early in our bug
+hunting and opam ecosystem fixing fun (see below for the installation
+instructions). More information about the whole release process is now available
+in the [compiler
+repository](https://github.com/ocaml/ocaml/blob/trunk/release-info/introduction.md),
+and we will try to propagate this information to ocaml.org shortly.
+
+
+The progresses on stabilising the ecosystem are tracked on the [opam readiness for 5.3.0 meta-issue](https://github.com/ocaml/opam-repository/issues/26596).
+
+The full release is expected around November, see the [new prospective
+calendar](https://github.com/ocaml/ocaml/blob/trunk/release-info/calendar.md)
+for more information.
+
+If you find any bugs, please report them on [OCaml's issue
+tracker](https://github.com/ocaml/ocaml/issues).
+
+If you are interested in the ongoing list of new features and bug fixes, the
+updated change log for OCaml 5.3.0 is available
+[on GitHub](https://github.com/ocaml/ocaml/blob/5.3/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1 and later:
+
+```bash
+opam update
+opam switch create 5.3.0~alpha1
+```
+
+The source code for the alpha is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.3.0-alpha1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3.0~alpha1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.3.0~alpha1+options <option_list>
+```
+
+where `option_list` is a space separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
+
+```bash
+opam switch create 5.3.0~alpha1+flambda+nffa ocaml-variants.5.3.0~alpha1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This is the changelog entry for the first alpha release of OCaml 5.3.0 .