### PR TITLE
Use ppx import in ood

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -70,6 +70,7 @@
   olinkcheck
   ; tools/ood-gen
   ppx_deriving_yaml
+  ppx_import
   ppx_stable
   ezjsonm
   lambdasoup

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -45,6 +45,7 @@ depends: [
   "mdx" {with-test & >= "1.10.0"}
   "olinkcheck"
   "ppx_deriving_yaml"
+  "ppx_import"
   "ppx_stable"
   "ezjsonm"
   "lambdasoup"

--- a/src/ocamlorg_data/data.ml
+++ b/src/ocamlorg_data/data.ml
@@ -152,9 +152,7 @@ module Paper = struct
   let get_by_slug slug = List.find_opt (fun x -> String.equal slug x.slug) all
 end
 
-module Planet = struct
-  include Planet
-end
+module Planet = Planet
 
 module Release = struct
   include Release

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -224,38 +224,9 @@ module Exercise = struct
 end
 
 module Governance = struct
-  module Member = struct
-    type t = { name : string; github : string; role : string }
-    [@@deriving of_yaml, show]
-
-    let compare a b = String.compare a.github b.github
-  end
-
-  type contact_kind = GitHub | Email | Discord | Chat [@@deriving show]
-
-  let contact_kind_of_yaml = function
-    | `String "github" -> Ok GitHub
-    | `String "email" -> Ok Email
-    | `String "discord" -> Ok Discord
-    | `String "chat" -> Ok Chat
-    | x -> (
-        match Yaml.to_string x with
-        | Ok str ->
-            Error
-              (`Msg
-                ("\"" ^ str
-               ^ "\" is not a valid contact_kind! valid options are: github, \
-                  email, discord, chat"))
-        | Error _ -> Error (`Msg "Invalid Yaml value"))
-
-  let contact_kind_to_yaml = function
-    | GitHub -> `String "github"
-    | Email -> `String "email"
-    | Discord -> `String "discord"
-    | Chat -> `String "chat"
-
+  type member = { name : string; github : string; role : string }
+  type contact_kind = GitHub | Email | Discord | Chat
   type contact = { name : string; link : string; kind : contact_kind }
-  [@@deriving of_yaml, show]
 
   type dev_meeting = {
     date : string;
@@ -264,7 +235,6 @@ module Governance = struct
     calendar : string option;
     notes : string;
   }
-  [@@deriving of_yaml, show]
 
   type team = {
     id : string;
@@ -272,10 +242,9 @@ module Governance = struct
     description : string;
     contacts : contact list;
     dev_meeting : dev_meeting option;
-    members : Member.t list;
+    members : member list;
     subteams : team list;
   }
-  [@@deriving show]
 end
 
 module Industrial_user = struct

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -147,7 +147,6 @@ module Changelog = struct
     body : string;
     authors : string list;
   }
-  [@@deriving of_yaml, show]
 end
 
 module Code_examples = struct
@@ -375,7 +374,6 @@ module Job = struct
     company : string;
     company_logo : string;
   }
-  [@@deriving of_yaml, show]
 end
 
 module Testimonial = struct
@@ -386,7 +384,6 @@ module Testimonial = struct
     role : string;
     logo : string;
   }
-  [@@deriving of_yaml, show]
 end
 
 module News = struct
@@ -409,7 +406,6 @@ module Opam_user = struct
     github_username : string option;
     avatar : string option;
   }
-  [@@deriving of_yaml, show]
 end
 
 module Outreachy = struct
@@ -493,7 +489,6 @@ module Resource = struct
     source_url : string option;
     featured : bool;
   }
-  [@@deriving of_yaml, show]
 end
 
 module Success_story = struct

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -73,7 +73,6 @@ module Academic_testimonial = struct
     publication : string;
     year : string;
   }
-  [@@deriving of_yaml, show]
 end
 
 module Blog = struct

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -104,7 +104,6 @@ end
 
 module Book = struct
   type difficulty = Beginner | Intermediate | Advanced
