### PR TITLE
Fixup constraints

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,6 +38,7 @@
   bos
   crunch
   mirage-kv-mem
+  (mirage-crypto-rng (>= 0.11.0))
   dream-accept
   dream-encoding
   (graphql

--- a/dune-project
+++ b/dune-project
@@ -70,7 +70,7 @@
   ppx_stable
   ezjsonm
   lambdasoup
-  ptime
+  (ptime (>= 1.1.0))
   (cmdliner
    (>= 1.1.0))
   xmlm

--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,7 @@
     (>= 1.10.0)))
   olinkcheck
   ; tools/ood-gen
-  ppx_deriving_yaml
+  (ppx_deriving_yaml (>= 0.3))
   ppx_stable
   ezjsonm
   lambdasoup

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -25,6 +25,7 @@ depends: [
   "bos"
   "crunch"
   "mirage-kv-mem"
+  "mirage-crypto-rng" {>= "0.11.0"}
   "dream-accept"
   "dream-encoding"
   "graphql" {>= "0.14.0"}

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -48,7 +48,7 @@ depends: [
   "ppx_stable"
   "ezjsonm"
   "lambdasoup"
-  "ptime"
+  "ptime" {>= "1.1.0"}
   "cmdliner" {>= "1.1.0"}
   "xmlm"
   "uri"

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -44,7 +44,7 @@ depends: [
   "alcotest" {with-test}
   "mdx" {with-test & >= "1.10.0"}
   "olinkcheck"
-  "ppx_deriving_yaml"
+  "ppx_deriving_yaml" {>= "0.3"}
   "ppx_stable"
   "ezjsonm"
   "lambdasoup"

--- a/src/ocamlorg_web/lib/dune
+++ b/src/ocamlorg_web/lib/dune
@@ -10,7 +10,8 @@
   cmarkit
   ocamlorg.data
   timedesc
-  mirage-kv-mem))
+  mirage-kv-mem
+  mirage-crypto-rng))
 
 (rule
  (deps (universe))


### PR DESCRIPTION
While updating an older OPAM switch I realized that the versions that are installed are too old to successfully compile, so I had to add a few constraints on versions and add dependencies that were not declared before.