### PR TITLE
Do not use field attributes

### DIFF
--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -1,33 +1,51 @@
 module Academic_institution = struct
   type location = { lat : float; long : float } [@@deriving of_yaml, show]
 
-  let pp_ptime fmt t =
-    Format.pp_print_string fmt "Ptime.of_rfc3339 \"";
-    Ptime.pp_rfc3339 () fmt t;
-    Format.pp_print_string fmt
-      "\" |> function Ok (t, _, _) -> t | Error _ -> failwith \"RFC 3339\""
+  include (
+    struct
+      module Ptime = struct
+        include Ptime
 
-  let pp_print_option pp fmt = function
-    | None -> Format.pp_print_string fmt "None"
-    | Some x ->
-        Format.pp_print_string fmt "Some (";
-        pp fmt x;
-        Format.pp_print_string fmt ")"
+        let pp fmt t =
+          Format.pp_print_string fmt "(Ptime.of_rfc3339 \"";
+          Ptime.pp_rfc3339 () fmt t;
+          Format.pp_print_string fmt
+            "\" |> function Ok (t, _, _) -> t | Error _ -> failwith \"RFC \
+             3339\")"
+      end
 
-  type course = {
-    name : string;
-    acronym : string option;
-    url : string option;
-    teacher : string option;
-    enrollment : string option;
-    year : int option;
-    description : string;
-    last_check : Ptime.t option; [@printer pp_print_option pp_ptime]
-    lecture_notes : bool;
-    exercises : bool;
-    video_recordings : bool;
-  }
-  [@@deriving show]
+      type course = {
+        name : string;
+        acronym : string option;
+        url : string option;
+        teacher : string option;
+        enrollment : string option;
+        year : int option;
+        description : string;
+        last_check : Ptime.t option;
+        lecture_notes : bool;
+        exercises : bool;
+        video_recordings : bool;
+      }
+      [@@deriving show]
+    end :
+      sig
+        type course = {
+          name : string;
+          acronym : string option;
+          url : string option;
+          teacher : string option;
+          enrollment : string option;
+          year : int option;
+          description : string;
+          last_check : Ptime.t option;
+          lecture_notes : bool;
+          exercises : bool;
+          video_recordings : bool;
+        }
+
+        val pp_course : Format.formatter -> course -> unit
+      end)
 
   type t = {
     name : string;

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -300,11 +300,11 @@ module Governance = struct
     name : string;
     description : string;
     contacts : contact list;
-    dev_meeting : dev_meeting option; [@default None] [@key "dev-meeting"]
-    members : Member.t list; [@default []]
-    subteams : team list; [@default []]
+    dev_meeting : dev_meeting option;
+    members : Member.t list;
+    subteams : team list;
   }
-  [@@deriving of_yaml, show]
+  [@@deriving show]
 end
 
 module Industrial_user = struct
@@ -611,7 +611,7 @@ module Video = struct
     title : string;
     url : string;
     thumbnail : string;
-    description : string; [@default ""]
+    description : string;
     published : string;
     author_name : string;
     author_uri : string;

--- a/tool/ood-gen/lib/governance.ml
+++ b/tool/ood-gen/lib/governance.ml
@@ -9,7 +9,8 @@ type team_metadata = {
   dev_meeting : dev_meeting option; [@default None] [@key "dev-meeting"]
   members : Member.t list; [@default []]
   subteams : team_metadata list; [@default []]
-} [@@deriving of_yaml, stable_record ~version:team]
+}
+[@@deriving of_yaml, stable_record ~version:team]
 
 let team_of_yaml yml =
   yml |> team_metadata_of_yaml |> Result.map team_metadata_to_team

--- a/tool/ood-gen/lib/governance.ml
+++ b/tool/ood-gen/lib/governance.ml
@@ -1,6 +1,19 @@
 open Ocamlorg.Import
 open Data_intf.Governance
 
+type team_metadata = {
+  id : string;
+  name : string;
+  description : string;
+  contacts : contact list;
+  dev_meeting : dev_meeting option; [@default None] [@key "dev-meeting"]
+  members : Member.t list; [@default []]
+  subteams : team_metadata list; [@default []]
+} [@@deriving of_yaml, stable_record ~version:team]
+
+let team_of_yaml yml =
+  yml |> team_metadata_of_yaml |> Result.map team_metadata_to_team
+
 type metadata = {
   teams : team list;
   working_groups : team list; [@key "working-groups"]

--- a/tool/ood-gen/lib/youtube.ml
+++ b/tool/ood-gen/lib/youtube.ml
@@ -1,6 +1,17 @@
 open Ocamlorg.Import
 open Data_intf.Video
 
+let to_yaml video = match to_yaml video with
+| `O u -> `O (List.filter (( <> ) ("description", `String "")) u)
+| x -> x
+
+let add_key_default k v = function
+| `O u when (u |> List.split |> fst |> List.mem k |> ( not )) -> prerr_endline k; `O ((k, v) :: u)
+| x -> x
+
+let of_yaml yml =
+  yml |> add_key_default "description" (`String "") |> of_yaml
+
 type kind = Playlist | Channel
 
 let kind_of_string = function

--- a/tool/ood-gen/lib/youtube.ml
+++ b/tool/ood-gen/lib/youtube.ml
@@ -1,16 +1,18 @@
 open Ocamlorg.Import
 open Data_intf.Video
 
-let to_yaml video = match to_yaml video with
-| `O u -> `O (List.filter (( <> ) ("description", `String "")) u)
-| x -> x
+let to_yaml video =
+  match to_yaml video with
+  | `O u -> `O (List.filter (( <> ) ("description", `String "")) u)
+  | x -> x
 
 let add_key_default k v = function
-| `O u when (u |> List.split |> fst |> List.mem k |> ( not )) -> prerr_endline k; `O ((k, v) :: u)
-| x -> x
+  | `O u when u |> List.split |> fst |> List.mem k |> not ->
+      prerr_endline k;
+      `O ((k, v) :: u)
+  | x -> x
 
-let of_yaml yml =
-  yml |> add_key_default "description" (`String "") |> of_yaml
+let of_yaml yml = yml |> add_key_default "description" (`String "") |> of_yaml
 
 type kind = Playlist | Channel
 


### PR DESCRIPTION
Record types Data_intf.Governance.team and Data_intf.Video.t no
longer have fields annotated with expression attributes.

This is needed to complete #2930
