### PR TITLE
fix: broken link for odoc authors documentation

### DIFF
--- a/data/tutorials/platform/2_08_odoc.md
+++ b/data/tutorials/platform/2_08_odoc.md
@@ -43,4 +43,4 @@ include this stanza:
 A common place to put `.mld` files is a directory named `doc` or `docs`.
 
 For more information on how to write documentation pages for `odoc`,
-see the [`odoc` for authors documentation](https://ocaml.github.io/odoc/odoc_for_authors.html#doc-pages).
+see the [`odoc` for authors documentation](https://ocaml.github.io/odoc/odoc/odoc_for_authors.html).


### PR DESCRIPTION
Simple fix for a broken link.