### PR TITLE
Update the CI and deployment to OCaml 5.2.1, Alpine 2.21, opam 2.3, and use BuildKit syntax in the Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - "5.2.0"
+          - "5.2"
 
     steps:
       - name: Checkout Repo
@@ -35,7 +35,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-repositories: |
-            pin: git+https://github.com/ocaml/opam-repository#c45f5bab71d3589f41f9603daca5acad14df0ab0
+            pin: git+https://github.com/ocaml/opam-repository#2c9566f0b0de5ab6dad7ce8d22b68a2999a1861f
           opam-disable-sandboxing: true
 
       - name: Install system dependencies (Linux)

--- a/.github/workflows/debug-ci.yml
+++ b/.github/workflows/debug-ci.yml
@@ -16,7 +16,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - "5.2.0"
+          - "5.2"
 
     steps:
       - name: Checkout Repo
@@ -28,7 +28,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: ${{ matrix.os != 'macos-latest' }}
           opam-repositories: |
-            pin: git+https://github.com/ocaml/opam-repository#c45f5bab71d3589f41f9603daca5acad14df0ab0
+            pin: git+https://github.com/ocaml/opam-repository#2c9566f0b0de5ab6dad7ce8d22b68a2999a1861f
           opam-disable-sandboxing: true
 
       - name: Install system dependencies (Linux)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ocaml/opam:alpine-3.19-ocaml-5.2 AS build
+FROM ocaml/opam:alpine-3.21-ocaml-5.2 AS build
+RUN sudo ln -sf /usr/bin/opam-2.3 /usr/bin/opam && opam init --reinit -ni
 
 # Install system dependencies
 RUN sudo apk -U upgrade --no-cache && sudo apk add --no-cache \
@@ -29,7 +30,8 @@ ENV OCAMLORG_PKG_STATE_PATH=package.state \
     OCAMLORG_REPO_PATH=opam-repository
 RUN touch package.state && ./init-cache package.state
 
-FROM alpine:3.19
+
+FROM alpine:3.21
 
 RUN apk -U upgrade --no-cache && apk add --no-cache \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN sudo apk -U upgrade --no-cache && sudo apk add --no-cache \
     openssl-dev
 
 # Branch freeze was opam-repo HEAD at the time of commit
-RUN cd ~/opam-repository && git reset --hard c45f5bab71d3589f41f9603daca5acad14df0ab0 && opam update
+RUN cd ~/opam-repository && git reset --hard 2c9566f0b0de5ab6dad7ce8d22b68a2999a1861f && opam update
 
 WORKDIR /home/opam
 


### PR DESCRIPTION
Update the CI and deployment from OCaml 5.2.0 to 5.2.1. Update the deployment image to Alpine 2.21, and opam 2.3 (should be faster).

Updating to the BuildKit syntax should speed up builds a bit, by (among other changes) allowing caching of apk and opam packages. Enabling BuildKit in the deployer also allows parallelism in building the image stages, where possible.
- [x] https://github.com/ocurrent/ocurrent-deployer/pull/248