### PR TITLE
fix: make playground build again (esbuild node:* external dep)

### DIFF
--- a/playground/dune
+++ b/playground/dune
@@ -14,6 +14,7 @@
     --external:tty
     --external:child_process
     --external:constants
+    --external:node:*
     --minify
     --bundle
     --outfile=playground.min.js


### PR DESCRIPTION
Fixes these errors:

```
make build
opam exec -- dune build --root .
File "dune", lines 3-20, characters 1-336:
 3 |  (rule
 4 |   (targets playground.min.js)
 5 |   (mode
....
18 |     --bundle
19 |     --outfile=playground.min.js
20 |     %{js})))
✘ [ERROR] Could not resolve "node:fs"

    ../src/main.bc.js:30302:22:
      30302 │     this.fs = require("node:fs");
            ╵                       ~~~~~~~~~

  You can mark the path "node:fs" as external to exclude it from the bundle, which will remove this error. You can also surround this "require" call with a try/catch block to handle this failure 
```