### PR TITLE
chore: changelog dune 3.17.1

### DIFF
--- a/data/changelog/dune/2024-12-18-dune.3.17.1.md
+++ b/data/changelog/dune/2024-12-18-dune.3.17.1.md
@@ -20,5 +20,5 @@ The Dune team is happy to announce the release of Dune 3.17.1!
 This patch release includes some bug fixes. To reduce computing time, it does
 not build `.cmxs` files anymore when the `(no_dynlink)` stanza is used instead.
 This behavior also corrects the semantic of the `(no_dynlink)` stanza which was
-building but not installing `.cmxs` files.
+building but not installing `.cmxs` files. It does not try to build and install them anymore.
 

--- a/data/changelog/dune/2024-12-18-dune.3.17.1.md
+++ b/data/changelog/dune/2024-12-18-dune.3.17.1.md
@@ -1,0 +1,24 @@
+---
+title: Dune 3.17.1
+tags: [dune, platform]
+changelog: |
+    ### Fixed
+
+    - When a library declares `(no_dynlink)`, then the `.cmxs` file for it
+      is no longer built. (#11176, @nojb)
+
+    - Fix bug that could result in corrupted file copies by Dune, for example when
+      using the `copy_files#` stanza or the `copy#` action. (@nojb, #11194, fixes
+      #11193)
+
+    - Remove useless error message when running `$ dune subst` in empty projects.
+      (@rgrinberg, #11204, fixes #11200)
+---
+
+The Dune team is happy to announce the release of Dune 3.17.1!
+
+This patch release includes some bug fixes. To reduce computing time, it does
+not build `.cmxs` files anymore when the `(no_dynlink)` stanza is used instead.
+This behavior also corrects the semantic of the `(no_dynlink)` stanza which was
+building but not installing `.cmxs` files.
+


### PR DESCRIPTION
This PR adds the changelog for the upcoming dune `3.17.1`.
