### PR TITLE
Update code_of_conduct.md replacing Sonja with Shon

### DIFF
--- a/data/pages/code_of_conduct.md
+++ b/data/pages/code_of_conduct.md
@@ -110,7 +110,7 @@ The members of the team are currently:
 * Marcello Seri <[marcello@ocaml.org](mailto:marcello@ocaml.org)>
 * Raja Boujbel <[raja@ocaml.org](mailto:raja@ocaml.org)>
 * Simon Cruanes <[simon@ocaml.org](mailto:simon@ocaml.org)>
-* Sonja Heinze <[sonja@ocaml.org](mailto:sonja@ocaml.org)>
+* Shon Feder <[shon@ocaml.org](mailto:shon@ocaml.org)>
 
 ## Strained Situations ##
 


### PR DESCRIPTION
I have been asked to support the CoC committee, and Sonja has decided to rotate out.

This has already been updated in https://github.com/ocaml/code-of-conduct/pull/22