### PR TITLE
Survive tailwindcss binary

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -147,6 +147,10 @@ was upgraded in the process, the files `.ocamlformat` and
 `.github/workflows/ci.yml` must be modified with the currently installed version
 of OCamlFormat.
 
+### Handling the Tailwind CSS
+
+The Tailwind CSS framework. The tailwind binary pulled from its GitHub [repo](https://github.com/tailwindlabs/tailwindcss). Download is performed by Dune during the build. When working on a local switch for hacking, you don't want `dune clean` to delete this binary. Just do `dune install tailwind` to have it installed in the local switch.
+
 ## Repository Structure
 
 The following snippet describes the repository structure:

--- a/dune
+++ b/dune
@@ -3,22 +3,13 @@
  (rule
   (target main.css)
   (deps
-   %{project_root}/tool/tailwind/tailwindcss
    (:config %{project_root}/tailwind.config.js)
    (:input %{project_root}/src/ocamlorg_frontend/css/styles.css)
    (source_tree %{project_root}/src/ocamlorg_frontend))
   (action
    (chdir
     %{project_root}
-    (run
-     %{project_root}/tool/tailwind/tailwindcss
-     -m
-     -c
-     %{config}
-     -i
-     %{input}
-     -o
-     %{target})))))
+    (run tailwindcss -m -c %{config} -i %{input} -o %{target})))))
 
 (subdir
  asset/

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,9 @@
 (using mdx 0.1)
 
 (package
+  (name tailwindcss) (allow_empty))
+
+(package
  (name ocamlorg)
  (synopsis "Official OCaml website")
  (description

--- a/tool/tailwind/dune
+++ b/tool/tailwind/dune
@@ -2,40 +2,40 @@
  (target tailwindcss-linux-x64)
  (action
   (progn
-   (run
-    curl
-    -sLO
-    https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target})
+   (with-stdout-to
+    %{target}
+    (bash
+     "cat 2> /dev/null < $(which tailwindcss) || curl -#fSL https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target}"))
    (run chmod +x %{target}))))
 
 (rule
  (target tailwindcss-linux-arm64)
  (action
   (progn
-   (run
-    curl
-    -sLO
-    https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target})
+   (with-stdout-to
+    %{target}
+    (bash
+     "cat 2> /dev/null < $(which tailwindcss) || curl -#fSL https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target}"))
    (run chmod +x %{target}))))
 
 (rule
  (target tailwindcss-macos-x64)
  (action
   (progn
-   (run
-    curl
-    -sLO
-    https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target})
+   (with-stdout-to
+    %{target}
+    (bash
+     "cat 2> /dev/null < $(which tailwindcss) || curl -#fSL https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target}"))
    (run chmod +x %{target}))))
 
 (rule
  (target tailwindcss-macos-arm64)
  (action
   (progn
-   (run
-    curl
-    -sLO
-    https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target})
+   (with-stdout-to
+    %{target}
+    (bash
+     "cat 2> /dev/null < $(which tailwindcss) || curl -#fSL https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.6/%{target}"))
    (run chmod +x %{target}))))
 
 (rule
@@ -81,3 +81,8 @@
 (alias
  (name default)
  (deps tailwindcss))
+
+(install
+ (section bin)
+ (package tailwindcss)
+ (files tailwindcss))


### PR DESCRIPTION
* When building target specific binary
  - If already available in installed world, copy
  - If not found, download
  - Using %{bin-available} does not work, targets are always available

* Define a package tailwindcss which allows installing tailwindcss in
local switch

* Making tailwindcss survive dune clean:
  - dune build tailwindcss.install
  - dune install -p tailwindcss
  - This does not work if written in dune file. Everything takes place
    indide _build

Note: While debugging, doing progn / chmod / copy in tailwindcss rules
made curl happen take place twice.
