### PR TITLE
Add preamble and example to pattern matching in definitions

### DIFF
--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -118,7 +118,7 @@ In both examples, `d` and `e` are local definitions.
 
 [Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a programming language construct that generalizes case analysis, it makes subexpression inspection possible and applies to values of any type. 
 
-In the following sections, we explore matching inside `let` bindings. In the next chapter on [Basic Data Types and Pattern Matching](/docs/basic-data-types), we examine pattern matching in the construction of conditional expressions using `match...with` and compare it to `if...then...else`. In the chapter on [Error Handling](/docs/error-handling), we explore how destructuring values aids in error handling when using `try...with`.
+In the following sections, we explore matching inside `let` bindings, which is a special case. In the next chapter on [Basic Data Types and Pattern Matching](/docs/basic-data-types), we examine pattern matching in general cases using `match...with`. The chapter on [Error Handling](/docs/error-handling) explores how destructuring values aids in error handling when using `try...with`.
 
 ## Pattern Matching in Definitions
 
@@ -231,7 +231,7 @@ val phone : int = 1234567890
 
 In the following example, we deconstruct a tuple nested within a record.
 
-Records require explicit type definitions wherein field names are annotated with field types. We first define a `person` record type, then create an instance of that type named `jane`:
+Records require explicit type definitions wherein field names are annotated with types. We first define a `person` record type, then create an instance of that type named `jane`:
 
 ```ocaml
 # type person = {
@@ -260,7 +260,7 @@ val jane : person =
    contact = ("jane@example.com", 1234567890)}
 ```
 
-The following examples demonstrate two methods by which we can extract Jane's `email` and `phone` number data in the nested `contact` tuple. We will do so first by using nested deconstruction, then demonstrate a brute force approach by first extracting `content` followed by accessing the `email` and `phone` by deconstructing `contact`. <!-- Note: This sequence is pedagologically backwards perhaps, but the goal is to show that `contact` does not become a bound variable when using nested deconstruction. This is difficult to demonstrate in a single utop session if `contact` is bound in the brute force approach first, as it will not show the desired error message -->  
+The following examples demonstrate two methods by which we can extract Jane's `email` and `phone` number data in the nested `contact` tuple. We will do so first by using nested deconstruction, then demonstrate another approach by first extracting `content` followed by accessing the `email` and `phone` by deconstructing `contact`. 
 
 First, lets use nested deconstruction to access the contents of the `contact` tuple directly:
 
@@ -281,9 +281,9 @@ Notice that `contact` is not available in our top-level scope:
 Error: Unbound value contact
 ```
 
-This is because "contact" is not a bound variable, rather it is an intermediate pattern for deconstructive pattern-matching.
+This is because "contact" is not a top-level definition; rather, it is a local definition from deconstructive pattern-matching.
 
-Next, we demonstrate the brute force approach for accessing `email` and `phone`. This brings `contact` into our top-level scope and requires two steps:
+Next, we demonstrate the two-phase approach for accessing `email` and `phone`. This brings `contact` into our top-level scope and requires two steps:
 
 ```ocaml
 (* Step 1: deconstruct all record fields *)
@@ -322,7 +322,7 @@ val email : string = "jane@example.com"
 val phone : int = 1234567890
 ```
 
-Tuples behave differently from records because they require positional consistency. To discard the `email` value from the tuple of the `contact` field, we need to use the catch-all pattern (`_`):
+Tuples behave differently from records; contained data is anonymous, and its position is used to access it. To discard the `email` value from the tuple of the `contact` field, we need to use the catch-all pattern (`_`):
 
 ```ocaml
 # let { name; street; city; contact = (_, phone) } = john;;

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -216,9 +216,7 @@ val surname : string = "Milner"
 
 ### Nested Pattern Matching on User-Defined Types
 
-Pattern matching also works with nested user-defined types.
-
-In the example below, we deconstruct nested tuples:
+Pattern matching also works with nested user-defined types. In the example below, we deconstruct nested tuples:
 ```ocaml
 # let (name, (street, city, zip), (email, phone)) =
   ("John Doe", ("123 Elm St", "Springfield", 12345), ("john@example.com", 1234567890));;

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -114,7 +114,7 @@ Arbitrary combinations of chaining or nesting are allowed.
 
 In both examples, `d` and `e` are local definitions.
 
-## Introduction to Pattern Matching
+## Forms of Pattern Matching
 
 [Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a programming language construct that generalizes case analysis, it makes subexpression inspection possible and applies to values of any type. 
 

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -116,7 +116,7 @@ In both examples, `d` and `e` are local definitions.
 
 ## Introduction to Pattern Matching
 
-[Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a mechanism in programming language design that enables the destructuring of values and facilitates case analysis in a concise and expressive manner.
+[Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a programming language construct that generalizes case analysis, it makes subexpression inspection possible and applies to values of any type. 
 
 In the following sections, we explore definitional pattern matching using `let` bindings. In the next chapter on [Basic Data Types and Pattern Matching](/docs/basic-data-types), we examine pattern matching in the construction of conditional expressions using `match...with` and compare it to `if...then...else`. In the chapter on [Error Handling](/docs/error-handling), we explore how destructuring values aids in error handling when using `try...with`.
 

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -232,9 +232,9 @@ In the following example, we deconstruct nested records and an associated tuple.
 First, define an address record type
 ```ocaml
 # type address = {
-  street: string;
-  city: string;
-  zip: int
+  street : string;
+  city : string;
+  zip : int
   };;
 type address = { street : string; city : string; zip : int; }
 ```

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -118,7 +118,7 @@ In both examples, `d` and `e` are local definitions.
 
 [Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a programming language construct that generalizes case analysis, it makes subexpression inspection possible and applies to values of any type. 
 
-In the following sections, we explore definitional pattern matching using `let` bindings. In the next chapter on [Basic Data Types and Pattern Matching](/docs/basic-data-types), we examine pattern matching in the construction of conditional expressions using `match...with` and compare it to `if...then...else`. In the chapter on [Error Handling](/docs/error-handling), we explore how destructuring values aids in error handling when using `try...with`.
+In the following sections, we explore matching inside `let` bindings. In the next chapter on [Basic Data Types and Pattern Matching](/docs/basic-data-types), we examine pattern matching in the construction of conditional expressions using `match...with` and compare it to `if...then...else`. In the chapter on [Error Handling](/docs/error-handling), we explore how destructuring values aids in error handling when using `try...with`.
 
 ## Pattern Matching in Definitions
 

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -276,8 +276,7 @@ val phone : int = 1234567890
 
 Now, we can use `name`, `street`, `city`, `zip`, `email`, and `phone` as bindings
 ```ocaml
