### PR TITLE
chore: changelog for dune 3.18.2

### DIFF
--- a/data/changelog/releases/dune/2025-04-30-dune.3.18.2.md
+++ b/data/changelog/releases/dune/2025-04-30-dune.3.18.2.md
@@ -1,0 +1,13 @@
+---
+title: Dune.3.18.2
+tags: [dune, platform]
+changelog: |
+    ### Fixed
+
+    - fix compatibility with `ocaml.5.4.0` by avoiding shadowing sigwinch (@nojb,
+    #11639)
+---
+
+The Dune Team is happy to announce the release of Dune `3.18.2`.
+
+This release contains a bug fix to fix a compatibility issue with `ocaml.5.4.0`.


### PR DESCRIPTION
This PR updates the changelog for `dune.3.18.2`.

I'll remove the draft when [opam-repository#27838](https://github.com/ocaml/opam-repository/pull/27838) will be merged.

Signed-off-by: Etienne Marais <dev@maiste.fr>
