### PR TITLE
Block some high frequency spider bots

### DIFF
--- a/asset/robots.txt
+++ b/asset/robots.txt
@@ -1,2 +1,38 @@
+# "The Meta-ExternalAgent crawler crawls the web for use cases such as training
+# AI models or improving products by indexing content directly"
+# See https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
+User-agent: meta-externalagent
+Disallow: /
+
+# https://platform.openai.com/docs/bots
+User-agent: GPTBot
+Disallow: /
+
+# A SEO consultancy
+# https://www.semrush.com/bot/
+User-agent: SemrushBot
+Disallow: /
+
+# We don't want these robots crawling our expensive documentation pages, as they
+# hit with high frequency
+
+User-agent: Amazonbot
+Disallow: /p/
+
+User-agent: Bingbot
+Disallow: /p/
+
+# A chinese search site
+# https://www-sogou-com.translate.goog/docs/help/webmasters.htm?_x_tr_sch=http&_x_tr_sl=la&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp#07
+User-agent: Sogou web spider
+Disallow: /p/
+
+# A korean web search
+# https://naver.me/spd
+User-agent: Yeti
+Disallow: /p/
+
+# Everything else is OK
+
 User-agent: *
 Allow: /


### PR DESCRIPTION
This introduces rules to the robots.txt to block some spiders based on:

- Blocking spiders that are just for LLM training or enrichment of the
company, and do not offer value to genuine searchers.

- Disallowing the package docs under /p from crawlers that hit those pages
frequently but without a lot of obvious benefit for genuine searchers.

These bots are behaving as worst-case users, based on our tests for
https://github.com/ocaml/infrastructure/issues/161 : they are hitting
our most expensive pages frequently, in patterns that bypass the
cache (newly added by @mtelvers!).

Requesting reviews and an expedited merge from @cuihtlauac or @sabine,
as this should help remove some pressure on the server in advance of
the weekend.

These are the most frequent bots we see in the logs, listed by frequency of calls,
over about 1.5 hrs:

```
     97 +http://www.semrush.com/bot.html
    150 +https://openai.com/gptbot
    163 +https://naver.me/spd
    177 +http://www.google.com/bot.html
    241 +ttp://www.sogou.com/docs/help/webmasters.htm#07
    763 +https://developers.facebook.com/docs/sharing/webmasters/crawler
   1532 +http://www.bing.com/bingbot.htm
   1835 +https://developer.amazon.com/support/amazonbot
```