### PR TITLE
changelog: OCaml 5.3.0~beta2

### DIFF
--- a/data/changelog/ocaml/2024-11-28-ocaml-5.3.0-beta2.md
+++ b/data/changelog/ocaml/2024-11-28-ocaml-5.3.0-beta2.md
@@ -1,0 +1,103 @@
+---
+title: OCaml 5.3.0 - Second Beta
+description: Second Beta Release of OCaml 5.3.0
+tags: [ocaml]
+changelog: |
+  # Changes Since The First Beta
+  ## Type system fixes
+  
+  - [#13501](https://github.com/ocaml/ocaml/issues/13501): Regression on mutually recursive types caused by [#12180](https://github.com/ocaml/ocaml/issues/12180).
+    Resuscitate Typedecl.update_type.
+    (Jacques Garrigue and Takafumi Saikawa, review by Florian Angeletti, Richard
+    Eisenberg and Gabriel Scherer)
+  
+  - [#13495](https://github.com/ocaml/ocaml/issues/13495), [#13514](https://github.com/ocaml/ocaml/issues/13514): Fix typechecker crash while typing objects
+    (Jacques Garrigue, report by Nicolás Ojeda Bär, review by
+     Nicolas Ojeda Bär, Gabriel Scherer, Stephen Dolan, Florian Angeletti)
+  
+  - [#13598](https://github.com/ocaml/ocaml/issues/13598): Falsely triggered warning 56 [unreachable-case]
+    This was caused by unproper protection of the retyping function.
+    (Jacques Garrigue, report by Tõivo Leedjärv, review by Florian Angeletti)
+  
+  ## Configuration fixes
+  * (*breaking change*) [#12578](https://github.com/ocaml/ocaml/issues/12578), [#12589](https://github.com/ocaml/ocaml/issues/12589), [#13322](https://github.com/ocaml/ocaml/issues/13322), +[#13519](https://github.com/ocaml/ocaml/issues/13519): Use configured CFLAGS and CPPFLAGS *only*
+    during the build of the compiler itself. Do not use them when
+    compiling third-party C sources through the compiler. Flags for
+    compiling third-party C sources can still be specified at configure
+    time in the COMPILER_{BYTECODE,NATIVE}_{CFLAGS,CPPFLAGS}
+    configuration variables.
+     (Sébastien Hinderer, report by William Hu, review by David Allsopp)
+  
+  ## C++ header compatibility
+  
+  - [#13541](https://github.com/ocaml/ocaml/issues/13541), [#13591](https://github.com/ocaml/ocaml/issues/13591): Fix headers for C++ inclusion.
+    (Antonin Décimo, review by Nick Barnes, report by Kate Deplaix)
+  
+  
+  ## Compiler library bug fix
+  
+  - [#13603](https://github.com/ocaml/ocaml/issues/13603), [#13604](https://github.com/ocaml/ocaml/issues/13604): fix source printing in the presence of the escaped raw
+    identifier `\#mod`.
+    (Florian Angeletti, report by Chris Casinghino, review by Gabriel Scherer)
+---
+
+One month after the release of the first beta for OCaml 5.3.0, 
+we are releasing a second and hopefully last beta release for OCaml
+5.3.0 .
+
+The most notable changes for this second beta are probably a handful of type
+system bugfixes. In particular, those fixes revert a change of behaviour in the
+first beta when pattern matching GADTs with non-injective type parameters.
+
+We also have a C++ header compatibility fix and the restoration of some
+configuration variable in Makefiles for the sake of backward compatibility.
+
+Overall, the release is converging and we are expecting to have a first release
+candidate around the middle of December. The progresses on stabilising the
+ecosystem are tracked on the
+[opam readiness for 5.3.0 meta-issue](https://github.com/ocaml/opam-repository/issues/26596).
+
+Meanwhile, the second beta release of OCaml 5.3.0 is here to help you update
+your software and libraries ahead of the release (see below for the installation
+instructions).
+
+The full release is expected before the end of December.
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+If you are interested in full list of features and bug fixes of the new OCaml
+version, the updated change log for OCaml 5.3.0 is available [on GitHub](https://github.com/ocaml/ocaml/blob/5.3/Changes).
+
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands
+on opam 2.1 and later:
+
+```bash
+opam update
+opam switch create 5.3.0~beta2
+```
+
+The source code for the beta is also available at these addresses:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.3.0-beta2.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3.0~beta2.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.3.0~beta2+options <option_list>
+```
+
+where `option_list` is a space separated list of `ocaml-option-*` packages. For instance, for a flambda and no-flat-float-array switch:
+
+```bash
+opam switch create 5.3.0~beta2+flambda+nffa ocaml-variants.5.3.0~beta2+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.


### PR DESCRIPTION
This PR adds a changelog entry for the second beta release of OCaml 5.3.0 .