### PR TITLE
Dune build with host network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ scrape: ## Generate the po files
 
 .PHONY: docker
 docker: ## Generate docker container
-	docker build -f Dockerfile . -t ocamlorg:latest
+	docker build --network host -f Dockerfile . -t ocamlorg:latest
 
 .PHONY: linkcheck
 linkcheck:


### PR DESCRIPTION
Dune build fails with error 40 at "opam install . --deps-only" in Ubuntu 24.04 withtout this. 
