### PR TITLE
Add OCaml Workshop 2024 and 2025

### DIFF
--- a/data/conferences/2024-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2024-ocaml-users-and-developers-workshop.md
@@ -1,0 +1,148 @@
+---
+title: OCaml Workshop 2024
+date: 2024-09-07
+location: Milan, Italy
+important_dates:
+  - date: 2024-05-30
+    info: Abstract submission deadline
+  - date: 2024-07-04
+    info: Author notification
+  - date: 2024-09-07
+    info: OCaml Workshop
+presentations:
+  - title: "A Non-allocating Option"
+    authors:
+      - Richard A. Eisenberg
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/8/A-Non-allocating-Option"
+    youtube_video: https://www.youtube.com/watch?v=9R9RFvjXMCU&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=6
+  - title: "B · o · B, a universal & secure file-transfer software in OCaml"
+    authors:
+      - Romain Calascibetta
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/2/B-o-B-a-universal-secure-file-transfer-software-in-OCaml"
+    youtube_video: https://www.youtube.com/watch?v=COmi9e7wHtI&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=3
+  - title: "ChorCaml: Functional Choreographic Programming in OCaml"
+    authors:
+      - Rokas Urbonas
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/13/ChorCaml-Functional-Choreographic-Programming-in-OCaml"
+    youtube_video: https://www.youtube.com/watch?v=KEkmcXVtFi0&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=9
+  - title: "Distributed Actors in OCaml"
+    authors:
+      - Wenke DU
+      - Gabriel Radanne
+      - Ludovic Henrio
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/9/Distributed-Actors-in-OCaml"
+    youtube_video: https://www.youtube.com/watch?v=FbsYIA38eng&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=4
+  - title: "First-Class Windows: Building a Roadmap for OCaml on Windows"
+    authors:
+      - Sudha Parimala
+      - Benjamin Canou
+      - Pierre Boutillier
+      - David Allsopp
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/14/First-Class-Windows-Building-a-Roadmap-for-OCaml-on-Windows"
+    youtube_video: https://www.youtube.com/watch?v=wjb63CS7fdE&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=10
+  - title: "Flambda2 Validator"
+    authors:
+      - Irene Yoon
+      - Chris Casinghino
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/6/Flambda2-Validator"
+    youtube_video: https://www.youtube.com/watch?v=phon73Ku-nM&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=15
+  - title: "Mica: Automated Differential Testing for OCaml Modules"
+    authors:
+      - Ernest Ng
+      - Harrison Goldstein
+      - Benjamin C. Pierce
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/4/Mica-Automated-Differential-Testing-for-OCaml-Modules"
+    youtube_video: https://www.youtube.com/watch?v=dQFjZI19Jd8&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=11
+  - title: "Mixed Blocks: Storing More Fields Flat"
+    authors:
+      - Nicholas Roberts
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/7/Mixed-Blocks-Storing-More-Fields-Flat"
+    youtube_video: https://www.youtube.com/watch?v=cnNe83QbZHU&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=16
+  - title: "On the design and implementation of Modular Explicits"
+    authors:
+      - Samuel Vivien
+      - Didier Rémy
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/1/On-the-design-and-implementation-of-Modular-Explicits"
+    youtube_video: https://www.youtube.com/watch?v=5AccIR_TP1A&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=1
+  - title: "Opam 2.2 and beyond"
+    authors:
+      - Raja Boujbel
+      - Kate Deplaix
+      - David Allsopp
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/10/Opam-2-2-and-beyond"
+    youtube_video: https://www.youtube.com/watch?v=vpASgFrwKEE&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=12
+  - title: "Picos — Interoperable effects based concurrency"
+    authors:
+      - Vesa Karvonen
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/5/Picos-Interoperable-effects-based-concurrency"
+    youtube_video: https://www.youtube.com/watch?v=iVpsVqd6eNE&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=7
+  - title: "Priodomainslib: Prioritized Fine-grained Parallelism for Multicore OCaml"
+    authors:
+      - Stefan K. Muller
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/15/Priodomainslib-Prioritized-Fine-grained-Parallelism-for-Multicore-OCaml"
+    youtube_video: https://www.youtube.com/watch?v=7yYC6EGYg10&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=8
+  - title: "Project-wide occurrences for OCaml, a progress report"
+    authors:
+      - Ulysse Gérard
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/3/Project-wide-occurrences-for-OCaml-a-progress-report"
+    youtube_video: https://www.youtube.com/watch?v=QxW1tDB88aY&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=13
+  - title: "Recursion schemes in OCaml: An experience report"
+    authors:
+      - Tim Williams
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/11/Recursion-schemes-in-OCaml-An-experience-report"
+    youtube_video: https://www.youtube.com/watch?v=AWH3DTDyAII&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=2
+  - title: "Saturn: a library of verified concurrent data structures for OCaml 5"
+    authors:
+      - Clément Allain
+      - Vesa Karvonen
+      - Carine Morel
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/12/Saturn-a-library-of-verified-concurrent-data-structures-for-OCaml-5"
+    youtube_video: https://www.youtube.com/watch?v=vanyv3ZEto8&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=5
+  - title: "Structured diagnostics for the OCaml compiler"
+    authors:
+      - Florian Angeletti
+    link: "https://icfp24.sigplan.org/details/ocaml-2024-papers/16/Structured-diagnostics-for-the-OCaml-compiler"
+    youtube_video: https://www.youtube.com/watch?v=tjPgg7hXodE&list=PLKO_ZowsIOu52jtALkYCvu_PnUTq0iBP_&index=14
+organising_committee: []
+program_committee:
+  - name: Armaël Guéneau
+    affiliation: Inria Saclay - LMF
+    role: co-chair
+  - name: Sonja Heinze
+    affiliation: Tarides
+    role: co-chair
+  - name: Abigael Decorne
+  - name: Antonio Monteiro
+  - name: Carine Morel
+    affiliation: Tarides
+  - name: Enrico Tassi
+    affiliation: INRIA
+  - name: Hugo Heuzard
+  - name: Kate Deplaix
+    affiliation: Consultant for the OCaml Software Foundation and Ahrefs
+  - name: Marcello Seri
+    affiliation: Bernoulli Institute for Mathematics, Computer Science and Artificial Intelligence, University of Groningen
+  - name: Milla Valnet
+    affiliation: Sorbonne Université
+  - name: Ningning Xie
+    affiliation: University of Toronto; Google DeepMind
+  - name: Richard A. Eisenberg
+    affiliation: Jane Street
+  - name: Robert Blanco
+    affiliation: Max Planck Institute for Security and Privacy (MPI-SP)
+  - name: Simmo Saan
+    affiliation: University of Tartu, Estonia
+  - name: Takafumi Saikawa
+    affiliation: Nagoya University
+  - name: Troels Henriksen
+    affiliation: University of Copenhagen
+---
+
+OCaml Workshop 2024 took place during ICFP 2024, in Milan, Italy.
+
+ACM Sigplan ICFP page: [OCaml Workshop 2024](https://icfp24.sigplan.org/home/ocaml-2024)
+
+The OCaml Users and Developers Workshop brings together the OCaml community, including users of OCaml in industry, academia, hobbyists, and the free software community.
+
+Video recordings can be found on the [@OCamlWorkshops YouTube Channel](https://www.youtube.com/@OCamlWorkshops).
+

--- a/data/conferences/2025-ocaml-users-and-developers-workshop.md
+++ b/data/conferences/2025-ocaml-users-and-developers-workshop.md
@@ -1,0 +1,23 @@
+---
+title: OCaml Workshop 2025
+date: 2025-10-17
+location: Singapore
+important_dates:
+  - date: 2025-07-03
+    info: Abstract submission deadline
+  - date: 2025-08-07
+    info: Author notification
+  - date: 2025-10-17
+    info: OCaml Workshop
+presentations: []
+organising_committee: []
+program_committee: []
+---
+
+OCaml Workshop 2025 will take place during ICFP 2025, in Singapore.
+
+ACM Sigplan ICFP page: [OCaml Workshop 2025](https://conf.researchr.org/home/icfp-splash-2025/ocaml-2025)
+
+The OCaml Users and Developers Workshop brings together the OCaml community, including users of OCaml in industry, academia, hobbyists, and the free software community.
+
+Video recordings can be found on the [@OCamlWorkshops YouTube Channel](https://www.youtube.com/@OCamlWorkshops).

--- a/data/events/2025-10-17-ocaml-workshop.md
+++ b/data/events/2025-10-17-ocaml-workshop.md
@@ -1,0 +1,13 @@
+---
+title: "OCaml Users and Developers Workshop 2025"
+event_type: conference
+country: "Singapore"
+city: "Singapore"
+url: https://conf.researchr.org/home/icfp-splash-2025/ocaml-2025#Call-for-Presentations
+starts:
+  yyyy_mm_dd: "2025-10-17"
+submission_deadline:
+  yyyy_mm_dd: "2025-07-03"
+author_notification_date:
+  yyyy_mm_dd: "2025-08-07"
+---


### PR DESCRIPTION
This PR:
- Adds the 2024 workshop to /conferences
- Adds the upcoming 2025 workshop to /events and /conferences