### PR TITLE
Cookbook: Debug Print a Value with ppx_deriving

### DIFF
--- a/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
+++ b/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
@@ -5,22 +5,7 @@ packages:
   used_libraries:
   - ppx_deriving
 discussion: |
-    To create a minimal project:
-    ```
-    mkdir printDebug
-    cd printDebug
-    printf "\
-    (executable
-     (name minimo)
-       (preprocess (pps ppx_deriving.show))
-       )" > ./dune
-    printf "(lang dune 3.17)" > ./dune-project
-    printf "let () = print_endline ([%%show: string] \"hello world\")" > ./minimo.ml
-    opam switch create ./
-    opam install dune ppx_deriving
-    ```
-    Check your dune version by `opam exec -- dune --version` and modify `dune-project` file if needed. Build and execute the project by `opam exec -- dune exec ./minimo.exe`.
-    For a background, see [minimum setup](https://ocaml.org/docs/your-first-program#minimum-setup), [opam switch intro](https://ocaml.org/docs/opam-switch-introduction), and [ppx](https://ocaml.org/docs/metaprogramming).
+    It is required to have `(preprocess (pps ppx_deriving.show))` in `dune` file.
 ---
 
 (* string *)
@@ -31,14 +16,14 @@ let () = print_endline ([%show: string] "hello world")
 let show_int = [%show: int]
 let () = print_endline (show_int 7)
 
-(* tuple *)
+(* tuple of integer and string *)
 let show_pair : (int * string) -> string = [%show: (int * string)]
 let () = print_endline (show_pair (3, "hello"))
 
-(* list of tuples *)
+(* list of tuples, each is a boolean and character *)
 let () = print_endline @@ [%show: (bool * char) list] [ (true, 'a'); (false, 'b') ]
 
-(* user-defined type *)
+(* user-defined type; binary tree with weighted vertices *)
 type tree =
     | Leaf of float
     | Node of float * tree * tree
@@ -48,7 +33,7 @@ let () = (Node (0.3,
                 Leaf 0.2, Leaf 0.3),
             Leaf 0.1) ) |> show_tree |> print_endline
 
-(* user-defined type, excluding path *)
+(* Excluding path in printing from a user-defined type *)
 type tree_char =
     | Leaf of char
     | Node of char * tree_char * tree_char
@@ -56,14 +41,14 @@ type tree_char =
 let foo : tree_char = Node('a', Leaf 'b', Leaf 'c')
 let () = foo |> show_tree_char |> print_endline
 
-(* list of option *)
+(* list of boolean option *)
 let () = print_endline @@ [%show: (bool option) list] @@ [Some true; None; Some false]
 
-(* result *)
+(* string integer result *)
 let () = Ok "hello" |> [%show: (string, int) result] |> print_endline
 let () = Error 404 |> [%show: (string, int) result] |> print_endline
 
