### PR TITLE
feat: enable linking to YouTube videos from conferences pages

### DIFF
--- a/data/conferences/2012-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2012-ocaml-users-and-developers-workshop.md
@@ -19,31 +19,31 @@ presentations:
   - title: Presenting Core
     authors: 
       - Yaron Minsky
-    video: https://watch.ocaml.org/videos/watch/3159e115-948e-4f67-9d45-403bef003c35
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/3159e115-948e-4f67-9d45-403bef003c35
   - title: 'Ocsigen/Eliom: The state of the art, and the prospects'
     authors: 
       - Benedikt Becker
       - Vincent Balat
-    video: https://watch.ocaml.org/videos/watch/d010b30f-61d5-4d70-b10a-518a7a6e1e3f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/d010b30f-61d5-4d70-b10a-518a7a6e1e3f
   - title: Experiments in Generic Programming
     authors: 
       - Pierre Chambart
       - Grégoire Henry
-    video: https://watch.ocaml.org/videos/watch/5ae26b10-9a5d-4395-89c6-a2e28e68d206
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/5ae26b10-9a5d-4395-89c6-a2e28e68d206
   - title: Async
     authors: 
       - Mark Shinwell
       - David House
-    video: https://watch.ocaml.org/videos/watch/8f50211a-1210-4849-a940-ea6e0bd1e022
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/8f50211a-1210-4849-a940-ea6e0bd1e022
   - title: OCamlCC -- Raising Low-Level Bytecode to High-Level C
     authors: 
       - Michel Mauny
       - Benoit Vaugon
-    video: https://watch.ocaml.org/videos/watch/c31ec9fa-7c65-46f5-bbc9-77c6ac87bf0b
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c31ec9fa-7c65-46f5-bbc9-77c6ac87bf0b
   - title: The State of OCaml
     authors: 
       - Xavier Leroy
-    video: https://watch.ocaml.org/videos/watch/b04b10c1-b924-4f58-8aa9-4527dcc11d8a
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/b04b10c1-b924-4f58-8aa9-4527dcc11d8a
   - title: 'OCamlPro: promoting OCaml use in industry'
     authors: 
       - Fabrice le Fessant
@@ -51,51 +51,51 @@ presentations:
   - title: Towards an OCaml Platform 
     authors: 
       - Yaron Minsky
-    video: https://watch.ocaml.org/videos/watch/96b1ab00-94a8-4059-aec6-a06a9c73c736
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/96b1ab00-94a8-4059-aec6-a06a9c73c736
   - title: 'OPAM: an OCaml Package Manager'
     authors: 
       - Frederic Tuong
       - Fabrice le Fessant
       - Thomas Gazagnaire
-    video: https://watch.ocaml.org/videos/watch/96b1ab00-94a8-4059-aec6-a06a9c73c736
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/96b1ab00-94a8-4059-aec6-a06a9c73c736
   - title: An LLVM Backend for OCaml
     authors: 
       - Colin Benner
-    video: https://watch.ocaml.org/videos/watch/3ede0b76-e250-4a43-af42-83c394cf4497
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/3ede0b76-e250-4a43-af42-83c394cf4497
   - title: 'DragonKit: an extensible language oriented compiler'
     authors: 
       - Wojciech Meyer
-    video: https://watch.ocaml.org/videos/watch/8326a03e-02d5-4b32-8789-b7a76c30cf95
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/8326a03e-02d5-4b32-8789-b7a76c30cf95
   - title: Programming the Xen cloud using OCaml 
     authors: 
       - David Scott
       - Richard Mortier
       - Anil Madhavapeddy
-    video: https://watch.ocaml.org/videos/watch/360f8fe3-3268-44da-a0c4-b37c26aa7e36
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/360f8fe3-3268-44da-a0c4-b37c26aa7e36
   - title: 'Arakoon: a consistent distributed key value store'
     authors: 
       - Romain Slootmaekers
       - Nicolas Trangez
-    video: https://watch.ocaml.org/videos/watch/5309b701-9def-47a4-8240-8a5b17a70b5a
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/5309b701-9def-47a4-8240-8a5b17a70b5a
   - title: 'gloc: Metaprogramming WebGL Shaders with OCaml'
     authors: 
       - David Sheets
-    video: https://watch.ocaml.org/videos/watch/41ca2c8d-2238-44ca-8744-70f114fbd326
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/41ca2c8d-2238-44ca-8744-70f114fbd326
   - title: Real-world debugging in OCaml  
     authors: 
       - Mark Shinwell
-    video: https://watch.ocaml.org/videos/watch/a8f4cf6b-9971-484b-ab5b-34a16fde1185
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/a8f4cf6b-9971-484b-ab5b-34a16fde1185
   - title: OCaml Companion Tools
     authors: 
       - Xavier Clerc
-    video: https://watch.ocaml.org/videos/watch/4583b254-82f9-4176-9f39-2bc0bb6a9c22
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/4583b254-82f9-4176-9f39-2bc0bb6a9c22
   - title: Study of OCaml programs' memory behavior
     authors: 
       - Çagdas Bozman
       - Thomas Gazagnaire
       - Fabrice Le Fessant
       - Michel Mauny
-    video: https://watch.ocaml.org/videos/watch/180ee1ea-6fa8-4dba-aa69-e3901cc3147f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/180ee1ea-6fa8-4dba-aa69-e3901cc3147f
   - title: Implementing an interval computation library for OCaml
     authors: 
       - Jean-Marc Alliot
@@ -103,11 +103,11 @@ presentations:
       - Jean-Baptiste Gotteland
       - Nicolas Durand
       - David Gianazza
-    video: https://watch.ocaml.org/videos/watch/e228951b-f544-4bd6-892a-2aca7e2065f9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/e228951b-f544-4bd6-892a-2aca7e2065f9
   - title: Automatic Analysis of Industrial Robot Programs
     authors: 
       - Markus Weißmann
