### PR TITLE
Update URL for caml-list

### DIFF
--- a/data/changelog/opam/2024-07-01-opam-2-2-0.md
+++ b/data/changelog/opam/2024-07-01-opam-2-2-0.md
@@ -49,7 +49,7 @@ support! A big thank you is due to Andreas Hauptmann ([@fdopen](https://github.c
 whose [WODI](https://github.com/fdopen/godi-repo) and [OCaml for Windows](https://fdopen.github.io/opam-repository-mingw/)
 projects were for many years the principal downstream way to obtain OCaml on
 Windows, Jun Furuse ([@camlspotter](https://github.com/camlspotter)) whose
-[initial experimentation with OPAM from Cygwin](https://inbox.vuxu.org/caml-list/CAAoLEWsQK7=qER66Uixx5pq4wLExXovrQWM6b69_fyMmjYFiZA@mail.gmail.com/)
+[initial experimentation with OPAM from Cygwin](https://inbox.ci.dev/caml-list/CAAoLEWsQK7=qER66Uixx5pq4wLExXovrQWM6b69_fyMmjYFiZA@mail.gmail.com/)
 formed the basis of opam-repository-mingw, and, most recently,
 Jonah Beckford ([@jonahbeckford](https://github.com/JonahBeckford)) whose
 [DkML](https://diskuv.com/dkmlbook/) distribution kept - and keeps - a full

--- a/data/planet/ocamlpro/opam-220-release.md
+++ b/data/planet/ocamlpro/opam-220-release.md
@@ -46,7 +46,7 @@ support! A big thank you is due to Andreas Hauptmann (<a href="https://github.co
 whose <a href="https://github.com/fdopen/godi-repo">WODI</a> and <a href="https://fdopen.github.io/opam-repository-mingw/">OCaml for Windows</a>
 projects were for many years the principal downstream way to obtain OCaml on
 Windows, Jun Furuse (<a href="https://github.com/camlspotter">@camlspotter</a>) whose
-<a href="https://inbox.vuxu.org/caml-list/CAAoLEWsQK7=qER66Uixx5pq4wLExXovrQWM6b69_fyMmjYFiZA@mail.gmail.com/">initial experimentation with OPAM from Cygwin</a>
+<a href="https://inbox.ci.dev/caml-list/CAAoLEWsQK7=qER66Uixx5pq4wLExXovrQWM6b69_fyMmjYFiZA@mail.gmail.com/">initial experimentation with OPAM from Cygwin</a>
 formed the basis of opam-repository-mingw, and, most recently,
 Jonah Beckford (<a href="https://github.com/JonahBeckford">@jonahbeckford</a>) whose
 <a href="https://diskuv.com/dkmlbook/">DkML</a> distribution kept - and keeps - a full

--- a/src/ocamlorg_frontend/pages/community.eml
+++ b/src/ocamlorg_frontend/pages/community.eml
@@ -81,7 +81,7 @@ Community_layout.single_column_layout
       </ul>
       <ul>
         <p class="text-title text-xl font-mono dark:text-dark-title mb-2">Mailing Lists</p>
-        <%s! social_list_item ~text:("Share experience, exchange ideas and code, and report on applications - ") ~href:("https://inbox.vuxu.org/caml-list") ~left_icon:(Icons.email "w-10 h-10") ~title:("Caml User's Mailing List") "" %>
+        <%s! social_list_item ~text:("Share experience, exchange ideas and code, and report on applications - ") ~href:("https://inbox.ci.dev/caml-list") ~left_icon:(Icons.email "w-10 h-10") ~title:("Caml User's Mailing List") "" %>
       </ul>
   </div>
 </div>


### PR DESCRIPTION
The archive at https://inbox.vuxu.org/caml-list has not been updated for a while.  This PR switches to https://inbox.ci.dev/caml-list.

see https://github.com/ocaml/infrastructure/issues/15 