-
   type link = { description : string; uri : string }
 
   type t = {
@@ -177,7 +176,6 @@ end
 
 module Event = struct
   type event_type = Meetup | Conference | Seminar | Hackathon | Retreat
-
   type location = { lat : float; long : float }
 
   type recurring_event = {
@@ -297,7 +295,6 @@ end
 
 module Is_ocaml_yet = struct
   type external_package = { url : string; synopsis : string }
-
   type package = { name : string; extern : external_package option }
 
   type category = {
@@ -402,7 +399,7 @@ module Paper = struct
 end
 
 module Release = struct
-  type kind = [ `Compiler ] 
+  type kind = [ `Compiler ]
 
   type t = {
     kind : kind;
@@ -463,7 +460,6 @@ end
 
 module Tool_page = struct
   type toc = { title : string; href : string; children : toc list }
-
   type contribute_link = { url : string; description : string }
 
   type t = {
@@ -481,11 +477,8 @@ end
 
 module Tutorial = struct
   type section = GetStarted | Language | Platform | Guides
-
   type toc = { title : string; href : string; children : toc list }
-
   type contribute_link = { url : string; description : string }
-
   type banner = { image : string; url : string; alt : string }
 
   type external_tutorial = {
@@ -496,7 +489,6 @@ module Tutorial = struct
 
   type recommended_next_tutorials = string list
   type prerequisite_tutorials = string list
-
   type search_document_section = { title : string; id : string }
 
   type search_document = {
@@ -541,7 +533,6 @@ end
 
 module Conference = struct
   type role = [ `Co_chair | `Chair ]
-
   type important_date = { date : string; info : string }
 
   type committee_member = {

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -336,7 +336,6 @@ module Industrial_user = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Is_ocaml_yet = struct
@@ -396,7 +395,6 @@ module News = struct
     body_html : string;
     authors : string list;
   }
-  [@@deriving show]
 end
 
 module Opam_user = struct
@@ -433,7 +431,6 @@ module Page = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Paper = struct
@@ -506,7 +503,6 @@ module Success_story = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Tool = struct

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -51,7 +51,6 @@ module Blog = struct
     only_ocaml : bool;
     disabled : bool;
   }
-  [@@deriving show]
 
   type post = {
     title : string;
@@ -64,7 +63,6 @@ module Blog = struct
     preview_image : string option;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Book = struct
@@ -462,7 +460,6 @@ module Video = struct
     source_link : string;
     source_title : string;
   }
-  [@@deriving yaml, show]
 end
 
 module Conference = struct
@@ -504,9 +501,5 @@ end
 (* Depends on Video and Blog modules to define the different kinds of entries of
    the OCaml Planet *)
 module Planet = struct
-  type entry = BlogPost of Blog.post | Video of Video.t [@@deriving show]
-
-  let date_of_post = function
-    | BlogPost { date; _ } -> date
-    | Video { published; _ } -> published
+  type entry = BlogPost of Blog.post | Video of Video.t
 end

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -150,7 +150,7 @@ module Changelog = struct
 end
 
 module Code_examples = struct
-  type t = { title : string; body : string } [@@deriving show]
+  type t = { title : string; body : string }
 end
 
 module Cookbook = struct
@@ -159,7 +159,6 @@ module Cookbook = struct
     slug : string;
     subcategories : category list;
   }
-  [@@deriving show]
 
   type task = {
     title : string;
@@ -167,17 +166,14 @@ module Cookbook = struct
     category_path : string list;
     description : string option;
   }
-  [@@deriving show]
 
   type code_block_with_explanation = { code : string; explanation : string }
-  [@@deriving show]
 
   type package = {
     name : string;
     tested_version : string;
     used_libraries : string list;
   }
-  [@@deriving of_yaml, show]
 
   type t = {
     slug : string;
@@ -188,7 +184,6 @@ module Cookbook = struct
     code_plaintext : string;
     discussion_html : string;
   }
-  [@@deriving show]
 end
 
 module Event = struct
@@ -340,10 +335,8 @@ end
 
 module Is_ocaml_yet = struct
   type external_package = { url : string; synopsis : string }
-  [@@deriving of_yaml, show]
 
   type package = { name : string; extern : external_package option }
-  [@@deriving of_yaml, show]
 
   type category = {
     name : string;
@@ -352,7 +345,6 @@ module Is_ocaml_yet = struct
     packages : package list;
     slug : string;
   }
-  [@@deriving show]
 
   type t = {
     id : string;
@@ -361,7 +353,6 @@ module Is_ocaml_yet = struct
     categories : category list;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Job = struct
@@ -416,9 +407,8 @@ module Outreachy = struct
     mentors : string list;
     video : string option;
   }
-  [@@deriving of_yaml, show]
 
-  type t = { name : string; projects : project list } [@@deriving of_yaml, show]
+  type t = { name : string; projects : project list }
 end
 
 module Page = struct
@@ -434,7 +424,7 @@ module Page = struct
 end
 
 module Paper = struct
-  type link = { description : string; uri : string } [@@deriving of_yaml, show]
+  type link = { description : string; uri : string }
 
   type t = {
     title : string;
@@ -447,7 +437,6 @@ module Paper = struct
     links : link list;
     featured : bool;
   }
-  [@@deriving show]
 end
 
 module Release = struct
@@ -534,10 +523,8 @@ end
 
 module Tool_page = struct
   type toc = { title : string; href : string; children : toc list }
-  [@@deriving of_yaml, show]
 
   type contribute_link = { url : string; description : string }
-  [@@deriving of_yaml, show]
 
   type t = {
     title : string;
@@ -550,7 +537,6 @@ module Tool_page = struct
     toc : toc list;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Tutorial = struct

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -103,19 +103,9 @@ module Blog = struct
 end
 
 module Book = struct
-  type difficulty = Beginner | Intermediate | Advanced [@@deriving show]
+  type difficulty = Beginner | Intermediate | Advanced
 
-  let difficulty_of_string = function
-    | "beginner" -> Ok Beginner
-    | "intermediate" -> Ok Intermediate
-    | "advanced" -> Ok Advanced
-    | s -> Error (`Msg ("Unknown difficulty type: " ^ s))
-
-  let difficulty_of_yaml = function
-    | `String s -> difficulty_of_string s
-    | _ -> Error (`Msg "Expected a string for difficulty type")
-
-  type link = { description : string; uri : string } [@@deriving of_yaml, show]
+  type link = { description : string; uri : string }
 
   type t = {
     title : string;
@@ -133,7 +123,6 @@ module Book = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Changelog = struct
@@ -188,21 +177,8 @@ end
 
 module Event = struct
   type event_type = Meetup | Conference | Seminar | Hackathon | Retreat
-  [@@deriving show]
 
-  let event_type_of_string = function
-    | "meetup" -> Ok Meetup
-    | "conference" -> Ok Conference
-    | "seminar" -> Ok Seminar
-    | "hackathon" -> Ok Hackathon
-    | "retreat" -> Ok Retreat
-    | s -> Error (`Msg ("Unknown event type: " ^ s))
-
-  let event_type_of_yaml = function
-    | `String s -> event_type_of_string s
-    | _ -> Error (`Msg "Expected a string for difficulty type")
-
-  type location = { lat : float; long : float } [@@deriving of_yaml, show]
+  type location = { lat : float; long : float }
 
   type recurring_event = {
     title : string;
@@ -213,10 +189,8 @@ module Event = struct
     location : location option;
     event_type : event_type;
   }
-  [@@deriving of_yaml, show]
 
   type utc_datetime = { yyyy_mm_dd : string; utc_hh_mm : string option }
-  [@@deriving of_yaml, show]
 
   type t = {
     title : string;
@@ -234,21 +208,10 @@ module Event = struct
     recurring_event : recurring_event option;
     event_type : event_type;
   }
-  [@@deriving show]
 end
 
 module Exercise = struct
-  type difficulty = Beginner | Intermediate | Advanced [@@deriving show]
-
-  let of_string = function
-    | "beginner" -> Ok Beginner
-    | "intermediate" -> Ok Intermediate
-    | "advanced" -> Ok Advanced
-    | s -> Error (`Msg ("Unknown difficulty type: " ^ s))
-
-  let difficulty_of_yaml = function
-    | `String s -> of_string s
-    | _ -> Error (`Msg "Expected a string for difficulty type")
+  type difficulty = Beginner | Intermediate | Advanced
 
   type t = {
     title : string;
@@ -260,7 +223,6 @@ module Exercise = struct
     solution : string;
     tutorials : string list;
   }
-  [@@deriving show]
 end
 
 module Governance = struct
@@ -440,15 +402,7 @@ module Paper = struct
 end
 
 module Release = struct
-  type kind = [ `Compiler ] [@@deriving show]
-
-  let kind_of_string = function
-    | "compiler" -> Ok `Compiler
-    | s -> Error (`Msg ("Unknown release type: " ^ s))
-
-  let kind_of_yaml = function
-    | `String s -> kind_of_string s
-    | _ -> Error (`Msg "Expected a string for release type")
+  type kind = [ `Compiler ] 
 
   type t = {
     kind : kind;
@@ -463,7 +417,6 @@ module Release = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Resource = struct
@@ -496,18 +449,6 @@ end
 
 module Tool = struct
   type lifecycle = [ `Incubate | `Active | `Sustain | `Deprecate ]
-  [@@deriving show]
-
-  let lifecycle_of_string = function
-    | "incubate" -> Ok `Incubate
-    | "active" -> Ok `Active
-    | "sustain" -> Ok `Sustain
-    | "deprecate" -> Ok `Deprecate
-    | s -> Error (`Msg ("Unknown lifecycle type: " ^ s))
-
-  let lifecycle_of_yaml = function
-    | `String s -> lifecycle_of_string s
-    | _ -> Error (`Msg "Expected a string for lifecycle type")
 
   type t = {
     name : string;
@@ -518,7 +459,6 @@ module Tool = struct
     description : string;
     lifecycle : lifecycle;
   }
-  [@@deriving show]
 end
 
 module Tool_page = struct
@@ -616,19 +556,9 @@ module Video = struct
 end
 
 module Conference = struct
-  type role = [ `Co_chair | `Chair ] [@@deriving show]
-
-  let role_of_string = function
-    | "chair" -> Ok `Chair
-    | "co-chair" -> Ok `Co_chair
-    | s -> Error (`Msg ("Unknown role type: " ^ s))
-
-  let role_of_yaml = function
-    | `String s -> role_of_string s
-    | _ -> Error (`Msg "Expected a string for role type")
+  type role = [ `Co_chair | `Chair ]
 
   type important_date = { date : string; info : string }
-  [@@deriving of_yaml, show]
 
   type committee_member = {
     name : string;
@@ -636,7 +566,6 @@ module Conference = struct
     affiliation : string option;
     picture : string option;
   }
-  [@@deriving of_yaml, show]
 
   type presentation = {
     title : string;
@@ -648,7 +577,6 @@ module Conference = struct
     poster : bool;
     additional_links : string list;
   }
-  [@@deriving of_yaml, show]
 
   type t = {
     title : string;
@@ -662,7 +590,6 @@ module Conference = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving of_yaml, show]
 end
 
 (* Depends on Video and Blog modules to define the different kinds of entries of

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -480,38 +480,24 @@ module Tool_page = struct
 end
 
 module Tutorial = struct
-  module Section = struct
-    type t = GetStarted | Language | Platform | Guides [@@deriving show]
-
-    let of_string = function
-      | "getting-started" -> Ok GetStarted
-      | "language" -> Ok Language
-      | "platform" -> Ok Platform
-      | "guides" -> Ok Guides
-      | s -> Error (`Msg ("Unknown section: " ^ s))
-  end
+  type section = GetStarted | Language | Platform | Guides
 
   type toc = { title : string; href : string; children : toc list }
-  [@@deriving show]
 
   type contribute_link = { url : string; description : string }
-  [@@deriving of_yaml, show]
 
   type banner = { image : string; url : string; alt : string }
-  [@@deriving of_yaml, show]
 
   type external_tutorial = {
     tag : string;
     banner : banner;
     contribute_link : contribute_link;
   }
-  [@@deriving of_yaml, show]
 
-  type recommended_next_tutorials = string list [@@deriving of_yaml, show]
-  type prerequisite_tutorials = string list [@@deriving of_yaml, show]
+  type recommended_next_tutorials = string list
+  type prerequisite_tutorials = string list
 
   type search_document_section = { title : string; id : string }
-  [@@deriving show]
 
   type search_document = {
     title : string;
@@ -520,7 +506,6 @@ module Tutorial = struct
     content : string;
     slug : string;
   }
-  [@@deriving show]
 
   type t = {
     title : string;
@@ -528,7 +513,7 @@ module Tutorial = struct
     fpath : string;
     slug : string;
     description : string;
-    section : Section.t;
+    section : section;
     category : string;
     external_tutorial : external_tutorial option;
     body_md : string;
@@ -537,7 +522,6 @@ module Tutorial = struct
     recommended_next_tutorials : recommended_next_tutorials;
     prerequisite_tutorials : prerequisite_tutorials;
   }
-  [@@deriving show]
 end
 
 module Video = struct

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -53,20 +53,18 @@ module Blog = struct
   }
   [@@deriving show]
 
-  module Post = struct
-    type t = {
-      title : string;
-      url : string;
-      slug : string;
-      source : source;
-      description : string option;
-      authors : string list;
-      date : string;
-      preview_image : string option;
-      body_html : string;
-    }
-    [@@deriving show]
-  end
+  type post = {
+    title : string;
+    url : string;
+    slug : string;
+    source : source;
+    description : string option;
+    authors : string list;
+    date : string;
+    preview_image : string option;
+    body_html : string;
+  }
+  [@@deriving show]
 end
 
 module Book = struct
@@ -506,7 +504,7 @@ end
 (* Depends on Video and Blog modules to define the different kinds of entries of
    the OCaml Planet *)
 module Planet = struct
-  type entry = BlogPost of Blog.Post.t | Video of Video.t [@@deriving show]
+  type entry = BlogPost of Blog.post | Video of Video.t [@@deriving show]
 
   let date_of_post = function
     | BlogPost { date; _ } -> date

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -1,51 +1,19 @@
 module Academic_institution = struct
-  type location = { lat : float; long : float } [@@deriving of_yaml, show]
+  type location = { lat : float; long : float }
 
-  include (
-    struct
-      module Ptime = struct
-        include Ptime
-
-        let pp fmt t =
-          Format.pp_print_string fmt "(Ptime.of_rfc3339 \"";
-          Ptime.pp_rfc3339 () fmt t;
-          Format.pp_print_string fmt
-            "\" |> function Ok (t, _, _) -> t | Error _ -> failwith \"RFC \
-             3339\")"
-      end
-
-      type course = {
-        name : string;
-        acronym : string option;
-        url : string option;
-        teacher : string option;
-        enrollment : string option;
-        year : int option;
-        description : string;
-        last_check : Ptime.t option;
-        lecture_notes : bool;
-        exercises : bool;
-        video_recordings : bool;
-      }
-      [@@deriving show]
-    end :
-      sig
-        type course = {
-          name : string;
-          acronym : string option;
-          url : string option;
-          teacher : string option;
-          enrollment : string option;
-          year : int option;
-          description : string;
-          last_check : Ptime.t option;
-          lecture_notes : bool;
-          exercises : bool;
-          video_recordings : bool;
-        }
-
-        val pp_course : Format.formatter -> course -> unit
-      end)
+  type course = {
+    name : string;
+    acronym : string option;
+    url : string option;
+    teacher : string option;
+    enrollment : string option;
+    year : int option;
+    description : string;
+    last_check : Ptime.t option;
+    lecture_notes : bool;
+    exercises : bool;
+    video_recordings : bool;
+  }
 
   type t = {
     name : string;
@@ -62,7 +30,6 @@ module Academic_institution = struct
     body_md : string;
     body_html : string;
   }
-  [@@deriving show]
 end
 
 module Academic_testimonial = struct

--- a/src/ocamlorg_frontend/pages/governance.eml
+++ b/src/ocamlorg_frontend/pages/governance.eml
@@ -1,4 +1,4 @@
-module MemberSet = Set.Make (Data.Governance.Member)
+module MemberSet = Set.Make (struct type t = Data.Governance.member let compare a b = let open Data.Governance in String.compare a.github b.github end)
 
 let count_members (team : Data.Governance.team) =
    MemberSet.cardinal (MemberSet.of_list (team.members @ List.concat (List.map (fun (team : Data.Governance.team) -> team.members) team.subteams)))

--- a/src/ocamlorg_frontend/pages/governance_team.eml
+++ b/src/ocamlorg_frontend/pages/governance_team.eml
@@ -4,7 +4,7 @@ let contact_icon (kind : Data.Governance.contact_kind) = match kind with
   | Discord -> Icons.discord
   | Chat -> Icons.chat
 
-let render_team_member (member : Data.Governance.Member.t) =
+let render_team_member (member : Data.Governance.member) =
   <a href="https://github.com/<%s member.github %>" class="flex gap-x-2 p-4 card dark:dark-card">
     <img src="https://github.com/<%s member.github %>.png" alt="" class="h-32 w-32 mr-3 inline-block rounded-full">
     <div class="flex flex-col h-full">
@@ -58,7 +58,7 @@ let render_subteam (team : Data.Governance.team) =
     </div>
     <% ); %>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10 mt-6 mb-4 pb-12">
-      <%s! team.members |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member member ) |> String.concat "\n" %>
+      <%s! team.members |> List.map (fun (member : Data.Governance.member) -> render_team_member member ) |> String.concat "\n" %>
     </div>
   </div>
 
@@ -107,7 +107,7 @@ Layout.render
      <div class="">
       <h2 class="font-bold gradient mb-6 mt-12 md:mt-16 text-4xl text-title dark:text-dark-title">People</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 mb-4">
-        <%s! t.members |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member member ) |> String.concat "\n" %>
+        <%s! t.members |> List.map (fun (member : Data.Governance.member) -> render_team_member member ) |> String.concat "\n" %>
       </div>
      </div>
       <% ); %>

