### PR TITLE
Fix metadata in Infrastrucure changelog update

### DIFF
--- a/data/changelog/infra/2024-10-02-updates.md
+++ b/data/changelog/infra/2024-10-02-updates.md
@@ -1,7 +1,7 @@
 ---
-title: OCaml Infrastructure: Enhancing Platform Support and User Experience
-authors: [Tarides OCaml Infrastructure Team]
-date: 2024-10-04
+title: "OCaml Infrastructure: Enhancing Platform Support and User Experience"
+authors: ["Tarides OCaml Infrastructure Team"]
+tags: [infrastructure]
 changelog: |
   - Added continuous deployment for service configuration (by @mtelvers, https://github.com/ocurrent/ocurrent-configurator)
   - Implemented linting for package maintainer email addresses (by @punchagan, https://github.com/ocurrent/opam-ci-check/pull/30)


### PR DESCRIPTION
Fixes several errors in the meta-data from https://github.com/ocaml/ocaml.org/pull/2744. 

These broke the build with uncaught exceptions such as

```
Ood_gen.Exn.Decode_error("data/changelog/infra/2024-10-02-updates.md : error calling parser: mapping values are not allowed in this context character 0 position 0 returned: 0")
```

and

```
Ood_gen.Exn.Decode_error("data/changelog/infra/2024-10-02-updates.md : data/changelog/infra/2024-10-02-updates.md : date2024-10-04\n")
```

Also added the infrastructure tag that had been lost during review.

CC @tmattio 