### PR TITLE
Add a preamble to the tutorial to introduce domain-specific language

### DIFF
--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -19,7 +19,7 @@ In the following toy project, we create an OCaml library for the World Meteorolo
 
 We use unique terms for different elements of our project to avoid ambiguity. For instance, the directory containing the file `cloud.ml` isn't named `cloud`. A different term is used. We also use the Spanish word "nube" and the [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl) word "mixtli," where both terms mean "cloud."
 
-**Note**: The other terms we will be using are classifications of clouds. These include "[cumulus](https://en.wikipedia.org/wiki/Cumulus_cloud)" (fluffy clouds), "[nimbus](https://www.merriam-webster.com/dictionary/nimbus)" (precipitating clouds), "[cumulonimbus](https://en.wikipedia.org/wiki/Cumulonimbus_cloud)" (fluffy clouds that precipitate), "[stratonimbus](https://en.wikipedia.org/wiki/Nimbostratus_cloud)" (flat, amorphous clouds that precipitate), and "[altocumulus](https://en.wikipedia.org/wiki/Altocumulus_cloud)" (high altitude fluffy clouds).
+**Note**: The other terms we use are classifications of clouds. These include "[cumulus](https://en.wikipedia.org/wiki/Cumulus_cloud)" (fluffy), "[nimbus](https://en.wiktionary.org/wiki/nimbus)" (precipitating), "[cumulonimbus](https://en.wikipedia.org/wiki/Cumulonimbus_cloud)" (fluffy and precipitating), "[nimbostratus](https://en.wikipedia.org/wiki/Nimbostratus_cloud)" (flat, amorphous and precipitating), and "[altocumulus](https://en.wikipedia.org/wiki/Altocumulus_cloud)" (high altitude and fluffy).
 
 ## Minimum Project Setup
 

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -9,11 +9,34 @@ prerequisite_tutorials:
   - functors
 ---
 
-## Introduction
+## Introduction To This Lesson
 
 Dune provides several means to arrange modules into libraries. We look at Dune's mechanisms for structuring projects with libraries that contain modules.
 
 This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have version 3.7 or later installed.
+
+In the following toy project, we will be creating a simple OCaml library for the World Meteorological Organization, with its subject being clouds.
+
+We will be using unique terms for different elements of our project to make the examples clear and unambiguous. For example, if a directory contains a `cloud.ml` file we could name the directory `cloud`, however this may be confusing in our examples below.
+
+The terms we will be using are:
+
+- WMO (World Meteorological Organization):
+  - a specialized agency of the United Nations (UN) responsible for promoting international cooperation in meteorology, climatology, hydrology, and related geophysical sciences.
+- Cloud:
+  - a cloud is a visible mass of tiny liquid water droplets, ice crystals, or both, suspended in the atmosphere.
+- Nimbus:
+  - a type of cloud associated with precipitation.
+- Stratonimbus
+  - A nimbostratus cloud is a multilevel, amorphous, nearly uniform, and often dark-grey cloud that usually produces continuous rain, snow, or sleet, but no lightning or thunder.
+- Cumulonimbus:
+  - a type of cloud that is fluffy and white and produces rain
+- Altocumulus
+  - a cumulous cloud at high altitude that does not produce rain
+- Mixtli:
+  - the word for *cloud* in Nahuatl (also known as Aztec)
+- Nube:
+  - the word for *cloud* in Spanish
 
 ## Minimum Project Setup
 
@@ -88,9 +111,9 @@ You can also configure your editor or IDE to ignore it too.
 In OCaml, each `.ml` file defines a module. In the `mixtli` project, the file `cloud.ml` defines the `Cloud` module, the file `wmo.ml` defines the `Wmo` module that contains two submodules: `Stratus` and `Cumulus`.
 
 Here are the different names:
-* `mixtli` is the project's name (it means *cloud* in Nahuatl).
+* `mixtli` is the project's name.
 * `cloud.ml` is the OCaml source file's name, referred as `cloud` in the `dune` file.