-    video: https://watch.ocaml.org/videos/watch/3cebba55-4032-4de5-93b5-8f3f67c04736
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/3cebba55-4032-4de5-93b5-8f3f67c04736
   - title: 'Biocaml: The OCaml Bioinformatics Library'
     authors: 
       - Ashish Agarwal
@@ -115,7 +115,7 @@ presentations:
       - Philippe Veber
       - Christophe Troestler
       - Francois Berenger
-    video: https://watch.ocaml.org/videos/watch/f9ce30b3-8143-4516-85f1-07c28f6337b2
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/f9ce30b3-8143-4516-85f1-07c28f6337b2
 organising_committee: []
 program_committee: 
 

--- a/data/conferences/2014-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2014-ocaml-users-and-developers-workshop.md
@@ -30,28 +30,28 @@ presentations:
       - Stephen Dolan
       - Leo White
       - Anil Madhavapeddy
-    video: https://watch.ocaml.org/videos/watch/490b5363-01b6-45d8-9b7e-c883a20026a1
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/490b5363-01b6-45d8-9b7e-c883a20026a1
   - title: Ephemerons meet OCaml GC
     authors:
       - François Bobot 
-    video: https://watch.ocaml.org/videos/watch/556c8f75-b456-43a3-b9cb-97ae35b82072
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/556c8f75-b456-43a3-b9cb-97ae35b82072
   - title: Introduction to 0install
     authors:
       - Thomas Leonard
-    video: https://watch.ocaml.org/videos/watch/21a21c83-a35d-4c09-b13c-8f060590c45c
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/21a21c83-a35d-4c09-b13c-8f060590c45c
   - title: Transport Layer Security purely in OCaml 
     authors:
       - Hannes Mehnert
       - David Kaloper Meršinjak
-    video: https://watch.ocaml.org/videos/watch/03721258-b275-4c98-8a0b-9e4606b32fec
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/03721258-b275-4c98-8a0b-9e4606b32fec
   - title: 'OCamlOScope: a New OCaml API Search'
     authors:
       - Jun Furuse 
-    video: https://watch.ocaml.org/videos/watch/c3e3cf25-0fa7-46ad-b0bf-f313bad7142d
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c3e3cf25-0fa7-46ad-b0bf-f313bad7142d
   - title: The State of OCaml (invited)
     authors:
       - Xavier Leroy
-    video: https://watch.ocaml.org/videos/watch/11844424-be9b-4427-b3dd-24c3e4ff85a9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/11844424-be9b-4427-b3dd-24c3e4ff85a9
   - title: The OCaml Platform v1.0
     authors:
       - Anil Madhavapeddy 
@@ -64,22 +64,22 @@ presentations:
       - Mark Shinwell
       - Leo White
       - Jeremy Yallop
-    video: https://watch.ocaml.org/videos/watch/37eaef0e-d826-4452-bf84-f04244a85ce9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/37eaef0e-d826-4452-bf84-f04244a85ce9
   - title: A Proposal for Non-Intrusive Namespaces in OCaml
     authors:
       - Pierrick Couderc
       - Fabrice Le Fessant
       - Benjamin Canou
       - Pierre Chambart
-    video: https://watch.ocaml.org/videos/watch/ded6e8bb-aebd-4fd2-989f-3f0b2b8efaf3
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/ded6e8bb-aebd-4fd2-989f-3f0b2b8efaf3
   - title: Improving Type Error Messages in OCaml
     authors:
       - Arthur Charguéraud 
-    video: https://watch.ocaml.org/videos/watch/9fa54aee-6b2f-492f-abbe-51affc07ec24
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/9fa54aee-6b2f-492f-abbe-51affc07ec24
   - title: 'Github Pull Requests for OCaml development: a field report'
     authors:
       - Gabriel Scherer
-    video: https://watch.ocaml.org/videos/watch/f0021d24-9104-4672-a363-de5c1c514c2e
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/f0021d24-9104-4672-a363-de5c1c514c2e
   - title: Irminsule; a branch-consistent distributed library database
     authors:
       - Thomas Gazagnaire 
@@ -90,29 +90,29 @@ presentations:
       - David Sheets
       - Gregory Tsipenyuk 
       - Jon Crowcroft
-    video: https://watch.ocaml.org/videos/watch/5546bb89-93a3-4407-a810-2d437479025f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/5546bb89-93a3-4407-a810-2d437479025f
   - title: A Case for Multi-Switch Constraints in OPAM
     authors:
       - Fabrice Le Fessant
-    video: https://watch.ocaml.org/videos/watch/744d4a0b-a44c-4040-853c-6be5223ec43b
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/744d4a0b-a44c-4040-853c-6be5223ec43b
   - title: 'LibreS3: design, challenges, and steps toward reusable libraries'
     authors:
       - Edwin Török
-    video: https://watch.ocaml.org/videos/watch/c1b00980-3a4f-4222-b539-392815f7954f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c1b00980-3a4f-4222-b539-392815f7954f
   - title: Nullable Type Inference
     authors:
       - Michel Mauny
       - Benoit Vaugon
-    video: https://watch.ocaml.org/videos/watch/380b1c2e-6298-49fc-88a1-c440ece29c76
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/380b1c2e-6298-49fc-88a1-c440ece29c76
   - title: Coq of OCaml
     authors:
       - Guillaume Claret
-    video: https://watch.ocaml.org/videos/watch/fc7201df-ec27-4735-a51d-d3170d390346
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/fc7201df-ec27-4735-a51d-d3170d390346
   - title: High Performance Client-Side Web Programming with SPOC and Js of ocaml
     authors:
       - Mathias Bourgoin
       - Emmmanuel Chailloux 
-    video: https://watch.ocaml.org/videos/watch/9e68174a-5c92-41f1-abdf-387a6cca7cf1
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/9e68174a-5c92-41f1-abdf-387a6cca7cf1
   - title: Using Preferences to Tame your Package Manager
     authors:
       - Roberto Di Cosmo
