### PR TITLE
format codeblocks with blank line padding

### DIFF
--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -33,6 +33,7 @@ The goal of this tutorial is to provide for the following capabilities:
 #### Integers
 
 The `int` type is the default and basic integer type in OCaml. When you enter a whole number, OCaml recognises it as an integer, as shown in this example:
+
 ```ocaml
 # 42;;
 - : int = 42
@@ -49,6 +50,7 @@ There are no dedicated types for unsigned integers in OCaml. Bitwise operations 
 Float numbers have type `float`.
 
 OCaml does not perform any implicit type conversion between values. Therefore, arithmetic expressions can't mix integers and floats. Arguments are either all `int` or all `float`. Arithmetic operators on floats are not the same, and they are written with a dot suffix: `+.`,  `-.`, `*.`, `/.`.
+
 ```ocaml
 # let pi = 3.14159;;
 val pi : float = 3.14159
@@ -64,11 +66,13 @@ Error: This expression has type int but an expression was expected of type
 Error: This expression has type float but an expression was expected of type
          int
 ```
+
 Operations on `float` are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Float`](/manual/api/Float.html) modules.
 
 #### Booleans
 
 Boolean values are represented by the type `bool`.
+
 ```ocaml
 # true;;
 - : bool = true
@@ -83,6 +87,7 @@ Boolean values are represented by the type `bool`.
 Operations on `bool` are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Bool`](/manual/api/Bool.html) modules. The conjunction “and” is written `&&` and disjunction “or” is written `||`. Both are short-circuited, meaning that they don't evaluate the argument on the right if the left one's value is sufficient to decide the whole expression's value.
 
 In OCaml, `if … then … else …` is a _conditional expression_. It has the same type as its branches.
+
 ```ocaml
 # 3 * if "foo" = "bar" then 5 else 5 + 2;;
 - : int = 21
@@ -91,6 +96,7 @@ In OCaml, `if … then … else …` is a _conditional expression_. It has the s
 The test subexpression must have type `bool`. Branches subexpressions must have the same type.
 
 Conditional expression and pattern matching on a Boolean are the same:
+
 ```ocaml
 # 3 * match "foo" = "bar" with true -> 5 | false -> 5 + 2;;
 - : int = 21
@@ -99,10 +105,12 @@ Conditional expression and pattern matching on a Boolean are the same:
 #### Characters
 
 Values of type `char` correspond to the 256 symbols of the Latin-1 set. Character literals are surrounded by single quotes, as shown below:
+
 ```ocaml
 # 'd';;
 - : char = 'd'
 ```
+
 Operations on `char` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Char`](/manual/api/Char.html) modules.
 
 The module [`Uchar`](/manual/api/Uchar.html) provides support for Unicode characters.
@@ -116,10 +124,12 @@ Strings are finite and fixed-sized sequences of char values. Strings are immutab
 -->
 
 Strings are immutable, meaning it is impossible to change a character's value inside a string.
+
 ```ocaml
 # "hello" ^ " " ^ "world!";;
 - : string = "hello world!"
 ```
+
 Strings are finite and fixed-sized sequences of `char` values. The string concatenation operator symbol is `^`.
 
 <!--CR
@@ -127,10 +137,12 @@ I'm not sure how to rearrange this to have the definition after the example? I'v
 -->
 
 Indexed access to string characters is possible using the following syntax:
+
 ```ocaml
 # "buenos dias".[4];;
 - : char : 'o'
 ```
+
 Operations on `string` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`String`](/manual/api/String.html) modules.
 
 #### Byte Sequences
@@ -143,6 +155,7 @@ Moved intro pp to after example, as it contains the definition. Perhaps a short 
 # String.to_bytes "hello";;
 - : bytes = Bytes.of_string "hello"
 ```
+
 Like strings, byte sequences are finite and fixed-sized. Each individual byte is represented by a `char` value. Like arrays, byte sequences are mutable, meaning they can't be extended or shortened, but each component byte may be updated. Essentially, a byte sequence (type `bytes`) is a mutable string that can't be printed. There is no way to write `bytes` literally, so they must be produced by a function.
 
 Operations on `bytes` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Bytes`](/manual/api/Bytes.html) modules. Only the function `Bytes.get` allows direct access to the characters contained in a byte sequence. Unlike arrays, there is no direct access operator on byte sequences.
@@ -153,6 +166,7 @@ The memory representation of `bytes` is four times more compact that `char array
 #### Arrays
 
 Arrays are finite and fixed-sized sequences of values of the same type. Here are a couple of examples:
+
 ```ocaml
 # [| 0; 1; 2; 3; 4; 5 |];;
 - : int array = [|0; 1; 2; 3; 4; 5|]
@@ -165,19 +179,23 @@ Arrays are finite and fixed-sized sequences of values of the same type. Here are
 ```
 
 Arrays may contain values of any type. Here arrays are `int array`, `char array`, and `string array`, but any type of data can be used in an array. Usually, `array` is said to be a polymorphic type. Strictly speaking, it is a type operator, and it accepts a type as argument (here `int`, `char`, and `string`) to form another type (those inferred here). This is the empty array.
+
 ```ocaml
 # [||];;
 - : 'a array = [||]
 ```
+
 Remember, `'a` ("alpha") is a type parameter that will be replaced by another type.
 
 Like `string` and `bytes`, arrays support direct access, but the syntax is not the same.
+
 ```ocaml
 # [| 'x'; 'y'; 'z' |].(2);;
 - : char = 'z'
 ```
 
 Arrays are mutable, meaning they can't be extended or shortened, but each element may be updated.
+
 ```ocaml
 # let letter = [| 'v'; 'x'; 'y'; 'z' |];;
 val letter : char array = [|'v'; 'x'; 'y'; 'z'|]
@@ -196,6 +214,7 @@ Operations on arrays are provided by the [`Array`](/manual/api/Array.html) modul
 #### Lists
 
 As literals, lists are very much like arrays. Here are the same previous examples turned into lists.
+
 ```ocaml
 # [ 0; 1; 2; 3; 4; 5 ];;
 - : int list = [0; 1; 2; 3; 4; 5]
@@ -216,6 +235,7 @@ There are symbols of special importance with respect to lists:
 - The list constructor operator, written `::` and pronounced “cons,” is used to add a value at the head of a list.
 
 Together, they are the basic means to build a list and access the data it stores. For instance, here is how lists are built by successively applying the cons (`::`) operator:
+
 ```ocaml
 # 3 :: [];;
 - : int list = [3]
@@ -228,6 +248,7 @@ Together, they are the basic means to build a list and access the data it stores
 ```
 
 Pattern matching provides the basic means to access data stored inside a list.
+
 ```ocaml
 # match [1; 2; 3] with
   | x :: u -> x
@@ -248,6 +269,7 @@ In the above expressions, `[1; 2; 3]` is the value that is matched over. Each ex
 #### Options
 
 The `option` type is also a polymorphic type. Option values can store any kind of data or represent the absence of any such data. Option values can only be constructed in two different ways: either `None`, when no data is available, or `Some`, otherwise.
+
 ```ocaml
 # None;;
 - : 'a option = None
@@ -260,6 +282,7 @@ The `option` type is also a polymorphic type. Option values can store any kind o
 ```
 
 Here is an example of pattern matching on an option value:
+
 ```ocaml
 # match Some 42 with None -> raise Exit | Some x -> x;;
 - : int = 42
@@ -283,6 +306,7 @@ Operations on results are provided by the [`Result`](/manual/api/Result.html) mo
 ### Tuples
 
 Here is a tuple containing two values, also known as a pair.
+
 ```ocaml
 # (3, 'K');;
 - : int * char = (3, 'K')
@@ -293,6 +317,7 @@ That pair contains the integer `3` and the character `'K'`; its type is `int * c
 This generalises to tuples with 3 or more elements. For instance, `(6.28, true, "hello")` has type `float * bool * string`. The types `int * char` and `float * bool * string` are called _product types_. The `*` symbol is used to denote types bundled together in products.
 
 The predefined function `fst` returns the first element of a pair, while `snd` returns the second element of a pair.
+
 ```ocaml
 # fst (3, 'g');;
 - : int = 3
@@ -302,6 +327,7 @@ The predefined function `fst` returns the first element of a pair, while `snd` r
 ```
 
 In the standard library, both are defined using pattern matching. Here is how a function extracts the third element of the product of four types:
+
 ```ocaml
 # let f x = match x with (h, i, j, k) -> j;;
 val f : 'a * 'b * 'c * 'd -> 'c = <fun>
@@ -314,6 +340,7 @@ Note that types `int * char * bool`, `int * (char * bool)`, and `(int * char) * 
 ### Functions
 
 The type of functions from type `m` to type `n` is written `m -> n`. Here are a few examples:
+
 ```ocaml
 # fun x -> x * x;;
 - : int -> int = <fun>
@@ -367,6 +394,7 @@ val g : int -> int = <fun>
 Executable OCaml code consists primarily of functions, so it's beneficial to make them as concise and clear as possible. The function `g` is defined here using a shorter, more common, and maybe more intuitive syntax.
 
 In OCaml, functions may terminate without returning the expected type value by throwing an exception (of type `exn`), which does not appear in its type. There is no way to know if a function may raise an exception without inspecting its code.
+
 ```ocaml
 # raise;;
 - : exn -> 'a' = <fun>
@@ -375,6 +403,7 @@ In OCaml, functions may terminate without returning the expected type value by t
 Exceptions are discussed in the [Error Handling](/docs/error-handling) guide.
 
 Functions may have several parameters.
+
 ```ocaml
 # fun s r -> s ^ " " ^ r;;
 - : string -> string -> string = <fun>
@@ -392,6 +421,7 @@ Like the product type symbol `*`, the function type symbol `->` is not associati
 Uniquely, the type `unit` has only one value. It is written `()` and pronounced “unit.”
 
 The `unit` type has several uses. Mainly, it serves as a token when a function does not need to be passed data or doesn't have any data to return once it has completed its computation. This happens when functions have side effects such as OS-level I/O. Functions need to be applied to something for their computation to be triggered, and they also must return something. When nothing meaningful can be passed or returned, `()` should be used.
+
 ```ocaml
 # read_line;;
 - : unit -> string = <fun>
@@ -401,6 +431,7 @@ The `unit` type has several uses. Mainly, it serves as a token when a function d
 ```
 
 The function `read_line` reads an end-of-line terminated sequence of characters from standard input and returns it as a string. Reading input begins when `()` is passed.
+
 ```ocaml
  # read_line ();;
 foo bar
