### PR TITLE
`dune` file cleanups

### DIFF
--- a/dune
+++ b/dune
@@ -3,15 +3,15 @@
  (rule
   (target main.css)
   (deps
-   %{workspace_root}/tool/tailwind/tailwindcss
-   (:config %{workspace_root}/tailwind.config.js)
-   (:input %{workspace_root}/src/ocamlorg_frontend/css/styles.css)
-   (source_tree %{workspace_root}/src/ocamlorg_frontend))
+   %{project_root}/tool/tailwind/tailwindcss
+   (:config %{project_root}/tailwind.config.js)
+   (:input %{project_root}/src/ocamlorg_frontend/css/styles.css)
+   (source_tree %{project_root}/src/ocamlorg_frontend))
   (action
    (chdir
-    %{workspace_root}
+    %{project_root}
     (run
-     %{workspace_root}/tool/tailwind/tailwindcss
+     %{project_root}/tool/tailwind/tailwindcss
      -m
      -c
      %{config}
@@ -25,12 +25,12 @@
  (rule
   (target planet.xml)
   (deps
-   (source_tree %{workspace_root}/data/planet)
-   (source_tree %{workspace_root}/data/planet-local-blogs)
-   (:gen_feed %{workspace_root}/tool/ood-gen/bin/feed.exe))
+   (source_tree %{project_root}/data/planet)
+   (source_tree %{project_root}/data/planet-local-blogs)
+   (:gen_feed %{project_root}/tool/ood-gen/bin/feed.exe))
   (action
    (chdir
-    %{workspace_root}
+    %{project_root}
     (with-stdout-to
      %{target}
      (run %{gen_feed} planet))))))
@@ -40,11 +40,11 @@
  (rule
   (target news.xml)
   (deps
-   (source_tree %{workspace_root}/data/news)
-   (:gen_feed %{workspace_root}/tool/ood-gen/bin/feed.exe))
+   (source_tree %{project_root}/data/news)
+   (:gen_feed %{project_root}/tool/ood-gen/bin/feed.exe))
   (action
    (chdir
-    %{workspace_root}
+    %{project_root}
     (with-stdout-to
      %{target}
      (run %{gen_feed} news))))))
@@ -54,11 +54,11 @@
  (rule
   (target changelog.xml)
   (deps
-   (source_tree %{workspace_root}/data/changelog)
-   (:gen_feed %{workspace_root}/tool/ood-gen/bin/feed.exe))
+   (source_tree %{project_root}/data/changelog)
+   (:gen_feed %{project_root}/tool/ood-gen/bin/feed.exe))
   (action
    (chdir
-    %{workspace_root}
+    %{project_root}
     (with-stdout-to
      %{target}
      (run %{gen_feed} changelog))))))
@@ -68,11 +68,11 @@
  (rule
   (target events.xml)
   (deps
-   (source_tree %{workspace_root}/data/events)
-   (:gen_feed %{workspace_root}/tool/ood-gen/bin/feed.exe))
+   (source_tree %{project_root}/data/events)
+   (:gen_feed %{project_root}/tool/ood-gen/bin/feed.exe))
   (action
    (chdir
-    %{workspace_root}
+    %{project_root}
     (with-stdout-to
      %{target}
      (run %{gen_feed} events))))))
@@ -82,11 +82,11 @@
  (rule
   (target jobs.xml)
   (deps
-   (:gen_feed %{workspace_root}/tool/ood-gen/bin/feed.exe)
-   %{workspace_root}/data/jobs.yml)
+   (:gen_feed %{project_root}/tool/ood-gen/bin/feed.exe)
+   %{project_root}/data/jobs.yml)
   (action
    (chdir
-    %{workspace_root}
+    %{project_root}
     (with-stdout-to
      %{target}
      (run %{gen_feed} job))))))