@@ -120,11 +120,11 @@ presentations:
       - Stefano Zacchiroli
       - Fabrice Le Fessant 
       - Louis Gesbert
-    video: https://watch.ocaml.org/videos/watch/43536918-a6e5-4a53-a680-bed527319e31
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/43536918-a6e5-4a53-a680-bed527319e31
   - title: Simple, efficient, sound-and-complete combinator parsing for all context-free grammars, using an oracle
     authors:
       - Tom Ridge
-    video: https://watch.ocaml.org/videos/watch/7a0a6d3c-dad0-4fe8-9c35-78cbfbd431d9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/7a0a6d3c-dad0-4fe8-9c35-78cbfbd431d9
 organising_committee: []
 program_committee: 
   - name: Esther Baruk

--- a/data/conferences/2015-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2015-ocaml-users-and-developers-workshop.md
@@ -12,32 +12,32 @@ presentations:
     authors: 
       - Fabrice Le Fessant
       - Pierre Chambart
-    video: https://watch.ocaml.org/videos/watch/e1a22cf8-5522-4c05-a8d4-af445bc73556
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/e1a22cf8-5522-4c05-a8d4-af445bc73556
   - title: 'Operf: Benchmarking the OCaml Compiler'
     authors: 
       - Pierre Chambart
       - Fabrice Le Fessant
       - Vincent Bernardoff
-    video: https://watch.ocaml.org/videos/watch/eb229518-1108-46bd-b8b2-3ce8b886c96f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/eb229518-1108-46bd-b8b2-3ce8b886c96f
   - title: 'Core.Time_stamp_counter: A fast high resolution time source'
     authors: 
       - Roshan James
       - Christopher Hardin
-    video: https://watch.ocaml.org/videos/watch/b6c7860d-e6eb-4404-96c3-917b81ee1f98
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/b6c7860d-e6eb-4404-96c3-917b81ee1f98
   - title: Specialization of Generic Array Accesses After Inlining
     authors: 
       - Ryohei Tokuda
       - Eijiro Sumii
       - Akinori Abe
-    video: https://watch.ocaml.org/videos/watch/515689cc-4736-4e1e-9f9f-be363b4551af
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/515689cc-4736-4e1e-9f9f-be363b4551af
   - title: Inline Assembly in OCaml 
     authors: 
       - Vladimir Brankov
-    video: https://watch.ocaml.org/videos/watch/736857f3-99d9-46fb-9b4a-92eba42b2672
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/736857f3-99d9-46fb-9b4a-92eba42b2672
   - title: The State of OCaml (invited talk) 
     authors: 
       - Xavier Leroy
-    video: https://watch.ocaml.org/videos/watch/69e486cd-191d-430b-8a41-0be0f806096b
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/69e486cd-191d-430b-8a41-0be0f806096b
   - title: 'The State of the OCaml Platform: September 2015'
     authors: 
       - Anil Madhavapeddy
@@ -45,7 +45,7 @@ presentations:
       - Thomas Gazagnaire
       - Jeremy Yallop
       - David Sheets
-    video: https://watch.ocaml.org/videos/watch/0eeab9cb-8984-4323-bad7-0630192c635d
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/0eeab9cb-8984-4323-bad7-0630192c635d
   - title: Modular macros
     authors: 
       - Jeremy Yallop

--- a/data/conferences/2016-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2016-ocaml-users-and-developers-workshop.md
@@ -14,41 +14,41 @@ presentations:
     authors: 
       - Hannes Mehnert 
       - Louis Gesbert
-    video: https://watch.ocaml.org/videos/watch/70fbf7db-28dc-4798-b068-460b5d93df4e
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/70fbf7db-28dc-4798-b068-460b5d93df4e
   - title: Generic Programming in OCaml
     authors:
       - Florent Balestrieri
       - Michel Mauny
-    video: https://watch.ocaml.org/videos/watch/0aae98b9-3d0c-427b-af09-802b671dd66e
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/0aae98b9-3d0c-427b-af09-802b671dd66e
   - title: 'Improving the OCaml Web Stack: Motivations and Progress'
     authors: 
       - Spiridon Eliopoulos
-    video: https://watch.ocaml.org/videos/watch/513a2157-6844-4823-bef7-b26f3b635fbe
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/513a2157-6844-4823-bef7-b26f3b635fbe
   - title: 'Learn OCaml: An Online Learning Center for OCaml'
     authors:
       - Benjamin Canou
       - Grégoire Henry
       - Çagdas Bozman
       - Fabrice Le Fessant
-    video: https://watch.ocaml.org/videos/watch/ea643e64-2393-4c24-9ccf-7216e3ded2ce
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/ea643e64-2393-4c24-9ccf-7216e3ded2ce
   - title: Lock-free programming for the masses
     authors:
       - Kc Sivaramakrishnan
       - Theo Laurent
-    video: https://watch.ocaml.org/videos/watch/4435adfc-e97e-42c5-8bb7-1578bd76e42b
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/4435adfc-e97e-42c5-8bb7-1578bd76e42b
   - title: 'OCaml inside: a drop-in replacement for libtls'
     authors: 
       - Enguerrand Decorne
       - Jeremy Yallop
       - David Kaloper Meršinjak
-    video: https://watch.ocaml.org/videos/watch/68a11315-f7ca-4c0e-a043-98008694671d
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/68a11315-f7ca-4c0e-a043-98008694671d
   - title: 'OPAM-builder: Continuous Monitoring of OPAM Repositories'
     authors: 
       - Fabrice Le Fessant
   - title: Semantics of the Lambda intermediate language
     authors: 
       - Pierre Chambart
