### PR TITLE
Add CTFP as a book suggestion

### DIFF
--- a/data/books/category-theory-for-programmers.md
+++ b/data/books/category-theory-for-programmers.md
@@ -1,0 +1,37 @@
+---
+title: "Category Theory For Programmers (OCaml & Reason Versions)"
+slug: "category-theory-for-programmers-ocaml-reason-version"
+description: >
+
+  This book is a compilation of Bartosz Milewski's blog posts
+  on Category Theory from the prespective of a practical programmer.
+  It is written primarily with Haskell examples, but variants of the
+  book exist with OCaml, Scala, It is highly (and unusually)
+  approachable, however familiarity with either Haskell or OCaml is
+  recommended as these languages provide the window by which Category
+  Theory is explored. Passing familiarity with Category Theory is
+  beneficial, as the motivation for Category Theory's relevance to
+  programming is assumed. This book goes well beyond Applicatives and
+  Monads and fills in the gaps between the traditional abstract
+  academic field of Category Theory and its implications for
+  functional programming. It is well worth a read for 
+  intermediate-level OCaml programmers. After all, the "C" in OCaml
+  stands for "Categorical".
+authors:
+  - Bartosz Milewski (Author)
+  - Igal Tabachnik (Editor)
+published: "2019"
+cover: books/-----fill_me_in------.jpg
+language:
+  - english
+isbn: "978-0464183648"
+links:
+  - description: Available for free on Github
+    uri: https://github.com/hmemcpy/milewski-ctfp-pdf
+difficulty: intermediate
+pricing: free
+---
+
+<!--
+Summary Here
+-->

--- a/data/books/category-theory-for-programmers.md
+++ b/data/books/category-theory-for-programmers.md
@@ -6,7 +6,7 @@ description: >
   This book is a compilation of Bartosz Milewski's blog posts
   on Category Theory from the prespective of a practical programmer.
   It is written primarily with Haskell examples, but variants of the
-  book exist with OCaml, Scala, It is highly (and unusually)
+  book exist with OCaml, Reason, and Scala. It is highly (and unusually)
   approachable, however familiarity with either Haskell or OCaml is
   recommended as these languages provide the window by which Category
   Theory is explored. Passing familiarity with Category Theory is


### PR DESCRIPTION
I want to suggest adding "Category Theory for Programmers" to OCaml.org's book list page. I created a new file that supplies most of the properties of this book you need for your website (the subject of this pull request).

Category Theory for Programmers by Bartosz Milewski is a one-of-a-kind book that is primarily targeted at Haskell developers, but the book is available with OCaml, Reason, and Scala versions as well.

The Haskell version is available for sale as a hardback, but it is also offered for free as a pdf. The Scala version is available for sale as a softcover. Unfortunately, the free OCaml, Reason, and Scala pdfs are only available through a github repo that require the reader build each version of the book with Nix :(

Additionally, I found a few errors in the OCaml and Reason code snippets that I submitted a pull request fixes for, but they have not been review and merged.

For your consideration of this book (both the OCaml and Reason versions) to be added to OCaml.org/books, here is a link to my Google Drive pointing to pre-built Haskell/OCaml and Haskell/Reason versions of the books. This pdfs at these links have my code snippet fixes applied:
  - OCaml-version pdf: https://drive.google.com/file/d/1mZFlOWdgQimkkaZPRl7BUNneYs4yfwBu/view?usp=drive_link 
  - Reason pdf: https://drive.google.com/file/d/1jLnUfMrhnVnOk5MM-NjwdGXWEi9188PZ/view?usp=drive_link

You can also build this yourself (without my pull request fixes) at:
  - https://github.com/hmemcpy/milewski-ctfp-pdf

You can view my pull request here:
  - https://github.com/hmemcpy/milewski-ctfp-pdf/pull/348
 
In regards to the `ocaml.org/data/books/category-theory-for-programmers.md` file, I could not find a summary of this book online that is suitable for the summary section your .md book files. It might exist, but I couldn't find it. Furthermore, I don't want to mock one up either for fear it might be published on OCaml.org and it not being approved by Milewski.

A potential issue with this book is that to get the OCaml and Reason versions it requires a reader to clone the book's github repo and build the book using Nix (as well as Nix's 'experimental'  `flake` and `nix-command` features). This is a bit of a chore and may not be something OCaml.org wishes its audience have to do.

Additionally, here is my Google Drive jpeg of the cover you can use for the website, but it is also findable using google images:
  - https://drive.google.com/file/d/1jv3jiQeCbAvLhEk-zE6kolkYF6-4T9vf/view?usp=sharing

I think this book would be a great addition to OCaml.org's books page. It fills a very specific niche that no other book does, and it has relevant OCaml and Reason variants.

If you agree and wish to post this book, here potential options:
  1. You can simply point your audience to the Github repo and let them sort out building the OCaml and/or Reason versions themselves (not unreasonable, but there is friction involved due to the build step)
  2. Someone can get in touch with Milewski or his team for approval to offer it on your site.

In addition to asking for permission from Milewski to host the OCaml and Reson versions on your site, Milewski can be asked for a summary of the book.