### PR TITLE
chore: changelog for dune 3.16.1

### DIFF
--- a/data/changelog/dune/2024-10-30-dune.3.16.1.md
+++ b/data/changelog/dune/2024-10-30-dune.3.16.1.md
@@ -1,0 +1,14 @@
+---
+title: Dune 3.16.1
+tags: [dune, platform]
+changelog: |
+    ### Fixed
+
+    - Call the C++ compiler with `-std=gnu++11` when using OCaml >= 5.0
+      (#10962, @kit-ty-kate)
+       ### Added
+---
+
+We're happy to announce the release of Dune 3.16.1.
+
+This is a patch release that fixes an issue with OCaml.5.3.0 and C++ flags.


### PR DESCRIPTION
We are releasing Dune.3.16.1 which includes a patch fix for OCaml.5.3.0. This is the changelog entry to announce it.

I'll keep this PR as a Draft until it is merged into opam :+1: 