### PR TITLE
changelog: entry for OCaml 5.3.0-beta1

### DIFF
--- a/data/changelog/ocaml/2024-10-31-ocaml-5.3.0.beta1.md
+++ b/data/changelog/ocaml/2024-10-31-ocaml-5.3.0.beta1.md
@@ -1,0 +1,157 @@
+---
+title: OCaml 5.3.0 - First Beta
+description: First Beta Release of OCaml 5.3.0
+tags: [ocaml]
+changelog: |
+  ### Runtime fixes
+  
+  - [#13502](https://github.com/ocaml/ocaml/issues/13502): Fix misindexing related to `Gc.finalise_last` that could prevent
+    finalisers from being run.
+    (Nick Roberts, review by Mark Shinwell)
+  
+  - [#13402](https://github.com/ocaml/ocaml/issues/13402), [#13512](https://github.com/ocaml/ocaml/issues/13512), [#13549](https://github.com/ocaml/ocaml/issues/13549), [#13553](https://github.com/ocaml/ocaml/issues/13553): Revise bytecode implementation of callbacks
+    so that it no longer produces dangling registered bytecode fragments.
+    (Xavier Leroy, report by Jan Midtgaard, analysis by Stephen Dolan,
+     review by Miod Vallat)
+  
+  - [#13520](https://github.com/ocaml/ocaml/issues/13520): Fix compilation of native-code version of systhreads. Bytecode fields
+    were being included in the thread descriptors.
+    (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
+  
+  ### Typechecker fixes
+  
+  - [#13579](https://github.com/ocaml/ocaml/issues/13579), [#13583](https://github.com/ocaml/ocaml/issues/13583): Unsoundness involving non-injective types + gadts
+    (Jacques Garrigue, report by @v-gb,
+     review by Richard Eisenberg and Florian Angeletti)
+  
+  - [#13388](https://github.com/ocaml/ocaml/issues/13388), [#13540](https://github.com/ocaml/ocaml/issues/13540): raises an error message (and not an internal compiler error)
+    when two local substitutions are incompatible (for instance `module type
+    S:=sig end type t:=(module S)`)
+    (Florian Angeletti, report by Nailen Matschke, review by Gabriel Scherer, and
+    Leo White)
+  
+  ### Compiler flag
+  
+  - [#13471](https://github.com/ocaml/ocaml/issues/13471): add `-keywords <version?+list>` flag to define the list of keywords
+    recognized by the lexer, for instance `-keywords 5.2` disable the `effect`
+    keyword.
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  ### Runtime event library fixes
+  
+  - [#13419](https://github.com/ocaml/ocaml/issues/13419): Fix memory bugs in runtime events system.
+    (B. Szilvasy and Nick Barnes, review by Miod Vallat, Nick Barnes,
+     Tim McGilchrist, and Gabriel Scherer)
+  
+  - [#13407](https://github.com/ocaml/ocaml/issues/13407): Add Runtime_events.EV_EMPTY_MINOR
+    (Thomas Leonard)
+  
+  - [#13522](https://github.com/ocaml/ocaml/issues/13522): Confirm runtime events ring is still active after callback.
+    (KC Sivaramakrishnan, review by Sadiq Jaffer and Miod Vallat)
+  
+  - [#13529](https://github.com/ocaml/ocaml/issues/13529): Do not write to event ring after going out of stw participant set.
+    (KC Sivaramakrishnan, review by Sadiq Jaffer)
+  
+  ### Documentation
+  
+  - [#13424](https://github.com/ocaml/ocaml/issues/13424): Fix `Gc.quick_stat` documentation to clarify that returned fields
+    `live_words`, `live_blocks`, `free_words`, and `fragments` are not zero.
+    (Jan Midtgaard, review by Damien Doligez and KC Sivaramakrishnan)
+  
+  - [#13440](https://github.com/ocaml/ocaml/issues/13440): Update documentation of `Gc.{control,get,set}` to reflect fields
+    not currently supported on OCaml 5.
+    (Jan Midtgaard, review by Gabriel Scherer)
+  
+  - [#13469](https://github.com/ocaml/ocaml/issues/13469), [#13474](https://github.com/ocaml/ocaml/issues/13474), [#13535](https://github.com/ocaml/ocaml/issues/13535): Document that [Hashtbl.create n] creates a hash table
+    with a default minimal size, even if [n] is very small or negative.
+    (Antonin Décimo, Nick Bares, report by Nikolaus Huber and Jan Midtgaard,
+     review by Florian Angeletti, Anil Madhavapeddy, Gabriel Scherer,
+     and Miod Vallat)
+  
+  ### Standard library internal fix
+  
+  
+  - [#13543](https://github.com/ocaml/ocaml/issues/13543): Remove some String-Bytes conversion from the stdlib to behave better
+    with js_of_ocaml
+    (Hugo Heuzard, review by Gabriel Scherer)
+  
+  ### Toplevel fix
+  
+  
+  - [#13263](https://github.com/ocaml/ocaml/issues/13263), [#13560](https://github.com/ocaml/ocaml/issues/13560): fix printing true and false in toplevel and error
+    messages (no more unexpected \#true)
+    (Florian Angeletti, report by Samuel Vivien, review by Gabriel Scherer)
+  
+  ### Compiler internals
+  
+  - [#13391](https://github.com/ocaml/ocaml/issues/13391), [#13551](https://github.com/ocaml/ocaml/issues/13551): fix a printing bug with `-dsource` when using
+    raw literal inside a locally abstract type constraint
+    (i.e. `let f: type \#for. ... `)
+    (Florian Angeletti, report by Nick Roberts, review by Richard Eisenberg)
+---
+
+One month and half after the release of the first alpha for OCaml 5.3.0, 
+the release of OCaml 5.3.0 is drawing near.
+
+The internal API of the compiler libraries has been frozen, and most core
+developer tools support (or will support soon) the new version of the compiler.
+
+We have thus released a first beta version of OCaml 5.3.0 to help you update
+your software and libraries ahead of the release (see below for the
+installation instructions). More information about the whole release process is
+now available in the [compiler repository](https://github.com/ocaml/ocaml/blob/trunk/release-info/introduction.md).
+
+Compared to the first alpha release, this beta contains a few runtime or
+typechecker fixes, a handful of fixes for the runtime event library and other
+miscellaneous fixes.
+
+Exceptionally, this beta release also introduces a new flag `-keywords` for the
+compiler. This backward compatibility flag aims to help compiling old code that
+are using `effect` as a normal identifier, now that `effect` is a keyword in the
+new effect handler syntax.
+
+The progresses on stabilising the ecosystem are tracked on the [opam readiness for 5.3.0 meta-issue](https://github.com/ocaml/opam-repository/issues/26596).
+
+The full release is expected in the end of November or beginning of December,
+see the [new prospective
+calendar](https://github.com/ocaml/ocaml/blob/trunk/release-info/calendar.md)
+for more information.
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+If you are interested in full list of features and bug fixes of the new OCaml
+version, the updated change log for OCaml 5.3.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.3/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1 and later:
+
+```bash
+opam update
+opam switch create 5.3.0~beta1
+```
+
+The source code for the beta is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.3.0-beta1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3.0~beta1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.3.0~beta1+options <option_list>
+```
+
+where `option_list` is a space separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
+
+```bash
+opam switch create 5.3.0~beta1+flambda+nffa ocaml-variants.5.3.0~beta1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This PR adds a changelog entry for the upcoming first beta for OCaml 5.3.0 .