### PR TITLE
(data) Update URL in Hyper success story

### DIFF
--- a/data/success_stories/hyper.md
+++ b/data/success_stories/hyper.md
@@ -4,7 +4,7 @@ logo: success-stories/white/hyper.svg
 background: /success-stories/hyper-bg.jpg
 theme: green
 synopsis: "Hyper Uses OCaml to Build an IoT System for High-Performing Farms."
-url: https://www.hyper.ag/
+url: https://hyper.systems/
 priority: 3
 ---
 


### PR DESCRIPTION
It seems that the link from the Hyper success story is dead and leads to a GoDaddy page.

Since the success story is not very tangible anyways, and since we are getting a bunch of new success stories, I propose to remove it.