### PR TITLE
Fix typo in documentation

### DIFF
--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -375,7 +375,7 @@ The following example shows that the identity function can apply to arguments of
 val f : 'a -> 'a = <fun>
 
 # f 9;;
-- : int = 81
+- : int = 9
 
 # f "hello";;
 - : string = "hello"


### PR DESCRIPTION
Fix small typo in section "Functions" of basic data types page