-    video: https://watch.ocaml.org/videos/watch/90d9b62f-f9d6-4dd5-a7fc-f584e45ef0b7
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/90d9b62f-f9d6-4dd5-a7fc-f584e45ef0b7
   - title: Statistically profiling memory in OCaml
     authors: 
       - Jacques-Henri Jourdan
@@ -57,15 +57,15 @@ presentations:
       - Timothy Bourke
       - Jun Inoue
       - Marc Pouzet
-    video: https://watch.ocaml.org/videos/watch/3a00e727-45da-4c4a-a446-927cb28bb6bc
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/3a00e727-45da-4c4a-a446-927cb28bb6bc
   - title: 'The State of the OCaml Platform: September 2016'
     authors: 
       - Louis Gesbert, on behalf of the OCaml Platform team
-    video: https://watch.ocaml.org/videos/watch/c386fc95-092e-4ea7-9317-91edf287fea6
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c386fc95-092e-4ea7-9317-91edf287fea6
   - title: "Who's got your Mail? Mr. Mime"
     authors: 
       - Romain Calascibetta
-    video: https://watch.ocaml.org/videos/watch/98a7972d-9323-46b3-81cc-dd86a4cc1ab3
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/98a7972d-9323-46b3-81cc-dd86a4cc1ab3
   - title: 'Inuit library: from printf to interactive user-interfaces'
     authors:
       - Frédéric Bour

--- a/data/conferences/2017-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2017-ocaml-users-and-developers-workshop.md
@@ -29,14 +29,14 @@ presentations:
     authors:
       - Runhang Li
       - Jeremy Yallop  
-    video: https://watch.ocaml.org/videos/watch/8d5a83f5-ad98-4f45-9259-c84194134c20
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/8d5a83f5-ad98-4f45-9259-c84194134c20
     link: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__runhang-li_jeremy-yallop__extending-ocaml-s-open.pdf
     additional_links:
       - https://github.com/objmagic/ocaml-workshop-17-open-ext-talk
   - title: "Genspio: Generating Shell Phrases In OCaml"
     authors: 
       - Sebastien Mondet  
-    video: https://watch.ocaml.org/videos/watch/9a7bf8cc-38c5-4f67-ab25-0ea1388100d3
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/9a7bf8cc-38c5-4f67-ab25-0ea1388100d3
     link: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/extended-abstract__2017__sebastien-mondet__genspio-generating-shell-phrases-in-ocaml.pdf
     slides: http://wr.mondet.org/slides/OCaml2017-Genspio/
     additional_links: 
@@ -44,7 +44,7 @@ presentations:
   - title: "Owl: A General-Purpose Numerical Library in OCaml"
     authors:  
       - Liang Wang  
-    video: https://watch.ocaml.org/videos/watch/d258fa91-ddb6-40d8-96de-e9ac97e8c899
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/d258fa91-ddb6-40d8-96de-e9ac97e8c899
     link: https://arxiv.org/abs/1707.09616
     slides: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__liang_wang__owl-a-general-purpose-numerical-library-in-ocaml.pdf
   - title: "ROTOR: First Steps Towards a Refactoring Tool for OCaml"
@@ -72,7 +72,7 @@ presentations:
   - title: "The State of the OCaml Platform: September 2017"
     authors:
       - Anil Madhavapeddy  
-    video: https://watch.ocaml.org/videos/watch/3940b98a-6b33-41f7-b0e7-4b7ae5ec2b4b
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/3940b98a-6b33-41f7-b0e7-4b7ae5ec2b4b
     slides: https://speakerdeck.com/avsm/ocaml-platform-2017
     link: https://github.com/ocaml/ocaml.org-media/blob/master/meetings/ocaml/2017/slides__2017__anil-madhavapeddy__the-state-of-the-ocaml-platform-september-2017.pdf
   - title: "Wodan: a pure OCaml, flash-aware filesystem library" 

--- a/data/conferences/2018-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2018-ocaml-users-and-developers-workshop.md
@@ -28,7 +28,7 @@ presentations:
       - Jordan Walke
       - Cheng Lou
       - Rick Vetter
-    video: https://watch.ocaml.org/videos/watch/af37368d-085d-431d-923f-cd1d81dfdbe9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/af37368d-085d-431d-923f-cd1d81dfdbe9
   - title: "RFCs, all the way down!"
     authors:
       - Romain Calascibetta
@@ -36,7 +36,7 @@ presentations:
     authors: 
       - Charles Chamberlain
       - Cyrus Omar
-    video: https://watch.ocaml.org/videos/watch/f75acae0-c24d-4d19-958e-0c76ff51603f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/f75acae0-c24d-4d19-958e-0c76ff51603f
   - title: The OCaml Platform 1.0
     authors:
       - Anil Madhavapeddy
@@ -54,11 +54,11 @@ presentations:
   - title: "Wall: rendering vector graphics with OCaml and OpenGL"
     authors:
       - Frédéric Bour
-    video: https://watch.ocaml.org/videos/watch/2472168c-04aa-497d-a931-f866c7036550
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/2472168c-04aa-497d-a931-f866c7036550
   - title: "Winning on Windows: porting the OCaml Platform"
     authors:
       - David Allsopp
-    video: https://watch.ocaml.org/videos/watch/5020256d-eeb0-4e0b-81db-cde8ba00e3d7
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/5020256d-eeb0-4e0b-81db-cde8ba00e3d7
 program_committee: 
   - name: Andrew Kennedy
     affiliation: Facebook, London

--- a/data/conferences/2020-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2020-ocaml-users-and-developers-workshop.md
@@ -18,22 +18,22 @@ presentations:
     authors:
       - Luis Eduardo de Souza Amorim
       - Eelco Visser
-    video: https://watch.ocaml.org/videos/watch/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/a5b86864-8e43-4138-b6d6-ed48d2d4b63d
   - title: "A Simple State-Machine Framework for Property-Based Testing in OCaml"
     authors:
       - Jan Midtgaard
