### PR TITLE
Don't save or republish full OCaml Planet blog post content

### DIFF
--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -61,7 +61,6 @@ module Blog = struct
     authors : string list;
     date : string;
     preview_image : string option;
-    body_html : string;
   }
 end
 

--- a/tool/ood-gen/lib/planet.ml
+++ b/tool/ood-gen/lib/planet.ml
@@ -105,7 +105,9 @@ module GlobalFeed = struct
              ())
 
   let entry_of_post (post : Blog.post) =
-    let content = Syndic.Atom.Html (None, post.body_html) in
+    let content =
+      Syndic.Atom.Html (None, Option.value post.description ~default:"")
+    in
     let url = Uri.of_string post.source.url in
     let source : Syndic.Atom.source =
       Syndic.Atom.source ~authors:[] ~id:url


### PR DESCRIPTION
Don't save the full post content in Markdown files like https://github.com/ocaml/ocaml.org/blob/main/data/planet/dra27/dipping-toes-into-oxcaml.md?plain=1 or republish the full content in the Planet RSS feed, https://ocaml.org/planet.xml

There's no need to save the full post content because we never display it anywhere in our site. We just directly link to the original blog posts.

Fix #3120