### PR TITLE
changelog: OCaml 5.3.0~rc1

### DIFF
--- a/data/changelog/ocaml/2024-12-19-ocaml-5.3.0-rc1.md
+++ b/data/changelog/ocaml/2024-12-19-ocaml-5.3.0-rc1.md
@@ -1,0 +1,65 @@
+---
+title: OCaml 5.3.0 - First Release Candidate
+description: First Release Candidate of OCaml 5.3.0
+tags: [ocaml]
+changelog: |
+  ## Changes since the second beta
+  
+  ### Type system
+  
+  - [#13690](https://github.com/ocaml/ocaml/issues/13690): some type expressions were incorrectly not generalized (because they
+     were assigned to the wrong level pool)
+  
+  ### Documentation
+  
+  - [#13666](https://github.com/ocaml/ocaml/issues/13666): Rewrite parts of the example code around nested lists in Chapter 6
+    (Polymorphism and its limitations -> Polymorphic recursion) giving the
+    "depth" function [in the non-polymorphically-recursive part of the example]
+    a much more sensible behavior; also fix a typo and some formatting.
+    (Frank Steffahn, review by Florian Angeletti)
+  
+  ### Compiler user-interface and warnings:
+  
+  - [#12084](https://github.com/ocaml/ocaml/issues/12084), +[#13669](https://github.com/ocaml/ocaml/issues/13669), +[#13673](https://github.com/ocaml/ocaml/issues/13673): Check link order when creating archive and when using
+     ocamlopt.
+---
+
+
+The release of OCaml 5.3.0 is imminent.
+As a final step, we are publishing a release candidate to check that everything is in order before the release in the upcoming week(s).
+
+If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
+
+Compared to the second beta, this release contains one small compiler-libs printer fix and one configuration tweak.
+
+The full change log for OCaml 5.3.0 is available [on
+GitHub](https://github.com/ocaml/ocaml/blob/5.3/Changes). A short summary of the
+changes since the second beta release is also available below.
+
+---
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands on opam 2.1 and later:
+```bash
+opam update
+opam switch create 5.3.0~rc1
+```
+
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/5.3.0-rc1.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3.0~rc1.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.3.0~rc1+options <option_list>
+```
+where `<option_list>` is a space-separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.3.0~rc1+flambda+nffa ocaml-variants.5.3.0~rc1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+All available options can be listed with `opam search ocaml-option`.

--- a/data/changelog/ocaml/2024-12-19-ocaml-5.3.0-rc1.md
+++ b/data/changelog/ocaml/2024-12-19-ocaml-5.3.0-rc1.md
@@ -30,7 +30,7 @@ As a final step, we are publishing a release candidate to check that everything 
 
 If you find any bugs, please report them on [OCaml's issue tracker](https://github.com/ocaml/ocaml/issues).
 
-Compared to the second beta, this release contains one small compiler-libs printer fix and one configuration tweak.
+Compared to the second beta, this release candidate contains a regression fix in the type system (some type expressions were not generalized when they ought to be), one fix for the new check for dependency order at link time, and a manual update.
 
 The full change log for OCaml 5.3.0 is available [on
 GitHub](https://github.com/ocaml/ocaml/blob/5.3/Changes). A short summary of the


### PR DESCRIPTION
This PR adds the change entry for the (first) release candidate of OCaml 5.3.0.