-    video: https://watch.ocaml.org/videos/watch/08b429ea-2eb8-427d-a625-5495f4ee0fef
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/08b429ea-2eb8-427d-a625-5495f4ee0fef
   - title: "AD-OCaml: Algorithmic Differentiation for OCaml"
     authors: 
       - Markus Mottl
-    video: https://watch.ocaml.org/videos/watch/c9e85690-732f-4b03-836f-2ee0fd8f0658
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c9e85690-732f-4b03-836f-2ee0fd8f0658
   - title: "API Migration: compare transformed"
     authors:
       - Joseph Harrison
       - Steven Varoumas
       - Simon Thompson 
       - Reuben Rowe
-    video: https://watch.ocaml.org/videos/watch/c46b925b-bd77-404f-ac5d-5dab65047529
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c46b925b-bd77-404f-ac5d-5dab65047529
   - title: "Irmin v2"
     authors:
       - Clément Pascutto
@@ -41,16 +41,16 @@ presentations:
       - Craig Ferguson
       - Thomas Gazagnaire
       - Romain Liautaud
-    video: https://watch.ocaml.org/videos/watch/53e497b0-898f-4c85-8da9-39f65ef0e0b1
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/53e497b0-898f-4c85-8da9-39f65ef0e0b1
   - title: "LexiFi Runtime Types"
     authors:
       - Patrik Keller
       - Marc Lasson
-    video: https://watch.ocaml.org/videos/watch/cc7e3242-0bef-448a-aa13-8827bba933e3 
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/cc7e3242-0bef-448a-aa13-8827bba933e3 
   - title: "OCaml Under The Hood: SmartPy"
     authors:
       - Sebastien Mondet
-    video: https://watch.ocaml.org/videos/watch/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/7446ad4d-4ae2-4e1a-bc38-af8f71e8ebd8
   - title: "OCaml-CI: A Zero-Configuration CI"
     authors: 
       - Thomas Leonard
@@ -58,7 +58,7 @@ presentations:
       - Kate Deplaix
       - Magnus Skjegstad
       - Anil Madhavapeddy
-    video: https://watch.ocaml.org/videos/watch/da88d6ac-7ba1-4261-9308-d03fe21e35b9 
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/da88d6ac-7ba1-4261-9308-d03fe21e35b9 
   - title: "Parallelising your OCaml Code with Multicore OCaml"
     authors:
       - Sadiq Jaffer
@@ -66,23 +66,23 @@ presentations:
       - KC Sivaramakrishnan
       - Tom Kelly
       - Anil Madhavapeddy
-    video: https://watch.ocaml.org/videos/watch/ce20839e-4bfc-4d74-925b-485a6b052ddf
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/ce20839e-4bfc-4d74-925b-485a6b052ddf
     link: https://github.com/ocaml-multicore/multicore-talks/tree/master/ocaml2020-workshop-parallel
   - title: "The ImpFS filesystem"
     authors:
       - Tom Ridge
-    video: https://watch.ocaml.org/videos/watch/28545b27-4637-47a5-8edd-6b904daef19c
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/28545b27-4637-47a5-8edd-6b904daef19c
   - title: "The Final Pieces of the OCaml Documentation Puzzle"
     authors: 
       - Jonathan Ludlam
       - Gabriel Radanne
       - Leo White
-    video: https://watch.ocaml.org/videos/watch/2acebff9-25fa-4733-83cc-620a65b12251
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/2acebff9-25fa-4733-83cc-620a65b12251
   - title: "Types in amber"
     authors:
       - Paul Steckler
       - Matthew Ryan
-    video: https://watch.ocaml.org/videos/watch/99b3dc75-9f93-4677-9f8b-076546725512
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/99b3dc75-9f93-4677-9f8b-076546725512
 program_committee: 
   - name: Ivan Gotovchits
     affiliation: CMU, USA

--- a/data/conferences/2021-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2021-ocaml-users-and-developers-workshop.md
@@ -13,12 +13,12 @@ presentations:
   - title: "25 Years of OCaml"
     authors:
       - Xavier Leroy
-    video: https://watch.ocaml.org/videos/watch/e1ee0fc0-50ef-4a1c-894a-17df181424cb
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/e1ee0fc0-50ef-4a1c-894a-17df181424cb
   - title: "A Multiverse of Glorious Documentation"
     authors:
       - Lucas Pluvinage
       - Jonathan Ludlam
-    video: https://watch.ocaml.org/videos/watch/9bb452d6-1829-4dac-a6a2-46b31050c931
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/9bb452d6-1829-4dac-a6a2-46b31050c931
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/15/A-Multiverse-of-Glorious-Documentation 
   - title: "Adapting the OCaml Ecosystem for Multicore OCaml"
     authors:
@@ -28,32 +28,32 @@ presentations:
       - Tom Kelly
       - KC Sivaramakrishnan
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/7/Adapting-the-OCaml-ecosystem-for-Multicore-OCaml
-    video: https://watch.ocaml.org/videos/watch/629b89a8-bbd5-490d-98b0-d0c740912b02
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/629b89a8-bbd5-490d-98b0-d0c740912b02
   - title: "Binary Analysis Platform (BAP). Using Universal Algebra and Tagless-Final Style for Developing Representation-Agnostic Frameworks"
     authors:
       - Ivan Gotovchits
       - David Brumley
-    video: https://watch.ocaml.org/videos/watch/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/8dc2d8d3-c140-4c3d-a8fe-a6fcf6fba988
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/10/Binary-Analysis-Platform-BAP-Using-Universal-Algebra-and-Tagless-Final-Style-for-D
   - title: "Continuous Benchmarking for OCaml Projects"
     authors:
       - Gargi Sharma
       - Rizo Isrof
       - Magnus Skjegstad
