### PR TITLE
Improve the formatting of some markdown files

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -26,13 +26,13 @@ To install opam, you can [use your system package manager](https://opam.ocaml.or
 If you're installing with [Homebrew](https://brew.sh/):
 
 ```shell
-$ brew install opam
+brew install opam
 ```
 
 Or if you're using [MacPorts](https://www.macports.org/):
 
 ```shell
-$ port install opam
+port install opam
 ```
 
 **Note**: While it's rather straightforward to install opam using macOS, it's possible you'll run into problems later with Homebrew because it has changed the way it installs. The executable files cannot be found in ARM64, the M1 processor used in newer Macs. Addressing this can be a rather complicated procedure, so we've made [a short ARM64 Fix doc](/docs/arm64-fix) explaining this so as not to derail this installation guide.
@@ -42,16 +42,19 @@ $ port install opam
 It's preferable to install opam with your system's package manager on Linux, as superuser. On the opam site, find [details of all installation methods](https://opam.ocaml.org/doc/Install.html). A version of opam above 2.0 is packaged in all supported Linux distributions. If you are using an unsupported Linux distribution, please either download a precompiled binary or build opam from sources.
 
 If you are installing in Debian or Ubuntu:
+
 ```shell
-$ sudo apt-get install opam
+sudo apt-get install opam
 ```
 
 If you are installing in Arch Linux:
+
 ```shell
-$ sudo pacman -S opam
+sudo pacman -S opam
 ```
 
 **Note**: The Debian package for opam, which is also used in Ubuntu, has the OCaml compiler as a recommended dependency. By default, such dependencies are installed. If you want to only install opam without OCaml, you need to run something like this:
+
 ```shell
 sudo apt-get install --no-install-recommends opam
 ```
@@ -69,8 +72,9 @@ PS C:\> winget install Git.Git OCaml.opam
 If you want the latest release of opam, install it through the binary distribution. On Unix and macOS, you'll need to install the following system packages first: `gcc`, `build-essential`, `curl`, `bubblewrap`, and `unzip`. Note that they might have different names depending on your operating system or distribution. Also, note this script internally calls `sudo`.
 
 The following command will install the latest version of opam that applies to your system:
+
 ```shell
-$ bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)"
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)"
 ```
 
 On Windows, the winget package is maintained by opam's developers and uses the binaries released [on GitHub](https://github.com/ocaml/opam/releases), however you can also install using an equivalent PowerShell script:
@@ -86,14 +90,15 @@ Invoke-Expression "& { $(Invoke-RestMethod https://opam.ocaml.org/install.ps1) }
 After you install opam, you'll need to initialise it. To do so, run the following command, as a normal user. This might take a few minutes to complete.
 
 ```shell
-$ opam init -y
+opam init -y
 ```
 
 **Note**: In case you are running `opam init` inside a Docker container, you will need to disable sandboxing, which is done by running `opam init --disable-sandboxing -y`. This is necessary, unless you run a privileged Docker container.
 
 Make sure you follow the instructions provided at the end of the output of `opam init` to complete the initialisation. Typically, this is:
+
 ```
-$ eval $(opam env)
+eval $(opam env)
 ```
 
 on Unix, and from the Windows Command Prompt:
@@ -112,7 +117,7 @@ Opam initialisation may take several minutes. While waiting for its installation
 
 **Note**: opam can manage something called _switches_. This is key when switching between several OCaml projects. However, in this “getting started” series of tutorials, switches are not needed. If interested, you can read an introduction to [opam switches here](/docs/opam-switch-introduction).
 
-**Any problems installing?** Be sure to read the [latest release notes](https://opam.ocaml.org/blog/opam-2-2-0/). You can file an issue at https://github.com/ocaml/opam/issues or https://github.com/ocaml-windows/papercuts/issues.
+**Any problems installing?** Be sure to read the [latest release notes](https://opam.ocaml.org/blog/opam-2-2-0/). You can file an issue at <https://github.com/ocaml/opam/issues> or <https://github.com/ocaml-windows/papercuts/issues>.
 
 ## Install Platform Tools
 
@@ -125,8 +130,9 @@ Now that we've successfully installed the OCaml compiler and the opam package ma
 - [OCamlFormat](https://opam.ocaml.org/packages/ocamlformat/) to automatically format OCaml code
 
 All these tools can be installed using a single command:
+
 ```shell
-$ opam install ocaml-lsp-server odoc ocamlformat utop
+opam install ocaml-lsp-server odoc ocamlformat utop
 ```
 
 You're now all set and ready to start hacking.
@@ -134,6 +140,7 @@ You're now all set and ready to start hacking.
 ## Check Installation
 
 To check that everything is working properly, you can start the UTop toplevel:
+
 ```shell
 $ utop
 ────────┬─────────────────────────────────────────────────────────────┬─────────
@@ -147,6 +154,7 @@ utop #
 ```
 
 You're now in an OCaml toplevel, and you can start typing OCaml expressions. For instance, try typing `21 * 2;;` at the `#` prompt, then hit `Enter`. You'll see the following:
+
 ```ocaml
 # 21 * 2;;
 - : int = 42

--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -49,6 +49,7 @@ The goal of this tutorial is to provide the following capabilities:
 ## Expressions and Definitions
 
 Let's start with a simple expression:
+
 ```ocaml
 # 50 * 50;;
 - : int = 2500
@@ -59,6 +60,7 @@ In OCaml, everything has a value, and every value has a type. The above example 
 The double semicolon `;;` at the end tells the toplevel to evaluate and print the result of the given phrase.
 
 Here are examples of other primitive values and types:
+
 ```ocaml
 # 6.28;;
 - : float = 6.28
@@ -74,6 +76,7 @@ Here are examples of other primitive values and types:
 ```
 
 OCaml has _type inference_. It automatically determines the type of an expression without much guidance from the programmer. _Lists_ have a [dedicated tutorial](/docs/lists). For the time being, the following two expressions are both lists. The former contains integers, and the latter, strings.
+
 ```ocaml
 # let u = [1; 2; 3; 4];;
 val u : int list = [1; 2; 3; 4]
@@ -83,12 +86,14 @@ val u : int list = [1; 2; 3; 4]
 ```
 
 The lists' types, `int list` and `string list`, have been inferred from the type of their elements. Lists can be empty `[]` (pronounced “nil”). Note that the first list has been given a name using the `let … = …` construction, which is detailed below. The most primitive operation on lists is to add a new element at the front of an existing list. This is done using the “cons” operator, written with the double colon operator `::`.
+
 ```ocaml
 # 9 :: u;;
 - : int list = [9; 1; 2; 3; 4]
 ```
 
 In OCaml, `if … then … else …` is not a statement; it is an expression.
+
 ```ocaml
 # 2 * if "hello" = "world" then 3 else 5;;
 - : int = 10
@@ -97,6 +102,7 @@ In OCaml, `if … then … else …` is not a statement; it is an expression.
 The source beginning at `if` and ending at `5` is parsed as a single integer expression that is multiplied by 2. OCaml has no need for two different test constructions. The [ternary conditional operator](https://en.wikipedia.org/wiki/Ternary_conditional_operator) and the `if … then … else …` are the same. Also note parentheses are not needed here, which is often the case in OCaml.
 
 Values can be given names using the `let` keyword. This is called _binding_ a value to a name. For example:
+
 ```ocaml
 # let x = 50;;
 val x : int = 50
@@ -124,6 +130,7 @@ val feets : int = 5280
 This is discussed further in [`odoc` for Authors: Special Comments](https://ocaml.github.io/odoc/odoc_for_authors.html#special_comments).
 
 Names can be defined locally, within an expression, using the `let … = … in …` syntax:
+
 ```ocaml
 # let y = 50 in y * y;;
 - : int = 2500
@@ -135,6 +142,7 @@ Error: Unbound value y
 This example defines the name `y` and binds it to the value `50`. It is then used in the expression `y * y`, resulting in the value `2500`. Note that `y` is only defined in the expression following the `in` keyword.
 
 Since `let … = … in …` is an expression, it can be used within another expression in order to have several values with their own names:
+
 ```ocaml
 # let a = 1 in
   let b = 2 in
@@ -145,6 +153,7 @@ Since `let … = … in …` is an expression, it can be used within another exp
 This defines two names: `a` with value `1` and `b` with value `2`. Then the example uses them in the expression `a + b`, resulting in the value of `3`.
 
 In OCaml, the equality symbol has two meanings. It is used in definitions and equality tests.
+
 ```ocaml
 # let dummy = "hi" = "hello";;
 val dummy : bool = false
@@ -155,6 +164,7 @@ This is interpreted as: “define `dummy` as the result of the structural equali
 ## Functions
 
 In OCaml, since everything is a value, functions are values too. Functions are defined using the `let` keyword:
+
 ```ocaml
 # let square x = x * x;;
 val square : int -> int = <fun>
@@ -177,17 +187,19 @@ The REPL indicates that the type of `square` is `int -> int`. This means it is a
 - : bool = true
 ```
 
-Some functions, such as `String.ends_with` have labelled parameters. Labels are useful when a function has several parameters of the same type; naming arguments allows to guess their purpose. Above, `~suffix:"less"` indicates `"less"` is passed as labelled argument `suffix`. Labelled arguments are detailed in the [Labelled Arguments](/docs/labels) tutorial. 
+Some functions, such as `String.ends_with` have labelled parameters. Labels are useful when a function has several parameters of the same type; naming arguments allows to guess their purpose. Above, `~suffix:"less"` indicates `"less"` is passed as labelled argument `suffix`. Labelled arguments are detailed in the [Labelled Arguments](/docs/labels) tutorial.
 
 ### Anonymous Functions
 
 _Anonymous_ functions do not have a name, and they are defined with the `fun` keyword:
+
 ```ocaml
 # fun x -> x * x;;
 - : int -> int = <fun>
 ```
 
 We can write anonymous functions and immediately apply them to a value:
+
 ```ocaml
 # (fun x -> x * x) 50;;
 - : int = 2500
@@ -196,18 +208,21 @@ We can write anonymous functions and immediately apply them to a value:
 ### Functions with Multiple Parameters and Partial Application
 
 A function may have several parameters, separated by spaces.
+
 ```ocaml
 # let cat a b = a ^ " " ^ b;;
 val cat : string -> string -> string = <fun>
 ```
 
 The function `cat` has two `string` parameters, `a` and `b`, and returns a value of type `string`.
+
 ```ocaml
 # cat "ha" "ha";;
 - : string = "ha ha"
 ```
 
 Functions don't have to be called with all the arguments they expect. It is possible to only pass `a` to `cat` without passing `b`.
+
 ```ocaml
 # let cat_hi = cat "hi";;
 val cat_hi : string -> string = <fun>
@@ -216,6 +231,7 @@ val cat_hi : string -> string = <fun>
 This returns a function that expects a single string, here the `b` from the definition of `cat`. This is called a _partial application_. In the above, `cat` was partially applied to `"hi"`.
 
 The function `cat_hi`, which resulted from the partial application of `cat`, behaves as follows:
+
 ```ocaml
 # cat_hi "friend";;
 - : string = "hi friend"
@@ -224,6 +240,7 @@ The function `cat_hi`, which resulted from the partial application of `cat`, beh
 ### Type Parameters and Higher-Order Functions
 
 A function may expect a function as a parameter, which is called a _higher-order_ function. A well-known example of higher-order function is `List.map`. Here is how it can be used:
+
 ```ocaml
 # List.map;;
 - : ('a -> 'b) -> 'a list -> 'b list = <fun>
@@ -245,6 +262,7 @@ The function `List.map` can be applied on any kind of list. Here it is given a l
 ### Side-Effects and the `unit` Type
 
 Performing operating system level input-output operations is done using functions. Here is an example of each:
+
 ```ocaml
 # read_line;;
 - : unit -> string = <fun>
@@ -272,6 +290,7 @@ Input-output is an example of something taking place when executing a function b
 A recursive function calls itself in its own body. Such functions must be declared using `let rec … = …` instead of just `let`. Recursion is not the only means to perform iterative computation on OCaml. Loops such as `for` and `while` are available, but they are meant to be used when writing imperative OCaml in conjunction with mutable data. Otherwise, recursive functions should be preferred.
 
 Here is an example of a function which creates a list of consecutive integers between two bounds.
+
 ```ocaml
 # let rec range lo hi =
     if lo > hi then
@@ -303,6 +322,7 @@ Each `=>` sign corresponds to the computation of a recursive step, except the la
 ### Type Conversion and Type-Inference
 
 OCaml has floating-point values of type `float`. To add floats, one must use `+.` instead of `+`:
+
 ```ocaml
 # 2.0 +. 2.0;;
 - : float = 4.
@@ -313,6 +333,7 @@ In OCaml, `+.` is the addition between floats, while `+` is the addition between
 In many programming languages, values can be automatically converted from one type into another. This includes _implicit type conversion_ and _promotion_. For example, in such a language, if you write `1 + 2.5`, the first argument (an integer) is promoted to a floating point number, making the result a floating point number, too.
 
 OCaml never implicitly converts values from one type to another. It is not possible to perform the addition of a float and integer. Both examples below throw an error:
+
 ```ocaml
 # 1 + 2.5;;
 Error: This expression has type float but an expression was expected of type
@@ -323,9 +344,11 @@ Error: This expression has type int but an expression was expected of type
          float
   Hint: Did you mean `1.'?
 ```
+
 In the first example, `+` is intended to be used with integers, so it can't be used with the `2.5` float. In the second example, `+.` is intended to be used with floats, so it can't be used with the `1` integer.
 
 In OCaml you need to explicitly convert the integer to a floating point number using the `float_of_int` function:
+
 ```ocaml
 # float_of_int 1 +. 2.5;;
 - : float = 3.5
@@ -336,6 +359,7 @@ There are several reasons why OCaml requires explicit conversions. Most importan
 ### Lists
 
 Lists may be the most common data type in OCaml. They are ordered collections of values having the same type. Here are a few examples.
+
 ```ocaml
 # [];;
 - : 'a list = []
@@ -351,18 +375,21 @@ Lists may be the most common data type in OCaml. They are ordered collections of
 ```
 
 The examples above read the following way:
+
 1. The empty list, nil
 1. A list containing the numbers 1, 2, and 3
 1. A list containing the Booleans `false`, `false`, and `true`. Repetitions are allowed.
 1. A list of lists
 
 Lists are defined as being either empty, written `[]`, or being an element `x` added at the front of another list `u`, which is written `x :: u` (the double colon operator is pronounced “cons”).
+
 ```ocaml
 # 1 :: [2; 3; 4];;
 - : int list = [1; 2; 3; 4]
 ```
 
 In OCaml, _pattern matching_ provides a means to inspect data of any kind, except functions. In this section, it is introduced on lists, and it will be generalised to other data types in the next section. Here is how pattern matching can be used to define a recursive function that computes the sum of a list of integers:
+
 ```ocaml
 # let rec sum u =
     match u with
@@ -377,6 +404,7 @@ val sum : int list -> int = <fun>
 #### Polymorphic Functions on Lists
 
 Here is how to write a recursive function that computes the length of a list:
+
 ```ocaml
 # let rec length u =
     match u with
@@ -399,6 +427,7 @@ This function operates not just on lists of integers but on any kind of list. It
 #### Defining a Higher-Order Function
 
 It is possible to pass a function as argument to another function. Functions having other functions as parameters are called _higher-order_ functions. This was illustrated earlier using function `List.map`. Here is how `map` can be written using pattern matching on lists.
+
 ```ocaml
 # let square x = x * x;;
 val square : int -> int
@@ -416,6 +445,7 @@ val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 ### Pattern Matching, Cont'd
 
 Pattern matching isn't limited to lists. Any kind of data can be inspected using it, except functions. Patterns are expressions that are compared to an inspected value. It could be performed using `if … then … else …`, but pattern matching is more convenient. Here is an example using the `option` data type that will be detailed in the [Modules and the Standard Library](#modules-and-the-standard-library) section.
+
 ```ocaml
 # #show option;;
 type 'a option = None | Some of 'a
@@ -432,6 +462,7 @@ The inspected value is `opt` of type `option`. It is compared against the patter
 Pattern matching is detailed in the [Basic Datatypes](/docs/basic-data-types) tutorial as well as in per data type tutorials.
 
 In this other example, the same comparison is made, using `if … then … else …` and pattern matching.
+
 ```ocaml
 # let g x =
   if x = "foo" then 1
@@ -453,6 +484,7 @@ val g' : string -> int = <fun>
 The underscore symbol is a catch-all pattern; it matches with anything.
 
 Note that OCaml throws a warning when pattern matching does not catch all cases:
+
 ```ocaml
 # fun i -> match i with 0 -> 1;;
 Line 1, characters 9-28:
@@ -465,6 +497,7 @@ Here is an example of a case that is not matched:
 ### Pairs and Tuples
 
 Tuples are fixed-length collections of elements of any type. Pairs are tuples that have two elements. Here is a 3-tuple and a pair:
+
 ```ocaml
 # (1, "one", 'K');;
 - : int * string * char = (1, "one", 'K')
@@ -474,6 +507,7 @@ Tuples are fixed-length collections of elements of any type. Pairs are tuples th
 ```
 
 Access to the components of tuples is done using pattern matching. For instance, the predefined function `snd` returns the second component of a pair:
+
 ```ocaml
 # let snd p =
     match p with
@@ -493,6 +527,7 @@ The type of tuples is written using `*` between the components' types.
 Like pattern matching generalises `switch` statements, variant types generalise enumerated and union types.
 
 Here is the definition of a variant type acting as an enumerated data type:
+
 ```ocaml
 # type primary_colour = Red | Green | Blue;;
 type primary_colour = Red | Green | Blue
@@ -502,6 +537,7 @@ type primary_colour = Red | Green | Blue
 ```
 
 Here is the definition of a variant type acting as a union type:
+
 ```ocaml
 # type http_response =
     | Data of string
@@ -528,6 +564,7 @@ Data
 ```
 
 Here is something sitting in between:
+
 ```ocaml
 # type page_range =
     | All
@@ -539,6 +576,7 @@ type page_range = All | Current | Range of int * int
 In the previous definitions, the capitalised identifiers are called _constructors_. They allow the creation of variant values. This is unrelated to object-oriented programming.
 
 As suggested in the first sentence of this section, variants go along with pattern matching. Here are some examples:
+
 ```ocaml
 # let colour_to_rgb colour =
     match colour with
@@ -562,6 +600,7 @@ val is_printable : int -> int -> page_range -> bool = <fun>
 ```
 
 Like a function, a variant can be recursive if it refers to itself in its own definition. The predefined type `list` provides an example of such a variant:
+
 ```ocaml
 # #show list;;
 type 'a list = [] | (::) of 'a * 'a list
@@ -572,6 +611,7 @@ As previously shown, `sum`, `length`, and `map` functions provide examples of pa
 ### Records
 
 Like tuples, records also pack elements of several types together. However, each element is given a name. Like variant types, records types must be defined before being used. Here are examples of a record type, a value, access to a component, and pattern matching on the same record.
+
 ```ocaml
 # type person = {
     first_name : string;
@@ -589,6 +629,7 @@ val gerard : person = {first_name = "Gérard"; surname = "Huet"; age = 76}
 ```
 
 When defining `gerard`, no type needs to be declared. The type checker will search for a record which has exactly three fields with matching names and types. Note that there are no typing relationships between records. It is not possible to declare a record type that extends another by adding fields. Record type search will succeed if it finds an exact match and fails in any other case.
+
 ```ocaml
 # let s = gerard.surname;;
 val s : string = "Huet"
@@ -609,12 +650,14 @@ Here, the pattern `{ age = x; _ }` is typed with the most recently declared reco
 ### Exceptions
 
 When a computation is interrupted, an exception is thrown. For instance:
+
 ```ocaml
 # 10 / 0;;
 Exception: Division_by_zero.
 ```
 
 Exceptions are raised using the `raise` function.
+
 ```ocaml
 # let id_42 n = if n <> 42 then raise (Failure "Sorry") else n;;
 val id_42 : int -> int = <fun>
@@ -629,6 +672,7 @@ Exception: Failure "Sorry".
 Note that exceptions do not appear in function types.
 
 Exceptions are caught using the `try … with …` construction:
+
 ```ocaml
 # try id_42 0 with Failure _ -> 0;;
 - : int = 0
@@ -640,12 +684,14 @@ The standard library provides several predefined exceptions. It is possible to d
 
 Another way to deal with errors in OCaml is by returning value of type `result`,
 which can represent either the correct result or an error. Here is how it is defined:
+
 ```ocaml
 # #show result;;
 type ('a, 'b) result = Ok of 'a | Error of 'b
 ```
 
 So one may write:
+
 ```ocaml
 # let id_42_res n = if n <> 42 then Error "Sorry" else Ok n;;
 val id_42_res : int -> (int, string) result = <fun>
@@ -665,6 +711,7 @@ val id_42_res : int -> (int, string) result = <fun>
 ## Working with Mutable State
 
 OCaml supports imperative programming. Usually, the `let … = …` syntax does not define variables, it defines constants. However, mutable variables exist in OCaml. They are called _references_. Here's how we create a reference to an integer:
+
 ```ocaml
 # let r = ref 0;;
 val r : int ref = {contents = 0}
@@ -673,6 +720,7 @@ val r : int ref = {contents = 0}
 It is syntactically impossible to create an uninitialised or null reference. The `r`
 reference is initialised with the integer zero. Accessing a reference's content
 is done using the `!` de-reference operator.
+
 ```ocaml
 # !r;;
 - : int = 0
@@ -684,18 +732,21 @@ it is not possible to update an integer or multiply a reference.
 
 Let's update the content of `r`. Here `:=` is the assignment operator; it is
 pronounced “receives”.
+
 ```ocaml
 # r := 42;;
 - : unit = ()
 ```
 
 This returns `()` because changing the content of a reference is a side-effect.
+
 ```ocaml
 # !r;;
 - : int = 42
 ```
 
 Execute an expression after another with the `;` operator. Writing `a; b` means: execute `a`. Once done, execute `b`, only returns the value of `b`.
+
 ```ocaml
 # let text = ref "hello ";;
 val text : string ref = {contents = "hello "}
@@ -706,6 +757,7 @@ hello world!
 ```
 
 Here are the side effects that occur in the second line:
+
 1. Display the contents of the reference `text` on standard output
 1. Update the contents of the reference `text`
 1. Display the contents of the reference `text` on standard output
@@ -715,6 +767,7 @@ This behaviour is the same as in an imperative language. However, although `;` i
 ## Modules and the Standard Library
 
 Organising source code in OCaml is done using something called _modules_. A module is a group of definitions. The _standard library_ is a set of modules available to all OCaml programs. Here are how the definitions contained in the `Option` module of the standard library can be listed:
+
 ```ocaml
 # #show Option;;
 module Option :
@@ -740,6 +793,7 @@ module Option :
 ```
 
 Definitions provided by modules are referred to by adding the module name as a prefix to their name.
+
 ```ocaml
 # Option.map;;
 - : ('a -> 'b) -> 'a option -> 'b option = <fun>
@@ -755,6 +809,7 @@ Definitions provided by modules are referred to by adding the module name as a p
 ```
 
 Here, usage of the function `Option.map` is illustrated in several steps.
+
 1. Display its type. It has two parameters: a function of type `'a -> 'b` and an `'a option`.
 1. Using partial application, only pass `fun x -> x * x`. Check the type of the resulting function.
 1. Apply with `None`.
@@ -763,6 +818,7 @@ Here, usage of the function `Option.map` is illustrated in several steps.
 When the option value provided contains an actual value (i.e., it is `Some` something), it applies the provided function and returns its result wrapped in an option. When the option value provided doesn't contain anything (i.e., it is `None`), the result doesn't contain anything as well (i.e., it is `None` too).
 
 The `List.map` function which was used earlier in this section is also part of a module, the `List` module.
+
 ```ocaml
 # List.map;;
 - : ('a -> 'b) -> 'a list -> 'b list = <fun>

--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -28,7 +28,6 @@ Once you've completed this tutorial, you should be able to:
 - Make a definition private
 - Download, install, and use a package from the open source repository
 
-
 How to work on several OCaml projects simultaneously is out of the scope of this tutorial. Currently (Summer 2023), this requires using opam local [_switches_](https://opam.ocaml.org/doc/man/opam-switch.html). This allows handling different sets of dependencies per project. Check the Best Practices document on [Dependencies](https://ocaml.org/docs/managing-dependencies) addressing that matter for detailed instructions. This document was written and tested using a global switch, which is created by default when installing opam and can be ignored in the beginning.
 -->
 
@@ -78,6 +77,7 @@ hello
 Unlike in Unix where they contain compiled binaries, directories `lib` and `bin` contain source code files, for libraries and programs, respectively. This is the convention used in many OCaml projects, including those created by Dune. All the built artifacts, and a copy of the sources, are stored in the `_build` directory. Do not edit anything in the `_build` directory, since any manual edits will be overwritten during subsequent builds.
 
 OCaml source files have the `.ml` extension, which stands for “Meta Language.” Meta Language (ML) is an ancestor of OCaml. This is also what the “ml” stands for in “OCaml.” Here is the content of the `bin/main.ml` file:
+
 ```ocaml
 let () = print_endline "Hello, World!"
 ```
@@ -87,11 +87,13 @@ The project-wide metadata is available in the `dune-project` file. It contains i
 Each directory containing source files that need to be built must contain a `dune` file describing how.
 
 This builds the project:
+
 ```shell
-$ opam exec -- dune build
+opam exec -- dune build
 ```
 
 This launches the executable it creates:
+
 ```shell
 $ opam exec -- dune exec hello
 Hello, World!
@@ -108,8 +110,8 @@ In the rest of this tutorial, we will make more changes to this project in order
 Before we dive in, note that you will typically want to use Dune's watch mode to continually compile and optionally restart your program. This ensures that the language server has the freshest possible data about your project, so your editor support will be top-notch. To use watch mode, just add the `-w` flag:
 
 ```shell
-$ opam exec -- dune build -w
-$ opam exec -- dune exec hello -w
+opam exec -- dune build -w
+opam exec -- dune exec hello -w
 ```
 
 ## Why Isn't There a Main Function?
@@ -123,11 +125,13 @@ However, it is common practice to single out a value that triggers all the side 
 ## Modules and the Standard Library, Cont'd
 
 Let's summarise what was said about modules in the [Tour of OCaml](/docs/tour-of-ocaml):
+
 - A module is a collection of named values.
 - Identical names from distinct modules don't clash.
 - The standard library is collection of several modules.
 
 Modules aid in organising projects; concerns can be separated into isolated modules. This is outlined in the next section. Before creating a module ourselves, we'll demonstrate using a definition from a module of the standard library. Change the content of the file `bin/main.ml` to this:
+
 ```ocaml
 let () = Printf.printf "%s\n" "Hello, World!"
 ```
@@ -139,16 +143,19 @@ This replaces the function `print_endline` with the function `printf` from the `
 Each OCaml file defines a module, once compiled. This is how separate compilation works in OCaml. Each sufficiently standalone concern should be isolated into a module. References to external modules create dependencies. Circular dependencies between modules are not allowed.
 
 To create a module, let's create a new file named `lib/en.ml` containing this:
+
 ```ocaml
 let v = "Hello, world!"
 ```
 
 Here is a new version of the `bin/main.ml` file:
+
 ```ocaml
 let () = Printf.printf "%s\n" Hello.En.v
 ```
 
 Now execute the resulting project:
+
 ```shell
 $ opam exec -- dune exec hello
 Hello, world!
@@ -156,13 +163,14 @@ Hello, world!
 
 The file `lib/en.ml` creates the module named `En`, which in turn defines a string value named `v`. Dune wraps `En` into another module called `Hello`; this name is defined by the stanza `name hello` in the file `lib/dune`. The string definition is `Hello.En.v` from the `bin/main.ml` file.
 
-
 Dune can launch UTop to access the modules exposed by a project interactively. Here's how:
+
 ```shell
-$ opam exec -- dune utop
+opam exec -- dune utop
 ```
 
 Then, inside the `utop` toplevel, it is possible to inspect our `Hello.En` module:
+
 ```ocaml
 # #show Hello.En;;
 module Hello : sig val v : string end
@@ -171,6 +179,7 @@ module Hello : sig val v : string end
 Now exit `utop` with `Ctrl-D` or enter `#quit;;` before going to the next section.
 
 **Note**: If you add a file named `hello.ml` in the `lib` directory, Dune will consider this the whole `Hello` module and it will make `En` unreachable. If you want your module `En` to be visible, you need to add this in your `hello.ml` file:
+
 ```ocaml
 module En = En
 ```
@@ -179,6 +188,7 @@ module En = En
 ## Defining Module Interfaces
 
 UTop's `#show` command displays an [API](https://en.wikipedia.org/wiki/API#Libraries_and_frameworks) (in the software library sense): the list of definitions provided by a module. In OCaml, this is called a _module interface_. An `.ml` file defines a module. In a similar way, an `.mli` file defines a module interface. The module interface file corresponding to a module file must have the same base name, e.g., `en.mli` is the module interface for module `en.ml`. Create a `lib/en.mli` file with this content:
+
 ```ocaml
 val v : string
 ```
@@ -195,11 +205,13 @@ let v = hello ^ ", world!"
 ```
 
 Also edit the `bin/main.ml` file like this:
+
 ```ocaml
 let () = Printf.printf "%s\n" Hello.En.hello
 ```
 
 Trying to compile this fails.
+
 ```shell
 $ opam exec -- dune build
 File "hello/bin/main.ml", line 1, characters 30-43:
@@ -212,6 +224,7 @@ This is because we haven't changed `lib/en.mli`. Since it does not list
 `hello`, it is therefore private.
 
 ## Defining Multiple Modules in a Library
+
 Multiple modules can be defined in a single library. To demonstrate this,
 create a new file named `lib/es.ml` with the following content:
 
@@ -220,6 +233,7 @@ let v = "¡Hola, mundo!"
 ```
 
 And use the new module in `bin/main.ml`:
+
 ```ocaml
 let () = Printf.printf "%s\n" Hello.Es.v
 let () = Printf.printf "%s\n" Hello.En.v
@@ -241,8 +255,9 @@ A more detailed introduction to modules can be found at [Modules](/docs/modules)
 OCaml has an active community of open-source contributors. Most projects are available using the opam package manager, which you installed in the [Install OCaml](/docs/up-and-ready) tutorial. The following section shows you how to install and use a package from opam's open-source repository.
 
 To illustrate this, let's update our `hello` project to parse a string containing an [S-expression](https://en.wikipedia.org/wiki/S-expression) and print back to a string, both using [Sexplib](https://github.com/janestreet/sexplib). First, update the package list for opam by running `opam update`. Then, install the `Sexplib` package with this command:
+
 ```shell
-$ opam install sexplib
+opam install sexplib
 ```
 
 Next, define a string containing a valid S-expression in `bin/main.ml`. Parse
@@ -258,8 +273,9 @@ let exp1 = Sexplib.Sexp.of_string "(This (is an) (s expression))"
 (* Convert back to a string to print *)
 let () = Printf.printf "%s\n" (Sexplib.Sexp.to_string exp1)
 ```
+
 The string you entered representing a valid S-expression is parsed into
-an S-expression type, which is defined as either an `Atom` (string) or a `List` 
+an S-expression type, which is defined as either an `Atom` (string) or a `List`
 of S-expressions (it's a recursive type). Refer to the [Sexplib documentation](https://github.com/janestreet/sexplib) for more information.
 
 Before the example will build and run, you need to tell Dune that it needs `Sexplib` to compile the project. Do this by adding `Sexplib` to the `library` stanza of the `bin/dune` file. The full `bin/dune` file should then match the following.
@@ -274,6 +290,7 @@ Before the example will build and run, you need to tell Dune that it needs `Sexp
 **Fun fact**: Dune configuration files are S-expressions.
 
 Finally, execute as before:
+
 ```shell
 $ opam exec -- dune exec hello
 (This(is an)(s expression))
@@ -285,11 +302,13 @@ $ opam exec -- dune exec hello
 **Note**: This example was successfully tested on Windows using DkML 2.1.0. Run `dkml version` to see the version.
 
 Let's assume we'd like `hello` to display its output as if it was a list of strings in UTop: `["hello"; "using"; "an"; "opam"; "library"]`. To do that, we need a function turning a `string list` into a `string`, adding brackets, spaces, and commas. Instead of defining it ourselves, let's generate it automatically with a package. We'll use [`ppx_deriving`](https://github.com/ocaml-ppx/ppx_deriving). Here is how to install it:
+
 ```shell
-$ opam install ppx_deriving
+opam install ppx_deriving
 ```
 
 Dune needs to be told how to use it, which is done in the `lib/dune` file. Note that this is different from the `bin/dune` file that you edited earlier! Open up the `lib/dune` file, and edit it to look like this:
+
 ```lisp
 (library
  (name hello)
@@ -301,12 +320,14 @@ The line `(preprocess (pps ppx_deriving.show))` means that before compilation th
 The files `lib/en.ml` and `lib/en.mli` need to be edited, too:
 
 **`lib/en.mli`**
+
 ```ocaml
 val string_of_string_list : string list -> string
 val v : string list
 ```
 
 **`lib/en.ml`**
+
 ```ocaml
 let string_of_string_list = [%show: string list]
 
@@ -314,15 +335,18 @@ let v = String.split_on_char ' ' "Hello using an opam library"
 ```
 
 Let's read this from the bottom up:
+
 - `v` has the type `string list`. We're using `String.split_on_char` to turn a `string` into a `string list` by splitting the string on space characters.
 - `string_of_string_list` has type `string list -> string`. This converts a list of strings into a string, applying the expected formatting.
 
 Finally, you'll also need to edit `bin/main.ml`
+
 ```ocaml
 let () = print_endline Hello.En.(string_of_string_list v)
 ```
 
 Here is the result:
+
 ```shell
 $ opam exec -- dune exec hello
 ["Hello"; "using"; "an"; "opam"; "library"]
@@ -333,11 +357,13 @@ $ opam exec -- dune exec hello
 This section explains the purpose of the files and directories created by `dune init proj` which haven't been mentioned earlier.
 
 Along the history of OCaml, several build systems have been used. As of writing this tutorial (Summer 2023), Dune is the mainstream one, which is why it is used in the tutorial. Dune automatically extracts the dependencies between the modules from the files and compiles them in a compatible order. It only needs one `dune` file per directory where there is something to build. The three directories created by `dune init proj` have the following purposes:
+
 - `bin`: executable programs
 - `lib`: libraries
 - `test`: tests
 
 There will be a tutorial dedicated to Dune. This tutorial will present the many features of Dune, a few of which are listed here:
+
 - Running tests
 - Generating documentation
 - Producing packaging metadata (here in `hello.opam`)
@@ -348,30 +374,35 @@ The `_build` directory is where Dune stores all the files it generates. It can b
 ## Minimum Setup
 
 In this last section, let's create a bare minimum project, highlighting what's really needed for Dune to work. We begin by creating a fresh project directory:
+
 ```shell
-$ cd ..
-$ mkdir minimo
-$ cd minimo
+cd ..
+mkdir minimo
+cd minimo
 ```
 
 At the very least, Dune only needs two files: `dune-project` and one `dune` file. Here is how to write them with as little text as possible:
 
 `dune-project`
+
 ```lisp
 (lang dune 3.6)
 ```
 
 `dune`
+
 ```lisp
 (executable (name minimo))
 ```
 
 `minimo.ml`
+
 ```ocaml
 let () = print_endline "My name is Minimo"
 ```
 
 That's all! This is sufficient for Dune to build and execute the `minimo.ml` file.
+
 ```shell
 $ opam exec -- dune exec ./minimo.exe
 My name is Minimo

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -16,26 +16,28 @@ OCaml has plugins for many editors, but the most actively maintained are for Vis
 For VSCode, install the [OCaml Platform Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform) from the Visual Studio Marketplace. The extension depends on OCaml LSP and OCamlFormat. To install them in your switch, you can run:
 
 ```shell
-$ opam install ocaml-lsp-server ocamlformat
+opam install ocaml-lsp-server ocamlformat
 ```
 
-Upon first loading an OCaml source file, you may be prompted to select the toolchain in use. Pick the version of OCaml you are using, e.g., `5.1.0` from the list. 
+Upon first loading an OCaml source file, you may be prompted to select the toolchain in use. Pick the version of OCaml you are using, e.g., `5.1.0` from the list.
 
 ### Editor Features at Your Disposal
+
 If your editor is setup correctly, here are some important features you can begin using to your advantage:
-#### 1) Hovering for Type Information: 
+
+#### 1) Hovering for Type Information
 
 ![VSCode Hovering](/media/tutorials/vscode-hover.gif)
 
 This is a great feature that let's you see type information of any OCaml variable or function. All you have to do is place your cursor over the code and it will be displayed in the tooltip.
 
-#### 2) Jump to Definitions With `Ctrl + Click`:
+#### 2) Jump to Definitions With `Ctrl + Click`
 
 ![VSCode Ctrl click](/media/tutorials/vscode-ctrl-click.gif)
 
 If you hold down the <kbd>Ctrl</kbd> key while hovering, the code appears as a clickable link which if clicked takes you to the file where the implementation is. This can be great if you want to understand how a piece of code works under the hood. In this example, hovering and `Ctrl + Clicking` over the `peek` method of the `Queue` module will take you to the definiton of the `peek` method itself and how it is implemented.
 
-#### 3) OCaml Commands With `Ctrl + Shift + P`:
+#### 3) OCaml Commands With `Ctrl + Shift + P`
 
 ![VSCode OCaml Commands](/media/tutorials/vscode-ocaml-commands.gif)
 
@@ -53,13 +55,13 @@ If you used the DkML distribution, you will need to:
 **For Vim and Emacs**, we won't use the LSP server but rather directly talk to Merlin.
 
 ```shell
-$ opam install merlin
+opam install merlin
 ```
 
 After installing Merlin above, instructions will be printed on how to link Merlin with your editor. If you do not have them visible, just run this command:
 
 ```shell
-$ opam user-setup install
+opam user-setup install
 ```
 
 ### Talking to Merlin

--- a/data/tutorials/getting-started/2_01_toplevel.md
+++ b/data/tutorials/getting-started/2_01_toplevel.md
@@ -9,6 +9,7 @@ category: "Tooling"
 An OCaml toplevel is a chat between the user and OCaml. The user writes OCaml code, and UTop evaluates it. This is why it is also called a Read-Eval-Print-Loop (REPL). Several OCaml toplevels exist, like `ocaml` and `utop`. We recommend using UTop, which is part of the [OCaml Platform](/docs/platform) toolchain.
 
 To run UTop, we use the `utop` command, which looks like this:
+
 ```shell
 $ utop
 ────────┬─────────────────────────────────────────────────────────────┬─────────
@@ -30,6 +31,7 @@ Lines ending with double semicolons trigger the parsing, type checking, and eval
 Code samples beginning with `#` are intended to be copied/pasted into UTop.
 
 For instance, consider the following code snippet:
+
 ```ocaml
 # 2 + 2;;
 - : int = 4
@@ -43,7 +45,7 @@ Commands beginning with a hash character `#`, such as `#quit` or `#help`, are no
 
 You're now ready to hack with UTop! If you hit any issue with the toplevel, don't hesitate to [ask on Discuss](https://discuss.ocaml.org/).
 
->  Note: The double semicolon `;;` is also a valid token in the OCaml syntax outside the toplevel. In OCaml source code, it is a [no-op](https://en.wikipedia.org/wiki/NOP_(code)), i.e., it does not trigger any behaviour, so it is ignored by the compiler. If your intention is to compile or interpret files as scripts, double semicolons can and should be avoided when writing in OCaml. Leaving them does not raise errors, but they are useless. The compiler tolerates them to allow copy-paste from UTop to a file without having to remove them.
+> Note: The double semicolon `;;` is also a valid token in the OCaml syntax outside the toplevel. In OCaml source code, it is a [no-op](https://en.wikipedia.org/wiki/NOP_(code)), i.e., it does not trigger any behaviour, so it is ignored by the compiler. If your intention is to compile or interpret files as scripts, double semicolons can and should be avoided when writing in OCaml. Leaving them does not raise errors, but they are useless. The compiler tolerates them to allow copy-paste from UTop to a file without having to remove them.
 
 ## Using Packages in UTop
 
@@ -66,6 +68,7 @@ Error: Unbound module Str
 # Str.quote {|"hello"|};;
 - : string = "\"hello\""
 ```
+
 **Tip**: UTop knows about the available libraries and completion works. Outside `utop` you can use `ocamlfind list` to display the complete list of libraries. Note that opam package may bundle several libraries and libraries may bundle several modules.
 
 ### Using a Pre-Processor Extension (PPX) in UTop

--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -6,13 +6,14 @@ description: |
 category: "Tooling"
 ---
 
-OCaml's package manager, opam, introduces the concept of a _switch_, which is an isolated OCaml environment. These switches often cause confusion amongst OCaml newcomers, so this document aims to provide a better understanding of opam switches and their usage for managing dependencies and project-specific configurations. 
+OCaml's package manager, opam, introduces the concept of a _switch_, which is an isolated OCaml environment. These switches often cause confusion amongst OCaml newcomers, so this document aims to provide a better understanding of opam switches and their usage for managing dependencies and project-specific configurations.
 
 Opam is designed to manage multiple concurrent installation prefixes called "switches." Similar to Python's `virtualenv`, an opam switch is a tool that creates isolated environments. They are independent of each other and have their own set of installed packages, repositories, and configuration options. Switches also have their own OCaml compiler, libraries, and binaries. This enables you to have multiple compiler versions available at once.
 
 ## Listing Switches
 
 The command below will display the opam switches that are configured on your system. After completing installation of OCaml, such as outlined in [Installing OCaml](/docs/installing-ocaml), a single switch called `default` will have been created. At that point, listing the switches will only show that switch.
+
 ```shell
 $ opam switch list
 #   switch   compiler      description
@@ -33,7 +34,7 @@ Next, **activate** your new switch. This will set it as the currently selected s
 
 ```
 opam switch my_project
-``` 
+```
 
 Replace `my_project` with the name of your new switch.
 
@@ -42,13 +43,14 @@ Replace `my_project` with the name of your new switch.
 ```
 opam switch
 ```
+
 If the output is the name of your new switch, you've successfully activated it! Now you can use it for your OCaml projects and install OCaml packages, libraries, and dependencies specific to this switch without affecting other switches or the system-wide OCaml environment.
 
 ## Types of Switches
 
 ### Global Switches
 
-Global switches are often used for system-wide OCaml installations and are not tied to a particular project or directory. A switch is created and configured at the system level and is typically used to manage OCaml and its ecosystem on a global scale. 
+Global switches are often used for system-wide OCaml installations and are not tied to a particular project or directory. A switch is created and configured at the system level and is typically used to manage OCaml and its ecosystem on a global scale.
 
 When creating an opam switch, it's global by default unless otherwise configured. You can also explicitly select a global switch by using the opam switch command with the `--global` flag.
 
@@ -78,6 +80,4 @@ Most package-related commands in opam operate within the context of a selected s
 
 ---
 
-> Learn more details and uses of opam switches in the [opam manual's File Hierarchies page](https://opam.ocaml.org/doc/Manual.html) and its [page dedicated to switches](https://opam.ocaml.org/doc/man/opam-switch.html). 
-
-
+> Learn more details and uses of opam switches in the [opam manual's File Hierarchies page](https://opam.ocaml.org/doc/Manual.html) and its [page dedicated to switches](https://opam.ocaml.org/doc/man/opam-switch.html).

--- a/data/tutorials/getting-started/3_01_ocaml_on_windows.md
+++ b/data/tutorials/getting-started/3_01_ocaml_on_windows.md
@@ -51,10 +51,10 @@ $ opam --version
 Once opam is installed, run the `opam init` command to set up your opam environment.
 
 You will notice that the repository information fetching stage takes a while to
-complete. This is normal (for the moment), so we advise our users to get 
+complete. This is normal (for the moment), so we advise our users to get
 themselves their favourite hot beverage while it runs.
 
-opam requires a Unix-like environment to function. By default, 
+opam requires a Unix-like environment to function. By default,
 opam relies on Cygwin and is also compatible with MSYS2.
 
 At *init-time*, opam scans your machine for available Unix environments and
@@ -64,10 +64,9 @@ by opam. This cuts down possible interferences from other tools
 that interact with such environments. Think of it as a
 sandboxed environment.
 
-
 Opam's default behavior when initialising is to install a fresh `switch` as
 well as an OCaml compiler of version `> 4.05`. By default, opam chooses `mingw` as
-a C compiler when creating switches, but know that you can choose to install an 
+a C compiler when creating switches, but know that you can choose to install an
 alternative instead, like `msvc`, with the following command:
 
 ```
@@ -77,13 +76,17 @@ opam install system-msvc
 After `opam init` completes, run the following command to update your environment:
 
 On CMD:
+
 ```
 > for /f "tokens=*" %i in ('opam env --switch=default') do @%i
 ```
+
 On PowerShell:
+
 ```
 > (& opam env --switch=default) -split '\\r?\\n' | ForEach-Object { Invoke-Expression $_ }
 ```
+
 Opam will display the shell update command each time it is needed.
 
 You can verify your installation with
@@ -108,7 +111,7 @@ You should now have a functioning OCaml environment ready for development. If yo
 
 ### WSL2
 
-If you only need to _run_ OCaml programs on a Windows machine, the simplest solution is to use the Windows Subsystem for Linux 2 (WSL2). WSL2 is a feature that allows Linux programs to run directly on Windows. WSL2 is substantially easier and faster to use than WSL1. Microsoft has comprehensive installation steps for [setting up WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+If you only need to *run* OCaml programs on a Windows machine, the simplest solution is to use the Windows Subsystem for Linux 2 (WSL2). WSL2 is a feature that allows Linux programs to run directly on Windows. WSL2 is substantially easier and faster to use than WSL1. Microsoft has comprehensive installation steps for [setting up WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
 After you have installed WSL2 and chosen one Linux distribution (we suggest [Ubuntu LTS](https://apps.microsoft.com/store/detail/ubuntu/9PDXGNCFSCZV?hl=en-us&gl=US)), you can follow the
 [Installing OCaml: Installation for Linux and macOS](/docs/installing-ocaml) steps.
@@ -124,6 +127,7 @@ easier way to get a working Windows environment on your machine.
 
 Diskuv OCaml ("DKML") is an OCaml distribution that supports software development in pure OCaml.
 The distribution is unique because of its:
+
 * full compatibility with OCaml standards like opam, Dune, and OCamlFind.
 * focus on "native" development (desktop software, mobile apps, and embedded software) through support for the standard native compilers,
   like Visual Studio and Xcode.
@@ -194,7 +198,7 @@ that covers getting WSL2 and Visual Studio Code connected.
 system using opam:
 
 ```console
-$ opam install merlin
+opam install merlin
 ```
 
 The installation procedure will print instructions on how to link Merlin with

--- a/data/tutorials/getting-started/3_02_arm_fix.md
+++ b/data/tutorials/getting-started/3_02_arm_fix.md
@@ -11,17 +11,18 @@ Since [Homebrew has changed](https://github.com/Homebrew/brew/issues/9177) the w
 Before we get started, let's check where Homebrew is installed. We can do this by running this in the CLI:
 
 ```shell
-$ where brew
+where brew
 ```
-If the response is `/usr/local/bin/brew`, we'll need to make the changes. It needs to be `/opt/homebrew/bin/brew`. 
+
+If the response is `/usr/local/bin/brew`, we'll need to make the changes. It needs to be `/opt/homebrew/bin/brew`.
 
 ### Install CLT
 
-First, ensure the Command Line Tools (CLT) are installed by running 
+First, ensure the Command Line Tools (CLT) are installed by running
 
 ```shell
 $ ls /Library/Developer/CommandLineTools
-Library	SDKs	usr
+Library SDKs usr
 ```
 
 If they're not installed, let's install them now. You don't have to install all of XCode; you can install just the CLT by [downloading them directly from Apple's Developer](https://developer.apple.com/download/all/). Look for a non-beta version for stability, like "Command Line Tools for XCode 14.3.1"
@@ -33,14 +34,14 @@ Next, it's necessary to disable Rosetta if you have it installed. This [Apple Su
 1. Uninstall Homebrew by running the following:
 
 ```shell
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 ```
 
 2. Reinstall Homebrew:
 
 ```Shell
-$ brew install /Users/tarides/Library/Caches/Homebrew/downloads/9e6d2a225119ad88cde6474d39696e66e4f87dc4a4d101243b91986843df691e--libev--4.33.arm64_monterey.bottle.tar.gz
+brew install /Users/tarides/Library/Caches/Homebrew/downloads/9e6d2a225119ad88cde6474d39696e66e4f87dc4a4d101243b91986843df691e--libev--4.33.arm64_monterey.bottle.tar.gz
 ```
 
 3. Check to see if Homebrew is in the correct location now. It should return what's shown below:

--- a/data/tutorials/getting-started/3_03_ocaml_playground.md
+++ b/data/tutorials/getting-started/3_03_ocaml_playground.md
@@ -7,7 +7,7 @@ description: |
 category: "Resources"
 ---
 
-Welcome to OCaml's in-browser playground! 
+Welcome to OCaml's in-browser playground!
 
 The [OCaml Playground](https://ocaml.org/play) is made to make it easier for users, especially beginners, to get started with OCaml without worrying about installing anything. Everything is ready to use once you open it.
 
@@ -38,6 +38,7 @@ Let's start with something simple. Type the following on your editor panel and c
 ```
 2+3
 ```
+
 You should see the following output.
 
 `- : int = 5`
@@ -47,6 +48,7 @@ Now, clear the output and also delete the things on the editor panel. Let's try 
 ```
 "OCaml is amazing"
 ```
+
 You should see the following output.
 
 `- : string = "OCaml is amazing"`
@@ -72,6 +74,7 @@ let () =
   let res = fib_par n num_domains in
   Printf.printf "fib(%d) = %d\n" n res
 ```
+
 The output will be the following.
 
 ```
@@ -82,6 +85,7 @@ val n : int = 20
 val fib : int -> int = <fun>
 val fib_par : int -> int -> int = <fun>
 ```
+
 ## Autocomplete
 
 The playground also supports code completion. It helps users by suggesting and completing their input based on the context.

--- a/data/tutorials/guides/0tt_00_formatting_text.md
+++ b/data/tutorials/guides/0tt_00_formatting_text.md
@@ -15,6 +15,7 @@ intended to break lines in a nice way (let's say “automatically when it
 is necessary”).
 
 ## Principles
+
 Line breaking is based on three concepts:
 
 * **boxes**: a box is a logical pretty-printing unit, which defines a
@@ -29,19 +30,20 @@ Line breaking is based on three concepts:
 * **Indentation rules**: When a line break occurs, the pretty-printing
  engines fixes the indentation (or amount of leading spaces) of the
  new line using indentation rules, as follows:
-    * A box can state the extra indentation of every new line opened
+  * A box can state the extra indentation of every new line opened
  in its scope. This extra indentation is named **box breaking
  indentation**.
-    * A break hint can also set the additional indentation of the new
+  * A break hint can also set the additional indentation of the new
  line it may fire. This extra indentation is named **hint
  breaking indentation**.
-    * If break hint `bh` fires a new line within box `b`, then the
+  * If break hint `bh` fires a new line within box `b`, then the
  indentation of the new line is simply the sum of: the current
  indentation of box `b` `+` the additional box breaking
  indentation, as defined by box `b` `+` the additional hint
  breaking indentation, as defined by break hint `bh`.
 
 ## Boxes
+
 There are 4 types of boxes. (The most often used is the “hov” box type,
 so skip the rest at first reading).
 
@@ -90,6 +92,7 @@ the value of the break that is explained below):
     ```text
     --b--b--
     ```
+
     But "---b---b---" that cannot fit on the line is written
 
     ```text
@@ -105,12 +108,14 @@ the value of the break that is explained below):
     ```text
     --b--b--
     ```
+
     But if "---b---b---" cannot fit on the line, it is written as
 
     ```text
     ---b---b
     ---
     ```
+
     The first break hint does not lead to a new line, since there is
     enough room on the line. The second one leads to a new line since
     there is no more room to print the material following it. If the
@@ -123,8 +128,8 @@ the value of the break that is explained below):
     ---
     ```
 
-
 ## Printing Spaces
+
 Break hints are also used to output spaces (if the line is not split
 when the break is encountered, otherwise the new line indicates properly
 the separation between printing items). You output a break hint using
@@ -153,6 +158,7 @@ For instance, if b is `break 1 0` in the output "--b--b--", we get
     ```text
     -- -- --
     ```
+
     or, according to the remaining room on the line:
 
     ```text
@@ -169,8 +175,8 @@ instead. (For instance `print_space ()` that is a convenient
 abbreviation for `print_break 1 0` and outputs a single space or break
 the line.)
 
-
 ## Indentation of New Lines
+
 The user gets 2 ways to fix the indentation of new lines:
 
 * **when defining the box**: when you open a box, you can fix the
@@ -183,12 +189,14 @@ The user gets 2 ways to fix the indentation of new lines:
     ---[--b--b
          --b--
     ```
+
     with `open_hovbox 2`, we get
 
     ```text
     ---[--b--b
           --b--
     ```
+
     Note: the `[` sign in the display is not visible on the screen, it
     is just there to materialise the aperture of the pretty-printing
     box. Last “screen” stands for:
@@ -214,8 +222,8 @@ The user gets 2 ways to fix the indentation of new lines:
           --
     ```
 
-
 ## Refinement on “hov” Boxes
+
 ### Packing and Structural “hov” Boxes
 
 The “hov” box type is refined into two categories.
@@ -231,6 +239,7 @@ The “hov” box type is refined into two categories.
  to new lines even if there is enough room on the current line.
 
 ### Differences Between a Packing and a Structural “hov” Box
+
 The difference between a packing and a structural “hov” box is shown by
 a routine that closes boxes and parentheses at the end of printing: with
 packing boxes, the closure of boxes and parentheses do not lead to new
@@ -245,6 +254,7 @@ box (open_hovbox), `[(---[(----[(---b)]b)]b)]` is printed as follows:
  (----
   (---)))
 ```
+
 If we replace the packing boxes by structural boxes (open_box), each
 break hint that precedes a closing parenthesis can show the boxes
 structure, if it leads to a new line; hence `[(---[(----[(---b)]b)]b)]`
@@ -277,7 +287,7 @@ When writing a pretty-printing routine, follow these simple rules:
  definition. You will probably treat the first three spaces as
  “unbreakable spaces” and write them directly in the string constants
  for keywords, and print `"let rec "` before the identifier, and
- similarly write ` =` to get an unbreakable space after the
+ similarly write `=` to get an unbreakable space after the
  identifier; in contrast, the space after the `=` sign is certainly a
  break hint, since breaking the line after `=` is a usual (and
  elegant) way to indent the expression part of a definition. In
@@ -301,6 +311,7 @@ When writing a pretty-printing routine, follow these simple rules:
  input.)
 
 ## Printing to `stdout`: Using `printf`
+
 The `format` module provides a general printing facility “à la”
 `printf`. In addition to the usual conversion facility provided by
 `printf`, you can write pretty-printing indications directly inside the
@@ -350,6 +361,7 @@ type lambda =
   | Var of string
   | Apply of lambda * lambda
 ```
+
 I use the format library to print the lambda-terms:
 
 ```ocaml
@@ -373,6 +385,7 @@ and print_lambda = function
       close_box()
   | e -> print_app e
 ```
+
 In Caml Light, replace the first line by:
 
 <!-- $MDX skip -->

--- a/data/tutorials/guides/0tt_02_file_manipulation.md
+++ b/data/tutorials/guides/0tt_02_file_manipulation.md
@@ -14,6 +14,7 @@ Official documentation for the modules of interest:
 the core library including the initially opened module Stdlib and Printf.
 
 ## Buffered Channels
+
 The normal way of opening a file in OCaml returns a **channel**. There
 are two kinds of channels:
 
@@ -21,6 +22,7 @@ are two kinds of channels:
 * channels that read from a file: type `in_channel`
 
 ### Writing
+
 For writing into a file, you would do this:
 
 1. Open the file to obtain an `out_channel`
@@ -36,6 +38,7 @@ Commonly used functions: `open_out`, `open_out_bin`, `flush`,
 Standard `out_channel`s: `stdout`, `stderr`
 
 ### Reading
+
 For reading data from a file you would do this:
 
 1. Open the file to obtain an `in_channel`
@@ -52,6 +55,7 @@ Commonly used functions: `open_in`, `open_in_bin`, `close_in`,
 Standard `in_channel`: `stdin`
 
 ### Seeking
+
 Whenever you write or read something to or from a channel, the current
 position changes to the next character after what you just wrote or
 read. Occasionally, you may want to skip to a particular position in the
@@ -59,6 +63,7 @@ file, or restart reading from the beginning. This is possible for
 channels that point to regular files, use `seek_in` or `seek_out`.
 
 ### Gotchas
+
 * Don't forget to flush your `out_channel`s if you want to actually
  write something. This is particularly important if you are writing
  to non-files such as the standard output (`stdout`) or a socket.

--- a/data/tutorials/guides/0tt_03_calling_c_libraries.md
+++ b/data/tutorials/guides/0tt_03_calling_c_libraries.md
@@ -7,6 +7,7 @@ category: "Tutorials"
 ---
 
 ## MiniGtk
+
 While the structure of lablgtk outlined in [Introduction to
 Gtk](https://v2.ocaml.org/learn/tutorials/introduction_to_gtk.html) seems perhaps
 over-complex, it's worth considering exactly why the author chose two
@@ -43,6 +44,7 @@ win#add lbl;;
 let () =
   Gtk.main ()
 ```
+
 I defined a single abstract type to cover all `GtkObject`s (and
 "subclasses" of this C structure). In the `Gtk` module you'll find this
 type definition:
@@ -82,6 +84,7 @@ gtk_label_new_c (value str)
     gtk_label_new (String_val (str)))));
  }
 ```
+
 Before explaining this function further, I'm going to take a step back
 and look at the hierarchy of our Gtk classes. I've chosen to reflect the
 actual Gtk widget hierarchy as closely as possible. All Gtk widgets are
@@ -141,6 +144,7 @@ class virtual widget ?show obj =
     initializer if show <> Some false then self#show
   end
 ```
+
 This class is considerably more complex. Let's look at the
 initialization code first:
 
@@ -266,6 +270,7 @@ class label ~text
       may (gtk_label_set_line_wrap obj) line_wrap
   end
 ```
+
 Although this class is bigger than the ones we've looked at up til now,
 it's really more of the same idea, *except* that this class isn't
 virtual. You can create instances of this class which means it finally
@@ -280,12 +285,14 @@ class label ~text ... () =
     inherit misc ... obj
   end
 ```
+
 (Pop quiz: what happens if we need to define a class which is both a
 base class from which other classes can be derived, and is also a
 non-virtual class of which the user should be allowed to create
 instances?)
 
 #### Wrapping Calls to C Libraries
+
 Now we'll look in more detail at actually wrapping up calls to C library
 functions. Here's a simple example:
 
@@ -303,6 +310,7 @@ gtk_label_set_text_c (value obj, value str)
   CAMLreturn (Val_unit);
 }
 ```
+
 Comparing the OCaml prototype for the external function call (in the
 comment) with the definition of the function we can see two things:
 
@@ -374,6 +382,7 @@ caml__roots_obj.ntables = 2;
 caml__roots_obj.tables [0] = &obj;
 caml__roots_obj.tables [1] = &str;
 ```
+
 And for `CAMLreturn (foo)`:
 
 ```C

--- a/data/tutorials/guides/0tt_04_calling_fortran_libraries.md
+++ b/data/tutorials/guides/0tt_04_calling_fortran_libraries.md
@@ -31,6 +31,7 @@ these have been tested with the GNU fortran 90 compiler (gfort) and will
 not be until it has proven itself through some time.
 
 ### Step 1: Compile the Fortran Routine
+
 Where C/C++ have only one category of subroutine (the function), Fortran
 has two: the function and the subroutine. The function is the equivalent
 to a non-void C function in that it takes parameters and always returns
@@ -65,7 +66,7 @@ Reals are equivalent to C doubles and integers are equivalent to C
 longs. In addition, Fortran passes everything by reference so the
 corresponding C prototype for our gtd6 function is
 
-` int gtd6_(integer *iyd, real* sec, real* alt, real* glat, real* glong, real* dens, real* temp);`
+`int gtd6_(integer *iyd, real* sec, real* alt, real* glat, real* glong, real* dens, real* temp);`
 
 Note that its up to the caller to know that `dens` and `temp` are
 actually arrays. Failure to pass an array will cause a segmentation
@@ -73,6 +74,7 @@ violation since the gtd6_ function is using them as arrays (yet another
 reason OCaml shines).
 
 ### Step 2: Create the C Wrapper
+
 Because OCaml's foreign function interface is C based, it is necessary
 to create a C wrapper. To avoid difficulties in passing back arrays of
 values, we are going to simply create a function that will return the
@@ -93,6 +95,7 @@ CAMLprim value gtd6_t (value iydV, value secVal, value altVal, value latVal, val
    CAMLreturn( caml_copy_double( t[1] ) );
 }
 ```
+
 A few points of interest
 
 1. The file must include the OCaml header files `alloc.h`, `memory.h`,
@@ -107,14 +110,15 @@ A few points of interest
  macro to create a new value containing the return value and to
  return it respectively.
 
-### Step 3: Compile the Shared Library.
+### Step 3: Compile the Shared Library
+
 Now having the two source files funcs.f and wrapper.c we need to create
 a shared library that can be loaded by OCaml. Its easier to do this as a
 multistep process, so here are the commands:
 
 `prompt> g77 -c funcs.f`
 
-`prompt> cc -I<ocaml include path> -c wrapper.c `
+`prompt> cc -I<ocaml include path> -c wrapper.c`
 
 `prompt> cc -shared -o wrapper.so wrapper.o funcs.o -lg2c`
 
@@ -124,6 +128,7 @@ required to provide the implementations of the built in fortran
 functions that are used.
 
 ### Step 4: Now to OCaml
+
 Now in an OCaml file (gtd6.ml) we have to define the external reference
 to the function and a function to call it.
 
@@ -135,6 +140,7 @@ let () =
   print_double (temp 1 2.0 3.0 4.0 5.0);
   print_newline ()
 ```
+
 This tells OCaml that the temp function takes 5 parameters and returns a
 single floating point and calls the C function gtd6_t.
 

--- a/data/tutorials/guides/1wf_00_using_the_ocaml_compiler_toolchain.md
+++ b/data/tutorials/guides/1wf_00_using_the_ocaml_compiler_toolchain.md
@@ -41,9 +41,10 @@ But if you want to try `ocamlc`, you can go ahead and try the following.
 Create a new directory named `hello` and navigate to the directory:
 
 ```shell
-$ mkdir hello
-$ cd hello
+mkdir hello
+cd hello
 ```
+
 Next, create a file named `hello.ml` and add the following code with your favorite text editor:
 
 ```shell
@@ -53,12 +54,12 @@ let () = print_endline "Hello OCaml!"
 Now, we are ready to run the code. Save the file and return to the command line. Let's compile the code:
 
 ```dune
-$ ocamlc -o hello hello.ml
+ocamlc -o hello hello.ml
 ```
 
-The `-o hello` option tells the compiler to name the output executable as `hello`. The executable `hello` contains compiled OCaml bytecode. In addition, two other files are produced, `hello.cmi` and `hello.cmo`. 
+The `-o hello` option tells the compiler to name the output executable as `hello`. The executable `hello` contains compiled OCaml bytecode. In addition, two other files are produced, `hello.cmi` and `hello.cmo`.
 
-`hello.cmi` contains compiled interface information for OCaml modules. An interface file includes type information and module signatures but doesn't contain the actual code. 
+`hello.cmi` contains compiled interface information for OCaml modules. An interface file includes type information and module signatures but doesn't contain the actual code.
 
 `hello.cmo` contains the compiled bytecode for OCaml modules. Bytecode is an intermediate representation of the code that is executed by the OCaml interpreter or runtime system.
 
@@ -70,6 +71,7 @@ Now let's run the executable and see what happens:
 $ ./hello
 Hello OCaml!
 ```
+
 Voilà! It says, `Hello OCaml!`.
 
 We can change the string or add more content, save the file, recompile, and rerun.
@@ -215,13 +217,13 @@ structure, build, and run dune projects.
 
 ### Bytecode Using Dune
 
-Dune is a build system for OCaml projects, and it allows you to configure different modes for building your executables. We will use `(modes byte exe)` stanza in the `dune` file, which will produce both bytecode (interpreted) and native executable versions of the OCaml program. 
+Dune is a build system for OCaml projects, and it allows you to configure different modes for building your executables. We will use `(modes byte exe)` stanza in the `dune` file, which will produce both bytecode (interpreted) and native executable versions of the OCaml program.
 
 Let's create an example project named `myproject`.
 
 ```dune
-$ mkdir myproject
-$ cd myproject
+mkdir myproject
+cd myproject
 ```
 
 Create a `dune-project` file, add the following content.
@@ -253,7 +255,7 @@ let () = print_endline "Hello Dune!"
 Finally, we compile and execute it.
 
 ```shell
-$ dune build main.bc
+dune build main.bc
 ```
 
 The `.bc` stands for generic bytecode file, and it can be an executable or library.
@@ -262,16 +264,18 @@ The `.bc` stands for generic bytecode file, and it can be an executable or libra
 $ dune exec ./main.bc
 Hello Dune!
 ```
+
 We can also do that with `.exe`.
 
 ```shell
-$ dune build main.exe
+dune build main.exe
 ```
 
 ```shell
 $ dune exec ./main.exe
 Hello Dune!
 ```
+
 ## Other Build Systems
 
 - [OMake](https://github.com/ocaml-omake/omake) Another OCaml build system.

--- a/data/tutorials/guides/1wf_01_debugging.md
+++ b/data/tutorials/guides/1wf_01_debugging.md
@@ -17,7 +17,6 @@ This tutorial presents four techniques for debugging OCaml programs:
   OCaml program
 * [Using Thread Sanitizer to detect a data race](#detecting-a-data-race-with-thread-sanitizer) in an OCaml 5 program
 
-
 ## Tracing Functions Calls in the Toplevel
 
 The simplest way to debug programs in the toplevel is to follow the function
@@ -161,14 +160,17 @@ purpose formats are more suited to get the relevant information, than what can
 be output automatically by the generic pretty-printer used by the trace
 mechanism.
 
-Compiler builtins help display useful debugging messages. They indicate a location in the program's source. 
+Compiler builtins help display useful debugging messages. They indicate a location in the program's source.
 For example,
+
 ```ocaml
 match Message.unpack response with
 | Some y -> y
 | None -> (Printf.eprintf "Invalid message at %s" __LOC__; raise Invalid_argument)
 ```
+
 At compile time, the `__LOC__` builtin is substituted with its location in the program, described as a string `"File %S, line %d, characters %d-%d"`. File name, line number, start character and end character are also available through the `__POS__` builtin:
+
 ```ocaml
 match Message.unpack response with
 | Some y -> y
@@ -186,9 +188,10 @@ Compiler builtins are described in the
 
 We now give a quick tutorial for the OCaml debugger (`ocamldebug`).  Before
 starting, please note that
-- `ocamldebug` runs on `ocamlc` bytecode programs (it does not work on
+
+* `ocamldebug` runs on `ocamlc` bytecode programs (it does not work on
   native code executables), and
-- it does not work under native Windows ports of OCaml (but it runs
+* it does not work under native Windows ports of OCaml (but it runs
   under the Cygwin port).
 
 ### Launching the Debugger
@@ -206,6 +209,7 @@ let () =
   add_address "IRIA" "Rocquencourt";;
   print_string (find_address "INRIA"); print_newline ();;
 ```
+
 ```mdx-error
 val l : (string * string) list ref = {contents = [("IRIA", "Rocquencourt")]}
 val find_address : string -> string = <fun>
@@ -286,7 +290,6 @@ let rec assoc x = function
 
 The function that calls it is in module `Uncaught`, file `uncaught.ml`
 line 8, char 38:
-
 
 <!-- $MDX skip -->
 ```ocaml
@@ -393,7 +396,6 @@ From this back trace it should be clear that we receive a `Not_found`
 exception in `List.assoc` from the `Stdlib` when calling
 `find_address` on line 8.
 
-
 The environment variable `OCAMLRUNPARAM` also works when working on a
 program built with `dune`:
 
@@ -404,6 +406,7 @@ program built with `dune`:
  (modules uncaught)
 )
 ```
+
 ```
 OCAMLRUNPARAM=b dune exec ./uncaught.exe
 Fatal error: exception Not_found
@@ -411,7 +414,6 @@ Raised at Stdlib__List.assoc in file "list.ml", line 191, characters 10-25
 Called from Dune__exe__Uncaught.find_address in file "uncaught.ml" (inlined), line 3, characters 24-42
 Called from Dune__exe__Uncaught in file "uncaught.ml", line 8, characters 15-37
 ```
-
 
 ## Detecting a Data Race with Thread Sanitizer
 
@@ -424,6 +426,7 @@ report these.
 
 To install the TSan mode, create a dedicated TSan switch by running the
 following command (here we create a 5.2.0 switch):
+
 ```
 opam switch create 5.2.0+tsan ocaml-variants.5.2.0+options ocaml-option-tsan
 ```
@@ -435,11 +438,12 @@ Note: TSan is supported on all architectures with a native code
 compiler since OCaml 5.2.0.
 
 Troubleshooting:
-- If the above fails during installation of `conf-unwind` with `No
+
+* If the above fails during installation of `conf-unwind` with `No
   package 'libunwind' found`, try setting the environment variable
   `PKG_CONFIG_PATH` to point to the location of `libunwind.pc`, for
   example, `PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig`
-- If the above fails with an error along the lines of
+* If the above fails with an error along the lines of
   `FATAL: ThreadSanitizer: unexpected memory mapping 0x61a1a94b2000-0x61a1a94ca000`,
   this is [a known issue with older versions of TSan](https://github.com/google/sanitizers/issues/1716)
   and can be addressed by reducing ASLR entropy by running
@@ -468,6 +472,7 @@ Next, it spawns two parallel `Domain`s `t1` and `t2` that both update
 the field `v.x`.
 
 Here is a corresponding `dune` file:
+
 ```dune
 (executable
  (name race)
@@ -477,6 +482,7 @@ Here is a corresponding `dune` file:
 
 If we compile and run the program using `dune` under a regular `5.2.0` switch the
 program appears to work:
+
 ```
 $ opam exec -- dune build ./race.exe
 $ opam exec -- dune exec ./race.exe
@@ -485,6 +491,7 @@ v.x is 11
 
 However, if we compile and run the program with Dune from the new
 `5.2.0+tsan` switch TSan warns us of a data race:
+
 ```
 $ opam switch 5.2.0+tsan
 $ opam exec -- dune build ./race.exe
@@ -521,9 +528,10 @@ this required no change to our `dune` file.
 
 The TSan report warns of a data race between two uncoordinated writes
 happening in parallel and prints a back trace for both:
-- The first back trace reports a write at `race.ml` in line
+
+* The first back trace reports a write at `race.ml` in line
   6 of `thread T4` and
-- the second back trace reports a previous write at
+* the second back trace reports a previous write at
   `race.ml` in line 5 of `thread T1`
 
 Looking again at our program, we realize that these two writes are in
@@ -545,6 +553,7 @@ let () =
 
 If we recompile and run our program with this change, it now completes
 without TSan warnings:
+
 ```
 $ opam exec -- dune build ./race.exe
 $ opam exec -- dune exec ./race.exe
@@ -555,6 +564,7 @@ The TSan instrumentation benefits from compiling programs with debug
 information, which happens by default under `dune`. To manually invoke
 the `ocamlopt` compiler under our `5.2.0+tsan` switch it is thus
 suffient to pass it the `-g` flag:
+
 ```
-$ ocamlopt -g -o race.exe -I +unix unix.cmxa race.ml
+ocamlopt -g -o race.exe -I +unix unix.cmxa race.ml
 ```

--- a/data/tutorials/guides/1wf_02_error_handling.md
+++ b/data/tutorials/guides/1wf_02_error_handling.md
@@ -34,6 +34,7 @@ errors aren't ignored. This has been the cause of many bugs, some with dire
 consequences. This is not the proper way to deal with errors in OCaml.
 
 There are three major ways to make it impossible to ignore errors in OCaml:
+
 1. Exceptions
 1. **`option`** values
 1. **`result`** values
@@ -101,6 +102,7 @@ Stack overflow during evaluation (looping recursion?).
 ```
 
 Although the last one doesn't look as an exception, it actually is.
+
 ```ocaml
 # try loop 42 with Stack_overflow -> [];;
 - : int list = []
@@ -117,6 +119,7 @@ are intended to be raised by user-written functions:
 
 Functions are provided by the standard library to raise `Invalid_argument` and
 `Failure` using a string parameter:
+
 ```ocaml
 val invalid_arg : string -> 'a
 (** @raise Invalid_argument *)
@@ -126,6 +129,7 @@ val failwith : string -> 'a
 
 When implementing a software component which exposes functions raising
 exceptions, a design decision must be made:
+
 * Use the preexisting exceptions
 * Raise custom exceptions
 
@@ -140,9 +144,11 @@ desirable for errors that must be handled at the client level.
 Because handling exceptions interrupts normal control flow, using them can
 complicate some tasks requiring strictly ordered and coupled processes. For
 these scenarios, the `Fun` module of the standard library provides:
+
 ```ocaml
 val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
 ```
+
 This function is meant to be used when something _always_ needs to be done
 _after_ a computation is complete, whether it succeeds or fails. The unlabeled
 function argument is called first, then the function passed as the
@@ -179,6 +185,7 @@ val head_channel : in_channel -> int -> string list = <fun>
   Fun.protect ~finally work;;
 val head_file : string -> int -> string list = <fun>
 ```
+
 When `head_file` is called, it opens a file descriptor, defines `finally` and
 `work`, then `Fun.protect ~finally work` performs two computations in order:
 `work ()` and then `finally ()`, and has the same result as `work ()`, either
@@ -188,7 +195,7 @@ closed after use.
 ### Asynchronous Exceptions
 
 Some exceptions don't arise because something attempted by the program failed,
-but rather because an external factor is impeding its execution. Those 
+but rather because an external factor is impeding its execution. Those
 exceptions are called asynchronous. These include:
 
 * `Out_of_memory`
@@ -301,6 +308,7 @@ Segmentation fault (core dumped)
 ### Language Bugs
 
 When a crash isn't coming from:
+
 * A limitation of the native code compiler
 * An inherently unsafe function such as are found in modules `Marshal` and `Obj`
 
@@ -312,12 +320,13 @@ it may be a language bug. It happens. Here is what to do when this is suspected:
 1. File an issue in the [OCaml Bug Tracker in
    GitHub](https://github.com/ocaml/ocaml/issues)
 
-Here is an example of such a bug: https://github.com/ocaml/ocaml/issues/7241
+Here is an example of such a bug: <https://github.com/ocaml/ocaml/issues/7241>
 
 ### Safe vs. Unsafe Functions
 
 Uncaught exceptions cause runtime crashes. Therefore, there is a tendency to use
 the following terminology:
+
 * Function raising exceptions: Unsafe
 * Function handling errors in data: Safe
 
@@ -335,6 +344,7 @@ is of type `int option` - or the absence of data due to any error as `None`.
 
 Using **`option`** it is possible to write functions that return `None` instead of
 throwing an exception. Here are two examples of such functions:
+
 ```ocaml
 # let div_opt m n =
   try Some (m / n) with
@@ -346,6 +356,7 @@ val div_opt : int -> int -> int option = <fun>
     Not_found -> None;;
 val find_opt : ('a -> bool) -> 'a list -> 'a option = <fun>
 ```
+
 We can try those functions:
 
 ```ocaml
@@ -375,17 +386,20 @@ behavior where one may raise an exception and the other returns an option. In
 the above examples, the convention of the standard library is used: adding an
 `_opt` suffix to the name of the version of the function that returns an option
 instead of raising an exception.
+
 ```ocaml
 val find: ('a -> bool) -> 'a list -> 'a
 (** @raise Not_found *)
 val find_opt: ('a -> bool) -> 'a list -> 'a option
 ```
+
 This is extracted from the `List` module of the standard library.
 
 However, some projects tend to avoid or reduce the usage of exceptions. In such
 a context, the opposite convention is relatively common: the version of the
 function that raises exceptions is suffixed with `_exn`. Using the same
 functions, that would give the specification:
+
 ```ocaml
 val find_exn: ('a -> bool) -> 'a list -> 'a
 (** @raise Not_found *)
@@ -410,17 +424,20 @@ Error: This expression has type 'a option
 In order to combine option values with other values, conversion functions are
 needed. Here are the functions provided by the **`option`** module to extract the
 data contained in an option:
+
 ```ocaml
 val get : 'a t -> 'a
 val value : 'a t -> default:'a -> 'a
 val fold : none:'a -> some:('b -> 'a) -> 'b t -> 'a
 ```
+
 `get` returns the contents, or raises `Invalid_argument` if applied to `None`.
 `value` returns the contents, or its `default` argument if applied to `None`.
 `fold` returns its `some` argument applied to the contents of the option, or its
 `none` argument if applied to `None`.
 
 As a remark, observe that `value` can be implemented using `fold`:
+
 ```ocaml
 # let value ~default = Option.fold ~none:default ~some:Fun.id;;
 val value : default:'a -> 'a option -> 'a = <fun>
@@ -431,11 +448,13 @@ val value : default:'a -> 'a option -> 'a = <fun>
 ```
 
 It is also possible to perform pattern matching on option values:
+
 ```ocaml
 match opt with
 | None -> ...    (* Something *)
 | Some x -> ...  (* Something else *)
 ```
+
 However, sequencing such expressions leads to deep nesting which is often
 considered bad:
 
@@ -458,6 +477,7 @@ provided as a string. For instance, given the string
 example).
 
 Here is a questionable but straightforward implementation using exceptions:
+
 ```ocaml
 # let host email =
   let fqdn_pos = String.index email '@' + 1 in
@@ -470,6 +490,7 @@ Here is a questionable but straightforward implementation using exceptions:
     if fqdn <> "" then fqdn else raise Not_found;;
 val host : string -> string = <fun>
 ```
+
 This may fail by raising `Not_found` if the first the call to `String.index`
 does, which could happen if there is no `@` character in the input string,
 signifying that it's not an email address. However, if the second call to
@@ -525,6 +546,7 @@ If there isn't anything to supply to `f`, `None` is forwarded.
 If we don't take arguments order into account, `Option.bind` is almost exactly
 the same, except we assume `f` returns an option. Therefore, there is no need to
 rewrap its result, since it's already an option value:
+
 ```ocaml
 let bind opt f = match opt with
 | Some x -> f x
@@ -534,12 +556,14 @@ let bind opt f = match opt with
 `bind` having flipped parameter order with respect to `map` allows its use as a
 [binding operator](/manual/bindingops.html), which is a popular extension of
 OCaml providing means to create “custom `let`”. Here is how it goes:
+
 ```ocaml
 # let ( let* ) = Option.bind;;
 val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
 ```
 
 Using these mechanisms, here is a possible way to rewrite `host_opt`:
+
 ```ocaml
 # let host_opt email =
   let* fqdn_pos = Option.map (( + ) 1) (String.index_opt email '@') in
@@ -554,15 +578,16 @@ val host_opt : string -> string option = <fun>
 This version was picked to illustrate how to use and combine operations on
 options allowing users to achieve some balance between understandability and
 robustness. A couple of observations:
+
 * As in the original `host` function (with exceptions):
-   - The calls to `String` functions (`index_opt`, `length`, and `sub`) are the
+  * The calls to `String` functions (`index_opt`, `length`, and `sub`) are the
   same and in the same order
-   - The same local names are used with the same types
+  * The same local names are used with the same types
 * There isn't any remaining indentation or pattern-matching
 * Line 1:
-  - right-hand side of `=` : `Option.map` allows adding 1 to the result of
+  * right-hand side of `=` : `Option.map` allows adding 1 to the result of
     `String.index_opt`, if it didn't fail
-  - left-hand side of `=` : the `let*` syntax turns all the rest of the code
+  * left-hand side of `=` : the `let*` syntax turns all the rest of the code
   (from line 2 to the end) into the body of an anonymous function which takes
   `fqdn_pos` as parameter, and the function `( let* )` is called with `fqdn_pos`
   and that anonymous function.
@@ -612,10 +637,13 @@ constructor. Nevertheless, `Result.map` is implemented similarly: on `Error`, it
 also behaves like identity.
 
 Here is its type:
+
 ```ocaml
 val map : ('a -> 'b) -> ('a, 'c) result -> ('b, 'c) result
 ```
+
 And here is how it is written:
+
 ```ocaml
 let map f = function
 | Ok x -> Ok (f x)
@@ -626,10 +654,13 @@ The **`result`** module has two map functions: the one we've just seen and anoth
 one, with the same logic, applied to `Error`
 
 Here is its type:
+
 ```ocaml
 val map_error : ('c -> 'd) -> ('a, 'c) result -> ('a, 'd) result
 ```
+
 And here is how it is written:
+
 ```ocaml
 let map_error f = function
 | Ok x -> Ok x
@@ -639,6 +670,7 @@ let map_error f = function
 The same reasoning applies to `Result.bind`, except there's no `bind_error`.
 Using those functions, here is an hypothetical example of code using [Anil
 Madhavapeddy's OCaml YAML library](https://github.com/avsm/ocaml-yaml):
+
 ```ocaml
 let file_opt = File.read_opt path in
 let file_res = Option.to_result ~none:(`Msg "File not found") file_opt in begin
@@ -650,6 +682,7 @@ end |> Result.map_error (Printf.sprintf "%s, error: %s: " path)
 ```
 
 Here are the types of the involved functions:
+
 ```ocaml
 val File.read_opt : string -> string option
 val Yaml.of_string : string -> (Yaml.value, [`Msg of string]) result
@@ -657,13 +690,13 @@ val Yaml.Util.find : string -> Yaml.value -> (Yaml.value option, [`Msg of string
 val Option.to_result : none:'e -> 'a option -> ('a, 'e) result
 ```
 
-- `File.read_opt` is supposed to open a file, read its contents and return it as
+* `File.read_opt` is supposed to open a file, read its contents and return it as
 a string wrapped in an option, if anything goes wrong `None` is returned.
-- `Yaml.of_string` parses a string and turns it into an ad hoc OCaml type
-- `Yaml.find` recursively searches for a key in a Yaml tree. If found, it returns
+* `Yaml.of_string` parses a string and turns it into an ad hoc OCaml type
+* `Yaml.find` recursively searches for a key in a Yaml tree. If found, it returns
   the corresponding data, wrapped in an option
-- `Option.to_result` performs conversion of an **`option`** into a **`result`**.
-- Finally, `let*` stands for `Result.bind`.
+* `Option.to_result` performs conversion of an **`option`** into a **`result`**.
+* Finally, `let*` stands for `Result.bind`.
 
 Since both functions from the `Yaml` module return **`result`** data, it is
 easier to write a pipe which processes that type all along. That's why
@@ -677,14 +710,17 @@ into an `Error` and `Result.map_error` will never turn an `Error` into an `Ok`.
 On the other hand, functions passed to `Result.bind` are allowed to fail. As
 stated before there isn't a `Result.bind_error`. One way to make sense out of
 that absence is to consider its type, it would have to be:
+
 ```ocaml
 val Result.bind_error : ('a, 'e) result -> ('e -> ('a, 'f) result) -> ('a, 'f) result
 ```
+
 We would have:
+
 * `Result.map_error f (Ok x) = Ok x`
 * And either:
-  - `Result.map_error f (Error e) = Ok y`
-  - `Result.map_error f (Error e) = Error e'`
+  * `Result.map_error f (Error e) = Ok y`
+  * `Result.map_error f (Error e) = Error e'`
 
 This means an error would be turned back into valid data or changed into
 another error. This is almost like recovering from an error. However, when
@@ -698,11 +734,12 @@ val recover : ('e -> 'a option) -> ('a, 'e) result -> ('a, 'e) result = <fun>
 
 Although any kind of data can be wrapped as a **`result`** `Error`, it is
 recommended to use that constructor to carry actual errors, for instance:
-- `exn`, in which case the result type just makes exceptions explicit
-- `string`, where the error case is a message that indicates what failed
-- `string Lazy.t`, a more elaborate form of error message that is only evaluated
+
+* `exn`, in which case the result type just makes exceptions explicit
+* `string`, where the error case is a message that indicates what failed
+* `string Lazy.t`, a more elaborate form of error message that is only evaluated
   if printing is required
-- some polymorphic variant, with one case per possible error. This is very
+* some polymorphic variant, with one case per possible error. This is very
   accurate (each error can be dealt with explicitly and occurs in the type), but
   the use of polymorphic variants sometimes make the code harder to read.
 
@@ -737,9 +774,11 @@ source code are functionally identical:
 ```ocaml
 bind a (fun x -> b)
 ```
+
 ```ocaml
 let* x = a in b
 ```
+
 ```ocaml
 a >>= fun x -> b
 ```
@@ -750,14 +789,17 @@ calls to `bind` are chained. The following three are also equivalent:
 ```ocaml
 bind a (fun x -> bind b (fun y -> c))
 ```
+
 ```ocaml
 let* x = a in
 let* y = b in
 c
 ```
+
 ```ocaml
 a >>= fun x -> b >>= fun y -> c
 ```
+
 Variables `x` and `y` may appear in `c` in the three cases. The first form isn't
 very convenient, as it uses a lot of parentheses. The second one is often
 preferred due to its resemblance with regular local definitions. The third
@@ -765,15 +807,19 @@ one is harder to read, as `>>=` associates to the right in order to avoid
 parentheses in that precise case, but it's easy to get lost. Nevertheless, it
 has some appeal when named functions are used. It looks a bit like good old Unix
 pipes:
+
 ```ocaml
 a >>= f >>= g
 ```
+
 looks better than:
+
 ```ocaml
 let* x = a in
 let* y = f x in
 g y
 ```
+
 Writing `x >>= f` is very close to what is found in functionally tainted
 programming languages which have methods and receivers such as Kotlin, Scala,
 Go, Rust, Swift, or even modern Java, where it would look like:
@@ -781,6 +827,7 @@ Go, Rust, Swift, or even modern Java, where it would look like:
 
 Here is the same code as presented at the end of the previous section, rewritten
 using `Result.bind` as a binary opeator:
+
 ```ocaml
 File.read_opt path
 |> Option.to_result ~none:(`Msg "File not found")
@@ -806,13 +853,15 @@ Guidelines](/docs/guidelines) for more details on those matters.
 
 This is done by using the following functions:
 
-- From **`option`** to `Invalid_argument` exception, use function `Option.get`:
+* From **`option`** to `Invalid_argument` exception, use function `Option.get`:
+
   ```ocaml
   val get : 'a option -> 'a
   ```
 
-- From **`result`** to `Invalid_argument` exception, use functions
+* From **`result`** to `Invalid_argument` exception, use functions
   `Result.get_ok` and `Result.get_error`:
+
   ```ocaml
   val get_ok : ('a, 'e) result -> 'a
   val get_error : ('a, 'e) result -> 'e
@@ -824,11 +873,14 @@ To raise other exceptions, pattern matching and `raise` must be used.
 
 This is done by using the following functions:
 
-- From **`option`** to **`result`**, use function `Option.to_result`:
+* From **`option`** to **`result`**, use function `Option.to_result`:
+
   ```ocaml
   val to_result : none:'e -> 'a option -> ('a, 'e) result
   ```
-- From **`result`** to **`option`**, use function `Result.to_option`:
+
+* From **`result`** to **`option`**, use function `Result.to_option`:
+
   ```ocaml
   val to_option : ('a, 'e) result -> 'a option
   ```
@@ -848,6 +900,7 @@ It would be same for **`result`**, except some data must be provided to the
 `Error` constructor.
 
 Some may like to turn this into a higher-order generic function:
+
 ```ocaml
 # let catch f x = try Some (f x) with _ -> None;;
 val catch : ('a -> 'b) -> 'a -> 'b option = <fun>
@@ -893,9 +946,11 @@ match Sys.os_type with
 
 It is right to use `failwith`, other operating systems aren't supported, but
 they are possible. Here is the dual example:
+
 ```ocaml
 function x when true -> () | _ -> assert false
 ```
+
 Here, it wouldn't be correct to use `failwith` because it requires a corrupted
 system or the compiler to be bugged for the second code path to be executed.
 Breakage of the language semantics qualifies as extraordinary circumstances. It
@@ -917,12 +972,12 @@ fine, so it's a balance.
 
 # External Resources
 
-- [“Exceptions”](/manual/coreexamples.html#s%3Aexceptions) in ”The OCaml Manual, The Core Language”, chapter 1, section 6, December 2022
-- [Module **`option`**](/manual/api/Option.html) in OCaml Library
-- [Module **`result`**](/manual/api/Result.html) in Ocaml Library
-- [“Error Handling”](https://dev.realworldocaml.org/error-handling.html) in “Real World OCaml”, part 7, Yaron Minsky and Anil Madhavapeddy, 2ⁿᵈ edition, Cambridge University Press, October 2022
-- “Add "finally" function to Pervasives”, Marcello Seri, GitHub PR, [ocaml/ocaml/pull/1855](https://github.com/ocaml/ocaml/pull/1855)
-- “A guide to recover from interrupts”, Guillaume Munch-Maccagnoni, parf the [`memprof-limits`](https://gitlab.com/gadmm/memprof-limits/) documentation
+* [“Exceptions”](/manual/coreexamples.html#s%3Aexceptions) in ”The OCaml Manual, The Core Language”, chapter 1, section 6, December 2022
+* [Module **`option`**](/manual/api/Option.html) in OCaml Library
+* [Module **`result`**](/manual/api/Result.html) in Ocaml Library
+* [“Error Handling”](https://dev.realworldocaml.org/error-handling.html) in “Real World OCaml”, part 7, Yaron Minsky and Anil Madhavapeddy, 2ⁿᵈ edition, Cambridge University Press, October 2022
+* “Add "finally" function to Pervasives”, Marcello Seri, GitHub PR, [ocaml/ocaml/pull/1855](https://github.com/ocaml/ocaml/pull/1855)
+* “A guide to recover from interrupts”, Guillaume Munch-Maccagnoni, parf the [`memprof-limits`](https://gitlab.com/gadmm/memprof-limits/) documentation
 
 <!--
 Acknowledgements

--- a/data/tutorials/guides/1wf_05_garbage_collection.md
+++ b/data/tutorials/guides/1wf_05_garbage_collection.md
@@ -11,6 +11,7 @@ In this tutorial, we look at how to use the `Gc` module and how to write your ow
 At the end of the tutorial, we give some exercises you might try in order to develop a better understanding.
 
 ## The `Gc` Module
+
 The `Gc` module contains some useful functions for querying and calling
 the garbage collector from OCaml programs.
 
@@ -85,6 +86,7 @@ but it should be mostly obvious what it does). The above code
 causes the GC to print a message at the start of every major collection.
 
 ## Finalisation and the Weak Module
+
 We can write a function called a **finaliser** which is called when an
 object is about to be freed by the GC.
 
@@ -156,7 +158,6 @@ the in-memory copy is written back out to the file, the program must
 release the lock. Here is some code to define the on-disk format and
 some low-level functions to read, write, lock, and unlock records:
 
-
 <!-- $MDX file=examples/objcache.ml,part=0 -->
 ```ocaml
 (* In-memory format. *)
@@ -199,7 +200,6 @@ let new_record () =
   { name = String.make name_size ' '; address = String.make addr_size ' ' }
 ```
 
-
 Because this is a really simple program, we're going to fix the number
 of records in advance:
 
@@ -230,7 +230,6 @@ yet, or it has been written out to disk (finalised) and dropped
 from the cache. If the cache gives us `Some record`, then we just return
 `record` (this promotes the weak pointer to the record to a normal
 pointer).
-
 
 <!-- $MDX file=examples/objcache.ml,part=4 -->
 ```ocaml
@@ -263,17 +262,17 @@ records. But it doesn't necessarily mean that the GC *will* collect the
 records straightaway. In fact it's not likely that it will, so to force
 the GC to collect the records immediately, we also invoke a major cycle.
 
-
 Finally, we have some test code. I won't reproduce the test code here, but you
 can download the complete program and test code
 [objcache.ml](/media/tutorials/objcache.ml) and compile it with:
 
 <!-- $MDX dir=examples -->
 ```sh
-$ ocamlc unix.cma objcache.ml -o objcache
+ocamlc unix.cma objcache.ml -o objcache
 ```
 
 ## Exercises
+
 Here are some ways to extend the example above, in approximately
 increasing order of difficulty:
 

--- a/data/tutorials/guides/rs_00_guidelines.md
+++ b/data/tutorials/guides/rs_00_guidelines.md
@@ -20,7 +20,9 @@ manually, there are some formatting guidelines at the end of this
 article.
 
 ## General Guidelines
-###  Be Simple and Readable
+
+### Be Simple and Readable
+
 The time you spend typing the programs is negligible compared to the
 time spent reading them. That's the reason why you save a lot of time if
 you work hard to optimise readability.
@@ -36,8 +38,8 @@ debugging).
 > modifications in mind, and never jeopardize readability.
 >
 
+### Naming Complex Arguments
 
-###  Naming Complex Arguments
 In place of
 
 <!-- $MDX skip -->
@@ -50,6 +52,7 @@ let temp =
     expression” in
 ...
 ```
+
 write
 
 <!-- $MDX skip -->
@@ -64,7 +67,9 @@ let temp =
   f x y z t u in
 ...
 ```
-###  Naming Anonymous Functions
+
+### Naming Anonymous Functions
+
 In the case of an iterator whose argument is a complex function, define
 the function by a `let` binding as well. In place of
 
@@ -77,6 +82,7 @@ List.map
     blabla)
   l
 ```
+
 write
 
 <!-- $MDX skip -->
@@ -93,26 +99,31 @@ List.map f l
 >
 
 ## Programming Guidelines
-###  How to Program
+
+### How to Program
 >
 > *Always put your handiwork back on the bench,<br />
->  then polish it and repolish it.*
+> then polish it and repolish it.*
 >
 
-####  Write Simple and Clear Programs
+#### Write Simple and Clear Programs
+
 Reread, simplify, and clarify at every stage of
 creation. Use your head!
 
-####  Subdivide Your Programs Into Little Functions
+#### Subdivide Your Programs Into Little Functions
+
 Small functions are easier to master.
 
-####  Factor out snippets of repeated code by defining them in separate functions
+#### Factor out snippets of repeated code by defining them in separate functions
+
 Sharing code obtained in this way facilitates maintenance, since
 every correction or improvement automatically spreads throughout the
 program. Besides, the simple act of isolating and naming a snippet of
 code sometimes lets you identify an unsuspected feature.
 
-####  Never copy-paste code when programming
+#### Never copy-paste code when programming
+
 Pasting code almost surely indicates introducing a code
 sharing default and neglecting to identify and write a useful auxiliary
 function. Hence, it means that some code sharing is lost in the program.
@@ -130,7 +141,7 @@ more difficult to understand.
 In conclusion, copy-pasting code leads to programs that are more
 difficult to read and more difficult to maintain. It must be banished.
 
-###  How to Comment Programs
+### How to Comment Programs
 
 Don't hesitate to comment when there's a difficulty. If there's no difficulty,
 there's no point in commenting. It merely creates unnecessary noise.
@@ -140,7 +151,8 @@ Prefer one comment at the beginning of the function that explains how a
 particular algorithm works. Once more, if there is no difficulty, there is no
 point in commenting.
 
-####  Avoid Nocuous Comments
+#### Avoid Nocuous Comments
+
 A *nocuous* comment is a comment that does not add any value, e.g.,
 trivial information. The nocuous comment is evidently not of
 interest; it is a nuisance that uselessly distracts the reader. It
@@ -173,13 +185,16 @@ let rec print_lambda lam =
   | App (l1, l2) ->
      printf "(%a %a)" print_lambda l1 print_lambda l2
 ```
-####  Usage in Module Interface
+
+#### Usage in Module Interface
+
 The function's usage must appear in the module's interface that
 exports it, not in the program that implements it. Choose comments as
 in the OCaml system's interface modules, which will subsequently automatically
 extract the documentation of the interface module if necessary.
 
-####  Use Assertions
+#### Use Assertions
+
 Use assertions as much as possible, as they let you avoid verbose comments
 while allowing a useful verification upon execution.
 
@@ -192,13 +207,15 @@ let f x =
   assert (x >= 0);
   ...
 ```
+
 Note as well that an assertion is often preferable to a comment because
 it's more trustworthy. An assertion is forced to be pertinent because it
 is verified upon each execution, while a comment can quickly become
 obsolete, making it detrimental to understanding
 the program.
 
-####  Comments line by line in imperative code
+#### Comments line by line in imperative code
+
 When writing difficult code, and particularly in case of highly
 imperative code with a lot of memory modifications (physical mutations
 in data structures), it is sometimes mandatory to comment inside the body
@@ -207,18 +224,21 @@ here or to follow successive invariant modifications that the
 function must maintain. Once more, if there is some difficulty
 commenting is mandatory, for each program line if necessary.
 
-###  How to Choose Identifiers
+### How to Choose Identifiers
+
 It's hard to choose identifiers whose name evokes the meaning of the
 corresponding portion of the program. This is why you must devote
 particular care to this, emphasising clarity and regularity of
 nomenclature.
 
-####  Don't use abbreviations for global names
+#### Don't use abbreviations for global names
+
 Global identifiers (including the names of functions) can be
 long because it's important to understand what purpose they serve far
 from their definition.
 
-####  Separate words by underscores: (`int_of_string`, not `intOfString`)
+#### Separate words by underscores: (`int_of_string`, not `intOfString`)
+
 Case modifications are meaningful in OCaml. In effect, capitalised words
 are reserved for constructors and module names. In contrast,
 regular variables (functions or identifiers) must start with a lowercase
@@ -227,12 +247,14 @@ separation in identifiers. The first word starts the identifier, hence
 it must be lowercase, and it is forbidden to choose `IntOfString` as a function
 name.
 
-####  Always give the same name to function arguments which have the same meaning
+#### Always give the same name to function arguments which have the same meaning
+
 If necessary, make this nomenclature explicit in a comment at the top of
 the file. If there are several arguments with the same meaning, then
 attach numeral suffixes to them.
 
-####  Local identifiers can be brief and should be reused from one function to another
+#### Local identifiers can be brief and should be reused from one function to another
+
 This augments style consistency. Avoid using identifiers whose
 appearance can lead to confusion, such as `l` or `O`, which are easy to confuse
 with `1` and `0`.
@@ -244,14 +266,17 @@ Example:
 let add_expression expr1 expr2 = ...
 let print_expression expr = ...
 ```
+
 A tolerated exception to the recommendation not to use capitalisation to separate
 words within identifiers when interfacing with
 existing libraries which use this naming convention. This lets OCaml
 library users to orient themselves in the original library
 documentation more easily.
 
-###  How to Use Modules
-####  Subdividing into modules
+### How to Use Modules
+
+#### Subdividing into modules
+
 You must subdivide your programs into coherent modules.
 
 For each module, you must explicitly write an interface.
@@ -259,7 +284,8 @@ For each module, you must explicitly write an interface.
 For each interface, you must document the things defined by the module:
 functions, types, exceptions, etc.
 
-####  Opening modules
+#### Opening modules
+
 Avoid `open` directives, using instead the qualified identifier
 notation. Thus you will prefer short but meaningful module names.
 
@@ -277,7 +303,9 @@ let lim = Array.length v - 1 in
 ... List.map succ ...
 ... Array.map succ ...
 ```
-####  When to use open modules rather than leaving them closed
+
+#### When to use open modules rather than leaving them closed
+
 Consider it normal to open a module that modifies the
 environment and brings other versions of an important set of functions.
 For example, the `Format` module automatically provides indented
@@ -296,6 +324,7 @@ instance:
 let f () =
   Format.print_string "Hello World!"; print_newline ()
 ```
+
 is bogus since it does not call `Format.print_newline` to flush the
 pretty-printer queue and output `"Hello World!"`. Instead
 `"Hello World!"` is stuck into the pretty-printer queue, while
@@ -329,7 +358,7 @@ these definitions into one or more module(s) without implementations
 (containing only types). Then it's acceptable to systematically open the
 module that exports the shared type definitions.
 
-###  Pattern-Matching
+### Pattern-Matching
 
 Never be afraid of overusing pattern-matching! On the other hand, be careful to
 avoid nonexhaustive pattern-matching constructs. Complete them with care,
@@ -337,22 +366,24 @@ without using a “catch-all” clause such as `| _ -> ...` or `| x -> ...` when
 it's unnecessary (for example when matching a concrete type
 defined within the program). See also the next section: compiler warnings.
 
-###  Compiler Warnings
+### Compiler Warnings
+
 Compiler warnings are meant to prevent potential errors, which is why you
 absolutely must heed them and correct your programs if compiling them
 produces such warnings. Besides, programs whose compilation produces
 warnings have an odor of amateurism which certainly doesn't suit your
 own work!
 
-####  Pattern-matching warnings
+#### Pattern-matching warnings
+
 Warnings about pattern-matching must be treated with the upmost care.
 
 * Those with useless clauses should be eliminated, of course.
 * For nonexhaustive pattern-matching, you must complete the
  corresponding pattern-matching construct without adding a default
- case “catch-all”, such as `| _ -> ... `, but rather with an explicit
+ case “catch-all”, such as `| _ -> ...`, but rather with an explicit
  constructor list not examined by the rest of the construct,
- e.g., `| Cn _ | Cn1 _ -> ... `.
+ e.g., `| Cn _ | Cn1 _ -> ...`.
 
 >
 > **Justification**: It's not really more complicated to write
@@ -366,12 +397,12 @@ Warnings about pattern-matching must be treated with the upmost care.
 > handled by the default case.
 >
 
-
 * Nonexhaustive pattern-matches induced by clauses with guards must
  also be corrected. A typical case consists in suppressing a
  redundant guard.
 
-####  Destructuring `let` bindings
+#### Destructuring `let` bindings
+
 A “destructuring `let` binding” is one which
 binds several names to several expressions simultaneously. You pack all
 the names you want bound into a collection such as a tuple or a list,
@@ -392,7 +423,8 @@ can use it with more complex or simpler patterns. For instance:
  `let _ = ...` does not define anything, it just evaluate the
  expression on the right hand side of the `=` symbol.
 
-####  The destructuring `let` must be exhaustive
+#### The destructuring `let` must be exhaustive
+
 Only use destructuring `let` bindings when the
 pattern-matching is exhaustive (the pattern can never fail to match).
 Typically, you will thus be limited to product-type definitions
@@ -411,7 +443,6 @@ match List.map succ (l1 @ l2) with
 | _ -> assert false
 ```
 
-
 * Global definition with destructuring `let` statements should be rewritten with
  explicit pattern-matching and tuples:
 
@@ -423,13 +454,13 @@ let x, y, l =
   | _ -> assert false
 ```
 
-
 >
 > **Justification**: There is no way to make the pattern-matching
 > exhaustive if you use general destructuring `let` bindings.
 >
 
-####  Sequence warnings and `let _ = ...`
+#### Sequence warnings and `let _ = ...`
+
 When the compiler emits a warning about a sequential expression type,
 you must explicitly indicate that you want to ignore this expression's
 result. To this end:
@@ -441,13 +472,13 @@ result. To this end:
 List.map f l;
 print_newline ()
 ```
+
 write
 <!-- $MDX skip -->
 ```ocaml
 let _ = List.map f l in
 print_newline ()
 ```
-
 
 * You can also use the predefined function `ignore : 'a     -> unit`,
  which ignores its argument to return `unit`.
@@ -457,7 +488,6 @@ print_newline ()
 ignore (List.map f l);
 print_newline ()
 ```
-
 
 * Regardless, the best way to suppress this warning is to understand
  why the compiler emits it. The compiler warns you because
@@ -480,6 +510,7 @@ print_newline ()
 List.iter f l;
 print_newline ()
 ```
+
 In actual programs, the suitable (side-effect-only) function may not
 exist and must be written. Frequently, a careful separation of the
 procedural part from the functional part of the function
@@ -493,10 +524,9 @@ let add x y =
   print_newline ();
   x + y;;
 ```
+
 into the clearer, separate definition and change old calls to `add`
 accordingly.
-
-
 
 In any case, use the `let _ = ...` construction exactly in those cases
 where you want to ignore a result. Don't systematically replace
@@ -511,7 +541,8 @@ sequences with this construction.
 > e3
 > ```
 
-###  The `hd` and `tl` Functions
+### The `hd` and `tl` Functions
+
 Don't use the `hd` and `tl` functions, but rather pattern-match the list
 argument explicitly.
 
@@ -522,8 +553,10 @@ argument explicitly.
 > functions.
 >
 
-###  Loops
-####  `for` loops
+### Loops
+
+#### `for` loops
+
 To simply traverse an array or a string, use a `for` loop.
 
 <!-- $MDX skip -->
@@ -532,6 +565,7 @@ for i = 0 to Array.length v - 1 do
   ...
 done
 ```
+
 If the loop is complex or returns a result, use a recursive function.
 
 <!-- $MDX skip -->
@@ -575,7 +609,8 @@ programs from algorithm courses where they were proved.
 > invariants, an interesting but difficult sport.
 >
 
-###  Exceptions
+### Exceptions
+
 Don't be afraid to define your own exceptions in your programs, but on
 the other hand, use as many exceptions predefined by the
 system as possible. For example, every search function that fails should raise the
@@ -604,7 +639,8 @@ with x -> close_in ic; close_out oc; raise x
 > computation will continue anyway!).
 >
 
-###  Data Structures
+### Data Structures
+
 One of the great strengths of OCaml is the power of definable data structures
 and the simplicity of manipulating them. So you
 must take advantage of this to the fullest extent! Don't hesitate to
@@ -686,17 +722,20 @@ types' definitions are then questionable:
 type switch = On | Off
 type bit = One | Zero
 ```
+
 The same objection is admissible for enumerated types represented as
 integers when those integers have an evident interpretation with
 respect to the represented data.
 
-###  When to Use Mutables
+### When to Use Mutables
+
 Mutable values are useful and sometimes indispensable for simple and
 clear programming. Nevertheless, you must use them with discernment because
 OCaml's normal data structures are immutable. They are preferred
 for the clarity and safety of programming they allow.
 
-###  Iterators
+### Iterators
+
 OCaml's iterators are a powerful and useful feature. However, you should
 not overuse them nor neglect them. They are provided
 by libraries and have every chance of being correct and
@@ -708,6 +747,7 @@ Write:
 ```ocaml
 let square_elements elements = List.map square elements
 ```
+
 rather than:
 <!-- $MDX skip -->
 ```ocaml
@@ -715,12 +755,14 @@ let rec square_elements = function
   | [] -> []
   | elem :: elements -> square elem :: square_elements elements
 ```
+
 On the other hand, avoid writing:
 <!-- $MDX skip -->
 ```ocaml
 let iterator f x l =
   List.fold_right (List.fold_left f) [List.map x l] l
 ```
+
 even though you get:
 <!-- $MDX skip -->
 ```ocaml
@@ -728,13 +770,14 @@ even though you get:
     List.fold_right (List.fold_left f) [List.map x l] l;;
   iterator (fun l x -> x :: l) (fun l -> List.rev l) [[1; 2; 3]]
 ```
+
 In case of express need, be sure to add an explanatory
 comment. In my opinion, it's absolutely necessary!
 
-###  How to Optimize Programs
+### How to Optimize Programs
 >
 > **Pseudo law of optimisation**: No optimisation *a priori*.<br />
->  No optimisation *a posteriori* either.
+> No optimisation *a posteriori* either.
 >
 
 Above all, program simply and clearly. Don't start optimising until the
@@ -751,7 +794,8 @@ program that poses a problem.
 > efficiency is of prime importance.
 >
 
-###  How to Choose Between Classes and Modules
+### How to Choose Between Classes and Modules
+
 Use OCaml classes when you need inheritance, i.e.,
 incremental refinement of data and their functionality.
 
@@ -762,7 +806,8 @@ Use modules when the data structures are fixed and their
 functionality is equally fixed or it's enough to add new functions in
 the programs which use them.
 
-###  Clarity of OCaml Code
+### Clarity of OCaml Code
+
 The OCaml language includes powerful constructs that allow simple and
 clear programming. The main problem to obtain crystal clear programs is
 to use them appropriately.
@@ -779,7 +824,8 @@ to use the language construct that expresses the computation to
 implement the algorithm in the most natural and
 easiest way.
 
-####  Style dangers
+#### Style dangers
+
 Concerning programming styles, one can usually observe the two
 symmetrical problematic behaviors. On one hand, the “all
 imperative” way (*systematic* usage of loops and assignment), and on
@@ -788,7 +834,7 @@ assignments). The “100% object” style will certainly appear in the
 future.
 
 * **The “too much imperative” danger**:
-    * It is a bad idea to use imperative style to code a function that
+  * It is a bad idea to use imperative style to code a function that
  is *naturally* recursive. For instance, to compute the length of
  a list, you shouldn't write:
 <!-- $MDX skip -->
@@ -801,6 +847,7 @@ let list_length l =
   done;
   !res;;
 ```
+
 in place of the following recursive function that's so simple and
 clear:
 <!-- $MDX skip -->
@@ -809,9 +856,9 @@ let rec list_length = function
   | [] -> 0
   | _ :: l -> 1 + list_length l
 ```
+
 (For those that would contest the equivalence of those two
 versions, see the [note below](#imperative-and-functional-versions-of-listlength)).
-
 
 * Another common “over-imperative error” in the imperative world is
   not to systematically choose the simple `for` loop to iterate on a vector's
@@ -823,22 +870,23 @@ versions, see the [note below](#imperative-and-functional-versions-of-listlength
   the record-type definitions should be implicit.
 
 * **The “too much functional” danger**:
-    * The programmer that adheres to this dogma avoids
+  * The programmer that adheres to this dogma avoids
  using arrays and assignment. In the most severe cases, one
  observes a complete denial of writing any imperative
  construction, even when it's evidently the most elegant way
  to solve the problem.
-    * Characteristic symptoms: systematic rewriting `for` loops
+  * Characteristic symptoms: systematic rewriting `for` loops
  with recursive functions, using lists in contexts where
  imperative data structures seem to be mandatory to anyone,
  passing numerous global parameters of the problem to every
  function, even when a global reference perfectly avoid
  these spurious parameters that are mainly invariants that must
  be repeatedly passed.
-    * This programmer feels that the `mutable` keyword in record-type
+  * This programmer feels that the `mutable` keyword in record-type
     definitions should be suppressed from the language.
 
-####  OCaml code generally considered unreadable
+#### OCaml code generally considered unreadable
+
 The OCaml language includes powerful constructs which allow simple and
 clear programming. However, the power of these constructs also lets you
 write uselessly complicated code to the point where you get a perfectly
@@ -852,13 +900,13 @@ Here are a number of common ways to write overly-complicated code:
 let flush_ps () =
   if not !psused then psused := true
 ```
+
 or (more subtle)
 <!-- $MDX skip -->
 ```ocaml
 let sync b =
   if !last_is_dvi <> b then last_is_dvi := b
 ```
-
 
 * Code one construct with another. For example, code a `let ... in` by
  the application of an anonymous function to an argument. You would
@@ -868,6 +916,7 @@ let sync b =
 (fun x y -> x + y)
    e1 e2
 ```
+
 instead of simply writing
 <!-- $MDX skip -->
 ```ocaml
@@ -876,9 +925,7 @@ and y = e2 in
 x + y
 ```
 
-
 * Systematically code sequences with `let in` bindings.
-
 
 * Mix computations and side effects, particularly in function calls.
  Recall that the evaluation order of function call arguments
@@ -889,14 +936,12 @@ x + y
  albeit without endangering the program semantics. This should be absolutely
  forbidden.
 
-
 * Misuse of iterators and higher-order functions (i.e., over- or
  underuse). For example, it's better to use `List.map` or
  `List.iter` than to write their equivalents inline by using your own
  recursive functions. Even worse, don't use
  `List.map` or `List.iter`, but rather write their equivalents in terms of
  `List.fold_right` and `List.fold_left`.
-
 
 * Another efficient way to write unreadable code is to mix all or some
  of these methods. For example:
@@ -908,17 +953,18 @@ x + y
     temp));;
 ```
 
-
 If you naturally write the program `print_string "Hello world!"` in this
 way, please submit your work to the [Obfuscated OCaml
 Contest](mailto:Pierre.Weis@inria.fr).
 
 ## Managing Program Development
+
 Below are tips from veteran OCaml programmers that have served in
 developing the compilers. These are good examples of large, complex
 programs developed by small teams.
 
-###  How to Edit Programs
+### How to Edit Programs
+
 Many developers nurture a kind of veneration towards writing their programs
 in the Emacs editor (GNU Emacs, in general). The
 editor interfaces with the language well because it is capable of syntax-coloring
@@ -938,7 +984,8 @@ succession of `` CTRL-X-` `` commands permits correction of all signalled
 errors; finally, the cycle begins again with a new recompilation
 launched by `CTRL-C-CTRL-C`.
 
-####  Other Emacs tricks
+#### Other Emacs tricks
+
 The `ESC-/` command (dynamic-abbrev-expand) automatically completes the
 word in front of the cursor with one of the words in a
 file being edited. This lets you always choose meaningful
@@ -955,7 +1002,8 @@ messages” from `grep` are compatible with the `` CTRL-X-` `` usage,
 which automatically takes you to the file and the place where the string
 is found.
 
-###  How to Edit With the Interactive System
+### How to Edit With the Interactive System
+
 Under Unix: use the line editor `ledit`, which offers great editing
 capabilities “à la Emacs” (including `ESC-/`!) as well as a history
 mechanism that lets you retrieve previously-typed commands and even
@@ -963,13 +1011,15 @@ retrieve commands from one session to another. `ledit` is written in
 OCaml and can be freely downnloaded
 [here](ftp://ftp.inria.fr/INRIA/Projects/cristal/caml-light/bazar-ocaml/ledit.tar.gz).
 
-###  How to Compile
+### How to Compile
+
 The `make` utility is indispensable for managing the compilation and
 recompilation of programs. Sample `make` files can be found on [The
 Hump](https://web.archive.org/web/20170809105617/http://caml.inria.fr/cgi-bin/hump.en.cgi). You can also consult
 the `Makefiles` for the OCaml compilers.
 
-###  How to Develop as a Team: Version Control
+### How to Develop as a Team: Version Control
+
 Users of the [Git](https://git-scm.com/) software version control system
 never run out of good things to say about the productivity gains it
 brings. This system supports managing development by a programming team
@@ -994,27 +1044,28 @@ consider these style guidelines when doing it manually.
 > keyboard, so press it as often as necessary!
 >
 
-###  Delimiters
+### Delimiters
+
 A space should always follow a delimiter symbol, and spaces should
 surround operator symbols. It has been a great step forward in
 typography to separate words by spaces in order to make written texts easier to
 read. Do the same in your programs if you want them to be readable.
 
+### How to Write Pairs
 
-
-###  How to Write Pairs
 A tuple is parenthesised, and the commas therein (delimiters) are each
 followed by a space: `(1, 2)`, `let triplet = (x, y, z)`...
 
 **Commonly accepted exceptions**:
-  - **Definition of the components of a pair**: In place of
+
+* **Definition of the components of a pair**: In place of
  `let (x, y) =       ...`, you can write `let x, y = ...`.
 
     > **Justification**: The point is to define several values
     > simultaneously, not to construct a tuple. Moreover, the
     > pattern is set off nicely between `let` and `=`.
 
-  - **Matching several values simultaneously**: It's okay to omit
+* **Matching several values simultaneously**: It's okay to omit
   parentheses around n-tuples when matching several values
   simultaneously.
 
@@ -1028,19 +1079,19 @@ followed by a space: `(1, 2)`, `let triplet = (x, y, z)`...
     > being matched are set off by `match` and `with`, while the
     > patterns are set off nicely by `|` and `->`.
 
+### How to Write Lists
 
-###  How to Write Lists
 Write `x :: l` with spaces around the `::` (since `::` is an infix
 operator, hence surrounded by spaces) and `[1; 2; 3]` (since `;` is a
 delimiter, hence followed by a space).
 
-###  How to Write Operator Symbols
+### How to Write Operator Symbols
+
 Be careful to keep operator symbols separated by spaces. Not only
 will your formulas be more readable, but you will also avoid confusion with
 multicharacter operators. (Obvious exceptions to this rule are the symbols
 `!` and `.`, which are not separated from their arguments.)<br />
 Example: write `x + 1` or `x + !y`.
-
 
 > **Justification**: If you left out the spaces then `x+1` would be
 > understood, but `x+!y` would change its meaning, since `+!` would
@@ -1079,8 +1130,8 @@ Example: write `x + 1` or `x + !y`.
 > follow. The space bar is the greatest and best-situated key on the
 > keyboard. It is the easiest to use because you cannot miss it!
 
+### How to Write Long Character Strings
 
-###  How to Write Long Character Strings
 Indent long character strings with the convention in force at that line,
 plus an indication of string continuation at the end of each line (a `\`
 character at the end of the line omits white spaces at the
@@ -1093,7 +1144,8 @@ let universal_declaration =
   ...
 ```
 
-###  When to Use Parentheses Within an Expression
+### When to Use Parentheses Within an Expression
+
 Parentheses are meaningful. They indicate the necessity of using an
 unusual precedence, so they should be used wisely and not sprinkled
 randomly throughout programs. To this end, you should know the usual
@@ -1101,10 +1153,12 @@ precedences, i.e., the combinations of operations which do not
 require parentheses. Quite fortunately, this is not complicated if you
 know a little mathematics or strive to follow the following rules:
 
-####  Arithmetic operators: the same rules as in mathematics
+#### Arithmetic operators: the same rules as in mathematics
+
 For example: `1 + 2 * x` means `1 + (2 * x)`.
 
-####  Function application: the same rules as those in mathematics for usage of *trigonometric functions*
+#### Function application: the same rules as those in mathematics for usage of *trigonometric functions*
+
 In mathematics you write `sin x` to mean `sin (x)`. In the same way
 `sin x + cos x` means `(sin x) + (cos x)` not `sin (x + (cos x))`. Use
 the same conventions in OCaml: write `f x + g x` to mean
@@ -1113,20 +1167,23 @@ This convention generalises **to all (infix) operators**: `f x :: g x`
 means `(f x) :: (g x)`, `f x @ g x` means `(f x) @ (g x)`, and
 `failwith s ^ s'` means `(failwith s) ^ s'`, *not* `failwith (s ^ s')`.
 
-####  Comparisons and Boolean operators
+#### Comparisons and Boolean operators
+
 Comparisons are infix operators, so the preceding rules apply. This is
 why `f x < g x` means `(f x) < (g x)`. For type reasons (and no other
 sensible interpretation), the expression `f x < x + 2` means
 `(f x) < (x + 2)`. Similarly, `f x < x + 2 && x > 3` means
 `((f x) < (x + 2)) && (x > 3)`.
 
-####  The relative precedences of the Boolean operators are those of mathematics
+#### The relative precedences of the Boolean operators are those of mathematics
+
 Although mathematicians have a tendency to overuse parentheses,
 the Boolean “or” operator is analogous to addition and the “and”
 to multiplication. So, just as `1 + 2 * x` means `1 + (2 * x)`,
 `true || false && x` means `true || (false && x)`.
 
-###  How to Delimit Constructs in Programs
+### How to Delimit Constructs in Programs
+
 When it is necessary to delimit syntactic constructs in programs, use
 the keywords `begin` and `end` as delimiters rather than parentheses.
 However, using parentheses is acceptable if you do it in a consistent,
@@ -1136,7 +1193,8 @@ This explicit delimiting of constructs essentially concerns
 pattern-matching constructs or sequences embedded within
 `if then     else` constructs.
 
-####  `match` construct in a `match` construct
+#### `match` construct in a `match` construct
+
 When a `match ... with` or `try ... with` construct appears in a
 pattern-matching clause, it is absolutely necessary to delimit this
 embedded construct (otherwise subsequent clauses of the enclosing
@@ -1153,7 +1211,9 @@ match x with
 | 2 ->
 ...
 ```
-####  Sequences inside branches of `if`
+
+#### Sequences inside branches of `if`
+
 In the same way, a sequence which appears in the `then` or `else` part
 of a conditional must be delimited:
 
@@ -1167,7 +1227,6 @@ end else begin
   e4
 end
 ```
-
 
 ## Indentation of Programs
 >
@@ -1189,38 +1248,39 @@ So each time, you must choose between the different styles
 suggested.<br />
  The only absolute rule is the first below.
 
-###  Consistency of Indentation
+### Consistency of Indentation
+
 Choose a generally accepted style of indentation, then use it
 systematically throughout the whole application.
 
-###  Width of the Page
+### Width of the Page
+
 The page is 80 columns wide.
 
 > **Justification**: This width makes it possible to read the code on
 > all displays and to print it in a legible font on a standard sheet.
 
+### Height of the Page
 
-###  Height of the Page
 A function should always fit within one screenful (of about 70 lines),
 or in exceptional cases two, at the very most three. To go beyond this
 is unreasonable.
-
 
 > **Justification**: When a function goes beyond one screenful, it's
 > time to divide it into subproblems and handle them independently.
 > Beyond a screenful, one gets lost in the code. The indentation is not
 > readable and is difficult to keep correct.
 
+### How Much to Indent
 
-###  How Much to Indent
 The change in indentation between successive lines of the program is
 generally 1 or 2 spaces. Pick an amount to indent and stick with it
 throughout the program.
 
-###  Using Tab Stops
+### Using Tab Stops
+
 Using the tab character (ASCII character 9) is absolutely *not*
 recommended.
-
 
 > **Justification**: Between one display and another, the indentation of
 > the program changes completely. It can also become completely wrong
@@ -1235,7 +1295,8 @@ recommended.
 > **Answer**: It seems almost impossible to use this method since you
 > should always use tabulations to indent, which is hard and unnatural.
 
-###  How to Indent Operations
+### How to Indent Operations
+
 When an operator takes complex arguments, or in the presence of multiple
 calls to the same operator, start the next the line with the operator,
 and don't indent the rest of the operation. For example:
@@ -1260,6 +1321,7 @@ x + y + z
 + “large
   expression”
 ```
+
 write
 
 <!-- $MDX skip -->
@@ -1269,6 +1331,7 @@ let t =
    expression” in
 x + y + z + t
 ```
+
 You most certainly must bind expressions too large to be written
 in one operation when using a combination of operators. In place of
 the unreadable expression
@@ -1279,6 +1342,7 @@ the unreadable expression
 / (“large
     expression”)
 ```
+
 write
 
 <!-- $MDX skip -->
@@ -1288,6 +1352,7 @@ let u =
   expression” in
 (x + y + z * t) / u
 ```
+
 These guidelines extend to all operators. For example:
 
 <!-- $MDX skip -->
@@ -1299,8 +1364,8 @@ x :: y
 :: z + 1 :: t :: u
 ```
 
+### How to Indent Global `let ... ;;` Definitions
 
-###  How to Indent Global `let ... ;;` Definitions
 The body of a function defined globally in a module is generally
 indented normally. However, it's okay to treat this case specially to
 better offset the definition.
@@ -1344,7 +1409,6 @@ let f x = function
 > **Criticism**: An unpleasant exception to the normal indentation.
 >
 
-
 * The body is justified just under the name of the defined function.
 
 <!-- $MDX skip -->
@@ -1362,8 +1426,8 @@ let f x =
 > **Criticism**: You run into the right margin too quickly.
 >
 
+### How to Indent `let ... in` Constructs
 
-###  How to Indent `let ... in` Constructs
 The expression following a definition introduced by `let` is indented to
 the same level as the keyword `let`, and the keyword `in`, which
 introduces it, is written at the end of the line:
@@ -1407,8 +1471,10 @@ Mult_expression (new_expr, new_expr)
 > **Criticism**: Lack of consistency.
 >
 
-###  How to Indent `if ... then   ... else ... `
-####  Multiple branches
+### How to Indent `if ... then   ... else ...`
+
+#### Multiple branches
+
 Write conditions with multiple branches at the same level of
 indentation:
 
@@ -1433,6 +1499,7 @@ if cond3 then e3 else
 e4
 
 ```
+
 If expressions in the branches of multiple conditions have to be
 enclosed (when they include statements for instance), write:
 
@@ -1446,6 +1513,7 @@ if cond2 then begin
   end else
 if cond3 then ...
 ```
+
 Some suggest another method for multiple conditionals: starting each
 line by the keyword `else`:
 
@@ -1467,7 +1535,8 @@ else if cond3 ...
 
 Yet again, choose your style and use it systematically.
 
-####  Single branches
+#### Single branches
+
 Several styles are possible for single branches, according to the size
 of the expressions in question and especially the presence of `begin`,
 `end`, or `(` `)` delimiters for these expressions.
@@ -1484,6 +1553,7 @@ are used:
 >   e2
 > )
 > ```
+>
 > Or alternatively first `begin` at beginning of line:
 >
 > ```ocaml
@@ -1503,6 +1573,7 @@ In fact, the conditional's indentation depends on their expressions' size.
 > ```ocaml
 > if cond then e1 else e2
 > ```
+>
 > If the expressions making up a conditional are purely functional
 > (without side effects), we advocate binding them within the
 > conditional by using `let e = ... in` when they're too big to fit on a single
@@ -1561,8 +1632,10 @@ In fact, the conditional's indentation depends on their expressions' size.
 > > ) else e2
 > > ```
 
-###  How to Indent Pattern-Matching Constructs
-####  General principles
+### How to Indent Pattern-Matching Constructs
+
+#### General principles
+
 All the pattern-matching clauses are introduced by a vertical bar,
 *including* the first one.
 
@@ -1589,7 +1662,8 @@ Then indent normally, starting from the beginning of the clause's pattern.
 
 Arrows of pattern-matching clauses should not be aligned.
 
-####  `match` or `try`
+#### `match` or `try`
+
 For a `match` or a `try`, align the clauses with the beginning of the
 construct:
 
@@ -1604,6 +1678,7 @@ try f x with
 | Not_found -> ...
 | Failure "not yet implemented" -> ...
 ```
+
 Put the keyword `with` at the end of the line. If the preceding
 expression extends beyond one line, put `with` on its own line:
 
@@ -1621,7 +1696,8 @@ with
 > the program enters the pattern-matching part of the construct.
 >
 
-####  Indenting expressions inside clauses
+#### Indenting expressions inside clauses
+
 If the expression on the right of the pattern-matching arrow is too
 large, cut the line after the arrow.
 
@@ -1634,6 +1710,7 @@ match lam with
    size_lambda lam1 + size_lambda lam2
 | Var v ->
 ```
+
 Some programmers generalise this rule to all clauses as soon as one
 expressions overflows. They will then indent the last clause like this:
 
@@ -1642,6 +1719,7 @@ expressions overflows. They will then indent the last clause like this:
 | Var v ->
    1
 ```
+
 Other programmers go one step further and apply this rule systematically
 to any clause of any pattern-matching.
 
@@ -1665,7 +1743,8 @@ let rec fib = function
 > OCaml programs!
 >
 
-####  Pattern-matching in anonymous functions
+#### Pattern-matching in anonymous functions
+
 Similarly to `match` or `try`, pattern-matching of anonymous functions,
 starting with `function`, are indented with respect to the `function`
 keyword:
@@ -1679,7 +1758,9 @@ map
    | Var v -> 1)
   lambda_list
 ```
-####  Pattern-matching in named functions
+
+#### Pattern-matching in named functions
+
 Pattern-matching in functions defined by `let` or `let rec` gives rise
 to several reasonable styles that obey the preceding pattern-matching rules
 (the one for anonymous functions being evidently excepted). See
@@ -1697,8 +1778,11 @@ let rec size_lambda accu = function
 | App (lam1, lam2) -> size_lambda (size_lambda accu lam1) lam2
 | Var v -> succ accu
 ```
-###  Bad Indentation of Pattern-Catching constructs
-####  No *beastly* indentation of functions and case analyses.
+
+### Bad Indentation of Pattern-Catching constructs
+
+#### No *beastly* indentation of functions and case analyses
+
 This consists in indenting normally under the keyword `match` or
 `function` that has previously been pushed to the right. Don't write:
 
@@ -1708,6 +1792,7 @@ let rec f x = function
               | [] -> ...
               ...
 ```
+
 but choose to indent the line under the `let` keyword:
 
 <!-- $MDX skip -->
@@ -1721,7 +1806,8 @@ let rec f x = function
 > doubtful.
 >
 
-####  No *beastly* alignment of the `->` symbols in pattern-matching clauses.
+#### No *beastly* alignment of the `->` symbols in pattern-matching clauses
+
 Careful alignment of pattern-matching arrows is considered bad
 practice, as exemplified in the following fragment:
 
@@ -1739,8 +1825,10 @@ let f = function
 > In this case, it's better not to align the arrows in the first place!).
 >
 
-###  How to Indent Function Calls
-####  Indentation to the function's name:
+### How to Indent Function Calls
+
+#### Indentation to the function's name
+
 No problem arises except for functions with many arguments&mdash;or very
 complicated arguments&mdash;which can't fit on the same line. You
 must indent the expressions with respect to the fucntion's name (1
@@ -1760,9 +1848,10 @@ construction.
 > explicitly define the evaluation order.
 >
 
+## Notes
 
-##  Notes
-###  Imperative and Functional Versions of `list_length`
+### Imperative and Functional Versions of `list_length`
+
 The two versions of `list_length` are not completely equivalent in terms
 of complexity. The imperative version uses a constant amount of
 stack room to execute, whereas the functional version needs to store
@@ -1781,12 +1870,14 @@ let list_length l =
     | _ :: l -> loop (accu + 1) l in
   loop 0 l
 ```
+
 This way, you get a program that has the same computational properties
 as the imperative program with the additional clarity and natural
 look of an algorithm that performs pattern-matching and recursive
 calls to handle an argument that belongs to a recursive sum data type.
 
 ## Credits
+
 Original translation from French: [Ruchira
 Datta](mailto:datta@math.berkeley.edu).
 

--- a/data/tutorials/guides/rs_01_common_error_messages.md
+++ b/data/tutorials/guides/rs_01_common_error_messages.md
@@ -11,7 +11,9 @@ messages that are emitted by the OCaml compilers. Longer explanations
 are usually given in dedicated sections of this tutorial.
 
 ## Type Errors
+
 ### `This expression has type ... but is here used with type ...`
+
 When the type of an object is not compatible with the context in which
 it is used, it is frequent to obtain this kind of message:
 
@@ -21,6 +23,7 @@ Line 1, characters 5-8:
 Error: This expression has type float but an expression was expected of type
          int
 ```
+
 "This expression has type *X* but is here used with type *Y*" means that
 if the contents of the expression is isolated (2.5), its type is
 inferred as *X* (float). But the context, i.e. everything which is
@@ -32,6 +35,7 @@ More disturbing is the following message:
 ```text
 This expression has type my_type but is here used with type my_type
 ```
+
 This error happens often while testing some type definitions using the
 interactive toplevel.  In OCaml, it is perfectly legal
 to define a type with a name
@@ -54,6 +58,7 @@ Error: This expression has type my_type/1
          toplevel session. Some toplevel values still refer to old versions
          of this type. Did you try to redefine them?
 ```
+
 For the compiler, the second definition of my_type is totally
 independent from the first definition. So we have defined two types
 which have the same name. Since "a" was defined earlier, it belongs to
@@ -64,6 +69,7 @@ the same name for the same type in the same module, which is highly
 discouraged.
 
 ### `Warning: This optional argument cannot be erased`
+
 Functions with optional arguments must have at least one non-labelled
 argument. For instance, this is not OK:
 
@@ -75,16 +81,19 @@ Line 1, characters 9-14:
 Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
 val f : ?x:int -> ?y:int -> unit = <fun>
 ```
+
 The solution is simply to add one argument of type unit, like this:
 
 ```ocaml
 # let f ?(x = 0) ?(y = 0) () = print_int (x + y);;
 val f : ?x:int -> ?y:int -> unit -> unit = <fun>
 ```
+
 See the [Labels](/docs/labels) section for more details on
 functions with labelled arguments.
 
 ### `The type of this expression... contains type variables that cannot be generalized`
+
 This happens in some cases when the full type of an object is not known
 by the compiler when it reaches the end of the compilation unit (file)
 but for some reason it cannot remain polymorphic. Example:
@@ -93,6 +102,7 @@ but for some reason it cannot remain polymorphic. Example:
 # let x = ref None;;
 val x : '_weak1 option ref = {contents = None}
 ```
+
 triggers the following message during the compilation:
 
 ```text
@@ -106,6 +116,7 @@ Solution: help the compiler with a type annotation, like for instance:
 # let x : string option ref = ref None;;
 val x : string option ref = {contents = None}
 ```
+
 or:
 
 ```ocaml env=ref
@@ -130,6 +141,7 @@ using `x` later, the compiler can infer the type of `x`:
 # x := Some 0;;
 - : unit = ()
 ```
+
 Now `x` has a known type:
 
 ```ocaml env=ref
@@ -138,7 +150,9 @@ Now `x` has a known type:
 ```
 
 ## Pattern Matching Warnings and Errors
+
 ### `This pattern is unused`
+
 This warning should be considered as an error, since there is no reason
 to intentionally keep such code. It may happen when the programmer
 introduced a catch-all pattern unintentionally such as in the following
@@ -158,6 +172,7 @@ Only the first match will be used to evaluate the guard expression.
 (See manual section 11.5)
 val test_member : 'a -> 'a * 'a -> bool = <fun>
 ```
+
 Obviously, the programmer had a misconception of what OCaml's pattern
 matching is about. Remember the following:
 
@@ -178,7 +193,9 @@ will ever be tested. This leads to the following results:
 # test_member 1 (0, 1);;
 - : bool = false
 ```
+
 ### `This pattern-matching is not exhaustive`
+
 OCaml's pattern matching can check whether a set of patterns is
 exhaustive or not, based on the *type* only. So in the following
 example, the compiler doesn't know what range of ints the "mod" operator
@@ -190,12 +207,14 @@ let is_even x =
   | 0 -> true
   | 1 | -1 -> false
 ```
+
 A short solution without pattern matching would be:
 
 ```ocaml
 # let is_even x = x mod 2 = 0;;
 val is_even : int -> bool = <fun>
 ```
+
 In general, that kind of simplification is not possible and the best
 solution is to add a catch-all case which should never be reached:
 
@@ -209,7 +228,9 @@ val is_even : int -> bool = <fun>
 ```
 
 ## Problems Recompiling Valid Programs
+
 ### `x.cmi is not a compiled interface`
+
 When recompiling some old program or compiling a program from an
 external source that was not cleaned properly, it is possible to get
 this error message:
@@ -220,10 +241,11 @@ some_module.cmi is not a compiled interface
 
 It means that some_module.cmi is not valid according to the *current
 version* of the OCaml compiler. Most of the time, removing the old
-compiled files (*.cmi, *.cmo, *.cmx, ...) and recompiling is
+compiled files (*.cmi,*.cmo, *.cmx, ...) and recompiling is
 sufficient to solve this problem.
 
 ### `Warning: Illegal backslash escape in string`
+
 Recent versions of OCaml warn you against unprotected backslashes in
 strings since they should be doubled. Such a message may be displayed
 when compiling an older program, and can be turned off with the `-w x`

--- a/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
+++ b/data/tutorials/guides/rs_02_comparison_of_standard_containers.md
@@ -6,7 +6,7 @@ description: >
 category: "Resources"
 ---
 
-This is a rough comparison of the different container types 
+This is a rough comparison of the different container types
 provided by the OCaml standard library. In each
 case, _n_ is the number of valid elements in the container.
 
@@ -17,6 +17,7 @@ you can read the [documentation](/manual/api/index.html) about each of the modul
 is also instructive to read the corresponding implementation.
 
 ## Lists: Immutable Singly-Linked Lists
+
 Adding an element always creates a new list _l_ from an element _x_ List
 _tl_. _tl_ remains unchanged, but it is not copied either.
 
@@ -30,6 +31,7 @@ Well-suited for: I/O, pattern-matching
 Not very efficient for: random access, indexed elements
 
 ## Arrays: Mutable Vectors
+
 Arrays are mutable data structures with a fixed length and random access.
 
 * Adding an element (by creating a new array): _O(n)_
@@ -40,6 +42,7 @@ Arrays are mutable data structures with a fixed length and random access.
 Well-suited for the following cases: dealing with sets of elements of known size, accessing elements by numeric index, and modifying in-place elements. Basic arrays have a fixed length.
 
 ## Strings: Immutable Vectors
+
 Strings are very similar to arrays, but they are immutable. Strings are
 specialised for storing chars (bytes) and have some convenient syntax.
 Strings have a fixed length. For extensible strings, the standard buffer
@@ -51,6 +54,7 @@ module can be used (see below).
 * Finding an element: _O(n)_
 
 ## Set and Map: Immutable Trees
+
 Like lists, these are immutable, and they may share some subtrees. These trees
 are a good solution for keeping older versions of sets of items.
 
@@ -62,6 +66,7 @@ Sets and maps are very useful in compilation and metaprogramming, but
 in other situations, hash tables are often more appropriate (see below).
 
 ## Hashtbl: Automatically Growing Hash Tables
+
 OCaml hash tables are mutable data structures, which are a good solution
 for storing (key, data) pairs in one single place.
 
@@ -73,6 +78,7 @@ for storing (key, data) pairs in one single place.
 * Finding an element: _O(1)_
 
 ## Buffer: Extensible Strings
+
 Buffers provide an efficient way to accumulate a byte sequence in a
 single place. They are mutable.
 
@@ -84,6 +90,7 @@ single place. They are mutable.
 * Accessing cell `i`: _O(1)_
 
 ## Queue
+
 OCaml queues are mutable first-in-first-out (FIFO) data structures.
 
 * Adding an element: _O(1)_
@@ -91,6 +98,7 @@ OCaml queues are mutable first-in-first-out (FIFO) data structures.
 * Length: _O(1)_
 
 ## Stack
+
 OCaml stacks are mutable last-in-first-out (LIFO) data structures. They
 are just like lists except they are mutable, i.e., adding an
 element doesn't create a new stack but simply adds it to the stack.


### PR DESCRIPTION
Basically, everything in "getting started" and "guide".

In case someone is wonder about the stripping of `$` from shell blocks - having them is considered a bad practice, as it:

- it makes it harder to copy commands
- `$` is reserved in markdown for `console` blocks with some output (e.g. from the compiler or whatever)