--- a/src/ocamlorg_frontend/pages/tutorial.eml
+++ b/src/ocamlorg_frontend/pages/tutorial.eml
@@ -18,7 +18,7 @@ let left_sidebar ~tutorials ~current_tutorial ~section =
     <%s! Learn_layout.render_sidebar ~tutorials ~current_tutorial ~section %>
   </div>
 
-let of_tutorial_section (s: Data.Tutorial.Section.t) =
+let of_tutorial_section (s: Data.Tutorial.section) =
   match s with
   | GetStarted -> Learn_layout.GetStarted
   | Language -> Learn_layout.Language

--- a/tool/ood-gen/lib/academic_testimonial.ml
+++ b/tool/ood-gen/lib/academic_testimonial.ml
@@ -1,4 +1,4 @@
-open Data_intf.Academic_testimonial
+type t = [%import: Data_intf.Academic_testimonial.t] [@@deriving of_yaml, show]
 
 let all () = Utils.yaml_sequence_file of_yaml "academic-testimonials.yml"
 

--- a/tool/ood-gen/lib/blog.ml
+++ b/tool/ood-gen/lib/blog.ml
@@ -58,7 +58,7 @@ module Post = struct
 
   let all_sources = Source.all ()
 
-  let of_metadata ~source ~body_html m : Post.t =
+  let of_metadata ~source ~body_html m : post =
     {
       title = m.title;
       source =
@@ -120,9 +120,9 @@ module Post = struct
     |> Result.map_error (Utils.where fpath)
     |> Result.map (of_metadata ~source ~body_html)
 
-  let all () : Post.t list =
+  let all () : post list =
     Utils.map_md_files decode "planet/*/*.md"
-    |> List.sort (fun (a : Post.t) (b : Post.t) -> String.compare b.date a.date)
+    |> List.sort (fun (a : post) (b : post) -> String.compare b.date a.date)
 end
 
 module Scraper = struct

--- a/tool/ood-gen/lib/book.ml
+++ b/tool/ood-gen/lib/book.ml
@@ -1,4 +1,18 @@
-open Data_intf.Book
+type difficulty = [%import: Data_intf.Book.difficulty] [@@deriving show]
+
+let difficulty_of_string = function
+| "beginner" -> Ok Beginner
+| "intermediate" -> Ok Intermediate
+| "advanced" -> Ok Advanced
+| s -> Error (`Msg ("Unknown difficulty type: " ^ s))
+
+let difficulty_of_yaml = function
+| `String s -> difficulty_of_string s
+| _ -> Error (`Msg "Expected a string for difficulty type")
+
+type link = [%import: Data_intf.Book.link] [@@deriving of_yaml, show]
+
+type t = [%import: Data_intf.Book.t] [@@deriving show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/book.ml
+++ b/tool/ood-gen/lib/book.ml
@@ -1,17 +1,16 @@
 type difficulty = [%import: Data_intf.Book.difficulty] [@@deriving show]
 
 let difficulty_of_string = function
-| "beginner" -> Ok Beginner
-| "intermediate" -> Ok Intermediate
-| "advanced" -> Ok Advanced
-| s -> Error (`Msg ("Unknown difficulty type: " ^ s))
+  | "beginner" -> Ok Beginner
+  | "intermediate" -> Ok Intermediate
+  | "advanced" -> Ok Advanced
+  | s -> Error (`Msg ("Unknown difficulty type: " ^ s))
 
 let difficulty_of_yaml = function
-| `String s -> difficulty_of_string s
-| _ -> Error (`Msg "Expected a string for difficulty type")
+  | `String s -> difficulty_of_string s
+  | _ -> Error (`Msg "Expected a string for difficulty type")
 
 type link = [%import: Data_intf.Book.link] [@@deriving of_yaml, show]
-
 type t = [%import: Data_intf.Book.t] [@@deriving show]
 
 type metadata = {

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -1,4 +1,4 @@
-open Data_intf.Changelog
+type t = [%import: Data_intf.Changelog.t] [@@deriving of_yaml, show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/code_example.ml
+++ b/tool/ood-gen/lib/code_example.ml
@@ -1,4 +1,4 @@
-open Data_intf.Code_examples
+type t = [%import: Data_intf.Code_examples.t] [@@deriving show]
 
 let all () =
   Utils.read_from_dir "code_examples/*.ml"

--- a/tool/ood-gen/lib/conference.ml
+++ b/tool/ood-gen/lib/conference.ml
@@ -9,9 +9,14 @@ let role_of_yaml = function
   | `String s -> role_of_string s
   | _ -> Error (`Msg "Expected a string for role type")
 
-type important_date = [%import: Data_intf.Conference.important_date] [@@deriving of_yaml, show]
-type committee_member = [%import: Data_intf.Conference.committee_member] [@@deriving of_yaml, show]
-type presentation = [%import: Data_intf.Conference.presentation] [@@deriving of_yaml, show]
+type important_date = [%import: Data_intf.Conference.important_date]
+[@@deriving of_yaml, show]
+
+type committee_member = [%import: Data_intf.Conference.committee_member]
+[@@deriving of_yaml, show]
+
+type presentation = [%import: Data_intf.Conference.presentation]
+[@@deriving of_yaml, show]
 
 type t = [%import: Data_intf.Conference.t] [@@deriving of_yaml, show]
 

--- a/tool/ood-gen/lib/conference.ml
+++ b/tool/ood-gen/lib/conference.ml
@@ -1,4 +1,19 @@
-open Data_intf.Conference
+type role = [%import: Data_intf.Conference.role] [@@deriving show]
+
+let role_of_string = function
+  | "chair" -> Ok `Chair
+  | "co-chair" -> Ok `Co_chair
+  | s -> Error (`Msg ("Unknown role type: " ^ s))
+
+let role_of_yaml = function
+  | `String s -> role_of_string s
+  | _ -> Error (`Msg "Expected a string for role type")
+
+type important_date = [%import: Data_intf.Conference.important_date] [@@deriving of_yaml, show]
+type committee_member = [%import: Data_intf.Conference.committee_member] [@@deriving of_yaml, show]
+type presentation = [%import: Data_intf.Conference.presentation] [@@deriving of_yaml, show]
+
+type t = [%import: Data_intf.Conference.t] [@@deriving of_yaml, show]
 
 type presentation_metadata = {
   title : string;

--- a/tool/ood-gen/lib/cookbook.ml
+++ b/tool/ood-gen/lib/cookbook.ml
@@ -1,4 +1,8 @@
-open Data_intf.Cookbook
+type category = [%import: Data_intf.Cookbook.category] [@@deriving show]
+type task = [%import: Data_intf.Cookbook.task] [@@deriving show]
+type code_block_with_explanation = [%import: Data_intf.Cookbook.code_block_with_explanation] [@@deriving show]
+type package = [%import: Data_intf.Cookbook.package] [@@deriving of_yaml, show]
+type t = [%import: Data_intf.Cookbook.t] [@@deriving show]
 
 type task_metadata = {
   title : string;

--- a/tool/ood-gen/lib/cookbook.ml
+++ b/tool/ood-gen/lib/cookbook.ml
@@ -1,6 +1,10 @@
 type category = [%import: Data_intf.Cookbook.category] [@@deriving show]
 type task = [%import: Data_intf.Cookbook.task] [@@deriving show]
-type code_block_with_explanation = [%import: Data_intf.Cookbook.code_block_with_explanation] [@@deriving show]
+
+type code_block_with_explanation =
+  [%import: Data_intf.Cookbook.code_block_with_explanation]
+[@@deriving show]
+
 type package = [%import: Data_intf.Cookbook.package] [@@deriving of_yaml, show]
 type t = [%import: Data_intf.Cookbook.t] [@@deriving show]
 

--- a/tool/ood-gen/lib/dune
+++ b/tool/ood-gen/lib/dune
@@ -22,4 +22,4 @@
   re
   xmlm)
  (preprocess
-  (pps ppx_deriving_yaml ppx_stable ppx_deriving.show)))
+  (staged_pps ppx_import ppx_deriving_yaml ppx_stable ppx_deriving.show)))

--- a/tool/ood-gen/lib/event.ml
+++ b/tool/ood-gen/lib/event.ml
@@ -1,22 +1,24 @@
 type event_type = [%import: Data_intf.Event.event_type] [@@deriving show]
 
 let event_type_of_string = function
-| "meetup" -> Ok Meetup
-| "conference" -> Ok Conference
-| "seminar" -> Ok Seminar
-| "hackathon" -> Ok Hackathon
-| "retreat" -> Ok Retreat
-| s -> Error (`Msg ("Unknown event type: " ^ s))
+  | "meetup" -> Ok Meetup
+  | "conference" -> Ok Conference
+  | "seminar" -> Ok Seminar
+  | "hackathon" -> Ok Hackathon
+  | "retreat" -> Ok Retreat
+  | s -> Error (`Msg ("Unknown event type: " ^ s))
 
 let event_type_of_yaml = function
-| `String s -> event_type_of_string s
-| _ -> Error (`Msg "Expected a string for difficulty type")
+  | `String s -> event_type_of_string s
+  | _ -> Error (`Msg "Expected a string for difficulty type")
 
 type location = [%import: Data_intf.Event.location] [@@deriving of_yaml, show]
 
