### PR TITLE
Updates to Infrastructure and Packaging governance contacts

### DIFF
--- a/data/governance.yml
+++ b/data/governance.yml
@@ -414,14 +414,17 @@ teams:
   - name: Anil Madhavapeddy
     github: avsm
     role: Maintainer
-  - name: Kate Deplaix
-    github: kit-ty-kate
-    role: Maintainer
   - name: Marcello Seri
     github: mseri
     role: Maintainer
+  - name: Raphaël Proust
+    github: raphael-proust
+    role: Maintainer
   - name: Thomas Gazagnaire
     github: samoht
+    role: Maintainer
+  - name: Shon Feder
+    github: shonfeder
     role: Maintainer
 - id: infrastructure
   name: Infrastructure
@@ -436,17 +439,17 @@ teams:
   - name: Anil Madhavapeddy
     github: avsm
     role: Owner
-  - name: Tim McGilchrist
-    github: tmcgilchrist
-    role: Maintainer
-  - name: Kate
-    github: kit-ty-kate
-    role: Maintainer
   - name: Mark Elvers
     github: mtelvers
     role: Maintainer
   - name: Thomas Gazagnaire
     github: samoht
+    role: Maintainer
+  - name: Shon Feder
+    github: shonfeder
+    role: Maintainer
+  - name: Puneeth Chaganti
+    github: punchagan
     role: Maintainer
 - id: ocamlorg
   name: OCaml.org


### PR DESCRIPTION
Someone pointed out the need for this update to me in a recent conversation, but I don't recall who!

In this PR, the follow contact changes are proposed:

- @kit-ty-kate is removed as a maintainer for packaging and infrastructure
- @tmcgilchrist is removed as a maintainer for infrastructure
- @raphael-proust is added as a maintainer for packaging
- @punchagan is added as a maintainer for infrastructure
- @shonfeder is added as a maintainer for packaging and infrastructure

If any of y'all would rather not be added or removed, please say so! My intent is just to ensure that currently responsible parties can be contacted and that those who have moved on to other responsibilities don't need to worry about misdirected contacts.