### PR TITLE
fix: update 2025-04-03-dune.3.18.0.md

### DIFF
--- a/data/changelog/dune/2025-04-03-dune.3.18.0.md
+++ b/data/changelog/dune/2025-04-03-dune.3.18.0.md
@@ -56,5 +56,5 @@ The Dune Team is happy to announce the release of Dune `3.18.0`!
 This release contains changes to support the new `x-maintenance-intent` field
 by default. It also contains some changes regarding the cache about how it
 handles file permissions. It introduces a new `(format-dune-file ...)` stanza
-with the intention to replace the `dune format-dune-file` command. Finally,
-it includes various bug fixes for Dune.
+with the intention to formalize the `dune format-dune-file` command as an inside
+rule. Finally, it includes various bug fixes for Dune.


### PR DESCRIPTION
This PR changes the previous text to clarify the intention to not get rid of the command, but more provide a "cleaner" alternative.