### PR TITLE
add Topiary to “Formatting Your Code”

### DIFF
--- a/data/tutorials/platform/1_07_code_formatting.md
+++ b/data/tutorials/platform/1_07_code_formatting.md
@@ -30,3 +30,64 @@ format all files from your codebase:
 ```shell
 opam exec -- dune fmt
 ```
+
+## Using Topiary
+
+[Topiary](https://topiary.tweag.io) is a Tree-sitter-based code formatter
+supporting multiple languages, including OCaml & OCamllex. It can be invoked
+with
+
+<!-- markdownlint-disable commands-show-output -->
+```shell-session
+$ topiary format source.ml
+```
+<!-- markdownlint-restore -->
+
+Topiary does not require an empty configuration file to operate & has its own
+set of defaults, however, it can be
+[configured](https://topiary.tweag.io/book/cli/configuration.html).
+
+### Example configuration setup
+
+This example configuration will override the default configuration to use 1 tab
+character for indentation by creating a `.topiary.ncl` Nickel configuration
+file.
+
+<!-- markdownlint-disable commands-show-output -->
+```shell-session
+$ touch .topiary.ncl
+$ $EDITOR .topiary.ncl
+```
+<!-- markdownlint-restore -->
+
+<!-- markdownlint-disable no-hard-tabs -->
+```nickel
+{
+	languages = {
+		nickel.indent | priority 1 = "\t",
+		ocaml.indent | priority 1 = "\t",
+		ocaml_interface.indent | priority 1 = "\t",
+		ocamllex.indent | priority 1 = "\t",
+	},
+}
+```
+<!-- markdownlint-restore -->
+
+Then this file needs to be exported to the environment such as `export
+TOPIARY_CONFIG_FILE=".topiary.ncl"` in Bash/ZSH or `set -x TOPIARY_CONFIG_FILE
+".topiary.ncl"` in Fish.
+
+TIP: If using Direnv, the environment variable can also be added to the user’s
+personal `.envrc` so it is exported on switching to the project directory by
+appending with `echo 'export TOPIARY_CONFIG_FILE=".topiary.ncl"' >> .envrc`.
+
+Afterwards, `--merge-configuration` will always merge in the example
+configuration. Invoke Topiary’s formatting with
+
+<!-- markdownlint-disable commands-show-output -->
+```shell-session
+$ topiary format --merge-configuration source.ml
+```
+<!-- markdownlint-restore -->
+
+and/or configure your editor to run this command on saving the file.

--- a/data/tutorials/platform/1_07_code_formatting.md
+++ b/data/tutorials/platform/1_07_code_formatting.md
@@ -9,19 +9,24 @@ category: "Editor Support"
 
 ## Using OCamlFormat
 
-Automatic formatting with OCamlFormat requires an `.ocamlformat` configuration file at the root of the project.
+Automatic formatting with OCamlFormat requires an `.ocamlformat` configuration
+file at the root of the project.
 
-An empty file is accepted, but since different versions of OCamlFormat will vary in formatting, it
-is good practice to specify the version you're using. Running
+An empty file is accepted, but since different versions of OCamlFormat will
+vary in formatting, it is good practice to specify the version you're using.
+Running
 
 ```shell
-$ echo "version = `ocamlformat --version`" > .ocamlformat
+echo "version = `ocamlformat --version`" > .ocamlformat
 ```
 
-creates a configuration file for the currently installed version of OCamlFormat.
+creates a configuration file for the currently installed version of
+OCamlFormat.
 
-In addition to editor plugins that use OCamlFormat for automatic code formatting, Dune also offers a command to run OCamlFormat to automatically format all files from your codebase:
+In addition to editor plugins that use OCamlFormat for automatic code
+formatting, Dune also offers a command to run OCamlFormat to automatically
+format all files from your codebase:
 
 ```shell
-$ opam exec -- dune fmt
+opam exec -- dune fmt
 ```

--- a/data/tutorials/platform/1_07_code_formatting.md
+++ b/data/tutorials/platform/1_07_code_formatting.md
@@ -1,11 +1,13 @@
 ---
 id: "formatting-your-code"
-title: "Formatting Your Code With OCamlFormat"
+title: "Formatting Your Code"
 short_title: "Formatting Your Code"
 description: |
-  How to set up OCamlFormat to automatically format your code
+  How to set up formatting of your code
 category: "Editor Support"
 ---
+
+## Using OCamlFormat
 
 Automatic formatting with OCamlFormat requires an `.ocamlformat` configuration file at the root of the project.
 


### PR DESCRIPTION
[Topiary](https://topiary.tweag.io) is a viable code formatter for OCaml projects. My favorite feature [compared to its competitor](https://github.com/ocaml-ppx/ocamlformat/issues/1613) is that Topiary can be configured to use tab indentation for user accessibility (which affects me). While Topiary can be configured, it isn’t as intuitive to configure as many other code formatters that just look for a specific file in a specific location.

Additionally, I removed the implicit assumptions of OCamlFormat in the description & title since the sidebar & URL slug generically state “Formatting Your Code” without specifying a tool. This also required moving the file whose name implied OCamlFormat.

It would have been nice to use a callout/admonition for the “TIP:”, but Markdown does not support this feature.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