@@ -432,6 +463,7 @@ Variants are also called [_tagged unions_](https://en.wikipedia.org/wiki/Tagged_
 The simplest form of a variant type corresponds to an [enumerated type](https://en.wikipedia.org/wiki/Enumerated_type). It is defined by an explicit list of named values. Defined values are called constructors and must be capitalised.
 
 For example, here is how variant data types could be defined to represent Dungeons & Dragons character classes and alignment.
+
 ```ocaml
 # type character_class =
     | Barbarian
@@ -471,6 +503,7 @@ ordering is defined on values following the definition order (e.g., `Druid
 < Ranger`).
 
 Pattern matching can be performed on the types defined above:
+
 ```ocaml
 # let rectitude_to_french = function
     | Evil -> "Mauvais"
@@ -487,6 +520,7 @@ Note that:
 #### Constructors With Data
 
 It is possible to wrap data in constructors. The following type has several constructors with data (e.g., `Hash of string`) and some without (e.g., `Head`). It represents the different means to refer to a Git [revision](https://git-scm.com/docs/gitrevisions).
+
 ```ocaml
 # type commit =
   | Hash of string
@@ -508,6 +542,7 @@ type commit =
 ```
 
 Here is how to convert a `commit` to a `string` using pattern matching:
+
 ```ocaml
 # let commit_to_string = function
   | Hash sha -> sha
@@ -521,6 +556,7 @@ val commit_to_string : commit -> string = <fun>
 ```
 
 Above, the `function …` construct is used instead of the `match … with …` construct used previously:
+
 ```ocaml
 let commit_to_string' x = match x with
   | Hash sha -> sha
@@ -532,9 +568,11 @@ let commit_to_string' x = match x with
   | Merge_head -> "MERGE_HEAD";;
 val commit_to_string' : commit -> string = <fun>
 ```
+
 We need to pass an inspected expression to the `match … with …` construct. The `function …` is a special form of an anonymous function that takes a parameter and forwards it to a `match … with …` construct, as shown above.
 
 **Warning**: Wrapping product types with parentheses turns them into a single parameter.
+
 ```ocaml
 # type t =
   | C1 of int * bool
@@ -559,6 +597,7 @@ The constructor `C1` has two parameters of type `int` and `bool`, whilst the con
 A variant definition referring to itself is recursive. A constructor may wrap data from the type being defined.
 
 This is the case for the following definition, which can be used to store JSON values.
+
 ```ocaml
 # type json =
   | Null
@@ -581,6 +620,7 @@ type json =
 Both constructors `Array` and `Object` contain values of type `json`.
 
 Functions defined using pattern matching on recursive variants are often recursive too. This function checks if a name is present in a whole JSON tree:
+
 ```ocaml
 # let rec has_field name = function
   | Array u ->
@@ -606,12 +646,14 @@ type 'a option = None | Some of 'a
 ```
 
 The predefined type `list` is polymorphic in the same sense. It is a variant with two constructors and can hold data of any type. Here is how it is defined in the standard library:
+
 ```ocaml
 # #show list;;
 type 'a list = [] | (::) of 'a * 'a list
 ```
 
 The only magic here is turning constructors into symbols, which we don't cover in this tutorial. The types `bool` and `unit` also are regular variants, with the same magic:
+
 ```ocaml
 # #show unit;;
 type unit = ()
@@ -621,6 +663,7 @@ type bool = false | true
 ```
 
 Implicitly, product types also behave as variant types. For instance, pairs can be seen as inhabitants of this type:
+
 ```ocaml
 # type ('a, 'b) pair = Pair of 'a * 'b;;
 type ('a, 'b) pair = Pair of 'a * 'b
@@ -635,6 +678,7 @@ In the end, the only type construction that does not reduce to a variant is the 
 #### User-Defined Polymorphic Types
 
 Here is an example of a variant type that combines constructors with data, constructors without data, polymorphism, and recursion:
+
 ```ocaml
 # type 'a tree =
   | Leaf
@@ -643,6 +687,7 @@ type 'a tree = Leaf | Node of 'a * 'a tree * 'a tree
 ```
 
 It can be used to represent arbitrarily labelled binary trees. Assuming such a tree would be labelled with integers, here is a possible way to compute the sum of its integers, using recursion and pattern matching.
+
 ```ocaml
 # let rec sum = function
   | Leaf -> 0
@@ -651,6 +696,7 @@ val sum : int tree -> int = <fun>
 ```
 
 Here is how the map function can be defined in this type:
+
 ```ocaml
 # let rec map f = function
   | Leaf -> Leaf
@@ -677,6 +723,7 @@ issue - "The polymorphic variants tutorial is unreleased, so the best at this po
 Records are like tuples in that several values are bundled together. In a tuple, elements are identified by their position in the corresponding product type. They are either first, second, third, or at some other position. In a record, each element has a name and a value. This name-value pair is known as a field. That's why record types must be declared before being used.
 
 For instance, here is the definition of a record type meant to partially represent a Dungeons & Dragons character class. Please note that the following code is dependent upon the definitions earlier in this tutorial. Ensure you have entered the definitions in the [Enumerated Data Types](/docs/basic-data-types#enumerated-data-types) section.
+
 ```ocaml
 # type character = {
   name : string;
@@ -695,9 +742,11 @@ type character = {
   armor_class : int;
 }
 ```
+
 Values of type `character` carry the same data as inhabitants of this product: `string * int * string * character_class * character_alignment * int`.
 
 Access the fields by using the dot notation, as shown:
+
 ```ocaml
 # let ghorghor_bey = {
     name = "Ghôrghôr Bey";
@@ -722,6 +771,7 @@ val ghorghor_bey : character =
 ```
 
 To construct a new record with some field values changed without typing in the unchanged fields we can use record update syntax as shown:
+
 ```ocaml
 # let togrev  = { ghorghor_bey with name = "Togrev"; level = 20; armor_class = -6 };;
 val togrev : character =
@@ -730,6 +780,7 @@ val togrev : character =
 ```
 
 Note that records behave like single constructor variants. That allows pattern matching on them.
+
 ```ocaml
 # match ghorghor_bey with { level; _ } -> level;;
 - : int = 17
@@ -740,6 +791,7 @@ Note that records behave like single constructor variants. That allows pattern m
 #### Type Aliases
 
 Just like values, any type can be given a name.
+
 ```ocaml
 # type latitude_longitude = float * float;;
 type latitude_longitude = float * float
@@ -750,6 +802,7 @@ This is mostly useful as a means of documentation or to shorten long type expres
 #### Function Parameter Aliases
 
 Function parameters can also be given a name with pattern matching for tuples and records.
+
 ```ocaml
 (* Tuples as parameters *)
 # let tuple_sum (x, y) = x + y;;
@@ -780,6 +833,7 @@ val meaning_of_life : int option -> int option = <fun>
 ## A Complete Example: Mathematical Expressions
 
 This example shows how to represent simple mathematical expressions like `n * (x + y)` and multiply them out symbolically to get `n * x + n * y`:
+
 ```ocaml env=expr
 # type expr =
   | Plus of expr * expr        (* a + b *)
@@ -796,6 +850,7 @@ type expr =
 ```
 
 The expression `n * (x + y)` would be written:
+
 ```ocaml env=expr
 # let e = Times (Var "n", Plus (Var "x", Var "y"));;
 val e : expr = Times (Var "n", Plus (Var "x", Var "y"))
@@ -803,6 +858,7 @@ val e : expr = Times (Var "n", Plus (Var "x", Var "y"))
 
 Here is a function that prints out `Times (Var "n", Plus (Var "x", Var "y"))`
 as something more like `n * (x + y)`:
+
 ```ocaml env=expr
 # let rec to_string = function
   | Plus (e1, e2) -> "(" ^ to_string e1 ^ " + " ^ to_string e2 ^ ")"
@@ -815,6 +871,7 @@ val to_string : expr -> string = <fun>
 
 We can write a function to multiply out expressions of the form `n * (x + y)`
 or `(x + y) * n`, and for this we will use a nested pattern:
+
 ```ocaml env=expr
 # let rec distrib = function
   | Times (e1, Plus (e2, e3)) ->
@@ -832,6 +889,7 @@ val distrib : expr -> expr = <fun>
 ```
 
 This is how it can be used:
+
 ```ocaml env=expr
 # e |> distrib |> to_string |> print_endline;;
 ((n * x) + (n * y))
@@ -852,6 +910,7 @@ the remaining patterns with a simple `e -> e` rule.)
 
 The reverse operation, i.e., factorising out common subexpressions, can be
 implemented in a similar fashion. The following version only works for the top-level expression.
+
 ```ocaml env=expr
 # let top_factorise = function
   | Plus (Times (e1, e2), Times (e3, e4)) when e1 = e3 ->

--- a/data/tutorials/language/0it_02_loops_and_recursion.md
+++ b/data/tutorials/language/0it_02_loops_and_recursion.md
@@ -16,6 +16,7 @@ it's an example of how to write the code.
 OCaml supports a rather limited form of the familiar `for` loop:
 
 <!-- $MDX skip -->
+
 ```ocaml
 for variable = start_value to end_value do
   expression
@@ -25,6 +26,7 @@ for variable = start_value downto end_value do
   expression
 done
 ```
+
 A simple but real example from LablGtk:
 
 <!-- $MDX skip -->
@@ -33,6 +35,7 @@ for i = 1 to n_jobs () do
   do_next_job ()
 done
 ```
+
 In OCaml, `for` loops are just shorthand for writing:
 
 <!-- $MDX skip -->
@@ -64,6 +67,7 @@ Line 1, characters 20-21:
 Warning 10 [non-unit-statement]: this expression should have type unit.
 - : unit = ()
 ```
+
 Functional programmers tend to use recursion instead of explicit loops,
 and it's wise to regard **for** loops with suspicion since it can't return anything,
 hence OCaml's relatively powerless **for** loop. We talk about recursion
@@ -77,6 +81,7 @@ while boolean-condition do
   expression
 done
 ```
+
 As with `for` loops, the language doesn't provide a way to break out
 of a `while` loop, except by throwing an exception, so this means that
 `while` loops have fairly limited use. Again, remember that functional
@@ -97,6 +102,7 @@ let quit_loop = false in
         (* how do I set quit_loop to true ?!? *)
   done
 ```
+
 Remember that `quit_loop` is not a real "variable." The let-binding
 just makes `quit_loop` shorthand for `false`. This means the `while`
 loop condition (shown in red) is always true, and the loop runs on
@@ -423,6 +429,7 @@ directory:
     End_of_file -> None;;
 val readdir_no_ex : dir_handle -> string option = <fun>
 ```
+
 The type of `readdir_no_ex` is this. Recall our earlier discussion about
 null pointers.
 
@@ -560,6 +567,7 @@ let rec loop () =
   | base case -> []
   | recursive case -> element :: loop ()
 ```
+
 Compare this to our previous `range` function. The pattern of recursion
 is exactly the same:
 
@@ -581,6 +589,7 @@ let rec read_directory path =
   else
     Leaf file
 ```
+
 All that remains now to make this a working program is a little bit of
 code to call `read_directory` and display the result:
 
@@ -601,6 +610,7 @@ let rec loop () =
   | base case -> []
   | recursive case -> element :: loop ()
 ```
+
 The key here is actually the use of the match / base case / recursive
 case pattern. In this example (finding the maximum element in a list),
 we'll have two base cases and one recursive case. But before we
@@ -651,6 +661,7 @@ Let's now code those rules above to get a working function:
       max x (list_max remainder);;
 val list_max : 'a list -> 'a = <fun>
 ```
+
 I've added comments so you can see how the rules / special cases we
 decided upon above really correspond to lines of code.
 
@@ -666,6 +677,7 @@ Exception: Failure "list_max called on empty list".
 # list_max [5; 4; 3; 2; 1; 100];;
 - : int = 100
 ```
+
 Notice how the solution proposed is both (a) very different from the
 imperative for-loop solution, and (b) much more closely tied to the
 problem specification. Functional programmers will tell you that it's
@@ -686,6 +698,7 @@ Let's look at the `range` function again for about the twentieth time:
   else a :: range (a+1) b;;
 val range : int -> int -> int list = <fun>
 ```
+
 I'm going to rewrite it slightly to make something about the structure
 of the program clearer (still the same function however):
 
@@ -696,6 +709,7 @@ of the program clearer (still the same function however):
       a :: result;;
 val range : int -> int -> int list = <fun>
 ```
+
 Let's call it:
 
 ```ocaml
@@ -704,6 +718,7 @@ Let's call it:
 # List.length (range 1 1000000);;
 Stack overflow during evaluation (looping recursion?).
 ```
+
 Hmmm ... at first sight this looks like a problem with recursive
 programming, and hence with the whole of functional programming! If you
 write your code recursively instead of iteratively then you necessarily
@@ -724,6 +739,7 @@ let rec loop () =
   (* do something *)
   loop ()
 ```
+
 Because the recursive call to `loop ()` happens last,
 `loop` is tail-recursive and the compiler will turn the whole thing into
 a `while` loop.
@@ -760,6 +776,7 @@ let rec range2 a b accum =
   else
     (* ... *)
 ```
+
 If `a > b` (i.e., if we've reached the end of the recursion), then stop
 and return the result (`accum`).
 
@@ -773,6 +790,7 @@ tail-recursive:
   else range2 (a + 1) b (a :: accum);;
 val range2 : int -> int -> int list -> int list = <fun>
 ```
+
 There's only one slight problem with this function. It constructs the
 list backwards! However, this is easy to rectify by redefining range as:
 
@@ -780,6 +798,7 @@ list backwards! However, this is easy to rectify by redefining range as:
 # let range a b = List.rev (range2 a b []);;
 val range : int -> int -> int list = <fun>
 ```
+
 It works this time, although it's a bit slow to run because it really
 does have to construct a list with a million elements in it:
 
@@ -787,6 +806,7 @@ does have to construct a list with a million elements in it:
 # List.length (range 1 1000000);;
 - : int = 1000000
 ```
+
 The following implementation is twice as fast as the previous one,
 because it does not need to reverse a list:
 
@@ -799,6 +819,7 @@ val range2 : int -> int -> int list -> int list = <fun>
   range2 a b [];;
 val range : int -> int -> int list = <fun>
 ```
+
 That was a brief overview of tail recursion, but in real world
 situations, determining if a function is tail-recursive can be quite
 hard. 
@@ -886,6 +907,7 @@ let you:
 Line 1, characters 1-23:
 Error: The record field name is not mutable
 ```
+
 References, with which we should be familiar by now, are implemented
 using records with a mutable `contents` field. Check out the definition
 in `Stdlib`:
@@ -927,6 +949,7 @@ val a : int array = [|0; 0; 0; 0; 0; 0; 0; 0; 0; 0|]
 # a;;
 - : int array = [|0; 1; 2; 3; 4; 5; 6; 7; 8; 9|]
 ```
+
 Notice the syntax for writing arrays: `[| element; element; ... |]`
 
 The OCaml compiler was designed with heavy numerical processing in mind

--- a/data/tutorials/language/0it_05_labels.md
+++ b/data/tutorials/language/0it_05_labels.md
@@ -15,12 +15,14 @@ Throughout this tutorial, the code is written in UTop. In this document paramete
 ## Passing Labelled Arguments
 
 The function `Option.value` from the standard library has a parameter labelled `default`.
+
 ```ocaml
 # Option.value;;
 - : 'a option -> default:'a -> 'a = <fun>
 ```
 
 Labelled arguments are passed using a tilde `~` and can be placed at any position and in any order.
+
 ```ocaml
 # Option.value (Some 10) ~default:42;;
 - : int = 10
@@ -42,6 +44,7 @@ Error: Syntax error
 ## Labelling Parameters
 
 Here is how to name parameters in a function definition:
+
 ```ocaml
 # let rec range ~first:lo ~last:hi =
     if lo > hi then []
@@ -54,6 +57,7 @@ The parameters of `range` are named
 - `first` and `last` when calling the function; these are the labels.
 
 Here is how `range` is used:
+
 ```ocaml
 # range ~first:1 ~last:10;;
 - : int list = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
@@ -63,6 +67,7 @@ Here is how `range` is used:
 ```
 
 It is possible to use a shorter syntax when using the same name as label and parameter.
+
 ```ocaml
 # let rec range ~first ~last =
     if first > last then []
@@ -75,6 +80,7 @@ At parameter definition `~first` is the same as `~first:first`. Passing argument
 ## Passing Optional Arguments
 
 Optional arguments can be omitted. When passed, a tilde `~` or a question mark `?` must be used. They can be placed at any position and in any order.
+
 ```ocaml
 # let sum ?(init=0) u = List.fold_left ( + ) init u;;
 val sum : ?init:int -> int list -> int = <fun>
@@ -87,6 +93,7 @@ val sum : ?init:int -> int list -> int = <fun>
 ```
 
 It is also possible to pass optional arguments as values of type `option`. This is done using a question mark when passing the argument.
+
 ```ocaml
 # sum [0; 1; 2; 3; 4; 5] ?init:(Some 100);;
 - : int = 115
@@ -98,6 +105,7 @@ It is also possible to pass optional arguments as values of type `option`. This 
 ## Defining Optional Parameters With Default Values
 
 In the previous section, we've defined a function with an optional parameter without explaining how it works. Let's look at a different variant of this function:
+
 ```ocaml
 # let sum ?init:(x=0) u = List.fold_left ( + ) x u;;
 val sum : ?init:int -> int list -> int = <fun>
@@ -128,6 +136,7 @@ val get_ok : ?exn:('a -> exn) -> ('b, 'a) result -> 'b = <fun>
 <!-- TODO: consider list take instead -->
 
 An optional parameter can be declared without specifying a default value.
+
 ```ocaml
 # let sub ?(pos=0) ?len:len_opt s =
     let default = String.length s - pos in
@@ -146,6 +155,7 @@ When an optional parameter isn't given a default value, its type inside the func
 <!-- TODO: consider a simpler example without any logic or exmplain use-case -->
 
 This enables the following usages:
+
 ```ocaml
 # sub ~len:5 ~pos:2 "immutability";;
 - : string = "mutab"
@@ -161,6 +171,7 @@ This enables the following usages:
 ```
 
 It is possible to use the same name for the `len` parameter and label name.
+
 ```ocaml
 # let sub ?(pos=0) ?len s =
     let default = String.length s - pos in
@@ -174,6 +185,7 @@ val sub : ?pos:int -> ?len:int -> string -> string = <fun>
 Let's compare two possible variants of the `String.concat` function from the standard library which has type `string -> string list -> string`.
 
 In the first version, the optional separator is the last declared parameter.
+
 ```ocaml
 # let concat_warn ss ?(sep="") = String.concat sep ss;;
 Line 1, characters 15-18:
@@ -192,6 +204,7 @@ val concat_warn : string list -> ?sep:string -> string = <fun>
 ```
 
 In the second version, the optional separator is the first declared parameter.
+
 ```ocaml
 # let concat ?(sep="") ss = String.concat sep ss;;
 val concat : ?sep:string -> string list -> string = <fun>
@@ -232,6 +245,7 @@ val range : int -> first:int -> last:int -> int list = <fun>
 ## Function with Only Optional Arguments
 
 When all parameters of a function need to be optional, a dummy, positional and occurring last parameter must be added. The unit `()` value comes in handy for this. This is what is done here.
+
 ```ocaml
 # let hello ?(who="world") () = "hello, " ^ who;;
 val hello : ?who:string -> string = <fun>
@@ -260,6 +274,7 @@ Without the unit parameter, the `optional argument cannot be erased` warning wou
 ## Forwarding an Optional Argument
 
 Passing an optional argument with a question mark sign `?` allows forwarding it without unwrapping. These examples reuse the `sub` function defined in the [Optional Arguments Without Default Values](#optional-arguments-without-default-values) section.
+
 ```ocaml
 # let take ?len s = sub ?len s;;
 val take : ?len:int -> string -> string = <fun>

--- a/data/tutorials/language/0it_06_imperative.md
+++ b/data/tutorials/language/0it_06_imperative.md
@@ -40,6 +40,7 @@ In the following sections, we introduce OCaml's language features for dealing wi
 ## References
 
 There is a special kind of value, called _reference_, whose contents can be updated:
+
 ```ocaml
 # let d = ref 0;;
 val d : int ref = {contents = 0}
@@ -79,6 +80,7 @@ The update takes place as a [side effect](https://en.wikipedia.org/wiki/Side_eff
 # ( ! );;
 - : 'a ref -> 'a = <fun>
 ```
+
 The dereference operator is a function that takes a reference and returns its contents.
 
 Refer to the [Operators](/docs/operators) documentation for more information on how unary and binary operators work in OCaml.
@@ -90,6 +92,7 @@ When working with mutable data in OCaml,
 ## Mutable Record Fields
 
 Any field in a record can be tagged using the `mutable` keyword. Such a field can be updated.
+
 ```ocaml
 # type book = {
   series : string;
@@ -112,6 +115,7 @@ For instance, here is how a bookshop could track its inventory:
 * Field `stock` is mutable because this value changes with each sale or restocking.
 
 Such a database should have an entry like this:
+
 ```ocaml
 # let vol_7 = {
     series = "Murderbot Diaries";
@@ -126,6 +130,7 @@ val vol_7 : book =
 ```
 
 When the bookshop receives a delivery of 10 of these books, we update the mutable `stock` field:
+
 ```ocaml
 # vol_7.stock <- vol_7.stock + 10;;
 - : unit = ()
@@ -145,6 +150,7 @@ In contrast to references, there is no special syntax to dereference a mutable r
 ### Remark: References Are Single Field Records
 
 In OCaml, references are records with a single mutable field:
+
 ```ocaml
 # #show_type ref;;
 type 'a ref = { mutable contents : 'a; }
@@ -153,6 +159,7 @@ type 'a ref = { mutable contents : 'a; }
 The type `'a ref` is a record with a single field `contents`, which is marked with the `mutable` keyword.
 
 Since references are single field records, we can define functions `create`, `assign`, and `deref` using the mutable record field update syntax:
+
 ```ocaml
 # let create v = { contents = v };;
 val create : 'a -> 'a ref = <fun>
@@ -184,6 +191,7 @@ The functions:
 ## Arrays
 
 In OCaml, an array is a mutable, fixed-size data structure that can store a sequence of elements of the same type. Arrays are indexed by integers, provide constant-time access, and allow the update of elements.
+
 ```ocaml
 # let g = [| 2; 3; 4; 5; 6; 7; 8 |];;
 val g : int array = [|2; 3; 4; 5; 6; 7; 8|]
@@ -207,6 +215,7 @@ For a more detailed discussion on arrays, see the [Arrays](/docs/arrays) tutoria
 ## Byte Sequences
 
 The `bytes` type in OCaml represents a fixed-length, mutable byte sequence. In a value of type `bytes`, each element has 8 bits. Since characters in OCaml are represented using 8 bits, `bytes` values are mutable `char` sequences. Like arrays, byte sequences support indexed access.
+
 ```ocaml
 # let h = Bytes.of_string "abcdefghijklmnopqrstuvwxyz";;
 val h : bytes = Bytes.of_string "abcdefghijklmnopqrstuvwxyz"
@@ -251,6 +260,7 @@ These attributes need to be set correctly (i.e., turn off echoing and disable ca
 We read characters from standard input using the `input_char` function from the OCaml standard library.
 
 Below is the first implementation. If you're working in macOS, run `#require "unix";;` first to avoid an `Unbound module error`.
+
 ```ocaml
 # let get_char () =
     let open Unix in
@@ -272,6 +282,7 @@ In this implementation, we update the fields of `termio`
 * after `input_char`, restoring the initial values.
 
 Here is the second implementation:
+
 ```ocaml
 # let get_char () =
     let open Unix in
@@ -321,9 +332,11 @@ Hello,
 world!
 - : int = 42
 ```
+
 In this example, the first two expressions are `print_endline` function calls, which produce side effects (printing to the console), and the last expression is simply the integer `42`, which becomes the value of the entire sequence. The `;` operator is used to separate these expressions.
 
 **Remark** Even though it's called the sequence operator, the semicolon is not truly an operator because it is not a function of type `unit -> 'a -> 'a`. It is rather a _construct_ of the language. It allows adding a semicolon at the end of a sequence expression.
+
 ```ocaml
 # (); 42; ;;
 - : int = 42
@@ -340,12 +353,14 @@ Imagine we want to write a function that:
 2. Updates the reference's contents to _2 &times; (n + 1)_
 
 This is arguably convoluted and does not work:
+
 ```ocaml
 # let f r = r := incr r; 2 * !r;;
 Error: This expression has type unit but an expression was expected of type int
 ```
 
 But here is how it can be made to work:
+
 ```ocaml
 # let f r = r := begin incr r; 2 * !r end;;
 val f : int ref -> unit = <fun>
@@ -359,6 +374,7 @@ The error came from assign `:=`, which associates stronger than a semicolon `;`.
 Remember the value of a semicolon-separated sequence is the value of its last expression. Grouping the first two steps with `begin … end` fixes the error.
 
 **Fun fact**: `begin … end` and parentheses are literally the same:
+
 ```ocaml
 # begin end;;
 - : unit = ()
@@ -367,12 +383,14 @@ Remember the value of a semicolon-separated sequence is the value of its last ex
 ### `if … then … else …` and Side Effects
 
 In OCaml, `if … then … else …` is an expression.
+
 ```ocaml
 # 6 * if "foo" = "bar" then 5 else 5 + 2;;
 - : int = 42
 ```
 
 A conditional expression return type can be `unit` if both branches are too.
+
 ```ocaml
 # if 0 = 1 then print_endline "foo" else print_endline "bar";;
 bar
@@ -380,6 +398,7 @@ bar
 ```
 
 The above can also be expressed this way:
+
 ```ocaml
 # print_endline (if 0 = 1 then "foo" else "bar");;
 bar
@@ -387,18 +406,21 @@ bar
 ```
 
 The `unit` value `()` can serve as a [no-op](https://en.wikipedia.org/wiki/Noop) when only one branch has something to execute.
+
 ```ocaml
 # if 0 = 1 then print_endline "foo" else ();;
 - : unit = ()
 ```
 
 But OCaml also allows writing `if … then … ` expressions without an `else` branch, which is the same as the above.
+
 ```ocaml
 # if 0 = 1 then print_endline "foo";;
 - : unit = ()
 ```
 
 In parsing, conditional expressions groups more than sequencing:
+
 ```ocaml
 # if true then print_endline "A" else print_endline "B"; print_endline "C";;
 A
@@ -409,7 +431,8 @@ C
 Here `; print_endline "C"` is executed after the whole conditional expression, not after `print_endline "B"`.
 
 If you want to have two prints in a conditional expression branch, use `begin … end`.
- ```ocaml
+
+```ocaml
 # if true then
     print_endline "A"
   else begin
@@ -421,6 +444,7 @@ A
 ```
 
 Here is an error you might encounter:
+
 ```ocaml
 # if true then
     print_endline "A";
@@ -435,6 +459,7 @@ Failing to group in the first branch results in a syntax error. What's before th
 ### For Loop
 
 A `for` loop is an expression of type `unit`. Here, `for`, `to`, `do`, and `done` are keywords.
+
 ```ocaml
 # for i = 0 to 5 do Printf.printf "%i\n" i done;;
 0
@@ -455,6 +480,7 @@ Here:
 The iteration evaluates the body expression (which may contain `i`) until `i` reaches `5`.
 
 The body of a `for` loop must be an expression of type `unit`:
+
 ```ocaml
 # let j = [| 2; 3; 4; 5; 6; 7; 8 |];;
 val j : int array = [|2; 3; 4; 5; 6; 7; 8|]
@@ -468,6 +494,7 @@ Warning 10 [non-unit-statement]: this expression should have type unit.
 When you use the `downto` keyword (instead of the `to` keyword), the counter decreases on every iteration of the loop.
 
 `for` loops are convenient to iterate over and modify arrays:
+
 ```ocaml
 # let sum = ref 0 in
   for i = 0 to Array.length j - 1 do sum := !sum + j.(i) done;
@@ -476,6 +503,7 @@ When you use the `downto` keyword (instead of the `to` keyword), the counter dec
 ```
 
 **Note:** Here is how to do the same thing using an iterator function:
+
 ```ocaml
 # let sum = ref 0 in Array.iter (fun i -> sum := !sum + i) j; !sum;;
 - : int = 35
@@ -484,6 +512,7 @@ When you use the `downto` keyword (instead of the `to` keyword), the counter dec
 ### While Loop
 
 A `while` loop is an expression of type `unit`. Here, `while`, `do`, and `done` are keywords.
+
 ```ocaml
 # let i = ref 0 in
   while !i <= 5 do
@@ -512,6 +541,7 @@ In this example, the `while` loop continues to execute as long as the value held
 Throwing the `Exit` exception is a recommended way to immediately exit from a loop.
 
 The following example uses the `get_char` function we defined earlier (in the section [Example: `get_char` Function](#example-get_char-function)).
+
 ```ocaml
 # try
     print_endline "Press Escape to exit";
@@ -536,6 +566,7 @@ In the following example, the function `create_counter` returns a closure that h
   fun () -> incr n; !n;;
 val create_counter : unit -> unit -> int = <fun>
 ```
+
 First, we define a function named `create_counter` that takes no arguments. Inside `create_counter`, a reference `n` is initialised with the value 0. This reference will hold the state of the counter. Next, we define a closure that takes no arguments (fun () ->). The closure increments the value of `n` (the counter) using `incr n`, then returns the current value of `n` using `!n`.
 
 ```ocaml
@@ -545,6 +576,7 @@ val c1 : unit -> int = <fun>
 # let c2 = create_counter ();;
 val c2 : unit -> int = <fun>
 ```
+
 Now, we shall create a closure `c1` that encapsulates a counter. Calling `c1 ()` will increment the counter associated with `c1` and return its current value. Similarly, we create another closure `c2` with its own independent counter.
 
 ```ocaml
@@ -560,6 +592,7 @@ Now, we shall create a closure `c1` that encapsulates a counter. Calling `c1 ()`
 # c1 ();;
 - : int = 3
 ```
+
 Calling `c1 ()` increments the counter associated with `c1` and returns its current value. Since this is the first call, the counter starts at 1. Another call to `c1 ()` increments the counter again, so it returns 2.
 
 Calling `c2 ()` increments the counter associated with `c2`. Since `c2` has its own independent counter, it starts at 1. Another call to `c1 ()` increments its counter, resulting in 3.
@@ -571,6 +604,7 @@ Functional and imperative programming styles are often used together. However, n
 ### Good: Function-Encapsulated Mutability
 
 Here is a function that computes the sum of an array of integers.
+
 ```ocaml
 # let sum m =
     let result = ref 0 in
@@ -592,6 +626,7 @@ Some applications maintain some state while they are running. Here are a couple 
 - A cache.
 
 The following is a toy line editor, using the `get_char` function [defined earlier](#example-getchar-function). It waits for characters on standard input and exits on end-of-file, carriage return, or newline. Otherwise, if the character is printable, it prints it and records it in a mutable list used as a stack. If the character is the delete code, the stack is popped and the last printed character is erased.
+
 ```ocaml
 # let record_char state c =
     (String.make 1 c, c :: state);;
@@ -635,6 +670,7 @@ This is a possible way to handle an application-wide state. As in the [Function-
 ### Good: Precomputing Values
 
 Let's imagine you store angles as fractions of the circle in 8-bit unsigned integers, storing them as `char` values. In this system, 64 is 90 degrees, 128 is 180 degrees, 192 is 270 degrees, 256 is full circle, and so on. If you need to compute cosine on those values, an implementation might look like this:
+
 ```ocaml
 # let char_cos c =
     c |> int_of_char |> float_of_int |> ( *. ) (Float.pi /. 128.0) |> cos;;
@@ -642,6 +678,7 @@ val char_cos : char -> float = <fun>
 ```
 
 However, it is possible to make a faster implementation by precomputing all the possible values in advance. There are only 256 of them, which you'll see listed after the first result below:
+
 ```ocaml
 # let char_cos_tab = Array.init 256 (fun i -> i |> char_of_int |> char_cos);;
 val char_cos_tab : float array =
@@ -678,6 +715,7 @@ A module may expose or encapsulate a state in several different ways:
 1. Bad: mutable state with no explicit initialisation function or no name referring to the mutable state
 
 For example, the [`Hashtbl`](/manual/api/Hashtbl.html) module provides an interface of the first kind. It has the type `Hashtbl.t` representing mutable data. It also exposes `create`, `clear`, and `reset` functions. The `clear` and `reset` functions return `unit`. This strongly signals the reader that they perform the side-effect of updating the mutable data.
+
 ```ocaml
 # #show Hashtbl.t;;
 type ('a, 'b) t = ('a, 'b) Hashtbl.t
@@ -697,6 +735,7 @@ On the other hand, a module may define mutable data internally impacting its beh
 ### Bad: Undocumented Mutation
 
 Here's an example of bad code:
+
 ```ocaml
 # let partition p k =
     let m = Array.copy k in
@@ -739,6 +778,7 @@ GOTCHA: This is the dual of the previous anti-pattern. “Mutable in disguise”
 ### Bad: Undocumented Side Effects
 
 Consider this code:
+
 ```ocaml
 # module Array = struct
     include Stdlib.Array
@@ -762,6 +802,7 @@ If you're writing functions with non-obvious side effects, don't shadow existing
 ### Bad: Side Effects Depending on Order of Evaluation
 
 Consider the following code:
+
 ```ocaml
 # let id_print s = print_string (s ^ " "); s;;
 val id_print : string -> string = <fun>
@@ -781,6 +822,7 @@ In the second line, we apply `id_print` to the arguments `"Monday"`, `"Tuesday"`
 Since the evaluation order for function arguments in OCaml is not explicitly defined, the order in which the `id_print` side effects take place is unreliable. In this example, the arguments are evaluated from right to left, but this could change in future compiler releases.
 
 This issue also arises when applying arguments to variant constructors, building tuple values, or initialising record fields. Here, it is illustrated on a tuple value:
+
 ```ocaml
 # let r = ref 0 in ((incr r; !r), (decr r; !r));;
 - : int * int = (0, -1)
@@ -792,6 +834,7 @@ To ensure that evaluation takes place in a specific order, use the means to put 
 
 <!--
 You can use the sequence operator `;` to execute expressions in a particular order:
+
 ```ocaml
 # print_endline "ha"; print_endline "ho";;
 ha
@@ -800,6 +843,7 @@ ho
 ```
 
 `let` expressions are executed in the order they appear, so you can nest them to achieve a particular order of evaluation:
+
 ```ocaml
 # let () = print_endline "ha" in print_endline "hu";;
 ha

--- a/data/tutorials/language/1ms_00_modules.md
+++ b/data/tutorials/language/1ms_00_modules.md
@@ -29,12 +29,14 @@ Here is a program using two files: `athens.ml` and `berlin.ml`. Each file
 defines a module named `Athens` and `Berlin`, respectively.
 
 Here is the file `athens.ml`:
+
 <!-- $MDX file=examples/athens.ml -->
 ```ocaml
 let hello () = print_endline "Hello from Athens"
 ```
 
 Here is the file `berlin.ml`:
+
 <!-- $MDX file=examples/berlin.ml -->
 ```ocaml
 let () = Athens.hello ()
@@ -43,17 +45,21 @@ let () = Athens.hello ()
 To compile them using [Dune](https://dune.build/), at least two
 configuration files are required:
 * The `dune-project` file contains project-wide configuration.
+
   ```lisp
   (lang dune 3.7)
   ```
+
 * The `dune` file contains actual build directives. A project may have several
   `dune` files, one per directory containing things to build. This single line is
   sufficient in this example:
+
   ```lisp
   (executable (name berlin))
   ```
 
 After you create those files, build and run them:
+
 <!-- $MDX dir=examples -->
 ```bash
 $ opam exec -- dune build
@@ -88,6 +94,7 @@ anything the module provides.
 If you are using a module heavily, you might want to `open` it. This brings the
 module's definitions into scope. In our example, `berlin.ml` could have been
 written:
+
 <!-- $MDX skip -->
 ```ocaml
 open Athens
@@ -98,6 +105,7 @@ Using `open` is optional. Usually, we don't open a module like `List` because it
 provides names other modules also provide, such as [`Array`](/manual/api/Array.html) or `Option`. Modules
 like `Printf` provide names that aren't subject to conflicts, such as `printf`.
 Placing `open Printf` at the top of a file avoids writing `Printf.printf` repeatedly.
+
 ```ocaml
 open Printf
 let data = ["a"; "beautiful"; "day"]
@@ -110,6 +118,7 @@ let () = List.iter (printf "%s\n") data
  at the top of every file. Refer to Dune documentation if you need to opt-out.
 
 You can open a module inside a definition, using the `let open ... in` construct:
+
 ```ocaml
 # let list_sum_sq m =
     let open List in
@@ -118,6 +127,7 @@ val list_sum_sq : int -> int = <fun>
 ```
 
 The module access notation can be applied to an entire expression:
+
 ```ocaml
 # let array_sum_sq m =
     Array.(init m Fun.id |> map (fun i -> i * i) |> fold_left ( + ) 0);;
@@ -139,6 +149,7 @@ interface. By default, when no corresponding `.mli` file is provided, an
 implementation has a default interface where everything is public.
 
 Copy the `athens.ml` file into `cairo.ml` and change its contents:
+
 <!-- $MDX file=examples/cairo.ml -->
 ```ocaml
 let message = "Hello from Cairo"
@@ -146,6 +157,7 @@ let hello () = print_endline message
 ```
 
 As it is, `Cairo` has the following interface:
+
 <!-- $MDX skip -->
 ```ocaml
 val message : string
@@ -158,6 +170,7 @@ acts as a mask over the module's implementation. The `cairo.ml` file defines
 Filenames without extensions must be the same.
 
 To turn `message` into a private definition, don't list it in the `cairo.mli` file:
+
 <!-- $MDX file=examples/cairo.mli -->
 ```ocaml
 val hello : unit -> unit
@@ -178,11 +191,13 @@ let () = Cairo.hello ()
 
 Update the `dune` file to allow this example's compilation aside from the
 previous one.
+
 ```lisp
 (executables (names berlin delhi))
 ```
 
 Compile and execute both programs:
+
 ```shell
 $ opam exec -- dune exec ./berlin.exe
 Hello from Athens
@@ -192,6 +207,7 @@ Hello from Cairo
 ```
 
 You can check that `Cairo.message` is not public by attempting to compile a `delhi.ml` file containing:
+
 ```ocaml
 let () = print_endline Cairo.message
 ```
@@ -239,12 +255,14 @@ let dalet_of = function
 ```
 
 Update file `dune` to have three targets; two executables: `berlin` and `delhi`; and a library `exeter`.
+
 ```lisp
 (executables (names berlin delhi) (modules athens berlin cairo delhi))
 (library (name exeter) (modules exeter))
 ```
 
 Run the `opam exec -- dune utop` command. This triggers `Exeter`'s compilation, launches `utop`, and loads `Exeter`.
+
 ```ocaml
 # open Exeter;;
 
@@ -253,12 +271,14 @@ type aleph = Ada | Alan | Alonzo
 ```
 
 Type `aleph` is public. Values can be created or accessed.
+
 ```ocaml
 # #show bet;;
 Unknown element.
 ```
 
 Type `bet` is private. It is not available outside of the implementation where it is defined, here `Exeter`.
+
 ```ocaml
 # #show gimel;;
 type gimel
@@ -277,6 +297,7 @@ val gimel_of_bool : bool -> gimel
 ```
 
 Type `gimel` is _abstract_. Values can be created or manipulated, but only as function results or arguments. Just the provided functions `gimel_of_bool`, `gimel_flip`, and `gimel_to_string` or polymorphic functions can receive or return `gimel` values.
+
 ```ocaml
 # #show dalet;;
 type dalet = private Dennis of int | Donald of string | Dorothy
@@ -337,6 +358,7 @@ executable:
 
 To define a submodule's interface, we can provide a _module signature_. This
 is done in this second version of the `florence.ml` file:
+
 ```ocaml
 module Hello : sig
  val print : unit -> unit
@@ -353,6 +375,7 @@ The first version made `Florence.Hello.message` public. In this version it can't
 ### Module Signatures are Types
 
 The role played by module signatures to implementations is akin to the role played by types to values. Here is a third possible way to write file `florence.ml`:
+
 ```ocaml
 module type HelloType = sig
   val print : unit -> unit
@@ -389,6 +412,7 @@ module Unit :
 ```
 
 The OCaml compiler tool chain can be used to dump an `.ml` file's default interface.
+
 ```shell
 $ ocamlc -i cairo.ml
 val message : string
@@ -423,6 +447,7 @@ module from another `.ml` file, we need to add `open Extlib` at the beginning.
 ## Stateful Modules
 
 A module may have an internal state. This is the case for the `Random` module from the standard library. The functions `Random.get_state` and `Random.set_state` provide read and write access to the internal state, which is nameless and has an abstract type.
+
 ```ocaml
 # let s = Random.get_state ();;
 val s : Random.State.t = <abstr>

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -25,12 +25,14 @@ $ mkdir funkt; cd funkt
 ```
 
 Place the following in the file **`dune-project`**:
+
 ```lisp
 (lang dune 3.7)
 (package (name funkt))
 ```
 
 The content of the file **`dune`** should be this:
+
 ```lisp
 (executable
   (name funkt)
@@ -47,6 +49,7 @@ Check that this works using the `opam exec -- dune exec funkt` command. It shoul
 The standard library contains a [`Set`](/manual/api/Set.html) module which is designed to handle sets. This module enables you to perform operations such as union, intersection, and difference on sets. You may check the [Set](/docs/sets) tutorial to learn more about this module, but it is not required to follow the present tutorial.
 
 To create a set module for a given element type (which allows you to use the provided type and its associated [functions](/manual/api/Set.S.html)), it's necessary to use the functor `Set.Make` provided by the `Set` module. Here is a simplified version of `Set`'s interface:
+
 ```ocaml
 module type OrderedType = sig
   type t
@@ -67,7 +70,6 @@ Here is how this reads (starting from the bottom, then going up):
 Here is an example of how to use `Set.Make`:
 
 **`funkt.ml`**
-
 ```ocaml
 module StringCompare = struct
   type t = string
@@ -86,11 +88,13 @@ This defines a module `Funkt.StringSet`. What `Set.Make` needs are:
 another type, here `string`. If that other type is also called `t`, the compiler
 will trigger an error _“The type abbreviation t is cyclic”_. This can be worked
 around by adding the `nonrec` keyword to the type definition, like this:
+
 ```ocaml
 type nonrec t = t
 ```
 
 This can be simplified using an _anonymous module_ expression:
+
 ```ocaml
 module StringSet = Set.Make(struct
   type t = string
@@ -105,6 +109,7 @@ However, since the module `String` already defines
 - Function `compare` of type `t -> t -> bool` compares two strings
 
 This can be simplified even further into this:
+
 ```ocaml
 module StringSet = Set.Make(String)
 ```
@@ -178,6 +183,7 @@ That's the case for the sets, maps, and hash tables provided by the standard lib
 * The functor returns a module that implements what is promised, as described by the result interface
 
 Here is the module's signature that the functors `Set.Make` and `Map.Make` expect:
+
 ```ocaml
 module type OrderedType = sig
   type t
@@ -186,6 +192,7 @@ end
 ```
 
 Here is the module's signature that the functor `Hashtbl.Make` expects:
+
 ```ocaml
 module type HashedType = sig
   type t
@@ -208,6 +215,7 @@ There are many kinds of [heap](https://en.wikipedia.org/wiki/Heap_(data_structur
 The kind of data structures and algorithms used to implement a heap is not discussed in this document.
 
 The common prerequisite to implement any heap is a means to compare the elements they contain. That's the same signature as the parameter of `Set.Make` and `Map.Make`:
+
 ```ocaml
 module type OrderedType = sig
   type t
@@ -216,6 +224,7 @@ end
 ```
 
 Using such a parameter, a heap implementation must provide at least this interface:
+
 ```ocaml
 module type HeapType = sig
   type elt
@@ -345,7 +354,6 @@ The module `IterPrint` is refactored into a functor that takes a module providin
 **Note**: An OCaml interface file (`.mli`) must be a module, not a functor. Functors must be embedded inside modules. Therefore, it is customary to call them `Make`.
 
 **`funkt.ml`**
-
 ```ocaml
 module StringSet = Set.Make(String)
 module IterPrint = IterPrint.Make(List)
@@ -535,6 +543,7 @@ end
 ```
 
 Create this file and launch `utop`.
+
 ```ocaml
 # #mod_use "random.ml";;
 

--- a/data/tutorials/language/1ms_02_dune.md
+++ b/data/tutorials/language/1ms_02_dune.md
@@ -24,6 +24,7 @@ We use unique terms for different elements of our project to avoid ambiguity. Fo
 ## Minimum Project Setup
 
 This section details the structure of an almost-minimum Dune project setup. Check [Your First OCaml Program](/docs/your-first-program) for automatic setup using the `dune init proj` command.
+
 ```shell
 $ mkdir mixtli; cd mixtli
 ```
@@ -68,6 +69,7 @@ let () =
 ```
 
 Here is the resulting output:
+
 ```shell
 $ opam exec -- dune exec nube
 Nimbostratus (Ns)
@@ -76,6 +78,7 @@ Cumulonimbus (Cb)
 
 
 Here is the directory contents:
+
 ```shell
 $ tree
 .
@@ -86,9 +89,11 @@ $ tree
 ```
 
 Dune stores the files it creates, and a copy of the sources, in a directory named `_build`. You don't need to edit anything there. In a project managed using Git, the `_build` directory should be ignored
+
 ```shell
 $ echo _build >> .gitignore
 ```
+
 You can also configure your editor or IDE to ignore it too.
 
 In OCaml, each `.ml` file defines a module. In the `mixtli` project, the file `cloud.ml` defines the `Cloud` module, the file `wmo.ml` defines the `Wmo` module that contains two submodules: `Stratus` and `Cumulus`.
@@ -102,6 +107,7 @@ Here are the different names:
 * `wmo-clouds` is the name of the package built by this project.
 
 The `dune describe` command allows having a look at the project's module structure. Here is its output:
+
 ```lisp
 ((root /home/cuihtlauac/caml/mixtli-dune)
  (build_context _build/default)
@@ -129,6 +135,7 @@ The `dune describe` command allows having a look at the project's module structu
 In OCaml, a library is a collection of modules. By default, when Dune builds a library, it wraps the bundled modules into a module. This allows having several modules with the same name, inside different libraries, in the same project. That feature is known as [_namespaces_](https://en.wikipedia.org/wiki/Namespace) for module names. This is similar to what modules do for definitions; they avoid name clashes.
 
 Dune creates libraries from directories. Let's look at an example. Here the `lib` directory contains its sources. This is different from the Unix standard, where `lib` stores compiled library binaries.
+
 ```shell
 $ mkdir lib
 ```
@@ -144,6 +151,7 @@ The `lib` directory is populated with the following source files:
 ```ocaml
 val nimbus : string
 ```
+
 <!-- FIXME: <> strings, no behaviour -->
 **`lib/cumulus.ml`**
 ```ocaml
@@ -161,6 +169,7 @@ let nimbus = "Nimbostratus (Ns)"
 ```
 
 All the modules found in the `lib` directory are bundled into the `Wmo` module. This module is the same as what we had in the `wmo.ml` file. To avoid redundancy, we delete it:
+
 ```shell
 $ rm wmo.ml
 ```
@@ -215,6 +224,7 @@ Using a wrapper file makes several things possible:
 By default, Dune builds a library from the modules found in the same directory as the `dune` file, but it doesn't look into subdirectories. It is possible to change this behaviour.
 
 In this example, we create subdirectories and move files there.
+
 ```shell
 $ mkdir lib/cumulus lib/stratus
 $ mv lib/cumulus.ml lib/cumulus/m.ml
@@ -249,6 +259,7 @@ The `include_subdirs qualified` stanza works recursively, except on subdirectori
 It is possible to start an empty Dune project from a single file.
 
 Create a fresh directory.
+
 ```shell
 $ mkdir foo.dir; cd foo.dir
 ```
@@ -331,6 +342,7 @@ let nimbus = "Nimbostratus (Ns)"
 ```
 
 In this setup, running `dune utop` allows discovering what's available.
+
 ```ocaml
 # #show Wmo;;
 module Wmo : sig module Cumulus = Wmo.Cumulus module Stratus = Wmo.Stratus end
@@ -382,6 +394,7 @@ Wrapping can be disabled in Dune's configuration.
 In that case, the “library” only contains the modules `Cumulus` and `Stratus`,
 bundled together, side by side. Check the following in `dune utop`, twice. Once
 with file `lib/wmo.ml` unchanged, and a second time after deleting it.
+
 ```ocaml
 # #show Cumulus;;
 module Cumulus : sig val nimbus : string val altus : string end

--- a/data/tutorials/language/3ds_00_options.md
+++ b/data/tutorials/language/3ds_00_options.md
@@ -9,6 +9,7 @@ category: "Data Structures"
 ## Introduction
 
 An [option](https://en.wikipedia.org/wiki/Option_type) value wraps another value or contains nothing if there isn't anything to wrap. The predefined type `option` represents such values.
+
 <!-- $MDX non-deterministic=command -->
 ```ocaml
 # #show option;;
@@ -16,6 +17,7 @@ type 'a option = None | Some of 'a
 ```
 
 Here are option values:
+
 ```ocaml
 # Some 42;;
 - : int option = Some 42
@@ -33,6 +35,7 @@ The option type is useful when the lack of data is better handled as the special
 ## Exceptions _vs_ Options
 
 The function `Sys.getenv : string -> string` from the OCaml standard library queries the value of an environment variable; however, it throws an exception if the variable is not defined. On the other hand, the function `Sys.getenv_opt : string -> string option` does the same, except it returns `None` if the variable is not defined. Here is what may happen if we try to access an undefined environment variable:
+
 ```ocaml
 # Sys.getenv "UNDEFINED_ENVIRONMENT_VARIABLE";;
 Exception: Not_found.
@@ -50,6 +53,7 @@ Most of the functions in this section, as well as other useful ones, are provide
 ### Map Over an Option
 
 Using pattern matching, it is possible to define functions, allowing to work with option values. Here is `map` of type `('a -> 'b) -> 'a option -> 'b option`. It allows to apply a function to the wrapped value inside an `option`, if present:
+
 ```ocaml
 let map f = function
   | None -> None
@@ -57,6 +61,7 @@ let map f = function
 ```
 
 In the standard library, this is `Option.map`.
+
 ```ocaml
 # Option.map (fun x -> x * x) (Some 3);;
 - : int option = Some 9
@@ -77,6 +82,7 @@ let join = function
 ```
 
 In the standard library, this is `Option.join`.
+
 ```ocaml
 # Option.join (Some (Some 42));;
 - : int option = Some 42
@@ -91,6 +97,7 @@ In the standard library, this is `Option.join`.
 ### Access the Content of an Option
 
 The function `get` of type `'a option -> 'a` allows access to the value contained inside an `option`.
+
 ```ocaml
 let get = function
   | Some v -> v
@@ -98,6 +105,7 @@ let get = function
 ```
 
 Beware, `get o` throws an exception if `o` is `None`. To access the content of an `option` without the risk of raising an exception, the function `value` of type `'a option -> 'a -> 'a` can be used:
+
 ```ocaml
 let value opt ~default = match opt with
   | Some v -> v
@@ -111,6 +119,7 @@ In the standard library, these functions are `Option.get` and `Option.value`.
 ### Fold an Option
 
 The function `fold` of type `none:'a -> some:('b -> 'a) -> 'b option -> 'a` can be seen as a combination of `map` and `value`
+
 ```ocaml
 let fold ~none ~some o = o |> Option.map some |> Option.value ~default:none
 ```
@@ -118,6 +127,7 @@ let fold ~none ~some o = o |> Option.map some |> Option.value ~default:none
 In the standard library, this function is `Option.fold`.
 
 The `Option.fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version uses pattern matching:
+
 ```ocaml
 # let path () =
     let split_on_colon = String.split_on_char ':' in
@@ -129,6 +139,7 @@ val path : unit -> string list = <fun>
 ```
 
 Here is the same function, using `Option.fold`:
+
 ```ocaml
 # let path () =
     let split_on_colon = String.split_on_char ':' in
@@ -141,6 +152,7 @@ val path : unit -> string list = <fun>
 The `bind` function of type `'a option -> ('a -> 'b option) -> 'b option` works a bit like `map`. But whilst `map` expects a function parameter `f` that returns an unwrapped value of type `b`, `bind` expects an `f` that returns a value already wrapped in an option `'b option`.
 
 Here, we display the type of `Option.map`, with parameters flipped and show a possible implementation of `Option.bind`.
+
 ```ocaml
 # Fun.flip Option.map;;
 - : 'a option -> ('a -> 'b) -> 'b option = <fun>

--- a/data/tutorials/language/3ds_02_maps.md
+++ b/data/tutorials/language/3ds_02_maps.md
@@ -20,6 +20,7 @@ To use `Map`, we first have to use the [`Map.Make`](/manual/api/Map.Make.html) f
 map module. Refer to the [Functors](/docs/functors) for more information on
 functors. This functor has a module parameter that defines the keys' type to
 be used in the maps, and a function for comparing them.
+
 ```ocaml
 # module StringMap = Map.Make(String);;
 
@@ -50,6 +51,7 @@ The `StringMap` module has an `empty` value that has a type parameter `'a` in
 its type: `empty : 'a t`.
 
 This means that we can use `empty` to create new empty maps where the value is of any type.
+
 ```ocaml
 # let int_map : int StringMap.t = StringMap.empty;;
 val int_map : int StringMap.t = <abstr>
@@ -61,6 +63,7 @@ val float_map : float StringMap.t = <abstr>
 The type of the values can be specified in two ways:
 * When you create your new map with an annotation
 * By adding an element to the map:
+
 ```ocaml
 # let int_map = StringMap.(empty |> add "one" 1);;
 val int_map : int StringMap.t = <abstr>
@@ -69,6 +72,7 @@ val int_map : int StringMap.t = <abstr>
 ## Working With Maps
 
 Throughout the rest of this tutorial, we use the following map:
+
 ```ocaml
 # let lucky_numbers = StringMap.of_seq @@ List.to_seq [
     ("leostera", 2112);
@@ -81,6 +85,7 @@ val lucky_numbers : int StringMap.t = <abstr>
 ## Finding Entries in a Map
 
 To find entries in a map, use the `find_opt` or `find` functions:
+
 ```ocaml
 # StringMap.find_opt "leostera" lucky_numbers;;
 - : int option = Some 2112
@@ -99,6 +104,7 @@ When the searched key is absent from the map:
 
 We can also use `find_first_opt` and `find_last_opt` if we want to use a
 predicate function:
+
 ```ocaml
 # let first_under_10_chars : (string * int) option =
   StringMap.find_first_opt
@@ -117,6 +123,7 @@ not just the value.
 
 To add an entry to a map, use the `add` function that takes a key, a value, and
 a map. It returns a new map with that key-value pair added:
+
 ```ocaml
 # let more_lucky_numbers = lucky_numbers |> StringMap.add "paguzar" 108;;
 val more_lucky_numbers : int StringMap.t = <abstr>
@@ -136,6 +143,7 @@ Note that the initial map `lucky_numbers` remains unchanged.
 
 To remove an entry from a map, use the `remove` function, which takes a key and
 a map. It returns a new map with that key's entry removed.
+
 ```ocaml
 # let less_lucky_numbers = lucky_numbers |> StringMap.remove "divagnz";;
 val less_lucky_numbers : int StringMap.t = <abstr>
@@ -175,6 +183,7 @@ You should experiment with different update functions; several behaviors are pos
 ## Checking if a Key is Contained in a Map
 
 To check if a map contains a key, use the `mem` function:
+
 ```ocaml
 # StringMap.mem "paguzar" less_lucky_numbers;;
 - : bool = false
@@ -185,6 +194,7 @@ To check if a map contains a key, use the `mem` function:
 To merge two maps, use the `union` function, which takes two maps, and a
 function deciding how to handle entries with identical keys. It returns a new map.
 Note that the input maps are not modified.
+
 ```ocaml
 # StringMap.union;;
 - : (string -> 'a -> 'a -> 'a option) ->
@@ -193,6 +203,7 @@ Note that the input maps are not modified.
 ```
 
 Here are examples of duplicate key resolution functions:
+
 ```ocaml
 # let pick_fst key v1 _ = Some v1;;
 val pick_fst : 'a -> 'b -> 'c -> 'b option = <fun>
@@ -233,6 +244,7 @@ val drop : 'a -> 'b -> 'c -> 'd option = <fun>
 To filter a map, use the `filter` function. It takes a predicate to filter
 entries and a map. It returns a new map containing the entries satisfying the
 predicate.
+
 ```ocaml
 # let even_numbers =
   StringMap.filter
@@ -244,24 +256,28 @@ val even_numbers : int StringMap.t = <abstr>
 ## Map a Map
 
 Map modules have a `map` function:
+
 ```ocaml
 StringMap.map;;
 - : ('a -> 'b) -> 'a StringMap.t -> 'b StringMap.t = <fun>
 ```
 
 The `lucky_numbers` map associates string keys with integer values.
+
 ```ocaml
 # lucky_numbers;;
 - : int StringMap.t = <abstr>
 ```
 
 Using `StringMap.map`, we create a map associating keys with string values:
+
 ```ocaml
 # let lucky_strings = StringMap.map string_of_int lucky_numbers;;
 val lucky_strings : string StringMap.t = <abstr>
 ```
 
 The keys are the same in both maps. For each key, a value in `lucky_numbers` is converted into a value in `lucky_strings` using `string_of_int`.
+
 ```ocaml
 # lucky_numbers |> StringMap.find "leostera" |> string_of_int;;
 - : string = "2112"
@@ -281,6 +297,7 @@ functor with a module of your own, provided that it implements two things:
 Let's define our custom map below for non-negative numbers.
 
 We'll start by defining a module for strings that compares them in case-insensitive way.
+
 ```ocaml
 # module Istring : sig
     type t

--- a/data/tutorials/language/3ds_03_sets.md
+++ b/data/tutorials/language/3ds_03_sets.md
@@ -13,6 +13,7 @@ category: "Data Structures"
 **Disclaimer:** The examples in this tutorial require OCaml 5.1. If you're running a previous version of OCaml , you can either use `elements` instead of `to_list`, which is a new function in OCaml 5.1, or upgrade OCaml by running `opam update`, then `opam upgrade ocaml`. Check your current version with `ocaml --version`. 
 
 If you need to work with string sets, you must invoke `Set.Make(String)`. That returns a new module.
+
 ```ocaml
 # module StringSet = Set.Make(String);;
 module StringSet :
@@ -38,6 +39,7 @@ This module also defines two types:
 ## Creating a Set
 
 1. We can create an empty set using `StringSet.empty`:
+
 ```ocaml
 # StringSet.empty ;;
 - : StringSet.t = <abstr>
@@ -51,6 +53,7 @@ For `StringSet.empty`, you can see that the OCaml toplevel displays the placehol
 (Remember, for OCaml versions before 5.1, it will be `StringeSet.empty |> StringSet.elements;;`)
 
 2. A set with a single element is created using `StringSet.singleton`:
+
 ```ocaml
 # StringSet.singleton "hello";;
 - : StringSet.t = <abstr>
@@ -60,6 +63,7 @@ For `StringSet.empty`, you can see that the OCaml toplevel displays the placehol
 ```
 
 3. Converting a list into a set using `StringSet.of_list`:
+
 ```ocaml
 # StringSet.of_list ["hello"; "hi"];;
 - : StringSet.t = <abstr>
@@ -73,6 +77,7 @@ There's another relevant function `StringSet.of_seq: string Seq.t -> StringSet.t
 ## Working With Sets
 
 Let's look at a few functions for working with sets using these two sets.
+
 ```ocaml
 # let first_set = ["hello"; "hi"] |> StringSet.of_list;;
 - : val first_set : StringSet.t = <abstr>
@@ -189,9 +194,11 @@ You can see that this module has the intended behavior:
 # CISS.singleton "hello" |> CISS.add "HELLO" |> CISS.to_list;;
 - : string list = ["hello"]
 ```
+
 The value `"HELLO"` is not added to the set because it is considered equal to the value `"hello"`, which is already contained in the set.
 
 You can use any type for elements, as long as you define a meaningful `compare` operation.
+
 ```ocaml
 # type color = Red | Green | Blue;;
 type color = Red | Green | Blue

--- a/data/tutorials/language/3ds_04_hashtbl.md
+++ b/data/tutorials/language/3ds_04_hashtbl.md
@@ -15,6 +15,7 @@ create a hash table we could write:
 # let my_hash = Hashtbl.create 123456;;
 val my_hash : ('_weak1, '_weak2) Hashtbl.t = <abstr>
 ```
+
 The 123456 is the initial size of the hashtbl. This initial number is
 just your best guess as to the amount of data that you will be putting
 into the hash table. The hash table can grow if you under-estimate the

--- a/data/tutorials/language/3ds_06_memoization.md
+++ b/data/tutorials/language/3ds_06_memoization.md
@@ -292,6 +292,7 @@ example
 ```
 
 Note that the optimal splitting is:
+
 ```text
 this may be
 a difficult

--- a/data/tutorials/language/3ds_07_monads.md
+++ b/data/tutorials/language/3ds_07_monads.md
@@ -270,6 +270,7 @@ function:
 ```ocaml
 let return (x : int) : int option = Some x
 ```
+
 This function has the *trivial effect* of putting a value into the metaphorical
 box.
 
@@ -491,6 +492,7 @@ calls a function and produces a log message:
 let log (name : string) (f : int -> int) : int -> int * string =
   fun x -> (f x, Printf.sprintf "Called %s on %i; " name x)
 ```
+
 The second helper produces a logging function of type
 `'a * string -> 'b * string` out of a non-loggable function:
 
@@ -547,6 +549,7 @@ the empty string. That's what `e` does. We could rename it `return`:
 ```ocaml
 let return (x : int) : int * string = (x, "")
 ```
+
 This function has the *trivial effect* of putting a value into the metaphorical
 box along with the empty log message.
 

--- a/data/tutorials/language/4ad_00_metaprogramming.md
+++ b/data/tutorials/language/4ad_00_metaprogramming.md
@@ -19,7 +19,6 @@ preprocessor](https://github.com/ocaml-ppx/ppxlib/tree/main/examples/simple-exte
 <!-- $MDX skip -->
 ```ocaml
 Printf.printf "This program has been compiled by user: %s" [%get_env "USER"]
-
 ```
 
 When you compile the code with the preprocessor, it will replace [%get_env "USER"] with the content of the USER environment variable. If the USER environment variable is set to "JohnDoe" for example, the line would become:
@@ -27,7 +26,6 @@ When you compile the code with the preprocessor, it will replace [%get_env "USER
 <!-- $MDX skip -->
 ```ocaml
 Printf.printf "This program has been compiled by user: %s" "JohnDoe"
-
 ```
 
 
@@ -200,7 +198,6 @@ or even directly with the OCaml toplevel using the option `-dparsetree` (also
 available in UTop).
 
 ```shell
-
 $ ocaml -dparsetree
 [Omitted output]
 # let x = 1 + 2 ;;
@@ -434,6 +431,7 @@ type t = int [@@deriving_inline yojson]
 ```
 
 Now, we run the PPX and promote the generated code in the original file:
+
 ```shell
 $ opam exec -- dune build @lint
 File "lib/lib.ml", line 1, characters 0-0:
@@ -452,8 +450,10 @@ index 4999e06..5516d41 100644
  [@@@deriving.end]
 Promoting _build/default/lib/lib.ml.lint-corrected to lib/lib.ml.
 ```
+
 The file now contains the generated value. While it is still a development
 dependency, the PPX dependency can be dropped for compiling the project:
+
 ```shell
 $ cat lib.ml
 type t = int [@@deriving_inline yojson]

--- a/data/tutorials/language/4ad_01_operators.md
+++ b/data/tutorials/language/4ad_01_operators.md
@@ -16,6 +16,7 @@ The learning goals of this tutorial are:
 ## Using Binary Operators
 
 In OCaml, almost all binary operators are regular functions. The function underlying an operator is referred by surrounding the operator symbol with parentheses. Here are the addition, string concatenation, and equality functions:
+
 ```ocaml
 # (+);;
 - : int -> int -> int = <fun>
@@ -26,12 +27,14 @@ In OCaml, almost all binary operators are regular functions. The function underl
 ```
 
 **Note**: the operator symbol for multiplication is ` * `, but can't be referred as `(*)`. This is because comments in OCaml are delimited by `(*` and `*)`. To resolve the parsing ambiguity, space characters must be inserted to get the multiplication function.
+
 ```ocaml
 # ( * );;
 - : int -> int -> int = <fun>
 ```
 
 Using operators as functions is convenient when combined with partial application. For instance, here is how to get the values that are greater than or equal to 10 in a list of integers, using the function `List.filter` and an operator.
+
 ```ocaml
 # List.filter;;
 - : ('a -> bool) -> 'a list -> 'a list = <fun>
@@ -56,6 +59,7 @@ Finally, in the third line, all the arguments expected by `List.filter` are prov
 ## Defining Binary Operators
 
 It is also possible to define binary operators. Here is an example:
+
 ```ocaml
 # let cat s1 s2 = s1 ^ " " ^ s2;;
 val cat : string -> string -> string = <fun>
@@ -71,6 +75,7 @@ It is a recommended practice to define operators in two steps, like shown in the
 ## Unary Operators
 
 Unary operators are also called prefix operators. In some contexts, it can make sense to shorten a function's name into a symbol. This is often used as a way to shorten the name of a function that performs some sort of conversion over its argument.
+
 ```ocaml
 # let ( !! ) = Lazy.force;;
 val ( !! ) : 'a lazy_t -> 'a = <fun>
@@ -123,6 +128,7 @@ Tips:
 ## Operator Associativity and Precedence
 
 Let's illustrate operator associativity with an example. The following function concatenates its string arguments, surrounded by `|` characters and separated by a `_` character.
+
 ```ocaml
 # let par s1 s2 = "|" ^ s1 ^ "_" ^ s2 ^ "|";;
 val par : string -> string -> string = <fun>
@@ -132,6 +138,7 @@ val par : string -> string -> string = <fun>
 ```
 
 Let's turn `par` into two different operators:
+
 ```ocaml
 # let ( @^ ) = par;;
 val ( @^ ) : string -> string -> string = <fun>
@@ -141,6 +148,7 @@ val ( &^ ) : string -> string -> string = <fun>
 ```
 
 At first sight, operators `@^` and `&^` are the same. However, the OCaml parser allows forming expressions using several operators without parentheses.
+
 ```ocaml
 # "foo" @^ "bar" @^ "bus";;
 - : string = "|foo_|bar_bus||"
@@ -154,6 +162,7 @@ Although both expressions are calling the same function (`par`), they are evalua
 1. Expression `"foo" &^ "bar" &^ "bus"` is evaluated as if it was `"(foo" &^ "bar") &^ "bus"`. Parentheses are added at the left, therefore `&^` _associates to the left_
 
 Operator _precedence_ rules how expressions combining different operators without parentheses are interpreted. For instance, using the same operators, here is how expressions using both are evaluated:
+
 ```ocaml
 # "foo" &^ "bar" @^ "bus";;
 - : string = "|foo_|bar_bus||"
@@ -176,6 +185,7 @@ The complete list of precedence is longer because it includes the predefined ope
 OCaml allows the creation of custom `let` operators. This is often used on monad-related functions such as `Option.bind` or `List.concat_map`. See [Monads](/docs/monads) for more on this topic.
 
 The `doi_parts` function attempts to extract the registrant and identifier parts from string expected to contain a [Digital Object Identifier (DOI)](https://en.wikipedia.org/wiki/Digital_object_identifier).
+
 ```ocaml
 # let ( let* ) = Option.bind;;
 val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
@@ -198,7 +208,6 @@ val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
 
 # doi_parts "https://doi.org/10.1000/182";;
 - : (string * string) option = Some ("1000", "182")
-
 ```
 
 This function is using `Option.bind` as a custom binder over the calls to `rindex_opt` and `rindex_from_opt`. This allows to only consider the case where both searches are successful and return the positions of the found characters. If any of them fails, `doi_parts` implicitly returns `None`.

--- a/data/tutorials/language/4ad_02_objects.md
+++ b/data/tutorials/language/4ad_02_objects.md
@@ -93,6 +93,7 @@ object. We use the familiar `new` operator:
 # let s = new stack_of_ints;;
 val s : stack_of_ints = <obj>
 ```
+
 Now we'll push and pop some elements off the stack:
 
 ```ocaml
@@ -115,6 +116,7 @@ Popped 2 off the stack.
 Popped 1 off the stack.
 - : unit = ()
 ```
+
 Notice the syntax. `object#method` means call `method` on `object`. This
 is the same as `object.method` or `object->method` that you will be
 familiar with in imperative languages.
@@ -245,6 +247,7 @@ widget  (superclass for all widgets)
   |
   +-------------> label
 ```
+
 (Notice that a `button` is a `container` because it can contain either a
 label or an image, depending on what is displayed on the button).
 
@@ -265,6 +268,7 @@ Error: Some type variables are unbound in this type:
            object method get_name : 'a method virtual repaint : unit end
        The method get_name has type 'a where 'a is unbound
 ```
+
 Oops! I forgot that OCaml cannot infer the type of `name` so will assume
 that it is `'a`. But that defines a polymorphic class, and I didn't
 declare the class as polymorphic (`class ['a] widget`). I need to narrow
@@ -280,6 +284,7 @@ the type of `name` like this:
 class virtual widget :
   string -> object method get_name : string method virtual repaint : unit end
 ```
+
 Now there are several new things going on in this code. Firstly, the
 class contains an **initialiser**. This is an argument to the class
 (`name`) which you can think of as exactly the equivalent of an argument
@@ -294,6 +299,7 @@ public class Widget
   }
 }
 ```
+
 In OCaml, a constructor constructs the whole class; it's not just a
 specially named function, so we write the arguments as if they are
 arguments to the class:
@@ -366,10 +372,10 @@ Notes:
  basically comes down to the fact that OCaml's linked lists are
  immutable. Let's imagine that someone wrote this code:
 
-  ```ocaml
-  # let list = container#get_widgets in
-    x :: list;;
-  ```
+```ocaml
+# let list = container#get_widgets in
+  x :: list;;
+```
 
 Would this modify the private internal representation of my `container`
 class, by prepending `x` to the list of widgets? No it wouldn't. If you run 
@@ -393,6 +399,7 @@ and I also use an anonymous function expression that might be unfamiliar:
 # (fun w -> w#repaint);;
 - : < repaint : 'a; .. > -> 'a = <fun>
 ```
+
 This defines an anonymous function with one argument `w` that just
 calls `w#repaint` (the `repaint` method on widget `w`).
 
@@ -490,6 +497,7 @@ class label :
   string ->
   string -> object method get_name : string method repaint : unit end
 ```
+
 Let's create a label which says "Press me!" and add it to the button:
 
 ```ocaml
@@ -513,6 +521,7 @@ class name =
     (* ... *)
   end
 ```
+
 The reference to `self` names the object,
 allowing you to call methods in the same class or pass the object to
 functions outside the class. In other words, it's exactly the same as
@@ -535,6 +544,7 @@ Error: This expression has type label but an expression was expected of type
          button
        The first object type has no method add
 ```
+
 We created a button `b` and a label `l` and then tried to create a list
 containing both, but we got an error. Yet `b` and `l` are both `widget`s,
 so maybe we can't put them into the same list because OCaml can't guess
@@ -629,6 +639,7 @@ but doing so can make things clearer. We can do it like this:
 # type counter = <get : int; incr : unit>;;
 type counter = < get : int; incr : unit >
 ```
+
 Compare with an equivalent record type definition:
 
 ```ocaml
@@ -637,6 +648,7 @@ Compare with an equivalent record type definition:
    incr : unit -> unit};;
 type counter_r = { get : unit -> int; incr : unit -> unit; }
 ```
+
 The implementation of a record working like our object would be:
 
 ```ocaml
@@ -646,6 +658,7 @@ The implementation of a record working like our object would be:
      incr = (fun () -> incr n)};;
 val r : counter_r = {get = <fun>; incr = <fun>}
 ```
+
 In terms of functionality, both the object and the record are similar,
 but each solution has its own advantages:
 

--- a/data/tutorials/language/5rt_01_garbage-collector.md
+++ b/data/tutorials/language/5rt_01_garbage-collector.md
@@ -167,7 +167,6 @@ profile). This setting can be overridden via the `s=<words>` argument to
 `OCAMLRUNPARAM`. You can change it after the program has started by calling
 the `Gc.set` function:
 
-
 ```ocaml env=tune
 # open Core;;
 # let c = Gc.get ();;

--- a/data/tutorials/language/5rt_02_compiler_frontend.md
+++ b/data/tutorials/language/5rt_02_compiler_frontend.md
@@ -288,7 +288,6 @@ illustrate their use without requiring any external tools.  Let's first look
 at the use of the standalone attribute `@@@warning` to toggle an OCaml
 compiler warning.
 
-
 ```ocaml env=main
 # module Abc = struct
 
@@ -1195,7 +1194,6 @@ $ ocamlc -dparsetree typedef.ml 2>&1
           None
     ]
 ]
-
 ```
 
 This is rather a lot of output for a simple two-line program, but it shows
@@ -1247,7 +1245,6 @@ $ ocamlc -dtypedtree typedef.ml 2>&1
           []
     ]
 ]
-
 ```
 
 The typed AST is more explicit than the untyped syntax tree. For instance,

--- a/data/tutorials/language/5rt_03_compiler_backend.md
+++ b/data/tutorials/language/5rt_03_compiler_backend.md
@@ -275,7 +275,6 @@ Estimated testing time 750ms (3 benchmarks x 250ms). Change using '-quota'.
   Monomorphic large pattern     6.54ns       67.89%
   Monomorphic small pattern     9.63ns      100.00%
   Polymorphic large pattern     9.63ns       99.97%
-
 ```
 
 These results confirm the performance hypothesis that we obtained earlier by
@@ -346,7 +345,6 @@ L2:	closure L1, 0
 	makeblock 1, 0
 	pop 1
 	setglobal Pattern_monomorphic_small!
-
 ```
 
 The preceding bytecode has been simplified from the lambda form into a set of
@@ -420,7 +418,6 @@ bytecode archive:
 
 ```
 $ ocamlc -a -o mylib.cma a.cmo b.cmo -dllib -lmylib
-
 ```
 
 The `dllib` flag embeds the arguments in the archive file. Any subsequent
@@ -434,7 +431,6 @@ a *custom runtime* mode and is built as follows:
 
 ```
 $ ocamlc -a -o mylib.cma -custom a.cmo b.cmo -cclib -lmylib
-
 ```
 
 The custom mode is the most similar mode to native code compilation, as both
@@ -846,8 +842,6 @@ output:
   (name      alternate_list)
   (libraries core))
 ```
-
-
 
 ```sh dir=examples/back-end/alternate_list
 $ opam exec -- dune build alternate_list.exe


### PR DESCRIPTION
I went through the .../tutorials/language/ directory and formatted the codeblocks to have padding. I avoided programmatic solutions to this, opting for a manual approach to avoid introducing new issues.