### PR TITLE
Add configuration for markdownlint

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,22 @@
+{
+  // Enable all rules by default
+  "default": true,
+
+  // Line length: increase default from 80
+  "MD013": {
+    "line_length": 100,
+    "code_blocks": false,
+    "tables": false
+  },
+
+  // Allow duplicate headers in different nested sections
+  "MD024": {
+    "allow_different_nesting": true
+  },
+
+  // Allow inline HTML
+  "MD033": false,
+
+  // First line in a file doesn't need to be a top-level header
+  "MD041": false,
+}


### PR DESCRIPTION
This adds some default markdownlint configuration for the repo. I've opted to use the `jsonc` format, so I can have comments explaining the configuration settings. 