-* `nube` is the executable command's name (it means *cloud* in Spanish).
+* `nube` is the executable command's name.
 * `Cloud` is the name of the module associated with the file `cloud.ml`.
 * `Wmo` is the name of the module associated with the file `wmo.ml`.
 * `wmo-clouds` is the name of the package built by this project.

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -17,7 +17,7 @@ This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have
 
 In the following toy project, we create an OCaml library for the World Meteorological Organization, with clouds as its subject.
 
-We will be using unique terms for different elements of our project to make the examples clear and unambiguous. For example, if a directory contains a `cloud.ml` file we could name the directory `cloud`, however this may be confusing in our examples below. For example, we will use the Spanish word "nube" and the [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl) word "mixtli", where both terms mean "cloud".
+We use unique terms for different elements of our project to avoid ambiguity. For instance, the directory containing the file `cloud.ml` isn't named `cloud`. A different term is used. We also use the Spanish word "nube" and the [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl) word "mixtli," where both terms mean "cloud."
 
 **Note**: The other terms we will be using are classifications of clouds. These include "[cumulus](https://en.wikipedia.org/wiki/Cumulus_cloud)" (fluffy clouds), "[nimbus](https://www.merriam-webster.com/dictionary/nimbus)" (precipitating clouds), "[cumulonimbus](https://en.wikipedia.org/wiki/Cumulonimbus_cloud)" (fluffy clouds that precipitate), "[stratonimbus](https://en.wikipedia.org/wiki/Nimbostratus_cloud)" (flat, amorphous clouds that precipitate), and "[altocumulus](https://en.wikipedia.org/wiki/Altocumulus_cloud)" (high altitude fluffy clouds).
 

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -9,7 +9,7 @@ prerequisite_tutorials:
   - functors
 ---
 
-## Introduction To This Lesson
+## Introduction
 
 Dune provides several means to arrange modules into libraries. We look at Dune's mechanisms for structuring projects with libraries that contain modules.
 
@@ -17,26 +17,12 @@ This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have
 
 In the following toy project, we will be creating a simple OCaml library for the World Meteorological Organization, with its subject being clouds.
 
-We will be using unique terms for different elements of our project to make the examples clear and unambiguous. For example, if a directory contains a `cloud.ml` file we could name the directory `cloud`, however this may be confusing in our examples below.
+We will be using unique terms for different elements of our project to make the examples clear and unambiguous. For example, if a directory contains a `cloud.ml` file we could name the directory `cloud`, however this may be confusing in our examples below. For example, we will use the Spanish word "nube" and the [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl) word "mixtli", where both terms mean "cloud".
 
-The terms we will be using are:
+.. note::
 
-- WMO (World Meteorological Organization):
-  - a specialized agency of the United Nations (UN) responsible for promoting international cooperation in meteorology, climatology, hydrology, and related geophysical sciences.
-- Cloud:
-  - a cloud is a visible mass of tiny liquid water droplets, ice crystals, or both, suspended in the atmosphere.
-- Nimbus:
-  - a type of cloud associated with precipitation.
-- Stratonimbus
-  - A nimbostratus cloud is a multilevel, amorphous, nearly uniform, and often dark-grey cloud that usually produces continuous rain, snow, or sleet, but no lightning or thunder.
-- Cumulonimbus:
-  - a type of cloud that is fluffy and white and produces rain
-- Altocumulus
-  - a cumulous cloud at high altitude that does not produce rain
-- Mixtli:
-  - the word for *cloud* in Nahuatl (also known as Aztec)
-- Nube:
-  - the word for *cloud* in Spanish
+The other terms we will be using are classifications of clouds. These include "[cumulus](https://en.wikipedia.org/wiki/Cumulus_cloud)" (fluffy clouds), "[nimbus](https://www.merriam-webster.com/dictionary/nimbus)" (precipitating clouds), "[cumulonimbus](https://en.wikipedia.org/wiki/Cumulonimbus_cloud)" (fluffy clouds that precipitate), "[stratonimbus](https://en.wikipedia.org/wiki/Nimbostratus_cloud)" (flat, amorphous clouds that precipitate), and "[altocumulus](https://en.wikipedia.org/wiki/Altocumulus_cloud)" (high altitude fluffy clouds).
+
 
 ## Minimum Project Setup
 

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -19,10 +19,7 @@ In the following toy project, we will be creating a simple OCaml library for the
 
 We will be using unique terms for different elements of our project to make the examples clear and unambiguous. For example, if a directory contains a `cloud.ml` file we could name the directory `cloud`, however this may be confusing in our examples below. For example, we will use the Spanish word "nube" and the [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl) word "mixtli", where both terms mean "cloud".
 
