### PR TITLE
Add overlay repo to dune-workspace

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -2,5 +2,7 @@
 
 (repository (name pinned_opam_repository) (url git+https://github.com/ocaml/opam-repository#584630e7a7e27e3cf56158696a3fe94623a0cf4f))
 
+(repository (name pinned_overlay_repository) (url git+https://github.com/ocaml-dune/opam-overlays#2a9543286ff0e0656058fee5c0da7abc16b8717d))
+
 (lock_dir
-  (repositories pinned_opam_repository))
+  (repositories pinned_opam_repository pinned_overlay_repository))


### PR DESCRIPTION
When setting the repositories associated with a lockdir the default list over repos is overriden with the new list. Dune package management relies on some forks of some low-level packages that have been patched by the dune developers to work with dune package management. This change adds the overlay back in, fixed at a given commit.