### PR TITLE
Change `#exit;;` to `#quit;;`

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -154,7 +154,7 @@ You're now in an OCaml toplevel, and you can start typing OCaml expressions. For
 
 **Congratulations**! You've installed OCaml! 🎉
 
-Exit UTop by typing `#exit;;` or pressing `Ctrl+D`.
+Exit UTop by typing `#quit;;` or pressing `Ctrl+D`.
 
 ## Join the Community
 


### PR DESCRIPTION
Seems like there was a minor mistake. `exit` is a function but it's used like an interpreter directive. It can be confusing to beginners since it doesn't work.