### PR TITLE
Update imperative md

### DIFF
--- a/data/tutorials/language/0it_02_loops_and_recursion.md
+++ b/data/tutorials/language/0it_02_loops_and_recursion.md
@@ -89,7 +89,7 @@ programmers like recursion, so `while` loops are second-class citizens
 in OCaml.
 
 If you stop to consider `while` loops, you may see that they aren't really
-any use at all, except in conjunction with our old friend *references*.
+any use at all except in conjunction with our old friend *references*.
 Let's imagine that OCaml didn't have references for a moment:
 
 <!-- $MDX skip -->
@@ -129,7 +129,7 @@ If you want to loop over a list, don't be an imperative programmer and
 reach for your trusty six-shooter Mr. `For` Loop! OCaml has some better
 and faster ways to loop over lists, and they are all located in the
 `List` module. In fact, there are dozens of good functions in `List`, but
-I'll only talk about the most useful ones here.
+we'll restrict ourselves to the most useful ones in this chapter.
 
 First off, let's define a list for us to use:
 
@@ -196,8 +196,8 @@ For operating over two lists at the same time, there are "-2" variants
 of some of these functions, namely `iter2`, `map2`, `for_all2`,
 `exists2`.
 
-The `map` and `filter` functions operate on individual list elements in
-isolation. **Fold** is a more unusual operation that is best
+While `map` and `filter` functions operate on individual list elements in
+isolation, **Fold** is a more unusual operation that is best
 thought about as "inserting an operator between each element of the
 list." Suppose I wanted to add all the numbers in my list together. In
 hand-waving terms, I want to insert a plus (+) sign between the
@@ -275,7 +275,7 @@ this:
 
 ### Approach 1
 Get the length of the file and read it all at once using the
