### PR TITLE
Reduce minimum version of ocaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
   "This repository contains the server that serves the official OCaml website at https://ocaml.org.")
  (depends
   (ocaml
-   (>= 5.2.0))
+   (>= 4.14.0))
   ppx_deriving
   cohttp
   cohttp-lwt-unix


### PR DESCRIPTION
The pinned version of the package "river" has a dependency on the package "ocamlnet" which is not compatible with ocaml 5. This fixes an issue where Dune is unable to find a package solution for this project.