### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN sudo apk -U upgrade --no-cache && sudo apk add --no-cache \
     oniguruma-dev \
     openssl-dev
 
+# Use Opam 2.2 and enable the backup mirror if primary sources of packages are unavailable
+RUN sudo mv /usr/bin/opam-2.2 /usr/bin/opam && opam update
+RUN opam option --global 'archive-mirrors+="https://opam.ocaml.org/cache"'
+
 # Branch freeze was opam-repo HEAD at the time of commit
 RUN cd ~/opam-repository && git reset --hard c45f5bab71d3589f41f9603daca5acad14df0ab0 && opam update
 


### PR DESCRIPTION
From https://github.com/ocaml/infrastructure/issues/172, download.camlcity.org is down which is preventing the current build. This PR will enable the backup mirror for opam packages. Opam 2.2 or later is required for this feature to work.

```
#13 296.3 [ERROR] The sources of the following couldn't be obtained, aborting:
#13 296.3           - ocamlfind.1.9.6: curl error code 504
#13 296.3 
#13 ERROR: executor failed running [/bin/sh -c opam install . --deps-only]: exit code: 40
------
 > [build  6/10] RUN opam install . --deps-only:
------
executor failed running [/bin/sh -c opam install . --deps-only]: exit code: 40
docker-build failed with exit-code 1
2025-05-26 10:30.29: Job failed: Failed: Build failed
```

Also, `ocaml/opam:alpine-3.19-ocaml-5.2` is not maintained and was last updated 11 months ago. I suggest moving to Alpine 3.21 and opam 2.3 under a second PR with proper testing.