--- a/playground/dune
+++ b/playground/dune
@@ -5,7 +5,7 @@
   (mode
    (promote (until-clean)))
   (deps
-   (:js %{workspace_root}/src/main.bc.js))
+   (:js %{project_root}/src/main.bc.js))
   (action
    (run
     esbuild
@@ -23,7 +23,7 @@
   (mode
    (promote (until-clean)))
   (deps
-   (:js %{workspace_root}/src/worker.js)
+   (:js %{project_root}/src/worker.js)
    stdlib)
   (action
    (run jsoo_minify %{js} -o %{targets})))
@@ -32,7 +32,7 @@
   (mode
    (promote (until-clean)))
   (deps
-   (:js %{workspace_root}/src/merlin_worker.bc.js))
+   (:js %{project_root}/src/merlin_worker.bc.js))
   (action
    (run jsoo_minify %{js} -o %{targets})))
  (rule

--- a/src/ocamlorg_static/dune
+++ b/src/ocamlorg_static/dune
@@ -5,39 +5,33 @@
 (rule
  (target asset.ml)
  (deps
-  %{workspace_root}/asset/css/main.css
-  %{workspace_root}/asset/changelog.xml
-  %{workspace_root}/asset/events.xml
-  %{workspace_root}/asset/jobs.xml
-  %{workspace_root}/asset/news.xml
-  %{workspace_root}/asset/planet.xml
-  (source_tree %{workspace_root}/asset))
+  %{project_root}/asset/css/main.css
+  %{project_root}/asset/changelog.xml
+  %{project_root}/asset/events.xml
+  %{project_root}/asset/jobs.xml
+  %{project_root}/asset/news.xml
+  %{project_root}/asset/planet.xml
+  (source_tree %{project_root}/asset))
  (action
   (with-stdout-to
    %{null}
-   (run %{bin:ocaml-crunch} -m plain %{workspace_root}/asset -o %{target}))))
+   (run %{bin:ocaml-crunch} -m plain %{project_root}/asset -o %{target}))))
 
 (rule
  (target media.ml)
  (deps
-  (source_tree %{workspace_root}/data/media))
+  (source_tree %{project_root}/data/media))
  (action
   (with-stdout-to
    %{null}
-   (run
-    %{bin:ocaml-crunch}
-    -m
-    plain
-    %{workspace_root}/data/media
-    -o
-    %{target}))))
+   (run %{bin:ocaml-crunch} -m plain %{project_root}/data/media -o %{target}))))
 
 (rule
  (target playground_digests.ml)
  (deps
-  %{workspace_root}/tool/static-file-digest/main.exe
-  (source_tree %{workspace_root}/playground/asset))
+  %{project_root}/tool/static-file-digest/main.exe
+  (source_tree %{project_root}/playground/asset))
  (action
   (with-stdout-to
    %{null}
-   (run %{deps} %{workspace_root}/playground/asset/ -s -o %{target}))))
+   (run %{deps} %{project_root}/playground/asset/ -s -o %{target}))))

--- a/src/ocamlorg_web/bin/dune
+++ b/src/ocamlorg_web/bin/dune
@@ -7,8 +7,8 @@
 
 (rule
  (alias run)
- (deps main.exe %{workspace_root}/asset/css/main.css)
+ (deps main.exe %{project_root}/asset/css/main.css)
  (action
   (chdir
-   %{workspace_root}
+   %{project_root}
    (run %{bin:server}))))

--- a/tool/static-file-digest/dune
+++ b/tool/static-file-digest/dune
@@ -1,8 +1,6 @@
 (library
  (name digest_map)
- (wrapped false)
- (modules digest_map)
- (flags :standard -safe-string))
+ (modules digest_map))
 
 (executable
  (name main)


### PR DESCRIPTION
I was looking for some improvements to the `dune` files to make them better and at the moment I have found

1. `workspace_root` vs `project_root` confusion. A lot of paths use `workspace_root` where they probably should point to the location relative to ocaml.org's `dune-project`, not where the workspace lies. `dream_eml` has a `--workspace` argument, I suspect it is thus smart enough to deal with workspaces properly.
2. Wrapping makes no difference to libraries whose names match single-file modules, thus the `wrapped` field can be removed.
3. Probably a lot of `ocamlorg_frontend/dune` could be auto-generated, but I haven't done this yet since I'd like to know if people are interested in that.