### PR TITLE
changelog: release candidate for OCaml 5.2.1

### DIFF
--- a/data/changelog/ocaml/2024-11-07-5.2.1-rc1.md
+++ b/data/changelog/ocaml/2024-11-07-5.2.1-rc1.md
@@ -6,33 +6,33 @@ changelog: |
   ## Changes Since OCaml 5.2.0
   ### Runtime System:
   - [#13207](https://github.com/ocaml/ocaml/issues/13207): Be sure to reload the register caching the exception handler in
-    caml_c_call and caml_c_call_stack_args, as its value may have been changed
+    `caml_c_call` and `caml_c_call_stack_args`, as its value may have been changed
     if the OCaml stack is expanded during a callback.
     (Miod Vallat, report by Vesa Karvonen, review by Gabriel Scherer and
      Xavier Leroy)
   
   - [#13252](https://github.com/ocaml/ocaml/issues/13252): Rework register assignment in the interpreter code on m68k on Linux,
-    due to the %a5 register being used by Glibc.
+    due to the %a5 register being used by GLIBC.
     (Miod Vallat, report by Stéphane Glondu, review by Gabriel Scherer and
      Xavier Leroy)
   
-  - [#13268](https://github.com/ocaml/ocaml/issues/13268): Fix a call to test in configure.ac that was causing errors when
+  - [#13268](https://github.com/ocaml/ocaml/issues/13268): Fix a call to test in `configure.ac` that was causing errors when
     LDFLAGS contains several words.
     (Stéphane Glondu, review by Miod Vallat)
   
-  - [#13234](https://github.com/ocaml/ocaml/issues/13234), [#13267](https://github.com/ocaml/ocaml/issues/13267): Open runtime events file in read-write mode on armel
-    (armv5) systems due to atomic operations limitations on that
+  - [#13234](https://github.com/ocaml/ocaml/issues/13234), [#13267](https://github.com/ocaml/ocaml/issues/13267): Open runtime events file in read-write mode on ARMel
+    (ARMv5) systems due to atomic operations limitations on that
     platform.
     (Stéphane Glondu, review by Miod Vallat and Vincent Laviron)
   
-  - [#13188](https://github.com/ocaml/ocaml/issues/13188): fix races in the FFI code coming from the use of Int_val(...)
+  - [#13188](https://github.com/ocaml/ocaml/issues/13188): fix races in the FFI code coming from the use of `Int_val(...)`
     on rooted values inside blocking questions / without the runtime lock.
-    (Calling Int_val(...) on non-rooted immediates is fine, but any
+    (Calling `Int_val(...)` on non-rooted immediates is fine, but any
      access to rooted values must be done outside blocking sections /
      with the runtime lock.)
     (Etienne Millon, review by Gabriel Scherer, Jan Midtgaard, Olivier Nicole)
   
-  - [#13318](https://github.com/ocaml/ocaml/issues/13318): Fix regression in GC alarms, and fix them for flambda.
+  - [#13318](https://github.com/ocaml/ocaml/issues/13318): Fix regression in GC alarms, and fix them for Flambda.
     (Guillaume Munch-Maccagnoni, report by Benjamin Monate, review by
      Vincent Laviron and Gabriel Scherer)
   
@@ -40,7 +40,7 @@ changelog: |
     from a DLL
     (Xavier Leroy, review by Miod Vallat)
   
-  - [#13370](https://github.com/ocaml/ocaml/issues/13370): Fix a low-probability crash when calling Gc.counters.
+  - [#13370](https://github.com/ocaml/ocaml/issues/13370): Fix a low-probability crash when calling `Gc.counters`.
     (Demi Marie Obenour, review by Gabriel Scherer)
   
   - [#13402](https://github.com/ocaml/ocaml/issues/13402), [#13512](https://github.com/ocaml/ocaml/issues/13512), [#13549](https://github.com/ocaml/ocaml/issues/13549), [#13553](https://github.com/ocaml/ocaml/issues/13553): Revise bytecode implementation of callbacks

--- a/data/changelog/ocaml/2024-11-07-5.2.1-rc1.md
+++ b/data/changelog/ocaml/2024-11-07-5.2.1-rc1.md
@@ -1,0 +1,97 @@
+---
+title: OCaml 5.2.1 - Release Candidate
+description: Release Candidate for OCaml 5.2.1
+tags: [ocaml]
+changelog: |
+  ## Changes Since OCaml 5.2.0
+  ### Runtime System:
+  - [#13207](https://github.com/ocaml/ocaml/issues/13207): Be sure to reload the register caching the exception handler in
+    caml_c_call and caml_c_call_stack_args, as its value may have been changed
+    if the OCaml stack is expanded during a callback.
+    (Miod Vallat, report by Vesa Karvonen, review by Gabriel Scherer and
+     Xavier Leroy)
+  
+  - [#13252](https://github.com/ocaml/ocaml/issues/13252): Rework register assignment in the interpreter code on m68k on Linux,
+    due to the %a5 register being used by Glibc.
+    (Miod Vallat, report by Stéphane Glondu, review by Gabriel Scherer and
+     Xavier Leroy)
+  
+  - [#13268](https://github.com/ocaml/ocaml/issues/13268): Fix a call to test in configure.ac that was causing errors when
+    LDFLAGS contains several words.
+    (Stéphane Glondu, review by Miod Vallat)
+  
+  - [#13234](https://github.com/ocaml/ocaml/issues/13234), [#13267](https://github.com/ocaml/ocaml/issues/13267): Open runtime events file in read-write mode on armel
+    (armv5) systems due to atomic operations limitations on that
+    platform.
+    (Stéphane Glondu, review by Miod Vallat and Vincent Laviron)
+  
+  - [#13188](https://github.com/ocaml/ocaml/issues/13188): fix races in the FFI code coming from the use of Int_val(...)
+    on rooted values inside blocking questions / without the runtime lock.
+    (Calling Int_val(...) on non-rooted immediates is fine, but any
+     access to rooted values must be done outside blocking sections /
+     with the runtime lock.)
+    (Etienne Millon, review by Gabriel Scherer, Jan Midtgaard, Olivier Nicole)
+  
+  - [#13318](https://github.com/ocaml/ocaml/issues/13318): Fix regression in GC alarms, and fix them for flambda.
+    (Guillaume Munch-Maccagnoni, report by Benjamin Monate, review by
+     Vincent Laviron and Gabriel Scherer)
+  
+  - [#13140](https://github.com/ocaml/ocaml/issues/13140): POWER back-end: fix issue with call to `caml_call_realloc_stack`
+    from a DLL
+    (Xavier Leroy, review by Miod Vallat)
+  
+  - [#13370](https://github.com/ocaml/ocaml/issues/13370): Fix a low-probability crash when calling Gc.counters.
+    (Demi Marie Obenour, review by Gabriel Scherer)
+  
+  - [#13402](https://github.com/ocaml/ocaml/issues/13402), [#13512](https://github.com/ocaml/ocaml/issues/13512), [#13549](https://github.com/ocaml/ocaml/issues/13549), [#13553](https://github.com/ocaml/ocaml/issues/13553): Revise bytecode implementation of callbacks
+    so that it no longer produces dangling registered bytecode fragments.
+    (Xavier Leroy, report by Jan Midtgaard, analysis by Stephen Dolan,
+     review by Miod Vallat)
+  
+  - [#13502](https://github.com/ocaml/ocaml/issues/13502): Fix misindexing related to `Gc.finalise_last` that could prevent
+    finalisers from being run.
+    (Nick Roberts, review by Mark Shinwell)
+  
+  - [#13520](https://github.com/ocaml/ocaml/issues/13520): Fix compilation of native-code version of systhreads. Bytecode fields
+    were being included in the thread descriptors.
+    (David Allsopp, review by Sébastien Hinderer and Miod Vallat)
+---
+
+The release of OCaml version 5.2.1 is imminent.
+
+OCaml 5.2.1 is a collection of safe but import runtime time bug fixes backported from the 5.3 branch of OCaml. The full list of bug fixes is available above.
+
+In order to ensure that the future release works as expected, we are planning to test a release candidate during the upcoming week.
+
+If you find any bugs, please report them here on [GitHub](https://github.com/ocaml/ocaml/issues).
+
+----
+
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1:
+```
+opam update
+opam switch create 5.2.1~rc1
+```
+
+
+The source code for the release candidate is available on
+
+- [GitHub](https://github.com/ocaml/ocaml/archive/5.2.1-rc1.tar.gz)
+- [Inria archives](https://caml.inria.fr/pub/distrib/ocaml-5.2/ocaml-5.2.1-rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.2.1~rc1+options <option_list>
+```
+where `<option_list>` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.2.1~rc1+flambda+nffa ocaml-variants.5.2.1~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This is a change entry for the release candidate for the upcoming release of OCaml 5.2.1 .