### PR TITLE
(data) Add 4 papers

### DIFF
--- a/data/papers.yml
+++ b/data/papers.yml
@@ -1393,3 +1393,134 @@ papers:
       - description: "Read Online"
         uri: https://icfp23.sigplan.org/details/ocaml-2023-papers/13/Wasocaml-a-compiler-from-OCaml-to-WebAssembly
     featured: false
+  - title: "Unboxed Data Constructors: Or, How cpp Decides a Halting Problem"
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      We propose a new language feature for ML-family languages, the ability to
+      selectively unbox certain data constructors, so that their runtime
+      representation gets compiled away to just the identity on their argument.
+      Unboxing must be statically rejected when it could introduce confusion,
+      that is, distinct values with the same representation. We discuss the
+      use-case of big numbers, where unboxing allows to write code that is both
+      efficient and safe, replacing either a safe but slow version or a fast
+      but unsafe version. We explain the static analysis necessary to reject
+      incorrect unboxing requests. We present our prototype implementation of
+      this feature for the OCaml programming language, discuss several design
+      choices and the interaction with advanced features such as Guarded
+      Algebraic Datatypes. Our static analysis requires expanding type
+      definitions in type expressions, which is not necessarily normalizing in
+      presence of recursive type definitions. In other words, we must decide
+      normalization of terms in the first-order λ-calculus with recursion. We
+      provide an algorithm to detect non-termination on-the-fly during
+      reduction, with proofs of correctness and completeness. Our algorithm
+      turns out to be closely related to the normalization strategy for macro
+      expansion in the cpp preprocessor.
+    authors:
+      - Nicolas Chataing
+      - Stephen Dolan
+      - Gabriel Scherer
+      - Jeremy Yallop
+    tags:
+      - icfp
+    year: 2023
+    links:
+      - description: "Read Online"
+        uri: https://dl.acm.org/doi/10.1145/3632893
+    featured: false
+  - title: "A practical mode system for recursive definitions"
+    publication: Principles of Programming Languages (POPL)
+    abstract: >
+      In call-by-value languages, some mutually-recursive definitions can be
+      safely evaluated to build recursive functions or cyclic data structures,
+      but some definitions (let rec x = x + 1) contain vicious circles and
+      their evaluation fails at runtime. We propose a new static analysis to
+      check the absence of such runtime failures. We present a set of
+      declarative inference rules, prove its soundness with respect to the
+      reference source-level semantics of Nordlander, Carlsson, and Gill
+      [2008], and show that it can be directed into an algorithmic backwards
+      analysis check in a surprisingly simple way. Our implementation of this
+      new check replaced the existing check used by the OCaml programming
+      language, a fragile syntactic criterion which let several subtle bugs
+      slip through as the language kept evolving. We document some issues that
+      arise when advanced features of a real-world functional language
+      (exceptions in first-class modules, GADTs, etc.) interact with safety
+      checking for recursive definitions.
+    authors:
+      - Alban Reynaud
+      - Gabriel Scherer
+      - Jeremy Yallop
+    tags:
+      - popl
+    year: 2021
+    links:
+      - description: "Read Online"
+        uri: https://dl.acm.org/doi/10.1145/3434326
+    featured: false
+  - title: "Merlin: A Language Server for OCaml (Experience Report)"
+    publication: International Conference on Functional Programming (ICFP)
+    abstract: >
+      We report on the experience of developing Merlin, a language server for
+      the OCaml programming language in development since 2013. Merlin is a
+      daemon that connects to your favourite text editor and provides services
+      that require a fine-grained understanding of the programming language
+      syntax and static semantics: instant feedback on warnings and errors,
+      autocompletion, 'type of the code under the cursor', 'go to definition',
+      etc. Language servers need to handle incomplete and partially-incorrect
+      programs, and try to be incremental to minimize recomputation after small
+      editing actions. Merlin was built by carefully adapting the existing tools
+      (the OCamllex lexer and Menhir parser generators) to better support
+      incrementality, incompleteness and error handling. These extensions are
+      elegant and general, as demonstrated by the interesting, unplanned uses
+      that the OCaml community found for them. They could be adapted to other
+      frontends -- in any language. Besides incrementality, we discuss the way
+      Merlin communicates with editors, describe the design decisions that went
+      into some demanding features and report on some of the non-apparent
+      difficulties in building good editor support, emerging from expressive
+      programming languages or frustrating tooling ecosystems. We expect this
+      experience report to be of interest to authors of interactive language
+      tooling for any programming language; many design choices may be reused,
+      and some hard-won lessons can serve as warnings.
+    authors:
+      - Frédéric Bour
+      - Thomas Refis
+      - Gabriel Scherer
+    tags:
+      - icfp
+    year: 2018
+    links:
+      - description: "Read Online"
+        uri: https://dl.acm.org/doi/10.1145/3236798
+    featured: false
+  - title: "Tail Modulo Cons, OCaml, and Relational Separation Logic"
+    publication: Principles of Programming Languages (POPL)
+    abstract: >
+      Common functional languages incentivize tail-recursive functions, as
+      opposed to general recursive functions that consume stack space and may
+      not scale to large inputs. This distinction occasionally requires writing
+      functions in a tail-recursive style that may be more complex and slower
+      than the natural, non-tail-recursive definition. This work describes our
+      implementation of the tail modulo constructor (TMC) transformation in the
+      OCaml compiler, an optimization that provides stack-efficiency for a
+      larger class of functions—tail-recursive modulo constructors—which
+      includes in particular the natural definition of `List.map` and many
+      similar recursive data-constructing functions. We prove the correctness
+      of this program transformation in a simplified setting—a small untyped
+      calculus—that captures the salient aspects of the OCaml implementation.
+      Our proof is mechanized in the Coq proof assistant, using the Iris base
+      logic. An independent contribution of our work is an extension of the
+      Simuliris approach to define simulation relations that support different
+      calling conventions. To our knowledge, this is the first use of Simuliris
+      to prove the correctness of a compiler transformation.
+    authors:
+      - Clément Allain
+      - Frédéric Bour
+      - Basile Clément
+      - François Pottier
+      - Gabriel Scherer
+    tags:
+      - popl
+    year: 2025
+    links:
+      - description: "Read Online"
+        uri: https://arxiv.org/abs/2411.19397
+    featured: false


### PR DESCRIPTION
Four papers on recent mainline OCaml features:

- Unboxed Data Constructors: Or, How cpp Decides a Halting Problem
- A practical mode system for recursive definitions
- Merlin: a language server for OCaml (experience report)
- Tail Modulo Cons, OCaml, and Relational Separation Logic