### PR TITLE
Move ocamlformat page under "Tooling"

### DIFF
--- a/data/tutorials/platform/1_07_ocamlformat.md
+++ b/data/tutorials/platform/1_07_ocamlformat.md
@@ -4,7 +4,7 @@ title: "Formatting Your Code With OCamlFormat"
 short_title: "Formatting Your Code"
 description: |
   How to set up OCamlFormat to automatically format your code
-category: "Editor Support"
+category: "Tooling"
 ---
 
 Automatic formatting with OCamlFormat requires an `.ocamlformat` configuration file at the root of the project.

--- a/data/tutorials/platform/1_07_ocamlformat.md
+++ b/data/tutorials/platform/1_07_ocamlformat.md
@@ -4,7 +4,7 @@ title: "Formatting Your Code With OCamlFormat"
 short_title: "Formatting Your Code"
 description: |
   How to set up OCamlFormat to automatically format your code
-category: "Tooling"
+category: "Additional Tooling"
 ---
 
 Automatic formatting with OCamlFormat requires an `.ocamlformat` configuration file at the root of the project.

--- a/data/tutorials/platform/2_08_odoc.md
+++ b/data/tutorials/platform/2_08_odoc.md
@@ -4,7 +4,7 @@ title: "Generating Documentation With odoc"
 short_title: "Generating Documentation"
 description: |
   How to use odoc to generate documentation.
-category: "Tooling"
+category: "Additional Tooling"
 ---
 
 The documentation rendering tool `odoc` generates documentation

--- a/data/tutorials/platform/2_08_odoc.md
+++ b/data/tutorials/platform/2_08_odoc.md
@@ -4,7 +4,7 @@ title: "Generating Documentation With odoc"
 short_title: "Generating Documentation"
 description: |
   How to use odoc to generate documentation.
-category: "Documentation"
+category: "Tooling"
 ---
 
 The documentation rendering tool `odoc` generates documentation


### PR DESCRIPTION
As mentioned in #2965, I think that's the right place for this page in the menu. The link's the same, so there's nothing else that needs changing. 