### PR TITLE
chore: changelog dune 3.17.2

### DIFF
--- a/data/changelog/dune/2025-01-23-dune.3.17.2.md
+++ b/data/changelog/dune/2025-01-23-dune.3.17.2.md
@@ -1,0 +1,20 @@
+---
+title: Dune 3.17.2
+tags: [dune, platform]
+changelog: |
+    ### Fixed
+
+    - Fix a crash in the Melange rules that would prevent compiling public library
+    implementations of virtual libraries. (@anmonteiro, #11248)
+    - Pass `melange.emit`'s `compile_flags` to the JS emission phase. (@anmonteiro,
+      #11252)
+    - Disallow private implementations of public virtual libs in melange mode.
+      (@anmonteiro, #11253)
+    - Wasm_of_ocaml: fix the execution of tests in a sandbox.  (#11304, @vouillon)
+---
+
+The Dune team is happy to announce the release of Dune 3.17.2!
+
+This patch release includes some bug fixes. It brings some fixes for Melange
+and Wasm_of_ocaml. It also fixes a bug that prevents the experimental feature,
+package management, to build with `ocaml.5.3.0`.


### PR DESCRIPTION
This PR creates the changelog for the last release of Dune (`3.17.2`).
