### PR TITLE
chore: use newer Docker image to reset opam-repository to the pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine-3.19-ocaml-5.2 AS build
+FROM ocaml/opam:alpine-3.21-ocaml-5.2 AS build
 
 # Install system dependencies
 RUN sudo apk -U upgrade --no-cache && sudo apk add --no-cache \


### PR DESCRIPTION
Related to https://github.com/ocaml/ocaml.org/pull/3131. Forgot to use a new enough Docker image to be able to set the opam-repository pin without pulling from GitHub.