### PR TITLE
chore: changelog for dune.3.18.0

### DIFF
--- a/data/changelog/dune/2025-04-03-dune.3.18.0.md
+++ b/data/changelog/dune/2025-04-03-dune.3.18.0.md
@@ -1,0 +1,60 @@
+---
+title: Dune 3.18.0
+tags: [dune, platform]
+changelog: |
+    ### Fixed
+
+    - Support HaikuOS: don't call `execve` since it's not allowed if other pthreads
+      have been created. The fact that Haiku can't call `execve` from other threads
+      than the principal thread of a process (a team in haiku jargon), is a
+      discrepancy to POSIX and hence there is a [bug about
+      it](https://dev.haiku-os.org/ticket/18665). (@Sylvain78, #10953)
+
+    - Fix flag ordering in generated Merlin configurations (#11503, @voodoos, fixes
+      ocaml/merlin#1900, reported by @vouillon)
+
+    ### Added
+
+    - Add `(format-dune-file <src> <dst>)` action. It provides a replacement to
+      `dune format-dune-file` command.  (#11166, @nojb)
+
+    - Allow the `--prefix` flag when configuring dune with `ocaml configure.ml`.
+      This allows to set the prefix just like `$ dune install --prefix`. (#11172,
+      @rgrinberg)
+
+    - Allow arguments starting with `+` in preprocessing definitions (starting with
+      `(lang dune 3.18)`). (@amonteiro, #11234)
+
+    - Support for opam `(maintenance_intent ...)` in dune-project (#11274, @art-w)
+
+    - Validate opam `maintenance_intent` (#11308, @art-w)
+
+    - Support `not` in package dependencies constraints (#11404, @art-w, reported
+      by @hannesm)
+
+    ### Changed
+
+    - Warn when failing to discover root due to reads failing. The previous
+      behavior was to abort. (@KoviRobi, #11173)
+
+    - Use shorter path for inline-tests artifacts. (@hhugo, #11307)
+
+    - Allow dash in `dune init` project name (#11402, @art-w, reported by @saroupille)
+
+    - On Windows, under heavy load, file delete operations can sometimes fail due to
+      AV programs, etc. Guard against it by retrying the operation up to 30x with a
+      1s waiting gap (#11437, fixes #11425, @MSoegtropIMC)
+
+    - Cache: we now only store the executable permission bit for files (#11541,
+      fixes #11533, @ElectreAAS)
+
+    - Display negative error codes on Windows in hex which is the more customary
+      way to display `NTSTATUS` codes (#11504, @MisterDA)
+---
+The Dune Team is happy to announce the release of Dune `3.18.0`!
+
+This release contains changes to support the new `x-maintenance-intent` field
+by default. It also contains some changes regarding the cache about how it
+handles file permissions. It introduces a new `(format-dune-file ...)` stanza
+with the intention to replace the `dune format-dune-file` command. Finally,
+it includes various bug fixes for Dune.


### PR DESCRIPTION
This PR adds the changelog for the newly release dune 3.18.0.

It needs to wait for [the opam PR](https://github.com/ocaml/opam-repository/pull/27704) to be merged before merging this one.