-    video: https://watch.ocaml.org/videos/watch/1c994370-1aaa-4db6-b901-d762786e4904
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/1c994370-1aaa-4db6-b901-d762786e4904
   - title: "Deductive Verification of Realistic OCaml Code"
     authors:
       - Carlos Pinto
       - Mário Pereira
       - Simão Melo de Sousa
-    video: https://watch.ocaml.org/videos/watch/92309d92-8cbf-4545-980c-209c96e42a79
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/92309d92-8cbf-4545-980c-209c96e42a79
   - title: "Digodoc and Docs"
     authors:
       - Mohamed Hernouf
       - Fabrice Le Fessant
       - Thomas Blanc
       - Louis Gesbert
-    video: https://watch.ocaml.org/videos/watch/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/db6ed2c4-e940-4d5f-82ee-d3d20eb4ceb7
   - title: "Experiences with Effects"
     authors:
       - Thomas Leonard
@@ -64,37 +64,37 @@ presentations:
       - KC Sivaramakrishnan
       - Anil Madhavapeddy
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/16/Experiences-with-Effects
-    video: https://watch.ocaml.org/videos/watch/74ece0a8-380f-4e2a-bef5-c6bb9092be89
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/74ece0a8-380f-4e2a-bef5-c6bb9092be89
   - title: "From 2n+1 to n"
     authors:
       - Nandor Licker
       - Timothy M. Jones
-    video: https://watch.ocaml.org/videos/watch/74b32dae-11c6-4713-be1b-946260196e50
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/74b32dae-11c6-4713-be1b-946260196e50
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/14/From-2n-1-to-n
   - title: "GopCaml: A Structural Editor for OCaml"
     authors:
       - Kiran Gopinathan
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/11/GopCaml-A-Structural-Editor-for-OCaml
-    video: https://watch.ocaml.org/videos/watch/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/e0a6e6f2-0d40-4dfc-9308-001c8e0f64d6
   - title: "Leveraging Formal Specifications to Generate Fuzzing Suites"
     authors:
       - Nicolas Osborne
       - Clément Pascutto
-    video: https://watch.ocaml.org/videos/watch/d9a36c9f-1611-42f9-8854-981b1e2d7d75
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/d9a36c9f-1611-42f9-8854-981b1e2d7d75
   - title: "Love: a readable language interpreted by a blockchain"
     authors:
       - Steven de Oliveira
       - David Declerck
-    video: https://watch.ocaml.org/videos/watch/d3b2b31e-1739-406e-8de7-d5f21bc01836
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/d3b2b31e-1739-406e-8de7-d5f21bc01836
   - title: "OCaml and Python: Getting the Best of Both Worlds"
     authors:
       - Laurent Mazare
-    video: https://watch.ocaml.org/videos/watch/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/9eafdb1e-9be9-4a52-98b4-f4696eda4c18
   - title: "Opam-bin: Binary Packages with Opam"
     authors:
       - Fabrice Le Fessant
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/5/Opam-bin-Binary-Packages-with-Opam
-    video: https://watch.ocaml.org/videos/watch/a889e4d3-0508-4734-b667-7060b0a253cd
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/a889e4d3-0508-4734-b667-7060b0a253cd
   - title: "Parafuzz: Coverage-guided Property Fuzzing for Multicore OCaml programs"
     authors:
       - Sumit Padhiyar
@@ -102,30 +102,30 @@ presentations:
       - KC Sivaramakrishnan
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/9/Parafuzz-Coverage-guided-Property-Fuzzing-for-Multicore-OCaml-programs
     slides: https://speakerdeck.com/kayceesrk/parafuzz-fuzzing-multicore-ocaml-programs
-    video: https://watch.ocaml.org/videos/watch/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c0d591e0-91c9-4eaa-a4d7-c4f514de0a57
   - title: "Probabilistic resource limits, or: Programming with interrupts in OCaml"
     authors: 
       - Guillaume Munch-Maccagnoni
-    video: https://watch.ocaml.org/videos/watch/bc297e85-82dd-4baf-8556-4a3a934978f9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/bc297e85-82dd-4baf-8556-4a3a934978f9
   - title: "Property-Based Testing for OCaml through Coq"
     authors:
       - Paaras Bhandari
       - Leonidas Lampropoulos
-    video: https://watch.ocaml.org/videos/watch/9324fba4-2482-4bab-bfdd-b8881b3ed94a
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/9324fba4-2482-4bab-bfdd-b8881b3ed94a
   - title: "Safe Protocol Updates via Propositional Logic"
     authors:
       - Michael O'Connor
-    video: https://watch.ocaml.org/videos/watch/c6176f51-0277-46f0-937b-1e2721044492
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c6176f51-0277-46f0-937b-1e2721044492
   - title: "Semgrep, a fast, lightweight, polyglot, static analysis tool to find bugs"
     authors:
       - Yoann Padioleau
     link: https://icfp21.sigplan.org/details/ocaml-2021-papers/18/Semgrep-a-fast-lightweight-polyglot-static-analysis-tool-to-find-bugs
-    video: https://watch.ocaml.org/videos/watch/c0d07213-1426-46a1-98e0-0b0c4515c841
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c0d07213-1426-46a1-98e0-0b0c4515c841
   - title: "Wibbily Wobbly Timey Camly"
     authors: 
       - Di Long Li
       - Gabriel Radanne
-    video: https://watch.ocaml.org/videos/watch/ec641446-823b-40ec-a207-85157a18f88e
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/ec641446-823b-40ec-a207-85157a18f88e
 organising_committee: 
   - name: Frédéric Bour
     affiliation: Tarides, France

--- a/data/conferences/2022-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2022-ocaml-users-and-developers-workshop.md
@@ -15,22 +15,22 @@ presentations:
       - Deepali Ande
       - KC Sivaramakrishnan
     link: https://kcsrk.info/papers/compose_ocaml22.pdf
