### PR TITLE
Fix: Contribute link on businesses page is broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ We've provided a list of community-driven content below. When adding content to 
 - [The OCaml Planet](#ocaml-planet)
 - [Job Board](#content-job)
 - [Success Stories](#content-success-story)
-- [Academic and Industrial Users](#content-user)
+- [Academic Users](#content-academic-user)
+- [Industrial Users](#content-industrial-user)
 - [OCaml Books](#content-book)
 - [OCaml Cookbook Recipes](#content-cookbook)
 - [Recurring Events](#content-recurring-event)
@@ -104,13 +105,50 @@ The success stories should be structured in the following way:
 
 You can read [Ahref's Success Story](https://ocaml.org/success-stories/peta-byte-scale-web-crawler) for a good example.
 
-### <a name="content-user"></a>Add an Academic or Industrial User
+### <a name="content-academic-user"></a>Add an Academic or Industrial User
 
-> Contribute to the [Academic Users](https://ocaml.org/academic-users) and [Industrial Users](https://ocaml.org/industrial-users).
+> Contribute to the [Academic Users](https://ocaml.org/academic-users).
 
-Add a new industrial user by creating a new Markdown file in [data/industrial_users/](data/industrial_users/). For instance: [cryptosense.md](data/industrial_users/cryptosense.md).
+You can add a new academic user by creating a new Markdown file in [data/academic_institutions/](data/academic_institutions). When submitting an academic institution to our webpage, please structure the data as follows:
 
-You can add a new academic user by creating a new Markdown file in [data/academic_institutions/](data/academic_institutions). For instance: [cornell.md](data/academic_institutions/cornell.md).
+Information about the institution
+- **`name`**: The full name of the academic institution.  
+- **`description`**: A brief overview of the institution, including its background and key details.  
+- **`url`**: The official website of the institution.  
+- **`logo`**: A link to the institution’s logo image.  
+- **`continent`**: The continent where the institution is located.  
+
+A list of courses available at the institution. Each course entry must include:  
+- **`name`**: The full name of the course.  
+- **`acronym`**: The course code or identifier.  
+- **`url`**: A direct link to the course webpage.  
+
+Location
+- **`lat`**: The latitude of the institution’s location.  
+- **`long`**: The longitude of the institution’s location. 
+
+For instance: [cornell.md](data/academic_institutions/cornell.md).
+
+### <a name="content-industrial-user"></a>Add an Academic or Industrial User
+
+> Contribute to the [Industrial Users](https://ocaml.org/industrial-users).
+
+Add a new industrial user by creating a new Markdown file in [data/industrial_users/](data/industrial_users/). When submitting an industrial user to our webpage, please structure the data as follows:
+  
+Information about the organization
+- **`name`**: The full name of the organization.  
+- **`description`**: A brief overview of the organization, including its mission and key details.  
+- **`logo`**: A link to the organization’s logo image.  
+- **`url`**: The official website of the organization.  
+
+Locations  
+- A list of countries where the organization operates.  
+
+Additional Information  
+- **`consortium`**: Indicates whether the organization is part of a consortium (`true` or `false`).  
+- **`featured`**: Indicates whether the organization is highlighted as a featured entity (`true` or `false`). 
+
+For instance: [cryptosense.md](data/industrial_users/cryptosense.md).
 
 ### <a name="content-book"></a>Add a Book
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ The success stories should be structured in the following way:
 
 You can read [Ahref's Success Story](https://ocaml.org/success-stories/peta-byte-scale-web-crawler) for a good example.
 
-### <a name="content-academic-user"></a>Add an Academic or Industrial User
+### <a name="content-academic-user"></a>Add an Academic User
 
 > Contribute to the [Academic Users](https://ocaml.org/academic-users).
 
@@ -129,7 +129,7 @@ Location
 
 For instance: [cornell.md](data/academic_institutions/cornell.md).
 
-### <a name="content-industrial-user"></a>Add an Academic or Industrial User
+### <a name="content-industrial-user"></a>Add an Industrial User
 
 > Contribute to the [Industrial Users](https://ocaml.org/industrial-users).
 

--- a/src/ocamlorg_frontend/pages/academic_institutions.eml
+++ b/src/ocamlorg_frontend/pages/academic_institutions.eml
@@ -29,7 +29,7 @@ Layout.render
 <div class="bg-background dark:bg-dark-background w-full py-8">
     <div class="container-fluid">
         <h3 class="text-2xl text-title dark:text-dark-title font-bold">30+ Academic Entries</h3>
-        <p class="text-content dark:text-dark-content text-base mb-4">To list an academic institution, check out the <a class="text-primary dark:text-white dark:underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-user">Contributing Guide</a> on GitHub.</p>
+        <p class="text-content dark:text-dark-content text-base mb-4">To list an academic institution, check out the <a class="text-primary dark:text-white dark:underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-academic-user">Contributing Guide</a> on GitHub.</p>
         <form action="<%s Url.academic_institutions %>" method="GET" class="flex gap-2 flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-full lg:w-auto mb-6">
             <%s! Forms.search_input
             ~name:"q"

--- a/src/ocamlorg_frontend/pages/industrial_businesses.eml
+++ b/src/ocamlorg_frontend/pages/industrial_businesses.eml
@@ -23,7 +23,7 @@ Layout.render
     <div class="container-fluid">
         <h3 class="text-2xl text-title dark:text-dark-title">Other Industry Users of OCaml</h3>
         <p class="text-content dark:text-dark-content text-base mb-4">With its strong security features and high performance, several companies rely on OCaml to keep their data operating both safely and efficiently. On this page, you can get an overview of the companies in the community and learn more about how they use OCaml.</p>
-        <p class="text-content dark:text-dark-content text-base mb-4">If you want to contribute to add a new industrial user, check out the <a class="text-primary dark:text-white dark:underline" href="#">Contributing Guide</a> on GitHub.</p>
+        <p class="text-content dark:text-dark-content text-base mb-4">If you want to contribute to add a new industrial user, check out the <a class="text-primary dark:text-white dark:underline" href="https://github.com/ocaml/ocaml.org/blob/main/CONTRIBUTING.md#content-industrial-user">Contributing Guide</a> on GitHub.</p>
         <% businesses |> List.iter (fun (item : Data.Industrial_user.t) -> let logo = match item.logo with | Some x -> Ocamlorg_static.Media.url x | None -> "" in %>
             <a href="<%s item.url %>" class="flex flex-col md:flex-row items-center border-b border-separator_20 dark:border-dark-separator_30 py-4">
                 <div class="w-44 h-24 rounded-lg flex justify-center items-center border border-separator_20 dark:border-dark-separator_30 bg-white overflow-hidden p-4 mr-5">


### PR DESCRIPTION
- Fixed broken industrial users link to ensure proper navigation.
- Reorganized contributing guide by separating industrial and academic user sections into two distinct links for better clarity and accessibility.