### PR TITLE
Fix: Syntax Error in Functors Tutorial

### DIFF
--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -506,11 +506,11 @@ Modules can hold a state. Functors can provide a means to initialise stateful mo
 
 **`random.ml`**
 ```ocaml
-module type SeedType : sig
+module type SeedType = sig
   val v : int array
 end
 
-module type S : sig
+module type S = sig
   val reset_state : unit -> unit
 
   val bits : unit -> int


### PR DESCRIPTION
Fixes issue #3085 

This change fixes the syntax error in ```random.ml``` on page [https://ocaml.org/docs/functors](https://ocaml.org/docs/functors). 