-    video: https://watch.ocaml.org/videos/watch/08ea09a1-e645-47cb-80c4-499dd4d93ac8
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/08ea09a1-e645-47cb-80c4-499dd4d93ac8
   - title: "Continuous Monitoring of OCaml Applications Using Runtime Events"
     authors:
       - Sadiq Jaffer
       - Patrick Ferris
     link: https://github.com/patricoferris/runtime-events-demo/blob/main/abstract.pdf
-    video: https://watch.ocaml.org/videos/watch/299cab02-db94-44ac-b926-ea90ddda1b09
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/299cab02-db94-44ac-b926-ea90ddda1b09
   - title: "Copying opam Switches - It Should Just Work™"
     authors:
       - David Allsopp
-    video: https://watch.ocaml.org/videos/watch/8c1c3fda-0106-4c7d-a794-33da7e758fee
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/8c1c3fda-0106-4c7d-a794-33da7e758fee
   - title: "Efficient “Out of Heap” Pointers for Multicore OCaml"
     authors:
       - Guillaume Munch-Maccagnoni
     link: https://guillaume.munch.name/files/large-pages-ocamlworkshop.pdf
-    video: https://watch.ocaml.org/videos/watch/0aa64600-b142-4c11-964d-dab8d509d08f
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/0aa64600-b142-4c11-964d-dab8d509d08f
   - title: "Highest-Performance Stream Processing"
     authors:
       - Oleg Kiselyov
@@ -38,7 +38,7 @@ presentations:
       - Aggelos Biboudis
       - Nick Palladinos
     link: https://okmij.org/ftp/meta-programming/strymonasv2-intro.pdf
-    video: https://watch.ocaml.org/videos/watch/c75ed758-d513-4453-af68-c50c1d9a1469
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c75ed758-d513-4453-af68-c50c1d9a1469
   - title: "Homogeneous Builds with OBuilder and OCaml"
     authors:
       - Tim McGilchrist
@@ -49,7 +49,7 @@ presentations:
       - Anil Madhavapeddy
       - Kate Deplaix
     link: https://github.com/tmcgilchrist/ocaml-2022-submission/blob/master/ocurrent.pdf
-    video: https://watch.ocaml.org/videos/watch/29055525-2b0f-4f00-a0a0-26c9d4e97f9c
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/29055525-2b0f-4f00-a0a0-26c9d4e97f9c
   - title: "Introducing the Bindoj Library, a Datatype-Centric Generative Programming Library for Real-World Programming in OCaml"
     authors:
       - Haochen M. Kotoi-Xie
@@ -57,19 +57,19 @@ presentations:
       - Yuta Sato
       - Shinya Yamaguchi
     link: https://icfp22.sigplan.org/details/ocaml-2022-papers/14/Introducing-the-Bindoj-library-a-datatype-centric-generative-programming-library-for
-    video: https://watch.ocaml.org/videos/watch/69755b27-85b1-4df4-9f01-b771cd15353a
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/69755b27-85b1-4df4-9f01-b771cd15353a
   - title: "Memo: An Incremental Computation Library That Powers Dune"
     authors:
       - Andrey Mokhov
       - Arseniy Alekseyev
     link: https://icfp22.sigplan.org/details/ocaml-2022-papers/4/Memo-an-incremental-computation-library-that-powers-Dune
-    video: https://watch.ocaml.org/videos/watch/d6a126b9-05f6-4b0f-ac6b-ad14d9bf12c9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/d6a126b9-05f6-4b0f-ac6b-ad14d9bf12c9
   - title: "Multicoretests - Parallel Testing Libraries for OCaml 5.0"
     authors:
       - Jan Midtgaard
       - Olivier Nicole
       - Nicolas Osborne
-    video: https://watch.ocaml.org/videos/watch/c844f844-acc1-4a8a-944e-4d99343a89c5
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/c844f844-acc1-4a8a-944e-4d99343a89c5
   - title: "OCamello: A Course and Summer School with Learn-OCaml"
     authors:
       - Roberto Blanco
@@ -84,27 +84,27 @@ presentations:
       - Stephen Dolan
       - Leo White
     link: http://stedolan.net/talks/ocaml22
-    video: https://watch.ocaml.org/videos/watch/6c86b050-334b-4a11-bb04-c347a6e57215
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/6c86b050-334b-4a11-bb04-c347a6e57215
   - title: "Supporting a Decade of Opam"
     authors:
       - David Allsopp
       - Raja Boujbel
       - Kate Deplaix
       - Louis Gesbert
-    video: https://watch.ocaml.org/videos/watch/039f1096-a63c-4a88-af4b-dcc48791d723
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/039f1096-a63c-4a88-af4b-dcc48791d723
   - title: "Supporting FLAT Concepts in Learn-OCaml: Seeing is Believing; Programming is Understanding"
     authors:
       - Artur Miguel Dias
       - Simão Melo de Sousa
       - Antonio Ravara
     link: https://release.di.ubi.pt/leafs/publications/ocamlws22.pdf
-    video: https://watch.ocaml.org/videos/watch/aa552395-666e-4394-a42f-faaa6f3da92c
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/aa552395-666e-4394-a42f-faaa6f3da92c
   - title: "Tracing OCaml Programs"
     authors:
       - Darius Foo
       - Wei-Ngan Chin
     link: https://web.archive.org/web/20230413145607/https://dariusf.github.io/tracing-ocaml22.pdf
-    video: https://watch.ocaml.org/videos/watch/3b4401ec-f0a8-44bb-97ad-18e05c2135f9
+    watch_ocamlorg_video: https://watch.ocaml.org/videos/watch/3b4401ec-f0a8-44bb-97ad-18e05c2135f9
 organising_committee: []
 program_committee: 
   - name: Matija Pretnar

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -648,7 +648,8 @@ module Conference = struct
     title : string;
     authors : string list;
     link : string option;
-    video : string option;
+    watch_ocamlorg_video : string option;
+    youtube_video : string option;
     slides : string option;
     poster : bool;
     additional_links : string list;

