### PR TITLE
Add GitHub Actions workflow for dune pkg

### DIFF
--- a/.github/workflows/build-dune.yml
+++ b/.github/workflows/build-dune.yml
@@ -1,0 +1,19 @@
+name: Build on Dune PM
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use dune
+        uses: ocaml-dune/setup-dune@v0.0.1
+        with:
+          automagic: true

--- a/src/ocamlorg_web/lib/ocamlorg_web.ml
+++ b/src/ocamlorg_web/lib/ocamlorg_web.ml
@@ -9,7 +9,7 @@ let () =
   Logs.set_level (Some Info)
 
 let run () =
-  Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna);
+  Mirage_crypto_rng_unix.use_default ();
   let state = Ocamlorg_package.init () in
   try
     Dream.run ~interface:"0.0.0.0" ~port:Config.http_port


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for ocaml.org. This would help us catch any failures with `dune pkg`. Also fixed a deprecated function in `Mirage_crypto_rng` along the way.