-.. note::
-
-The other terms we will be using are classifications of clouds. These include "[cumulus](https://en.wikipedia.org/wiki/Cumulus_cloud)" (fluffy clouds), "[nimbus](https://www.merriam-webster.com/dictionary/nimbus)" (precipitating clouds), "[cumulonimbus](https://en.wikipedia.org/wiki/Cumulonimbus_cloud)" (fluffy clouds that precipitate), "[stratonimbus](https://en.wikipedia.org/wiki/Nimbostratus_cloud)" (flat, amorphous clouds that precipitate), and "[altocumulus](https://en.wikipedia.org/wiki/Altocumulus_cloud)" (high altitude fluffy clouds).
-
+**Note**: The other terms we will be using are classifications of clouds. These include "[cumulus](https://en.wikipedia.org/wiki/Cumulus_cloud)" (fluffy clouds), "[nimbus](https://www.merriam-webster.com/dictionary/nimbus)" (precipitating clouds), "[cumulonimbus](https://en.wikipedia.org/wiki/Cumulonimbus_cloud)" (fluffy clouds that precipitate), "[stratonimbus](https://en.wikipedia.org/wiki/Nimbostratus_cloud)" (flat, amorphous clouds that precipitate), and "[altocumulus](https://en.wikipedia.org/wiki/Altocumulus_cloud)" (high altitude fluffy clouds).
 
 ## Minimum Project Setup
 

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -113,7 +113,7 @@ In OCaml, each `.ml` file defines a module. In the `mixtli` project, the file `c
 Here are the different names:
 * `mixtli` is the project's name (it means *cloud* in [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl)
 * `cloud.ml` is the OCaml source file's name, referred as `cloud` in the `dune` file.
-* `nube` is the executable command's name.
+* `nube` is the executable command's name (it means *cloud* in Spanish).
 * `Cloud` is the name of the module associated with the file `cloud.ml`.
 * `Wmo` is the name of the module associated with the file `wmo.ml`.
 * `wmo-clouds` is the name of the package built by this project.

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -111,7 +111,7 @@ You can also configure your editor or IDE to ignore it too.
 In OCaml, each `.ml` file defines a module. In the `mixtli` project, the file `cloud.ml` defines the `Cloud` module, the file `wmo.ml` defines the `Wmo` module that contains two submodules: `Stratus` and `Cumulus`.
 
 Here are the different names:
-* `mixtli` is the project's name.
+* `mixtli` is the project's name (it means *cloud* in [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl)
 * `cloud.ml` is the OCaml source file's name, referred as `cloud` in the `dune` file.
 * `nube` is the executable command's name.
 * `Cloud` is the name of the module associated with the file `cloud.ml`.

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -15,7 +15,7 @@ Dune provides several means to arrange modules into libraries. We look at Dune's
 
 This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have version 3.7 or later installed.
 
-In the following toy project, we will be creating a simple OCaml library for the World Meteorological Organization, with its subject being clouds.
+In the following toy project, we create an OCaml library for the World Meteorological Organization, with clouds as its subject.
 
 We will be using unique terms for different elements of our project to make the examples clear and unambiguous. For example, if a directory contains a `cloud.ml` file we could name the directory `cloud`, however this may be confusing in our examples below. For example, we will use the Spanish word "nube" and the [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl) word "mixtli", where both terms mean "cloud".
 


### PR DESCRIPTION
I added a preamble to this tutorial to introduce the domain-specific cloud terminology before the dune concepts are explored. The goal is to keep these concerns separate.