-# let () =
-  Printf.printf "Name: %s\nStreet: %s\nCity: %s\nZip: %d\nEmail: %s\nPhone: %d\n"
+# Printf.printf "Name: %s\nStreet: %s\nCity: %s\nZip: %d\nEmail: %s\nPhone: %d\n"
     name street city zip email phone;;
 Name: John Doe
 Street: 123 Elm St


### PR DESCRIPTION
@cuihtlauac 

As I work my way though your tutorials, I am happy to make little updates and tweaks like the present one and the ones we've worked through in the last few days, but I want to make sure I'm not swamping you with extra work.

Over the last year I've been studying Category and Type Theory, with a notable focus on Grothendieck Toposes. I am currently refreshing my knowledge in OCaml, and want to improve my fluency and accuracy when discussing the programming language concretely and functional programming in the abstract. By participating in pull requests of the tutorials, I am able to practice this. 

But I want to check in with you and your team to ensure that I am not giving you additional overhead when checking these pull requests. I'd much rather align with your goals.

If you have any thoughts or suggestions, please let me know.

For example, if you would like me to only focus on typos I can restrict myself to those. A slightly wider scope would include disambiguation, and minor expansion or preambles on topics. For an even wider scope, if you don't mind I take a stab at modifying a document when I find a `FIXME` (like the present pull request),  I'd greatly appreciate it (as well as any feedback you have as we refine it). 

Finally, if you have any larger tasks for your tutorials that you've been ruminating on but not had the chance to work on, I'd be happy to work on them if you can itemize and prioritize them.