### PR TITLE
chore: changelog for dune.3.18.1

### DIFF
--- a/data/changelog/dune/2025-04-17-dune.3.18.1.md
+++ b/data/changelog/dune/2025-04-17-dune.3.18.1.md
@@ -1,0 +1,15 @@
+---
+title: Dune.3.18.1
+tags: [dune, platform]
+changelog: |
+    ### Fixed
+
+    - fix: pass pkg-config (extra) args in all pkgconfig invocations. A missing
+      `--personality` flag would result in pkgconf not finding libraries in some
+      contexts. (#11619, @MisterDA)
+---
+
+The Dune Team is happy to announce the release of Dune `3.18.1`!
+
+This release contains a bug fix for `pkg-config` that prevents it from finding some
+libraries in specific contexts.


### PR DESCRIPTION
This PR updates the changelog for the Dune patch release, `3.18.1`.

This time the PR is already merged :wink:

cc @cuihtlauac 
