### PR TITLE
Revert "Strengthen feed filtering freshness"

### DIFF
--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -93,8 +93,7 @@ module ChangelogFeed = struct
   let create_feed () =
     let open Rss in
     () |> all
-    |> create_entries ~create_entry
-    |> Ocamlorg.Import.List.take 365
+    |> create_entries ~create_entry ~days:365
     |> entries_to_feed ~id:"changelog.xml" ~title:"OCaml Changelog"
     |> feed_to_string
 end

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -54,8 +54,7 @@ module RssFeed = struct
   let create_feed () =
     let open Rss in
     all ()
-    |> create_entries ~create_entry
-    |> Ocamlorg.Import.List.take 90
+    |> create_entries ~create_entry ~days:9000 (* FIXME *)
     |> entries_to_feed ~id:"news.xml" ~title:"OCaml News @ OCaml.org"
     |> feed_to_string
 end

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -148,9 +148,7 @@ module GlobalFeed = struct
 
   let create_feed () =
     let open Rss in
-    let entries =
-      all () |> create_entries ~create_entry |> Ocamlorg.Import.List.take 90
-    in
+    let entries = all () |> create_entries ~create_entry ~days:90 in
 
     match create_events_announcement_entry () with
     | None ->

--- a/tool/ood-gen/lib/rss.ml
+++ b/tool/ood-gen/lib/rss.ml
@@ -1,4 +1,14 @@
-let create_entries ~create_entry = List.map create_entry
+let create_entries ~create_entry ?days u =
+  let is_fresh =
+    let some days (entry : Syndic.Atom.entry) =
+      let now = Ptime.of_float_s (Unix.gettimeofday ()) |> Option.get in
+      let than = Ptime.sub_span now (Ptime.Span.v (days, 0L)) |> Option.get in
+      if Ptime.is_later entry.updated ~than then Some entry else None
+    in
+    Option.fold ~none:Option.some ~some days
+  in
+  let entries = u |> List.filter_map (fun x -> x |> create_entry |> is_fresh) in
+  entries
 
 let entries_to_feed ~id ~title (entries : Syndic.Atom.entry list) =
   let id = Uri.of_string ("https://ocaml.org/" ^ id) in


### PR DESCRIPTION
Reverts ocaml/ocaml.org#2882 because it makes the social media automation post way old posts. Applying a different fix instead.