### PR TITLE
fix: add missing word

### DIFF
--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -416,7 +416,7 @@ The function `print_endline` prints the string followed by a line ending on stan
 
 ## User-Defined Types
 
-User-defined types are always introduced using the `type … = …` statement. The keyword `type` must written in lowercase. The first ellipsis stands for type name and must not begin with a capital. The second ellipsis stands for the type definition. Three cases are possible:
+User-defined types are always introduced using the `type … = …` statement. The keyword `type` must be written in lowercase. The first ellipsis stands for type name and must not begin with a capital. The second ellipsis stands for the type definition. Three cases are possible:
 1. Variant
 1. Record
 1. Aliases


### PR DESCRIPTION
Stumbled upon a missing word while reading the "Basic Data Types and Pattern Matching" page.