### PR TITLE
data scraper for Changelogs

### DIFF
--- a/.github/workflows/scrape_changelog.yml
+++ b/.github/workflows/scrape_changelog.yml
@@ -1,0 +1,58 @@
+name: Scrape
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every day
+    - cron: 36 5 * * *
+
+jobs:
+  scrape:
+    name: Run Scrapers
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - "5.2.0"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
+          opam-repositories: |
+            pin: git+https://github.com/ocaml/opam-repository#584630e7a7e27e3cf56158696a3fe94623a0cf4f
+          opam-disable-sandboxing: true
+
+      - name: Install system dependencies
+        run: sudo apt update && sudo apt-get install libev-dev libonig-dev libcurl4-openssl-dev
+
+      - name: Install opam dependencies
+        run: opam install --deps-only --with-test .
+
+      - name: Build scraper
+        run: |
+          opam exec -- dune build tool/ood-gen/bin/scrape.exe
+
+      - name: Run scrapers
+        run: |
+          opam exec -- dune exec tool/ood-gen/bin/scrape.exe platform_releases
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: '[scrape.yml] New Platform Releases'
+          labels: scrape
+          add-paths: |
+            data/changelog/*/*.md
+          commit-message: |
+            [scrape.yml] New Platform Releases

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,14 @@ watch: ## Watch for the filesystem and rebuild on every change
 utop: ## Run a REPL and link with the project's libraries
 	opam exec -- dune utop --root . . -- -implicit-bindings
 
-.PHONY: scrape
-scrape: ## Generate the po files
+.PHONY: scrape_ocaml_planet
+scrape_ocaml_planet:
 	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe planet
 	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe video
+
+.PHONY: scrape_platform_releases
+scrape_changelog:
+	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe platform_releases
 
 .PHONY: docker
 docker: ## Generate docker container

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ scrape_ocaml_planet:
 	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe planet
 	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe video
 
-.PHONY: scrape_platform_releases
+.PHONY: scrape_changelog
 scrape_changelog:
 	opam exec -- dune exec --root . tool/ood-gen/bin/scrape.exe platform_releases
 

--- a/data/changelog/releases/dune/2024-06-17-dune.3.16.0.md
+++ b/data/changelog/releases/dune/2024-06-17-dune.3.16.0.md
@@ -1,6 +1,7 @@
 ---
 title: Dune 3.16.0
 tags: [dune, platform]
+versions: [3.16.0, "3.16.0~alpha2", "3.16.0~alpha1"]
 changelog: |
    ### Added
    

--- a/data/changelog/releases/dune/2024-11-27-dune.3.17.0.md
+++ b/data/changelog/releases/dune/2024-11-27-dune.3.17.0.md
@@ -1,6 +1,7 @@
 ---
 title: Dune 3.17.0
 tags: [dune, platform]
+versions: [3.17.0, "3.17.0~alpha0"]
 changelog: |
    ### Fixed
    

--- a/data/changelog/releases/ocaml-lsp/2024-12-23-ocaml-lsp-1.20.1.md
+++ b/data/changelog/releases/ocaml-lsp/2024-12-23-ocaml-lsp-1.20.1.md
@@ -1,6 +1,7 @@
 ---
 title: OCaml-LSP 1.20.1
 tags: [ocaml-lsp, platform]
+versions: ["1.20.1", "1.20.1-4.14", "1.20.0-4.14"]
 changelog: |
     ## Features  
     - Add custom `ocamllsp/typeSearch` request ([#1369](https://github.com/ocaml/ocaml-lsp/pull/1369))  

--- a/data/changelog/releases/ocaml/2024-05-13-ocaml-5.2.0.md
+++ b/data/changelog/releases/ocaml/2024-05-13-ocaml-5.2.0.md
@@ -2,6 +2,7 @@
 title: Release of OCaml 5.2.0
 description: Release of OCaml 5.2.0
 tags: [ocaml]
+versions: ["OCaml 5.2.0"]
 changelog: |
 
   (Changes that can break existing programs are marked with a "*")

--- a/data/changelog/releases/ocaml/2024-11-18-ocaml-5.2.1.md
+++ b/data/changelog/releases/ocaml/2024-11-18-ocaml-5.2.1.md
@@ -2,6 +2,7 @@
 title: Release of OCaml 5.2.1
 description: Release of OCaml 5.2.1
 tags: [ocaml]
+versions: ["OCaml 5.2.1"]
 changelog: |
 
   ## Changes Since OCaml 5.2.0

--- a/data/changelog/releases/ocaml/2025-01-08-ocaml-5.3.0.md
+++ b/data/changelog/releases/ocaml/2025-01-08-ocaml-5.3.0.md
@@ -2,6 +2,7 @@
 title: Release of OCaml 5.3.0
 description: Release of OCaml 5.3.0
 tags: [ocaml]
+versions: ["OCaml 5.3.0"]
 changelog: |
   (Changes that can break existing programs are marked with a "*")
   ### Restored backend:

--- a/data/changelog/releases/ocamlformat/2022-07-18-ocamlformat-0.24.1.md
+++ b/data/changelog/releases/ocamlformat/2022-07-18-ocamlformat-0.24.1.md
@@ -1,6 +1,7 @@
 ---
 title: OCamlFormat 0.24.1
 tags: [ocamlformat, platform]
+versions: ["0.24.0", "0.24.1"]
 changelog: |
   ### New features
 

--- a/data/changelog/releases/ocamlformat/2023-03-06-ocamlformat-0.25.1.md
+++ b/data/changelog/releases/ocamlformat/2023-03-06-ocamlformat-0.25.1.md
@@ -1,6 +1,7 @@
 ---
 title: OCamlFormat 0.25.1
 tags: [ocamlformat, platform]
+versions: ["0.25.0", "0.25.1"]
 changelog: |
   ### Library
 

--- a/data/changelog/releases/omp/2020-04-15-omp-1.7.1.md
+++ b/data/changelog/releases/omp/2020-04-15-omp-1.7.1.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-1.7.1
 tags: [omp]
+versions: ["v1.7.1"]
 changelog: |
   - Fix build with OCaml < 4.08
 

--- a/data/changelog/releases/omp/2020-04-20-omp-1.7.2.md
+++ b/data/changelog/releases/omp/2020-04-20-omp-1.7.2.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-1.7.2
 tags: [omp]
+versions: ["v1.7.2"]
 changelog: |
   - Remove toplevel `Option` module accidentally added in 1.7.0
 ---

--- a/data/changelog/releases/omp/2020-05-07-omp-1.7.3.md
+++ b/data/changelog/releases/omp/2020-05-07-omp-1.7.3.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-1.7.3
 tags: [omp]
+versions: ["v1.7.3"]
 changelog: |
   - Fix magic numbers for the 4.11 ast (#96, @hhugo)
 ---

--- a/data/changelog/releases/omp/2020-08-12-omp-2.0.0.md
+++ b/data/changelog/releases/omp/2020-08-12-omp-2.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-2.0.0
 tags: [omp]
+versions: ["v2.0.0"]
 changelog: |
   - No longer expose the unwrapped modules (#94, @jonludlam)
   - Remove everything but Ast versions and upgrade/downgrade

--- a/data/changelog/releases/omp/2020-10-22-omp-2.1.0.md
+++ b/data/changelog/releases/omp/2020-10-22-omp-2.1.0.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-2.1.0
 tags: [omp]
+versions: ["v2.1.0"]
 changelog: |
   - Add support for 4.12 (#107, @ceastlund)
 ---

--- a/data/changelog/releases/omp/2020-10-23-omp-1.8.0.md
+++ b/data/changelog/releases/omp/2020-10-23-omp-1.8.0.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-1.8.0
 tags: [omp]
+versions: ["v1.8.0"]
 changelog: |
   Oops, we went looking but didn't find the changelog for this release 🙈
 ---

--- a/data/changelog/releases/omp/2021-06-22-omp-2.2.0.md
+++ b/data/changelog/releases/omp/2021-06-22-omp-2.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: Omp ocaml-migrate-parsetree-2.2.0
 tags: [omp]
+versions: ["v2.2.0"]
 changelog: |
   - Add support for 4.13 (#114, @kit-ty-kate)
 ---

--- a/data/changelog/releases/opam-publish/2018-09-19-opam-publish-2.0.0.md
+++ b/data/changelog/releases/opam-publish/2018-09-19-opam-publish-2.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: Opam-publish 2.0.0
 tags: [opam-publish, platform]
+versions: ["2.0.0", "2.0.0: Merge pull request #66 from rjbou/push-on-master"]
 changelog: |
   * Switch default branch from 2.0.0 to master
   * Minor fix

--- a/data/changelog/releases/opam/2024-05-22-opam-2-1-6.md
+++ b/data/changelog/releases/opam/2024-05-22-opam-2-1-6.md
@@ -1,6 +1,7 @@
 ---
 title: opam 2.1.5
 authors: [ "Raja Boujbel" ]
+versions: ["2.1.6"]
 description: "Release of opam 2.1.5"
 tags: [opam, platform]
 changelog: |

--- a/data/changelog/releases/opam/2024-07-01-opam-2-2-0.md
+++ b/data/changelog/releases/opam/2024-07-01-opam-2-2-0.md
@@ -5,6 +5,7 @@ authors: [
   "Kate Deplaix",
   "David Allsopp",
 ]
+versions: ["2.2.0"]
 description: "Release of opam 2.2.0"
 tags: [opam, platform]
 ---

--- a/data/changelog/releases/opam/2024-08-22-opam-2-2-1.md
+++ b/data/changelog/releases/opam/2024-08-22-opam-2-2-1.md
@@ -5,6 +5,7 @@ authors: [
   "Kate Deplaix",
   "David Allsopp",
 ]
+versions: ["2.2.1"]
 description: "opam 2.2.1 release"
 tags: [opam, platform]
 ---

--- a/data/changelog/releases/opam/2024-11-13-opam-2-3-0.md
+++ b/data/changelog/releases/opam/2024-11-13-opam-2-3-0.md
@@ -5,6 +5,7 @@ authors: [
   "Kate Deplaix",
   "David Allsopp",
 ]
+versions: ["2.3.0"]
 description: "Release of opam 2.3.0"
 tags: [opam, platform]
 ---

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -99,7 +99,7 @@ module Changelog = struct
     authors : string list;
     contributors : string list;
     project_name : string;
-    version : string option;
+    versions : string list;
   }
 
   type post = {

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -98,6 +98,8 @@ module Changelog = struct
     body : string;
     authors : string list;
     contributors : string list;
+    project_name : string;
+    version : string option;
   }
 
   type post = {

--- a/tool/ood-gen/bin/scrape.ml
+++ b/tool/ood-gen/bin/scrape.ml
@@ -1,7 +1,12 @@
 open Cmdliner
 open Ood_gen
 
-let term_scrapers = [ ("planet", Blog.Scraper.scrape); ("video", Video.scrape) ]
+let term_scrapers =
+  [
+    ("planet", Blog.Scraper.scrape);
+    ("video", Video.scrape);
+    ("changelog", Changelog.Scraper.scrape);
+  ]
 
 let cmds =
   Cmd.group (Cmd.info "ood-scrape")

--- a/tool/ood-gen/bin/scrape.ml
+++ b/tool/ood-gen/bin/scrape.ml
@@ -5,7 +5,7 @@ let term_scrapers =
   [
     ("planet", Blog.Scraper.scrape);
     ("video", Video.scrape);
-    ("changelog", Changelog.Scraper.scrape);
+    ("platform_releases", Changelog.Scraper.scrape_platform_releases);
   ]
 
 let cmds =

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -321,7 +321,7 @@ module Scraper = struct
 
   (** This does not generate any file. Instead, it exits with an error if a
       changelog entry is missing. *)
-  let scrape () =
+  let scrape_platform_releases () =
     Releases.all () |> group_releases_by_project |> SMap.iter check_if_uptodate;
     if !warning_count > 0 then exit 1
 end

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -41,8 +41,12 @@ type t = [%import: Data_intf.Changelog.t] [@@deriving of_yaml, show]
    a pull request to mirror a release announcement that likely already happened
    on discuss.ocaml.org. *)
 
-(** Location from where to check for new releases while scraping. Keys are
-    'tags' listed in changelogs. *)
+(** A scraper is provided to check whether changelog entries are missing. Run it
+    like this:
+    {v
+     dune exec -- tool/ood-gen/bin/scrape.exe changelog
+    v}
+    The list below describes how to query the latest releases. *)
 let projects_release_feeds =
   [
     ("ocamlformat", `Github "https://github.com/ocaml-ppx/ocamlformat");

--- a/tool/ood-gen/test/test_ood_gen.ml
+++ b/tool/ood-gen/test/test_ood_gen.ml
@@ -3,14 +3,23 @@ let test_parse_date_from_slug =
     ( name,
       `Quick,
       fun () ->
-        let got = Ood_gen.Changelog.parse_date_from_slug s in
-        Alcotest.check (Alcotest.option Alcotest.string) __LOC__ expected got )
+        let got = Ood_gen.Changelog.parse_slug s in
+        Alcotest.(check (option (pair string (option string))))
+          __LOC__ expected got )
   in
   [
-    test ~name:"ok" "2020-03-02-something.md" ~expected:(Some "2020-03-02");
+    test ~name:"ok" "2020-03-02-something.md"
+      ~expected:(Some ("2020-03-02", None));
     test ~name:"no date" "something.md" ~expected:None;
     test ~name:"day not padded correctly" "2021-1-2-title.md"
-      ~expected:(Some "2021-01-02");
+      ~expected:(Some ("2021-01-02", None));
+    test ~name:"ok with project-version" "2025-01-31-project-1.2.3"
+      ~expected:(Some ("2025-01-31", Some "1.2.3"));
+    test ~name:"ok with project.version" "2025-01-31-project.1.2.3"
+      ~expected:(Some ("2025-01-31", Some "1.2.3"));
+    test ~name:"ok with project.version-suffix"
+      "2025-01-31-project.1.2.3-something"
+      ~expected:(Some ("2025-01-31", Some "1.2.3-something"));
   ]
 
 let tests = [ ("parse_date_from_slug", test_parse_date_from_slug) ]


### PR DESCRIPTION
This adds a tool that detects missing changelogs by looking at projects' release pages. My intention is to write a GA that will notify maintainers (perhaps by opening draft PRs) for new releases.
Does that sound good ?

This will not help catching new releases in its current form but it can be used to add changelogs that are already missing. Here's its output:

<details>

```
Downloading https://github.com/ocaml/dune/releases.atom ... done 
Downloading https://github.com/tarides/dune-release/releases.atom ... done 
Downloading https://github.com/realworldocaml/mdx/releases.atom ... done 
No changelog entry for "mdx" version "2.5.0"

No changelog entry for "mdx" version "Release 0.3.3"

No changelog entry for "mdx" version "Release 0.3.2"

No changelog entry for "mdx" version "Release 0.3.1"

Downloading https://github.com/ocaml/merlin/releases.atom ... done 
No changelog entry for "merlin" version "5.4.1-503"

No changelog entry for "merlin" version "5.4-503"

No changelog entry for "merlin" version "4.18-414"

No changelog entry for "merlin" version "5.3-502"

No changelog entry for "merlin" version "4.17.1-414"

No changelog entry for "merlin" version "4.17.1-501"

No changelog entry for "merlin" version "5.2.1-502"

No changelog entry for "merlin" version "4.17-414"

No changelog entry for "merlin" version "4.17-501"

No changelog entry for "merlin" version "5.2-502"

Downloading https://github.com/ocaml/ocaml/releases.atom ... done 
No changelog entry for "ocaml" version "5.2.1-rc1"

Downloading https://github.com/ocaml/ocaml-lsp/releases.atom ... done 
No changelog entry for "ocaml-lsp" version "1.22.0"

No changelog entry for "ocaml-lsp" version "1.21.0"

No changelog entry for "ocaml-lsp" version "1.20.0"

Downloading https://github.com/ocaml-ppx/ocamlformat/releases.atom ... done 
Downloading https://github.com/OCamlPro/ocp-indent/releases.atom ... done 
No changelog entry for "ocp-indent" version "nlfork-1.5.5"

No changelog entry for "ocp-indent" version "1.8.2"

No changelog entry for "ocp-indent" version "nlfork-1.5.4"

No changelog entry for "ocp-indent" version "nlfork-1.5.3"

Downloading https://github.com/ocaml/odoc/releases.atom ... done 
No changelog entry for "odoc" version "3.0.0~beta1"

No changelog entry for "odoc" version "2.4.4"

No changelog entry for "odoc" version "2.4.3"

No changelog entry for "odoc" version "2.2.2"

Downloading https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases.atom ... d
one 
No changelog entry for "omp" version "v1.7.0"

Downloading https://github.com/ocaml/opam//releases.atom ... done 
Downloading https://github.com/ocaml-opam/opam-publish/releases.atom ... done 
No changelog entry for "opam-publish" version "2.5.0"

No changelog entry for "opam-publish" version "2.4.0"

No changelog entry for "opam-publish" version "2.3.1"

Downloading https://github.com/ocaml-ppx/ppxlib/releases.atom ... done 
No changelog entry for "ppxlib" version "0.34.0"

Downloading https://github.com/ocaml-community/utop/releases.atom ... done 
No changelog entry for "utop" version "Utop 2.15.0"
```

</details>