-(* record *)
+(* record of a string, integer, and boolean *)
 type person = {
     last_name : string;
     age : int;
@@ -77,7 +62,7 @@ let gerard = {
 }
 let () = print_endline @@ show_person @@ gerard
 
-(* formatter *)
+(* all strings generated above can be used with a formatter like Printf or anything else that works with strings *)
 let () =
     let i = 20 in
     Printf.printf "At line 20 - and variable i is %i" i

--- a/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
+++ b/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
@@ -5,7 +5,7 @@ packages:
   used_libraries:
   - ppx_deriving
 discussion: |
-    It is required to have `(preprocess (pps ppx_deriving.show))` in `dune` file.
+    To use `[@@deriving show]`, you need to add the `ppx_deriving.show` preprocessor in your dune file, like this: `(preprocess (pps ppx_deriving.show))`.
 ---
 
 (* converting an integer to string *)

--- a/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
+++ b/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
@@ -8,13 +8,8 @@ discussion: |
     It is required to have `(preprocess (pps ppx_deriving.show))` in `dune` file.
 ---
 
-(* string *)
-let () = print_endline "hello world"
-let () = print_endline ([%show: string] "hello world")
-
-(* integer *)
-let show_int = [%show: int]
-let () = print_endline (show_int 7)
+(* converting an integer to string *)
+let () = print_endline (string_of_int 7)
 
 (* tuple of integer and string *)
 let show_pair : (int * string) -> string = [%show: (int * string)]

--- a/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
+++ b/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
@@ -1,0 +1,84 @@
+---
+packages:
+- name: "ppx_deriving"
+  tested_version: "6.0.3"
+  used_libraries:
+  - ppx_deriving
+discussion: |
+    To create a minimal project:
+    ```
+    mkdir printDebug
+    cd printDebug
+    printf "\
+    (executable
+     (name minimo)
+       (preprocess (pps ppx_deriving.show))
+       )" > ./dune
+    printf "(lang dune 3.17)" > ./dune-project
+    printf "let () = print_endline ([%%show: string] \"hello world\")" > ./minimo.ml
+    opam switch create ./
+    opam install dune ppx_deriving
+    ```
+    Check your dune version by `opam exec -- dune --version` and modify `dune-project` file if needed. Build and execute the project by `opam exec -- dune exec ./minimo.exe`.
+    For a background, see [minimum setup](https://ocaml.org/docs/your-first-program#minimum-setup), [opam switch intro](https://ocaml.org/docs/opam-switch-introduction), and [ppx](https://ocaml.org/docs/metaprogramming).
+---
+
+(* string *)
+let () = print_endline "hello world"
+let () = print_endline ([%show: string] "hello world")
+
+(* integer *)
+let show_int = [%show: int]
+let () = print_endline (show_int 7)
+
+(* tuple *)
+let show_pair : (int * string) -> string = [%show: (int * string)]
+let () = print_endline (show_pair (3, "hello"))
+
+(* list of tuples *)
+let () = print_endline @@ [%show: (bool * char) list] [ (true, 'a'); (false, 'b') ]
+
+(* user-defined type *)
+type tree =
+    | Leaf of float
+    | Node of float * tree * tree
+    [@@deriving show]
+let () = (Node (0.3,
+            Node (0.5,
+                Leaf 0.2, Leaf 0.3),
+            Leaf 0.1) ) |> show_tree |> print_endline
+
+(* user-defined type *)
+(* excluding path *)
+type tree_char =
+    | Leaf of char
+    | Node of char * tree_char * tree_char
+    [@@deriving show { with_path = false }]
+let foo : tree_char = Node('a', Leaf 'b', Leaf 'c')
+let () = foo |> show_tree_char |> print_endline
+
+(* list of option *)
+let () = print_endline @@ [%show: (bool option) list] @@ [Some true; None; Some false]
+
+(* result *)
+let () = Ok "hello" |> [%show: (string, int) result] |> print_endline
+let () = Error 404 |> [%show: (string, int) result] |> print_endline
+
+(* record *)
+type person = {
+    last_name : string;
+    age : int;
+    is_married : bool
+} [@@deriving show]
+
+let gerard = {
+    last_name = "Touny";
+    age = 26;
+    is_married = true
+}
+let () = print_endline @@ show_person @@ gerard
+
+(* formatter *)
+let () =
+    let i = 20 in
+    Printf.printf "At line 20 - and variable i is %i" i

--- a/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
+++ b/data/cookbook/debug-print-a-value/00-ppx_deriving.ml
@@ -48,8 +48,7 @@ let () = (Node (0.3,
                 Leaf 0.2, Leaf 0.3),
             Leaf 0.1) ) |> show_tree |> print_endline
 
-(* user-defined type *)
-(* excluding path *)
+(* user-defined type, excluding path *)
 type tree_char =
     | Leaf of char
     | Node of char * tree_char * tree_char


### PR DESCRIPTION
Hello,

I am contributing to [Debug Print a Value](https://ocaml.org/cookbook/debug-print-a-value).

Moreover,
- I hope someone shows how to use `ppx_deriving` with `utop -ppx`.
- I nominate @yawaramin to add his post, as he commented [here](https://discuss.ocaml.org/t/contributing-to-ocaml-recipes-debug-print-a-value/15898/19?u=mostafatouny).
- I hope someone add printing recipes for maps (association table), Sets, Hash-tables, and Sequences data structures.