### PR TITLE
Revert "(data) jobs: add a XenServer position again (#2414)"

### DIFF
--- a/data/jobs.yml
+++ b/data/jobs.yml
@@ -137,13 +137,6 @@ jobs:
     publication_date: 2023-03-06
     company: IRIF, Université Paris-Cité
     company_logo: img/community/jobs/IRIF_university_city_paris_svg.svg
-  - title: XenServer Toolstack - Software Engineer
-    link: https://careers.cloud.com/jobs/software-engineer-xenserver-toolstack-cambridge-cambridgeshire-united-kingdom-79cbbe38-5430-4596-b39d-ffb4ed8a0f83
-    locations:
-      - Cambridge, United-Kingdom
-    publication_date: 2024-05-07
-    company: XenServer
-    company_logo: img/community/jobs/xenserver_svg.svg
   - title: Software Engineer
     link: https://base.routine.co/jobs/positions/backend-software-engineer
     locations:


### PR DESCRIPTION
The XenServer job link is 404, so remove it for now.

This reverts commit 19ac1e9e8de0a3be7f9bf9d8e2b47f64ae5a9895.