### PR TITLE
Update second half of seq.md, structural changes

### DIFF
--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -77,11 +77,11 @@ With this understanding, we can manually construct a sequence like so:
     fun () -> Seq.Cons (1,
       fun () -> Seq.Cons (2,
         fun () -> Seq.Cons (3,
-          fun () -> Seq.Nil)))
+          fun () -> Seq.Nil)));;
 val seq_123 : unit -> int Seq.node = <fun>
 ```
 
-**Note:** The second component of each `Seq.Con`'s tuple is a function. This has
+**Note:** The second component of each `Seq.Cons`' tuple is a function. This has
 the effect of providing a means of acquiring a value rather than providing a
 value directly.
 
@@ -350,7 +350,7 @@ element as they are generated. If `List.iter` was used, the whole integer list w
 ### Sequence Producers: Functions as Results
 
 A producer is a function that **generates** a sequence. Producers return a function so that elements are only computed when needed.  This
-ensures defered evaluation and avoids unnecessary computation.
+ensures deferred evaluation and avoids unnecessary computation.
 
 #### Producer Example: `Seq.unfold`
 
@@ -378,7 +378,7 @@ type 'a node = 'a Seq.node = Nil | Cons of 'a * 'a Seq.t
  ```
 
 The other version of "cons-ing" is the
-function `Seq.cons` (with a lowercase "c") with the following value declaration:
+function `Seq.cons` (with a lowercase `c`) with the following value declaration:
 
 ```ocaml
 val cons : 'a -> 'a Seq.t -> 'a Seq.t
@@ -408,8 +408,7 @@ val new_cons_v2 : int list = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
 ```
 
 Now that we have seen these two versions of "cons-ing" can construct the same
-sequence, it begs the question: what does the function `Seq.cons` provide us
-that the constructor `Seq.Cons` does not?
+sequence, it begs the question: what makes `Seq.cons` and `Seq.Cons` different?
 
 Lets look at how confusing `Seq.Cons` and `Seq.con` can lead to unintended
 behavior.

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -396,15 +396,18 @@ val cons : 'a -> 'a t -> unit -> 'a node = <fun>
 sequence:
 
  ``` ocaml
-# let base_cons = List.to_seq [2; 3; 4; 5; 6; 7; 8; 9]
+# let ints_from_2 = Seq.ints 2
+  let ints_a () = Seq.Cons (1, ints_from_2)  (* With Seq.Cons *)
+  let ints_b = Seq.cons 1 ints_from_2;;      (* With Seq.cons *)
+val ints_from_2 : int Seq.t = <fun>
+val ints_a : unit -> int Seq.node = <fun>
+val ints_b : int Seq.t = <fun>
 
-  let new_cons_v1 = (fun () -> Seq.Cons(1, base_cons))
-                                 |> List.of_seq            (* With Seq.Cons *)
+# ints_a |> Seq.take 3 |> List.of_seq;;
+- : int list = [1; 2; 3]
 
-  let new_cons_v2 = Seq.cons 1 base_cons |> List.of_seq;;  (* With Seq.cons *)
-val base_cons : int Seq.t = <fun>
-val new_cons_v1 : int list = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
-val new_cons_v2 : int list = [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
+# ints_b |> Seq.take 3 |> List.of_seq;;
+- : int list = [1; 2; 3]
 ```
 
 Now that we have seen these two versions of "cons-ing" can construct the same

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -411,11 +411,6 @@ Now that we have seen these two versions of "cons-ing" can construct the same
 sequence, it begs the question: what does the function `Seq.cons` provide us
 that the constructor `Seq.Cons` does not?
 
-In short, `Seq.Cons` provides a convenient means of recursively defining a
-sequence generator and a clumsy means to prepend a value to a sequence.
-Conversely, `Seq.cons` provides a convenient means to prepend a value to a
-sequence and an impossible means to recursively defining a sequence generator.
-
 Lets look at how confusing `Seq.Cons` and `Seq.con` can lead to unintended
 behavior.
 
@@ -441,7 +436,7 @@ val fibs : int -> int -> int Seq.t = <fun>
 # let res = ints_v1 0;;
 Stack overflow during evaluation (looping recursion?).
 
-```
+n```
 -->
 
 This produces a never-ending recursion that leads to a stack overflow.
@@ -497,6 +492,14 @@ If the distinction remains a mystery, take a moment to compare the inputs to the
 `Seq.Cons` constructor and `Seq.cons` function. They look deceptively similar,
 but one takes as input a value of type `'a * 'a t` and the other takes as input
 arguments of `'a` and `'a t`.
+
+### A Mental Model for `Seq.Cons` vs `Seq.cons`
+
+It useful to think of `Seq.Cons` and `Seq.cons` as accomplishing different
+tasks. `Seq.Cons` provides a convenient means of recursively defining a sequence
+generator and a clumsy means to prepend a value to a sequence.  Conversely,
+`Seq.cons` provides a convenient means to prepend a value to a sequence and an
+impossible means to recursively defining a sequence generator.
 
 ## Sequences for Conversions
 


### PR DESCRIPTION
Some of these updates are to convert code blocks into Utop format.

The remaining update is for the second half of this document. This second half included several suggestions for improvement that required structural changes. 

This pull request may be difficult to read using diff comparison for this reason.

The updated headings read:

```
...
## Consumers vs Producers
### Sequence Consumers: Partially Applied Functions as Parameters
### Sequence Producers: Partially Applied Functions as Results
## Beware of Seq.Cons vs Seq.cons
### Understanding the Difference
## Sequences for Conversions
## Miscellaneous Considerations

- In "Understanding the Difference", I make the generalization that Seq.Cons is particularly useful for generating recursive producers, while Seq.cons is particularly useful for prepending a cons cell to a sequence. I hope this is accurate, happy to be told otherwise if it is overly generic

- After reading some of the suggestions, I kept the `fibs` examples over using a suggested simpler example for `ints`, but I left comments where the simpler `ints` version could be placed. These would require minor updates to the surrounding text, which I can make if you prefer the simpler example

- I expanded a bit on the section describing "producers" and "consumers"

As always, I'm happy to make updates or leave it the way it currently is.