-type recurring_event = [%import: Data_intf.Event.recurring_event] [@@deriving of_yaml, show]
+type recurring_event = [%import: Data_intf.Event.recurring_event]
+[@@deriving of_yaml, show]
 
-type utc_datetime = [%import: Data_intf.Event.utc_datetime] [@@deriving of_yaml, show]
+type utc_datetime = [%import: Data_intf.Event.utc_datetime]
+[@@deriving of_yaml, show]
 
 type t = [%import: Data_intf.Event.t] [@@deriving show]
 

--- a/tool/ood-gen/lib/event.ml
+++ b/tool/ood-gen/lib/event.ml
@@ -1,4 +1,24 @@
-open Data_intf.Event
+type event_type = [%import: Data_intf.Event.event_type] [@@deriving show]
+
+let event_type_of_string = function
+| "meetup" -> Ok Meetup
+| "conference" -> Ok Conference
+| "seminar" -> Ok Seminar
+| "hackathon" -> Ok Hackathon
+| "retreat" -> Ok Retreat
+| s -> Error (`Msg ("Unknown event type: " ^ s))
+
+let event_type_of_yaml = function
+| `String s -> event_type_of_string s
+| _ -> Error (`Msg "Expected a string for difficulty type")
+
+type location = [%import: Data_intf.Event.location] [@@deriving of_yaml, show]
+
+type recurring_event = [%import: Data_intf.Event.recurring_event] [@@deriving of_yaml, show]
+
+type utc_datetime = [%import: Data_intf.Event.utc_datetime] [@@deriving of_yaml, show]
+
+type t = [%import: Data_intf.Event.t] [@@deriving show]
 
 let recurring_event_all () : recurring_event list =
   Utils.yaml_sequence_file recurring_event_of_yaml "events/recurring.yml"

--- a/tool/ood-gen/lib/exercise.ml
+++ b/tool/ood-gen/lib/exercise.ml
@@ -1,4 +1,16 @@
-open Data_intf.Exercise
+type difficulty = [%import: Data_intf.Exercise.difficulty] [@@deriving show]
+
+let of_string = function
+| "beginner" -> Ok Beginner
+| "intermediate" -> Ok Intermediate
+| "advanced" -> Ok Advanced
+| s -> Error (`Msg ("Unknown difficulty type: " ^ s))
+
+let difficulty_of_yaml = function
+| `String s -> of_string s
+| _ -> Error (`Msg "Expected a string for difficulty type")
+
+type t = [%import: Data_intf.Exercise.t] [@@deriving show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/exercise.ml
+++ b/tool/ood-gen/lib/exercise.ml
@@ -1,14 +1,14 @@
 type difficulty = [%import: Data_intf.Exercise.difficulty] [@@deriving show]
 
 let of_string = function
-| "beginner" -> Ok Beginner
-| "intermediate" -> Ok Intermediate
-| "advanced" -> Ok Advanced
-| s -> Error (`Msg ("Unknown difficulty type: " ^ s))
+  | "beginner" -> Ok Beginner
+  | "intermediate" -> Ok Intermediate
+  | "advanced" -> Ok Advanced
+  | s -> Error (`Msg ("Unknown difficulty type: " ^ s))
 
 let difficulty_of_yaml = function
-| `String s -> of_string s
-| _ -> Error (`Msg "Expected a string for difficulty type")
+  | `String s -> of_string s
+  | _ -> Error (`Msg "Expected a string for difficulty type")
 
 type t = [%import: Data_intf.Exercise.t] [@@deriving show]
 