-`really_input` method. This is the simplest, but it might not work on
+[`really_input`](https://ocaml.org/manual/5.3/api/Stdlib.html#VALreally_input) method. This is the simplest, but it might not work on
 channels that are not really files (e.g., reading keyboard input), which
 is why we have two other approaches.
 
@@ -367,7 +367,7 @@ has a polymorphic type, so it will unify with whatever value is returned
 by the `with` branch.
 
 Here's the recursive version. Notice that it's *shorter* than Approach
-2, but it's not so easy to understand, for imperative programmers at least:
+2, but it's not so easy to understand (for imperative programmers at least):
 
 ```ocaml
 (* Read whole file: Approach 3 *)

--- a/data/tutorials/language/0it_04_higher_order_functions.md
+++ b/data/tutorials/language/0it_04_higher_order_functions.md
@@ -444,16 +444,16 @@ let c = baz (bar (foo ())) in
 (* ... *)
 ```
 
-But this is not so easy read sometimes, especially as the number of functions grows, as it goes from the inside out.
+But this is not so easy to read sometimes, especially as the number of functions grows, as it goes from the inside out.
 
-To avoid this we have use the `|>` operator:
+To avoid this we have to use the `|>` operator:
 
 ```ocaml
 let c = foo () |> bar |> baz in
 (* ... *)
 ```
 
-This operator translates to the exact same nested calls we would've done by hand, and is really no magic. It is defined as a function:
+This operator translates to the exact same nested calls we would've done by hand (there is really no magic to it). It is defined as a function:
 
 ```ocaml
 (* the pipeline operator *)
@@ -481,6 +481,9 @@ email
 Thanks to OCaml currying functions by default, it is practical to _partially apply_ a function with only some of its arguments, and leave the last one to be passed along in the pipeline.
 
 This is true for functions that have the most important argument in the last position (which we call **t-last**) and for functions that use labeled arguments and allow the most important argument to be passed last by passing all the names arguments first (which we usually call **t-first**).
+
+**Note**:
+The "t" in "**t-first**" and "**t-last**" stand for "**target argument**", as in "**target argument first**" and "**target argument last**".
 
 These two cases sound very similar, but have a big practical difference when it comes to usability. Let's revisit our example above using labeled argument versions of those functions:
 
@@ -514,13 +517,13 @@ We usually think of iteration when we think of looping, and going through collec
 
 But in OCaml the pattern for iteration can be extended to other kinds of data types, like optional values or results, or trees and lazy sequences.
 
-Iterating in OCaml means that if there is a value (or more), we'd like to apply a function to it.
+Iterating in OCaml means that if there is one value (or more), we'd like to apply a function to it.
 
 #### Iterating over Lists
 
-A list in OCaml is a linked-list that is composed by a head (the first element) and a tail (the rest of the list).
+A list in OCaml is a linked-list that is composed of a head (the first element) and a tail (the rest of the list).
 
-We can iterate over lists by pattern matching on then. When doing so, we either get an empty list (`[]`), or we get a pattern with a head and a tail (`n :: rest`). On the branch with a head and a tail, we can directly use the head value and apply a function to it, and then recurse with the tail.
+We can iterate over lists by pattern matching on them. When doing so, we either get an empty list (`[]`), or we get a pattern with a head and a tail (`n :: rest`). On the branch with a head and a tail we can directly use the head value and apply a function to it and then recurse with the tail.
 
 ```ocaml
 let rec print_nums nums =
@@ -574,7 +577,7 @@ This is how `Option.iter` and `Result.iter` are defined in the standard library.
 
 #### Iterating over Maps and Sets
 
-Larger collections of data like maps and sets, are also common in OCaml. We have dedicated modules for them but they have a _functor_ interface. This means you can't really use `Set` or `Map` directly, but you have to call the module-level function `Set.Make` to create your own custom version of the Set module for the specific types you want to store in it.
+Larger collections of data like maps and sets are also common in OCaml. We have dedicated modules for them but they have a _functor_ interface. This means you can't really use `Set` or `Map` directly, but you have to call the module-level function `Set.Make` to create your own custom version of the Set module for the specific types you want to store in it.
 
 Once you create your Set or Map module, you'll find they provide functions to convert their values into lists.
 
@@ -593,7 +596,7 @@ let iter_map map fn = iter IntMap.bindings map fn ;;
 let iter_set set fn = iter StringSet.elements set fn ;;
 ```
 
-You'll notice that we did not use pattern-matching this time around to iterate over the values of the Map or the Set directly. This is because   the representation of Sets and Maps is private.
+You'll notice that we did not use pattern-matching this time around to iterate over the values of the Map or the Set directly. This is because the representation of Sets and Maps is private.
 
 The actual implementation of iteration functions for Maps and Sets does use pattern-matching under the hood.
 
@@ -623,7 +626,7 @@ This is almost exactly how `Seq.iter` is defined in the standard library.
 
 So far we've seen how to iterate over data types from the standard library. Now we'll see how to iterate over our own data type for trees.
 
-We'll define our tree type to include 2 constructors. One for a leaf node, which is a node at the _end_ of the tree. The other one for nodes that have children.
+We'll define our tree type to include 2 constructors. One is for a leaf node (which is a node at the _end_ of the tree), and the other is for nodes that have children.
 
 ```ocaml
 type 'value tree =
@@ -673,7 +676,7 @@ This is called _mapping_.
 
 Mapping lists is very similar to iterating over them. We pattern match on a list, get the head of it, run a function over it, and recurse over the body.
 
-The main difference is that instead of throwing away the resulting value from running our function over the elemnts, we will _reconstruct_ a list from it.
+The main difference is that instead of throwing away the resulting value from running our function over the elements, we will _reconstruct_ a list from it.
 
 ```ocaml
 let rec map list fn =
@@ -788,7 +791,7 @@ let rec fold_tree tree fn acc =
 ;;
 ```
 
-And voila! Our function now types correctly and we can use it to reduce our trees down to any value.
+And voila! Our function now type-checks correctly and we can use it to reduce our trees down to any value.
 
 ### Sorting
 
@@ -820,6 +823,7 @@ Most OCaml modules include a `compare` function that can be pass in to `sort`:
 
 ```ocaml
 let int_array = [|3;0;100|];;
+
 Array.sort Int.compare int_array;;
 
 List.sort String.compare ["z";"b";"a"];;
@@ -831,7 +835,7 @@ List.sort Bool.compare [true;false;false];;
 
 One last common higher-order pattern in functional programming is the ability to _join_ data from within. For historical reasons, this is normally called a _bind_.
 
-For example, if we have a list, and map over it with a function that returns a list, then we'll have a list of lists. Sometimes we want this, but some times we would rather the new list was _flattened_ instead of _nested_.
+For example, if we have a list and we map over it with a function that returns a list, then we'll have a list of lists. Sometimes we want this, but sometimes we would rather the new list was _flattened_ instead of _nested_.
 
 To do this with lists we can use the `concat_map` function, which looks like this:
 

--- a/data/tutorials/language/0it_06_imperative.md
+++ b/data/tutorials/language/0it_06_imperative.md
@@ -147,6 +147,8 @@ Mutable record fields are updated using the left arrow symbol `<-`. In the expre
 
 In contrast to references, there is no special syntax to dereference a mutable record field.
 
+**Remark** the left arrow symbol `<-` for mutating mutable record field values is not an operator like the assignment operator `( := )` is for `refs`. It is rather a _construct_ of the language. 
+
 ### Remark: References Are Single Field Records
 
 In OCaml, references are records with a single mutable field:
@@ -366,7 +368,7 @@ But here is how it can be made to work:
 val f : int ref -> unit = <fun>
 ```
 
-The error came from assign `:=`, which associates stronger than a semicolon `;`. Here is what we want to do, in order:
+The error came from the assign operator `:=`, which associates stronger than a semicolon `;`. Here is what we want to do, in order:
 1. Increment `r`
 2. Compute `2 * !r`
 3. Assign into `r`
@@ -695,9 +697,7 @@ However, instead of precomputing everything, memoization uses a cache that is po
 * are found in the cache (it is a hit) and the stored result is returned, or they
 * are not found in the cache (it's a miss), and the result is computed, stored in the cache, and returned.
 
-You can find a concrete example of memoization and a more in-depth explanation in the chapter on [Memoization](https://cs3110.github.io/textbook/chapters/ds/memoization.html) of "OCaml Programming: Correct + Efficient + Beautiful."
-
-<!-- FIXME: reference CS3110 memoization documented on ocaml.org after it is merged -->
+You can find a concrete example of memoization and a more in-depth explanation in the chapter on [Memoization](https://ocaml.org/docs/memoization) of "OCaml Programming: Correct + Efficient + Beautiful."
 
 ### Good: Functional by Default
 
@@ -705,13 +705,13 @@ By default, OCaml programs should be written in a mostly functional style. This 
 
 It is possible to use an imperative programming style without losing the benefits of type and memory safety. However, it doesn't usually make sense to only program in an imperative style. Not using functional programming idioms at all would result in non-idiomatic OCaml code.
 
-Most existing modules provide an interface meant to be used in a functional way. Some would require the development and maintenance of [wrapper libraries](https://en.wikipedia.org/wiki/Wrapper_library) to be used in an imperative setting and such use would in many cases be inefficient.
+Most existing modules provide an interface meant to be used in a functional way. Some require the development and maintenance of [wrapper libraries](https://en.wikipedia.org/wiki/Wrapper_library) to be used in an imperative setting and such use results in inefficient code.
 
 ###  It Depends: Module State
 
 A module may expose or encapsulate a state in several different ways:
 1. Good: expose a type representing a state, with state creation or reset functions
-1. It depends: only expose state initialisation, which implies there only is a single state
+1. It depends: only expose state initialisation, which implies there is only a single state
 1. Bad: mutable state with no explicit initialisation function or no name referring to the mutable state
 
 For example, the [`Hashtbl`](/manual/api/Hashtbl.html) module provides an interface of the first kind. It has the type `Hashtbl.t` representing mutable data. It also exposes `create`, `clear`, and `reset` functions. The `clear` and `reset` functions return `unit`. This strongly signals the reader that they perform the side-effect of updating the mutable data.
@@ -734,6 +734,8 @@ On the other hand, a module may define mutable data internally impacting its beh
 
 ### Bad: Undocumented Mutation
 
+**Note**: The following example code will not run in your REPL; the function `Array.truncate` is not defined. It is provided as an example to contemplate.
+
 Here's an example of bad code:
 
 ```ocaml
@@ -754,7 +756,6 @@ Here's an example of bad code:
 Error: Unbound value Array.truncate
 ```
 
-**Note:** This example will not run in the REPL, since the function `Array.truncate` is not defined.
 
 To understand why this is bad code, assume that the function `Array.truncate` has type `int -> 'a array -> 'a array`. It behaves such that `Array.truncate 3 [5; 6; 7; 8; 9]` returns `[5; 6; 7]`, and the returned array physically corresponds to the 3 first cells of the input array.
 
@@ -779,6 +780,8 @@ GOTCHA: This is the dual of the previous anti-pattern. “Mutable in disguise”
 
 Consider this code:
 
+**Note**: The following example will not run in your REPL; there is no module `Analytics` defined. It is provided as an example to contemplate. [Analytics](https://en.wikipedia.org/wiki/Web_analytics) are remote monitoring libraries.
+
 ```ocaml
 # module Array = struct
     include Stdlib.Array
@@ -788,8 +791,6 @@ Consider this code:
     end;;
 Error: Unbound module Analytics
 ```
-
-**Note:** This code will not run because there is no module called `Analytics`. [Analytics](https://en.wikipedia.org/wiki/Web_analytics) are remote monitoring libraries.
 
 A module called `Array` is defined; it shadows and includes the [`Stdlib.Array`](/manual/api/Array.html) module. See the [Module Inclusion](docs/modules#module-inclusion) part of the [Modules](docs/modules) tutorial for details about this pattern.
 
@@ -830,7 +831,7 @@ This issue also arises when applying arguments to variant constructors, building
 
 The value of this expression depends on the order of subexpression evaluation. Since this order is not specified, there is no reliable way to know what this value is. At the time of writing this tutorial, the evaluation produced `(0, -1)`, but if you see something else, it is not a bug. Such an unreliable value must a avoided.
 
-To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences. Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.
+To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences using either `let … in` expressions or the semi-colon sequence opertor (`;`). Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.
 
 <!--
 You can use the sequence operator `;` to execute expressions in a particular order:

--- a/data/tutorials/language/0it_06_imperative.md
+++ b/data/tutorials/language/0it_06_imperative.md
@@ -831,7 +831,7 @@ This issue also arises when applying arguments to variant constructors, building
 
 The value of this expression depends on the order of subexpression evaluation. Since this order is not specified, there is no reliable way to know what this value is. At the time of writing this tutorial, the evaluation produced `(0, -1)`, but if you see something else, it is not a bug. Such an unreliable value must a avoided.
 
-To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences using either `let … in` expressions or the semi-colon sequence opertor (`;`). Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.
+To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences using either `let … in` expressions or the semi-colon sequence operator (`;`). Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.
 
 <!--
 You can use the sequence operator `;` to execute expressions in a particular order:


### PR DESCRIPTION
These are minor tweaks.

The following are annotations to the diff:

1) add remark noting distinction between operators and language constructs (to complement a similar remark about the sequencing 'operator' later in the document)
+**Remark** the left arrow symbol `<-` for mutating mutable record field values is not an operator like the assignment operator `( := )` is for `refs`. It is rather a _construct_ of the language.


2) explicitly state that 'assign' is an operator:
-The error came from assign `:=`, which associates stronger than a semicolon `;`. Here is what we want to do, in order:
+The error came from the assign operator `:=`, which associates stronger than a semicolon `;`. Here is what we want to do, in order:

3) Follow direction in `FIXME` and link to internal version of "Memoization" page and delete related comments:
-You can find a concrete example of memoization and a more in-depth explanation in the chapter on [Memoization](https://cs3110.github.io/textbook/chapters/ds/memoization.html) of "OCaml Programming: Correct + Efficient + Beautiful."
-
-<!-- FIXME: reference CS3110 memoization documented on ocaml.org after it is merged -->
+You can find a concrete example of memoization and a more in-depth explanation in the chapter on [Memoization](https://ocaml.org/docs/memoization) of "OCaml Programming: Correct + Efficient + Beautiful."

4) delete indecisive "would" to improve flow
-Most existing modules provide an interface meant to be used in a functional way. Some would require the development and maintenance of [wrapper libraries](https://en.wikipedia.org/wiki/Wrapper_library) to be used in an imperative setting and such use would in many cases be inefficient.
+Most existing modules provide an interface meant to be used in a functional way. Some require the development and maintenance of [wrapper libraries](https://en.wikipedia.org/wiki/Wrapper_library) to be used in an imperative setting and such use results in inefficient code.

5) flip "only is" to "is only"
-1. It depends: only expose state initialisation, which implies there only is a single state
+1. It depends: only expose state initialisation, which implies there is only a single state
 1. Bad: mutable state with no explicit initialisation function or no name referring to the mutable state

6) Move **note** about `Array.truncate` from below the code snippet to above:
+**Note**: The following example code will not run in your REPL; the function `Array.truncate` is not defined. It is provided as an example to contemplate.
-**Note:** This example will not run in the REPL, since the function `Array.truncate` is not defined.

7) Move **note** about an `Analytics` module from below the code snippet to above:
+**Note**: The following example will not run in your REPL; there is no module `Analytics` defined. It is provided as an example to contemplate. [Analytics](https://en.wikipedia.org/wiki/Web_analytics) are remote monitoring libraries.
-**Note:** This code will not run because there is no module called `Analytics`. [Analytics](https://en.wikipedia.org/wiki/Web_analytics) are remote monitoring libraries.

8) inline relevant information from linked content, keeping the link for further reading:
-To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences. Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.
+To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences using either `let … in` expressions or the semi-colon sequence opertor (`;`). Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.