--- a/src/ocamlorg_frontend/pages/conference.eml
+++ b/src/ocamlorg_frontend/pages/conference.eml
@@ -89,7 +89,10 @@ Community_layout.single_column_layout
               <% (match presentation.link with None -> () | Some link -> %>
               <%s! resource_link ~link (Icons.link "h-6 w-6") "Details" %>
               <% ); %>
-              <% (match presentation.video with None -> () | Some link -> %>
+              <% (match presentation.youtube_video with None -> () | Some link -> %>
+              <%s! resource_link ~link (Icons.youtube "h-6 w-6") "View on YouTube" %>
+              <% ); %>
+              <% (match presentation.watch_ocamlorg_video with None -> () | Some link -> %>
               <%s! resource_link ~link (Icons.video "h-6 w-6") "View Video" %>
               <% ); %>
               <% (match presentation.slides with None -> () | Some link -> %>
@@ -106,6 +109,7 @@ Community_layout.single_column_layout
     </div>
 </div>
 
+<% if conference.program_committee <> [] then ( %>
 <div class="w-full deep-blue-gradient dark:section-blue-gradient">
   <div class="container-fluid pt-6 pb-12">
     <p class="uppercase text-sm text-dark-content dark:text-dark-content tracking-widest font-medium my-4">Conference Details</p>
@@ -132,22 +136,57 @@ Community_layout.single_column_layout
     </ul>
   </div>
 </div>
-<% let videos = List.filter (fun (p : Data.Conference.presentation) -> Option.is_some p.video)
+<% ); %>
+
+<% if conference.organising_committee <> [] then ( %>
+<div class="w-full deep-blue-gradient dark:section-blue-gradient">
+  <div class="container-fluid pt-6 pb-12">
+    <p class="uppercase text-sm text-dark-content dark:text-dark-content tracking-widest font-medium my-4">Conference Details</p>
+    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2">Organisers</h2>
+    <div class="flex flex-wrap justify-center space-x-12 mt-8">
+      <% 
+      let committee_with_pictures = List.filter (fun (x : Data.Conference.committee_member) -> Option.is_some x.picture) conference.organising_committee in
+      let committee_without_pictures = List.filter (fun (x : Data.Conference.committee_member) -> Option.is_none x.picture) conference.organising_committee in
+      let names = List.map (fun (x : Data.Conference.committee_member) -> match x.affiliation with None -> (x.name, "") | Some affiliation -> (x.name, affiliation)) committee_without_pictures in
+      committee_with_pictures |> List.iter (fun (member : Data.Conference.committee_member) -> %>
+      <div href="" class="mt-12">
+        <img src="<%s Option.get member.picture %>" width="148px" class="m-auto h-auto rounded-lg" alt="" />
+        <div class="font-medium mt-3"><%s member.name %></div>
+        <% (match member.affiliation with None -> () | Some affiliation -> %>
+        <div class="text-sm mt-1"><%s affiliation %></div>
+        <% ); %>
+      </div>
+      <% ); %>
+    </div>
+    <ul class="grid grid-cols-1 md:grid-cols-2">
+      <% names |> List.iter (fun (name, affiliation) -> %>
+        <li class="mb-4"><p class="text-dark-content"><span class="mr-2">•</span><span class="font-bold mr-2"><%s name %></span><span>
+        <% (match affiliation with "" -> () | _ -> %>
+        (<%s affiliation %>)
+        <% ); %>
+        </span></p></li>
+      <% ); %>
+    </ul>
+  </div>
+</div>
+<% ); %>
+
+<% let videos = List.filter (fun (p : Data.Conference.presentation) -> Option.is_some p.watch_ocamlorg_video)
 conference.presentations in (match List.length videos with | 0 -> () | _ -> %>
 <div class="bg-background dark:bg-dark-background py-16">
   <div class="container-fluid">
     <h3 class="font-bold mb-12 text-title dark:text-dark-title">Some Videos</h3>
     <div class="grid lg:grid-cols-3 gap-14">
-      <% let videos = List.filteri (fun i _ -> i < 6) videos in videos |> List.iter (fun (video : Data.Conference.presentation) -> %>
+      <% let videos = List.filteri (fun i _ -> i < 6) videos in videos |> List.iter (fun (presentation : Data.Conference.presentation) -> %>
       <div class="inline-block">
         <iframe
           loading="lazy"
           class="w-full"
           sandbox="allow-scripts allow-popups"
-          src="<%s video.video |> Option.get |> video_embed_path %>"
+          src="<%s presentation.watch_ocamlorg_video |> Option.get |> video_embed_path %>"
           allowfullscreen
         ></iframe>
-        <h6 class="font-bold mt-4 text-title dark:text-dark-title"><%s video.title %></h6>
+        <h6 class="font-bold mt-4 text-title dark:text-dark-title"><%s presentation.title %></h6>
       </div>
       <% ); %>
     </div>

--- a/tool/ood-gen/lib/conference.ml
+++ b/tool/ood-gen/lib/conference.ml
@@ -4,7 +4,8 @@ type presentation_metadata = {
   title : string;
   authors : string list;
   link : string option;
-  video : string option;
+  watch_ocamlorg_video : string option;
+  youtube_video : string option; 
   slides : string option;
   poster : bool option;
   additional_links : string list option;

--- a/tool/ood-gen/lib/conference.ml
+++ b/tool/ood-gen/lib/conference.ml
@@ -5,7 +5,7 @@ type presentation_metadata = {
   authors : string list;
   link : string option;
   watch_ocamlorg_video : string option;
-  youtube_video : string option; 
+  youtube_video : string option;
   slides : string option;
   poster : bool option;
   additional_links : string list option;


### PR DESCRIPTION
IMO we want both watch.ocaml.org and the videos on the conference YouTube channel to be discoverable here.