### PR TITLE
Add a belated changelog update with recent OCaml Infrastructure updates 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,7 @@ The [OCaml Changelog](https://ocaml.org/changelog) is a feed of the latest relea
 
 - [The OCaml Compiler](https://github.com/ocaml/ocaml)
 - [OCaml Platform Tools](https://ocaml.org/docs/platform)
+- [OCaml Infrastructure](https://infra.ocaml.org/)
 
 Before a release of the above tools land on the `opam-repository`, the project's release manager opens a pull request (PR) on OCaml.org with the release announcement.
 

--- a/data/changelog/infra/2024-10-02-updates.md
+++ b/data/changelog/infra/2024-10-02-updates.md
@@ -1,112 +1,80 @@
 ---
-title: Infrastructure Updates
-tags: [infrastructure]
+title: OCaml Infrastructure: Enhancing Platform Support and User Experience
+authors: [Tarides OCaml Infrastructure Team]
+date: 2024-10-04
+changelog: |
+  - Added continuous deployment for service configuration (by @mtelvers, https://github.com/ocurrent/ocurrent-configurator)
+  - Implemented linting for package maintainer email addresses (by @punchagan, https://github.com/ocurrent/opam-ci-check/pull/30)
+  - Mitigated solver timeout errors in opam repo CI (by @mtelvers and @shonfeder, https://github.com/ocaml/infrastructure/issues/147)
+  - Fixed uncaught exception in opam repo CI linting checks (by @shonfeder, https://github.com/ocurrent/opam-repo-ci/pull/341)
+  - Updated systems to address CVE-2024-6387 (by @mtelvers, https://github.com/ocaml/infrastructure/issues/140)
+  - Added support for OCaml 5.2 and 5.3 (by @mtelvers, https://github.com/ocurrent/opam-repo-ci/issues/268 and https://github.com/ocurrent/opam-repo-ci/issues/363)
+  - Improved Windows support (by @mtelvers, https://github.com/ocurrent/docker-base-images/issues/241)
+  - Added support for GCC 14 (by @mtelvers, https://github.com/ocurrent/docker-base-images/issues/279)
+  - Dropped support for Debian 10 and 11 (by @mtelvers and @shonfeder, https://github.com/ocurrent/ocaml-dockerfile/pull/220 and https://github.com/ocurrent/ocaml-dockerfile/pull/210)
+  - Generated documentation of CI test platforms and deployed services (by @benmandrew, https://github.com/ocurrent/opam-repo-ci/blob/master/doc/platforms.md and https://github.com/ocurrent/ocurrent-deployer/blob/master/doc/services.md)
+  - Improved error reporting and local lint check instructions in opam CI (by @punchagan, https://github.com/ocurrent/opam-repo-ci/issues/359 and https://github.com/ocurrent/opam-repo-ci/issues/360)
 ---
 
-# Catching up
+[Tarides'](https://tarides.com/) OCaml Infrastructure team has been hard at work
+over the last few months, focusing on improving the stability, reliability, and
+user experience of the OCaml ecosystem's core infrastructure. We are preparing
+for more substantive changes to come. We will have more fruit from this work to
+share soon, but updates on our efforts are overdue and we wanted to get you all
+caught up.
 
-[Taride](https://tarides.com/)'s OCaml Infrastructure team has been hard at work
-over the last months, focused on sustaining the existing systems and
-regenerating our team's capacities. This work is in preparation for more
-substantive changes to improve the reliability and scalability of essential
-OCaml ecosystem infrastructure. We will have more fruits from this work to share
-soon, but updates on our efforts are overdue and we wanted to get you all caught
-up.
+## Platform Support
 
-Since we last published an announcement, we have been...
+We've expanded and updated our platform support to keep pace with the evolving OCaml ecosystem:
 
-## making the systems more stable
+- As part of the compiler release readiness, we've added support for OCaml 5.2
+  and the upcoming 5.3, currently in alpha.
+- We're now publishing Windows Server 2022 Docker images to the OCaml Dockerhub.
+  See for instance
+  [windows-server-msvc-ltsc2022-ocaml-4.14](https://hub.docker.com/layers/ocaml/opam/windows-server-msvc-ltsc2022-ocaml-4.14/images/sha256-cfe98cb048514e9eace3c4d4e607b7e7fce5abba3a49e9a07318180d6213eee2?context=explore)
+- Dropped support for the post-LTS distro versions Debian 10 and 11, focusing
+  our resources on the OCaml compiler's Tier 1 platform.
 
-- We have maintained opam repo CI at an average of 99.9% availability for the
-  last 2 months.
+These updates ensure that our systems continue to support OCaml developers on a
+broad range of systems, in particular by testing package publication to the opam
+repository and publishing Docker images.
 
-- The Ansible scripts that configure our services has been put under continuous
-  deployment via [@mtelvers](https://github.com/mtelvers) work on the
-  https://github.com/ocurrent/ocurrent-configurator utility.
+## Opam Repository Publishing Experience
 
-- We've added a linting step to ensure packages include an email address for
-  maintainers. This is needed to ensure opam repo curators can reliably contact
-  package maintainers when needed (by
-  [@punchagan](https://github.com/punchagan), see
-  [ocurrent/opam-ci-check#30](https://github.com/ocurrent/opam-ci-check/pull/30)).
+We've made improvements to enhance the experience of publishing packages to the
+opam repository:
 
-- There was a profusion of solver timeout errors impacting the opam repo CI
-  system, and we have managed to mitigate these (by
-  [@mtelvers](https://github.com/mtelvers) and
-  [@shonfeder](https://github.com/shonfeder) see
-  [ocaml/infrastructure#147](https://github.com/ocaml/infrastructure/issues/147).
-
-- We fixed an uncaught exception that sometimes occurred during linting checks
-  in the opam repo CI (by [@shonfeder](https://github.com/shonfeder), see
-  [ocurrent/opam-repo-ci#341](https://github.com/ocurrent/opam-repo-ci/pull/341).
-
-## keeping the systems up to date
-
-- Updates to address [CVE-2024-6387](https://www.cve.main
-  /CVERecord?id=CVE-2024-6387) (by [@mtelvers](https://github.com/mtelvers), see
-  [ocaml/infrastructure#140](https://github.com/ocaml/infrastructure/issues/140)).
-
-- Updates to support OCaml 5.2 and 5.3 (by
-  [@mtelvers](https://github.com/mtelvers), see
-  [ocurrent/opam-repo-ci#268](https://github.com/ocurrent/opam-repo-ci/issues/268)
-  and
-  [ocurrent/opam-repo-ci#363](https://github.com/ocurrent/opam-repo-ci/issues/363)).
-
-- Updates for better support for Windows (by
-  [@mtelvers](https://github.com/mtelvers), see
-  [ocurrent/docker-base-images#241](https://github.com/ocurrent/docker-base-images/issues/241)).
-
-- Support for GCC 14, culminating in a patch for the compiler (by
-  [@mtelvers](https://github.com/mtelvers), see
-  [ocurrent/docker-base-images#279](https://github.com/ocurrent/docker-base-images/issues/279)).
-
-- Dropped support for the post-LTS distro versions Debian 10 and 11 (by
-  [@mtelvers](https://github.com/mtelvers) and
-  [@shonfeder](https://github.com/shonfeder) see
-  [ocurrent/ocaml-dockerfile#220](https://github.com/ocurrent/ocaml-dockerfile/pull/220)
-  and
-  [ocurrent/ocaml-dockerfile#210](https://github.com/ocurrent/ocaml-dockerfile/pull/210)).
-
-## making it easier to understand the systems
-
+- Implemented a linting check for package maintainer email addresses,
+  ensuring package maintainers can be reliably contacted when needed.
+- Mitigated solver timeout errors in the opam repo CI system, reducing
+  frustrating delays in the package publishing process.
+- Fixed an uncaught exception that sometimes occurred during linting checks in
+  the opam repo CI.
+- Improved error reporting and added instructions for running lint checks
+  locally, making it easier for package authors to identify and resolve issues
+  before submitting to the repository.
 - We are [generating documentation of the platforms under test in opam
-  CI][platforms] (by [@benmandrew](https://github.com/benmandrew)).
+  CI][platforms], allowing package others a clear overview of the extensive
+  build matrix we are providing.
 
-- We are [generating documentation of the services under continuous
-  deployment][services] (by [@benmandrew](https://github.com/benmandrew)).
+We hope these changes will make package publication experience smoother. We're
+committed to improving the experience for newcomers and existing repository
+contributors alike, stay tuned for more improvements!
 
-[services]: https://github.com/ocurrent/ocurrent-deployer/blob/master/doc/services.md
-[platforms]: https://github.com/ocurrent/opam-repo-ci/blob/master/doc/platforms.md
+## Security and Reliability
 
-## improving the functionality and usability of the systems
+Maintaining the security and reliability of the OCaml infrastructure remains a
+top priority:
 
-- We have been developing
-  [opam-ci-check](https://github.com/ocurrent/opam-repo-ci/tree/master/opam-ci-check),
-  a command line utility aiming to make opam repo CI's logic local-first. It is
-  still in the early stages and far from finished, but it is enabling faster
-  development iteration already, and it will soon be fit for early adopting
-  package authors to use locally or in their own CI pipelines (by
-  [@punchagan](https://github.com/punchagan) and
-  [@shonfeder](https://github.com/shonfeder)).
+- Updated our systems to address
+  [CVE-2024-6387](https://nvd.nist.gov/vuln/detail/CVE-2024-6387).
+- We maintained 99.9% availability for the opam repo CI over the last two
+  months, providing a stable and reliable service for the OCaml community.
 
-- The first benefits of `opam-ci-check`'s local-first approach have made their
-  way into opam CI as logged instructions for running the lint checks locally
-  and as improved error reporting (by
-  [@punchagan](https://github.com/punchagan), see
-  [ocurrent/opam-repo-ci#359](https://github.com/ocurrent/opam-repo-ci/issues/359)
-  and
-  [ocurrent/opam-repo-ci#360](https://github.com/ocurrent/opam-repo-ci/issues/360)).
-
-# Forging ahead
+## Forging Ahead
 
 Much has been done but much more is in the works! Expect updates more regularly
 going forward, and don't hesitate to reach out on
 [ocaml/infrastructure/issues](https://github.com/ocaml/infrastructure/issues) or
 [discuss.ocaml.org](https://discuss.ocaml.org/tag/infrastructure) if you have
 questions, requests, or ideas!
-
-💚🛠 [Taride](https://tarides.com/)'s OCaml Infrastructure Team\
-([@mtelvers](https://github.com/mtelvers),
-[@punchagan](https://github.com/punchagan),
-[@cuihtlauac](https://github.com/cuihtlauac), and
-[@shonfeder](https://github.com/shonfeder)).

--- a/data/changelog/infra/2024-10-02-updates.md
+++ b/data/changelog/infra/2024-10-02-updates.md
@@ -1,0 +1,112 @@
+---
+title: Infrastructure Updates
+tags: [infrastructure]
+---
+
+# Catching up
+
+[Taride](https://tarides.com/)'s OCaml Infrastructure team has been hard at work
+over the last months, focused on sustaining the existing systems and
+regenerating our team's capacities. This work is in preparation for more
+substantive changes to improve the reliability and scalability of essential
+OCaml ecosystem infrastructure. We will have more fruits from this work to share
+soon, but updates on our efforts are overdue and we wanted to get you all caught
+up.
+
+Since we last published an announcement, we have been...
+
+## making the systems more stable
+
+- We have maintained opam repo CI at an average of 99.9% availability for the
+  last 2 months.
+
+- The Ansible scripts that configure our services has been put under continuous
+  deployment via [@mtelvers](https://github.com/mtelvers) work on the
+  https://github.com/ocurrent/ocurrent-configurator utility.
+
+- We've added a linting step to ensure packages include an email address for
+  maintainers. This is needed to ensure opam repo curators can reliably contact
+  package maintainers when needed (by
+  [@punchagan](https://github.com/punchagan), see
+  [ocurrent/opam-ci-check#30](https://github.com/ocurrent/opam-ci-check/pull/30)).
+
+- There was a profusion of solver timeout errors impacting the opam repo CI
+  system, and we have managed to mitigate these (by
+  [@mtelvers](https://github.com/mtelvers) and
+  [@shonfeder](https://github.com/shonfeder) see
+  [ocaml/infrastructure#147](https://github.com/ocaml/infrastructure/issues/147).
+
+- We fixed an uncaught exception that sometimes occurred during linting checks
+  in the opam repo CI (by [@shonfeder](https://github.com/shonfeder), see
+  [ocurrent/opam-repo-ci#341](https://github.com/ocurrent/opam-repo-ci/pull/341).
+
+## keeping the systems up to date
+
+- Updates to address [CVE-2024-6387](https://www.cve.main
+  /CVERecord?id=CVE-2024-6387) (by [@mtelvers](https://github.com/mtelvers), see
+  [ocaml/infrastructure#140](https://github.com/ocaml/infrastructure/issues/140)).
+
+- Updates to support OCaml 5.2 and 5.3 (by
+  [@mtelvers](https://github.com/mtelvers), see
+  [ocurrent/opam-repo-ci#268](https://github.com/ocurrent/opam-repo-ci/issues/268)
+  and
+  [ocurrent/opam-repo-ci#363](https://github.com/ocurrent/opam-repo-ci/issues/363)).
+
+- Updates for better support for Windows (by
+  [@mtelvers](https://github.com/mtelvers), see
+  [ocurrent/docker-base-images#241](https://github.com/ocurrent/docker-base-images/issues/241)).
+
+- Support for GCC 14, culminating in a patch for the compiler (by
+  [@mtelvers](https://github.com/mtelvers), see
+  [ocurrent/docker-base-images#279](https://github.com/ocurrent/docker-base-images/issues/279)).
+
+- Dropped support for the post-LTS distro versions Debian 10 and 11 (by
+  [@mtelvers](https://github.com/mtelvers) and
+  [@shonfeder](https://github.com/shonfeder) see
+  [ocurrent/ocaml-dockerfile#220](https://github.com/ocurrent/ocaml-dockerfile/pull/220)
+  and
+  [ocurrent/ocaml-dockerfile#210](https://github.com/ocurrent/ocaml-dockerfile/pull/210)).
+
+## making it easier to understand the systems
+
+- We are [generating documentation of the platforms under test in opam
+  CI][platforms] (by [@benmandrew](https://github.com/benmandrew)).
+
+- We are [generating documentation of the services under continuous
+  deployment][services] (by [@benmandrew](https://github.com/benmandrew)).
+
+[services]: https://github.com/ocurrent/ocurrent-deployer/blob/master/doc/services.md
+[platforms]: https://github.com/ocurrent/opam-repo-ci/blob/master/doc/platforms.md
+
+## improving the functionality and usability of the systems
+
+- We have been developing
+  [opam-ci-check](https://github.com/ocurrent/opam-repo-ci/tree/master/opam-ci-check),
+  a command line utility aiming to make opam repo CI's logic local-first. It is
+  still in the early stages and far from finished, but it is enabling faster
+  development iteration already, and it will soon be fit for early adopting
+  package authors to use locally or in their own CI pipelines (by
+  [@punchagan](https://github.com/punchagan) and
+  [@shonfeder](https://github.com/shonfeder)).
+
+- The first benefits of `opam-ci-check`'s local-first approach have made their
+  way into opam CI as logged instructions for running the lint checks locally
+  and as improved error reporting (by
+  [@punchagan](https://github.com/punchagan), see
+  [ocurrent/opam-repo-ci#359](https://github.com/ocurrent/opam-repo-ci/issues/359)
+  and
+  [ocurrent/opam-repo-ci#360](https://github.com/ocurrent/opam-repo-ci/issues/360)).
+
+# Forging ahead
+
+Much has been done but much more is in the works! Expect updates more regularly
+going forward, and don't hesitate to reach out on
+[ocaml/infrastructure/issues](https://github.com/ocaml/infrastructure/issues) or
+[discuss.ocaml.org](https://discuss.ocaml.org/tag/infrastructure) if you have
+questions, requests, or ideas!
+
+💚🛠 [Taride](https://tarides.com/)'s OCaml Infrastructure Team\
+([@mtelvers](https://github.com/mtelvers),
+[@punchagan](https://github.com/punchagan),
+[@cuihtlauac](https://github.com/cuihtlauac), and
+[@shonfeder](https://github.com/shonfeder)).


### PR DESCRIPTION
Requested by @rikusilvola and @tmattio, and in accordance with our discussion today about improving the cadence and regularity of changelog updates.

This is an unusually long entry, relative to past entries and what you can expect from us in the future. That is only because we are making up for a lapse in external communication.

In https://github.com/ocaml/infrastructure/pull/159 we will be announcing the plan to shift to using the ocaml changelog as our main venue for updates.

It's my first time writing one of these, so please let me know if the content or tone should be adjusted. 

cc @mtelvers, @cuihtlauac (since I cannot request you are reviewers :)).