--- a/tool/ood-gen/lib/governance.ml
+++ b/tool/ood-gen/lib/governance.ml
@@ -1,5 +1,36 @@
 open Ocamlorg.Import
-open Data_intf.Governance
+
+type member = [%import: Data_intf.Governance.member] [@@deriving of_yaml, show]
+
+type contact_kind = [%import: Data_intf.Governance.contact_kind]
+[@@deriving show]
+
+let contact_kind_of_yaml = function
+  | `String "github" -> Ok GitHub
+  | `String "email" -> Ok Email
+  | `String "discord" -> Ok Discord
+  | `String "chat" -> Ok Chat
+  | x -> (
+      match Yaml.to_string x with
+      | Ok str ->
+          Error
+            (`Msg
+              ("\"" ^ str
+             ^ "\" is not a valid contact_kind! valid options are: github, \
+                email, discord, chat"))
+      | Error _ -> Error (`Msg "Invalid Yaml value"))
+
+let contact_kind_to_yaml = function
+  | GitHub -> `String "github"
+  | Email -> `String "email"
+  | Discord -> `String "discord"
+  | Chat -> `String "chat"
+
+type contact = [%import: Data_intf.Governance.contact]
+[@@deriving of_yaml, show]
+
+type dev_meeting = [%import: Data_intf.Governance.dev_meeting]
+[@@deriving of_yaml, show]
 
 type team_metadata = {
   id : string;
@@ -7,13 +38,16 @@ type team_metadata = {
   description : string;
   contacts : contact list;
   dev_meeting : dev_meeting option; [@default None] [@key "dev-meeting"]
-  members : Member.t list; [@default []]
+  members : member list; [@default []]
   subteams : team_metadata list; [@default []]
 }
-[@@deriving of_yaml, stable_record ~version:team]
+[@@deriving of_yaml, stable_record ~version:Data_intf.Governance.team]
 
 let team_of_yaml yml =
-  yml |> team_metadata_of_yaml |> Result.map team_metadata_to_team
+  yml |> team_metadata_of_yaml
+  |> Result.map team_metadata_to_Data_intf_Governance_team
+
+type team = [%import: Data_intf.Governance.team] [@@deriving show]
 
 type metadata = {
   teams : team list;

--- a/tool/ood-gen/lib/industrial_user.ml
+++ b/tool/ood-gen/lib/industrial_user.ml
@@ -1,4 +1,4 @@
-open Data_intf.Industrial_user
+type t = [%import: Data_intf.Industrial_user.t] [@@deriving show]
 
 type metadata = {
   name : string;

--- a/tool/ood-gen/lib/is_ocaml_yet.ml
+++ b/tool/ood-gen/lib/is_ocaml_yet.ml
@@ -1,4 +1,7 @@
-open Data_intf.Is_ocaml_yet
+type external_package = [%import: Data_intf.Is_ocaml_yet.external_package] [@@deriving of_yaml, show]
+type package = [%import: Data_intf.Is_ocaml_yet.package] [@@deriving of_yaml, show]
+type category = [%import: Data_intf.Is_ocaml_yet.category] [@@deriving show]
+type t = [%import: Data_intf.Is_ocaml_yet.t] [@@deriving show]
 
 type category_meta = {
   name : string;

--- a/tool/ood-gen/lib/is_ocaml_yet.ml
+++ b/tool/ood-gen/lib/is_ocaml_yet.ml
@@ -1,5 +1,9 @@
-type external_package = [%import: Data_intf.Is_ocaml_yet.external_package] [@@deriving of_yaml, show]
-type package = [%import: Data_intf.Is_ocaml_yet.package] [@@deriving of_yaml, show]
+type external_package = [%import: Data_intf.Is_ocaml_yet.external_package]
+[@@deriving of_yaml, show]
+
+type package = [%import: Data_intf.Is_ocaml_yet.package]
+[@@deriving of_yaml, show]
+
 type category = [%import: Data_intf.Is_ocaml_yet.category] [@@deriving show]
 type t = [%import: Data_intf.Is_ocaml_yet.t] [@@deriving show]
 

--- a/tool/ood-gen/lib/job.ml
+++ b/tool/ood-gen/lib/job.ml
@@ -1,4 +1,4 @@
-open Data_intf.Job
+type t = [%import: Data_intf.Job.t] [@@deriving of_yaml, show]
 
 let all () =
   let job_date j = Option.value ~default:"1970-01-01" j.publication_date in

--- a/tool/ood-gen/lib/news.ml
+++ b/tool/ood-gen/lib/news.ml
@@ -1,4 +1,4 @@
-open Data_intf.News
+type t = [%import: Data_intf.News.t] [@@deriving show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/opam_user.ml
+++ b/tool/ood-gen/lib/opam_user.ml
@@ -1,4 +1,4 @@
-open Data_intf.Opam_user
+type t = [%import: Data_intf.Opam_user.t] [@@deriving of_yaml, show]
 
 let all () = Utils.yaml_sequence_file of_yaml "opam-users.yml"
 

--- a/tool/ood-gen/lib/outreachy.ml
+++ b/tool/ood-gen/lib/outreachy.ml
@@ -1,4 +1,5 @@
-open Data_intf.Outreachy
+type project = [%import: Data_intf.Outreachy.project] [@@deriving of_yaml, show]
+type t = [%import: Data_intf.Outreachy.t] [@@deriving of_yaml, show]
 
 let modify_project (p : project) =
   {

--- a/tool/ood-gen/lib/page.ml
+++ b/tool/ood-gen/lib/page.ml
@@ -1,4 +1,4 @@
-open Data_intf.Page
+type t = [%import: Data_intf.Page.t] [@@deriving show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/paper.ml
+++ b/tool/ood-gen/lib/paper.ml
@@ -1,4 +1,5 @@
-open Data_intf.Paper
+type link = [%import: Data_intf.Paper.link] [@@deriving of_yaml, show]
+type t = [%import: Data_intf.Paper.t] [@@deriving show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -1,9 +1,15 @@
 open Ocamlorg.Import
-open Data_intf.Planet
+
+type entry = BlogPost of Blog.post | Video of Vid.t
+[@@deriving show { with_path = false }]
+
+let date_of_post = function
+  | BlogPost { date; _ } -> date
+  | Video { published; _ } -> published
 
 let all () =
   let external_posts =
-    Blog.Post.all () |> List.map (fun (p : Data_intf.Blog.post) -> BlogPost p)
+    Blog.Post.all () |> List.map (fun (p : Blog.post) -> BlogPost p)
   in
   let videos =
     Video.all () |> List.map (fun (v : Data_intf.Video.t) -> Video v)
@@ -99,7 +105,7 @@ module GlobalFeed = struct
              ~content:(Syndic.Atom.Html (None, content))
              ())
 
-  let entry_of_post (post : Data_intf.Blog.post) =
+  let entry_of_post (post : Blog.post) =
     let content = Syndic.Atom.Html (None, post.body_html) in
     let url = Uri.of_string post.source.url in
     let source : Syndic.Atom.source =

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -3,7 +3,7 @@ open Data_intf.Planet
 
 let all () =
   let external_posts =
-    Blog.Post.all () |> List.map (fun (p : Data_intf.Blog.Post.t) -> BlogPost p)
+    Blog.Post.all () |> List.map (fun (p : Data_intf.Blog.post) -> BlogPost p)
   in
   let videos =
     Video.all () |> List.map (fun (v : Data_intf.Video.t) -> Video v)
@@ -99,7 +99,7 @@ module GlobalFeed = struct
              ~content:(Syndic.Atom.Html (None, content))
              ())
 
-  let entry_of_post (post : Data_intf.Blog.Post.t) =
+  let entry_of_post (post : Data_intf.Blog.post) =
     let content = Syndic.Atom.Html (None, post.body_html) in
     let url = Uri.of_string post.source.url in
     let source : Syndic.Atom.source =

--- a/tool/ood-gen/lib/release.ml
+++ b/tool/ood-gen/lib/release.ml
@@ -1,4 +1,14 @@
-open Data_intf.Release
+type kind = [%import: Data_intf.Release.kind] [@@deriving show]
+
+let kind_of_string = function
+  | "compiler" -> Ok `Compiler
+  | s -> Error (`Msg ("Unknown release type: " ^ s))
+
+let kind_of_yaml = function
+  | `String s -> kind_of_string s
+  | _ -> Error (`Msg "Expected a string for release type")
+
+type t = [%import: Data_intf.Release.t] [@@deriving show]
 
 type metadata = {
   kind : kind;

--- a/tool/ood-gen/lib/resource.ml
+++ b/tool/ood-gen/lib/resource.ml
@@ -1,4 +1,4 @@
-open Data_intf.Resource
+type t = [%import: Data_intf.Resource.t] [@@deriving of_yaml, show]
 
 let all () = Utils.yaml_sequence_file of_yaml "resources.yml"
 

--- a/tool/ood-gen/lib/success_story.ml
+++ b/tool/ood-gen/lib/success_story.ml
@@ -1,4 +1,4 @@
-open Data_intf.Success_story
+type t = [%import: Data_intf.Success_story.t] [@@deriving show]
 
 type metadata = {
   title : string;

--- a/tool/ood-gen/lib/testimonial.ml
+++ b/tool/ood-gen/lib/testimonial.ml
@@ -1,4 +1,4 @@
-open Data_intf.Testimonial
+type t = [%import: Data_intf.Testimonial.t] [@@deriving of_yaml, show]
 
 let all () = Utils.yaml_sequence_file of_yaml "testimonials.yml"
 

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -1,4 +1,17 @@
-open Data_intf.Tool
+type lifecycle = [%import: Data_intf.Tool.lifecycle] [@@deriving show]
+
+let lifecycle_of_string = function
+| "incubate" -> Ok `Incubate
+| "active" -> Ok `Active
+| "sustain" -> Ok `Sustain
+| "deprecate" -> Ok `Deprecate
+| s -> Error (`Msg ("Unknown lifecycle type: " ^ s))
+
+let lifecycle_of_yaml = function
+| `String s -> lifecycle_of_string s
+| _ -> Error (`Msg "Expected a string for lifecycle type")
+
+type t = [%import: Data_intf.Tool.t] [@@deriving show]
 
 type metadata = {
   name : string;

--- a/tool/ood-gen/lib/tool.ml
+++ b/tool/ood-gen/lib/tool.ml
@@ -1,15 +1,15 @@
 type lifecycle = [%import: Data_intf.Tool.lifecycle] [@@deriving show]
 
 let lifecycle_of_string = function
-| "incubate" -> Ok `Incubate
-| "active" -> Ok `Active
-| "sustain" -> Ok `Sustain
-| "deprecate" -> Ok `Deprecate
-| s -> Error (`Msg ("Unknown lifecycle type: " ^ s))
+  | "incubate" -> Ok `Incubate
+  | "active" -> Ok `Active
+  | "sustain" -> Ok `Sustain
+  | "deprecate" -> Ok `Deprecate
+  | s -> Error (`Msg ("Unknown lifecycle type: " ^ s))
 
 let lifecycle_of_yaml = function
-| `String s -> lifecycle_of_string s
-| _ -> Error (`Msg "Expected a string for lifecycle type")
+  | `String s -> lifecycle_of_string s
+  | _ -> Error (`Msg "Expected a string for lifecycle type")
 
 type t = [%import: Data_intf.Tool.t] [@@deriving show]
 

--- a/tool/ood-gen/lib/tool_page.ml
+++ b/tool/ood-gen/lib/tool_page.ml
@@ -1,5 +1,7 @@
 open Ocamlorg.Import
-open Data_intf.Tool_page
+type toc = [%import: Data_intf.Tool_page.toc] [@@deriving of_yaml, show]
+type contribute_link = [%import: Data_intf.Tool_page.contribute_link] [@@deriving of_yaml, show]
+type t = [%import: Data_intf.Tool_page.t] [@@deriving show]
 
 type metadata = {
   id : string;

--- a/tool/ood-gen/lib/tool_page.ml
+++ b/tool/ood-gen/lib/tool_page.ml
@@ -1,6 +1,10 @@
 open Ocamlorg.Import
+
 type toc = [%import: Data_intf.Tool_page.toc] [@@deriving of_yaml, show]
-type contribute_link = [%import: Data_intf.Tool_page.contribute_link] [@@deriving of_yaml, show]
+
+type contribute_link = [%import: Data_intf.Tool_page.contribute_link]
+[@@deriving of_yaml, show]
+
 type t = [%import: Data_intf.Tool_page.t] [@@deriving show]
 
 type metadata = {

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -1,5 +1,25 @@
 open Ocamlorg.Import
-open Data_intf.Tutorial
+
+type section = [%import: Data_intf.Tutorial.section] [@@deriving show]
+
+let section_of_string = function
+| "getting-started" -> Ok GetStarted
+| "language" -> Ok Language
+| "platform" -> Ok Platform
+| "guides" -> Ok Guides
+| s -> Error (`Msg ("Unknown section: " ^ s))
+
+type toc = [%import: Data_intf.Tutorial.toc] [@@deriving show]
+
+type contribute_link = [%import: Data_intf.Tutorial.contribute_link] [@@deriving of_yaml, show]
+type banner = [%import: Data_intf.Tutorial.banner] [@@deriving of_yaml, show]
+
+type external_tutorial = [%import: Data_intf.Tutorial.external_tutorial] [@@deriving of_yaml, show]
+type recommended_next_tutorials = [%import: Data_intf.Tutorial.recommended_next_tutorials] [@@deriving of_yaml, show]
+type prerequisite_tutorials = [%import: Data_intf.Tutorial.prerequisite_tutorials] [@@deriving of_yaml, show]
+type search_document_section = [%import: Data_intf.Tutorial.search_document_section] [@@deriving of_yaml, show]
+type search_document = [%import: Data_intf.Tutorial.search_document] [@@deriving show]
+type t = [%import: Data_intf.Tutorial.t] [@@deriving show]
 
 type metadata = {
   id : string;
@@ -55,7 +75,7 @@ let decode (fpath, (head, body_md)) =
   in
   let section =
     List.nth (String.split_on_char '/' fpath) 1
-    |> Section.of_string
+    |> section_of_string
     |> Result.get_ok ~error:(fun (`Msg msg) ->
            Exn.Decode_error (fpath ^ ":" ^ msg))
   in

--- a/tool/ood-gen/lib/tutorial.ml
+++ b/tool/ood-gen/lib/tutorial.ml
@@ -3,22 +3,37 @@ open Ocamlorg.Import
 type section = [%import: Data_intf.Tutorial.section] [@@deriving show]
 
 let section_of_string = function
-| "getting-started" -> Ok GetStarted
-| "language" -> Ok Language
-| "platform" -> Ok Platform
-| "guides" -> Ok Guides
-| s -> Error (`Msg ("Unknown section: " ^ s))
+  | "getting-started" -> Ok GetStarted
+  | "language" -> Ok Language
+  | "platform" -> Ok Platform
+  | "guides" -> Ok Guides
+  | s -> Error (`Msg ("Unknown section: " ^ s))
 
 type toc = [%import: Data_intf.Tutorial.toc] [@@deriving show]
 
-type contribute_link = [%import: Data_intf.Tutorial.contribute_link] [@@deriving of_yaml, show]
+type contribute_link = [%import: Data_intf.Tutorial.contribute_link]
+[@@deriving of_yaml, show]
+
 type banner = [%import: Data_intf.Tutorial.banner] [@@deriving of_yaml, show]
 
-type external_tutorial = [%import: Data_intf.Tutorial.external_tutorial] [@@deriving of_yaml, show]
-type recommended_next_tutorials = [%import: Data_intf.Tutorial.recommended_next_tutorials] [@@deriving of_yaml, show]
-type prerequisite_tutorials = [%import: Data_intf.Tutorial.prerequisite_tutorials] [@@deriving of_yaml, show]
-type search_document_section = [%import: Data_intf.Tutorial.search_document_section] [@@deriving of_yaml, show]
-type search_document = [%import: Data_intf.Tutorial.search_document] [@@deriving show]
+type external_tutorial = [%import: Data_intf.Tutorial.external_tutorial]
+[@@deriving of_yaml, show]
+
+type recommended_next_tutorials =
+  [%import: Data_intf.Tutorial.recommended_next_tutorials]
+[@@deriving of_yaml, show]
+
+type prerequisite_tutorials =
+  [%import: Data_intf.Tutorial.prerequisite_tutorials]
+[@@deriving of_yaml, show]
+
+type search_document_section =
+  [%import: Data_intf.Tutorial.search_document_section]
+[@@deriving of_yaml, show]
+
+type search_document = [%import: Data_intf.Tutorial.search_document]
+[@@deriving show]
+
 type t = [%import: Data_intf.Tutorial.t] [@@deriving show]
 
 type metadata = {

--- a/tool/ood-gen/lib/vid.ml
+++ b/tool/ood-gen/lib/vid.ml
@@ -1,0 +1,2 @@
+type t = [%import: Data_intf.Video.t] [@@deriving yaml, show]
+type video_list = t list [@@deriving yaml, show]

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -1,7 +1,3 @@
-open Data_intf.Video
-
-type video_list = t list [@@deriving show]
-
 let all () = Youtube.all () @ Watch.all ()
 
 let template () =
@@ -9,7 +5,7 @@ let template () =
 include Data_intf.Video
 let all =%a
 |ocaml}
-    pp_video_list (all ())
+    Vid.pp_video_list (all ())
 
 let scrape () =
   Youtube.scrape "data/video-youtube.yml";

--- a/tool/ood-gen/lib/video.ml
+++ b/tool/ood-gen/lib/video.ml
@@ -1,6 +1,6 @@
 open Data_intf.Video
 
-type video_list = t list [@@deriving yaml, show]
+type video_list = t list [@@deriving show]
 
 let all () = Youtube.all () @ Watch.all ()
 

--- a/tool/ood-gen/lib/watch.ml
+++ b/tool/ood-gen/lib/watch.ml
@@ -1,7 +1,7 @@
 open Ocamlorg.Import
 open Data_intf.Video
 
-type video_list = t list [@@deriving yaml, show]
+type video_list = t list [@@deriving yaml]
 
 let all () =
   let ( let* ) = Result.bind in

--- a/tool/ood-gen/lib/watch.ml
+++ b/tool/ood-gen/lib/watch.ml
@@ -1,14 +1,11 @@
 open Ocamlorg.Import
-open Data_intf.Video
-
-type video_list = t list [@@deriving yaml]
 
 let all () =
   let ( let* ) = Result.bind in
   let videos =
     let file = "video-watch.yml" in
     let* yaml = Utils.yaml_file file in
-    yaml |> video_list_of_yaml |> Result.map_error (Utils.where file)
+    yaml |> Vid.video_list_of_yaml |> Result.map_error (Utils.where file)
   in
   Result.get_ok ~error:(fun (`Msg msg) -> Exn.Decode_error msg) videos
 
@@ -28,7 +25,7 @@ let get_string_or_none = function `String s -> s | _ -> ""
 
 let of_json json =
   {
-    title = Ezjsonm.find json [ "name" ] |> Ezjsonm.get_string;
+    Vid.title = Ezjsonm.find json [ "name" ] |> Ezjsonm.get_string;
     description = Ezjsonm.find json [ "description" ] |> get_string_or_none;
     url = Ezjsonm.find json [ "url" ] |> Ezjsonm.get_string;
     thumbnail =
@@ -44,7 +41,7 @@ let of_json json =
 let watch_to_yaml t =
   `O
     [
-      ("title", `String t.title);
+      ("title", `String t.Vid.title);
       ("description", `String t.description);
       ("url", `String t.url);
       ("thumbnail", `String t.thumbnail);
@@ -92,7 +89,7 @@ let get_all_videos () =
 let scrape yaml_file =
   let watch =
     get_all_videos ()
-    |> List.stable_sort (fun w1 w2 -> String.compare w1.title w2.title)
+    |> List.stable_sort (fun w1 w2 -> String.compare w1.Vid.title w2.Vid.title)
   in
   let yaml = to_yaml watch in
   let output =

--- a/tool/ood-gen/lib/youtube.ml
+++ b/tool/ood-gen/lib/youtube.ml
@@ -1,8 +1,7 @@
 open Ocamlorg.Import
-open Data_intf.Video
 
 let to_yaml video =
-  match to_yaml video with
+  match Vid.to_yaml video with
   | `O u -> `O (List.filter (( <> ) ("description", `String "")) u)
   | x -> x
 
@@ -12,7 +11,8 @@ let add_key_default k v = function
       `O ((k, v) :: u)
   | x -> x
 
-let of_yaml yml = yml |> add_key_default "description" (`String "") |> of_yaml
+let of_yaml yml =
+  yml |> add_key_default "description" (`String "") |> Vid.of_yaml
 
 type kind = Playlist | Channel
 
@@ -52,8 +52,6 @@ let source_to_url { kind; id; _ } =
 
 let source_to_id { kind; id; _ } =
   Printf.sprintf "yt:%s:%s" (kind_to_string kind) id
-
-type video_list = t list [@@deriving yaml]
 
 type tag =
   | Entry
@@ -116,7 +114,7 @@ let video_opt source = function
       Some author_uri ) ->
       Some
         {
-          title;
+          Vid.title;
           url;
           thumbnail;
           description;
@@ -155,14 +153,14 @@ let all () =
   let videos =
     let file = "video-youtube.yml" in
     let* yaml = Utils.yaml_file file in
-    yaml |> video_list_of_yaml |> Result.map_error (Utils.where file)
+    yaml |> Vid.video_list_of_yaml |> Result.map_error (Utils.where file)
   in
   Result.get_ok ~error:(fun (`Msg msg) -> Exn.Decode_error msg) videos
 
 module VideoSet = Set.Make (struct
-  type nonrec t = t
+  type nonrec t = Vid.t
 
-  let compare a b = compare a.url b.url
+  let compare a b = compare a.Vid.url b.Vid.url
 end)
 
 let scrape yaml_file =
@@ -183,8 +181,8 @@ let scrape yaml_file =
            |> Seq.filter (fun video ->
                   (not src.only_ocaml)
                   || String.(
-                       is_sub_ignore_case "ocaml" video.title
-                       || is_sub_ignore_case "ocaml" video.description)))
+                       is_sub_ignore_case "ocaml" video.Vid.title
+                       || is_sub_ignore_case "ocaml" video.Vid.description)))
     |> VideoSet.of_seq |> Result.ok
   in
   match fetched with
@@ -192,8 +190,8 @@ let scrape yaml_file =
       let yaml =
         VideoSet.union fetched scraped
         |> VideoSet.to_seq |> List.of_seq
-        |> List.sort (fun a b -> compare b.published a.published)
-        |> video_list_to_yaml
+        |> List.sort (fun a b -> compare b.Vid.published a.Vid.published)
+        |> Vid.video_list_to_yaml
       in
       let output =
         Yaml.pp Format.str_formatter yaml;

--- a/tool/ood-gen/lib/youtube.ml
+++ b/tool/ood-gen/lib/youtube.ml
@@ -53,7 +53,7 @@ let source_to_url { kind; id; _ } =
 let source_to_id { kind; id; _ } =
   Printf.sprintf "yt:%s:%s" (kind_to_string kind) id
 
-type video_list = t list [@@deriving yaml, show]
+type video_list = t list [@@deriving yaml]
 
 type tag =
   | Entry


### PR DESCRIPTION
Move `@@deriving` attributes from `Data_intf` to ood/lib files

Module `Data_intf` does not need to expose Yaml parsing or
pp/show functions at runtime. This is only used when crunching
the data. Types are duplicated in ood using `ppx_import` and
 `ppx_deriving` is applied to those definitions. 

Staged preprocessing is used.