### PR TITLE
chore: add UTM links to changelog and newsletter for Dune Developer Preview

### DIFF
--- a/data/changelog/posts/dune-developer-preview/2024-09-25-call-for-feedback.md
+++ b/data/changelog/posts/dune-developer-preview/2024-09-25-call-for-feedback.md
@@ -5,7 +5,7 @@ tags: [dune, platform, developer-preview]
 
 Hello folks! 👋 
 
-We'd like to welcome everyone to try and play with the [Dune Developer Preview](https://preview.dune.build)! 🎉
+We'd like to welcome everyone to try and play with the [Dune Developer Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog)! 🎉
 
 This experimental nightly release of dune includes a lot of improvements, including the much expected package management features, and it can be installed from that website or by using the new installation script:
 

--- a/data/changelog/posts/dune-developer-preview/2024-10-29-shell-completions-in-dune-developer-preview.md
+++ b/data/changelog/posts/dune-developer-preview/2024-10-29-shell-completions-in-dune-developer-preview.md
@@ -6,9 +6,9 @@ tags: [dune, developer-preview]
 _Discuss this post on [Discuss](https://discuss.ocaml.org/t/shell-completions-in-dune-developer-preview/15522)!_
 
 Support for dune shell completions for bash and zsh has just landed in the
-[Dune Developer Preview](https://preview.dune.build/)!
+[Dune Developer Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog)!
 
-Running the [installer](https://preview.dune.build/#download) adds a snippet to
+Running the [installer](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog#download) adds a snippet to
 your shell config (e.g. ~/.bashrc) that installs a completion handler for `dune`.
 The completion script was taken from
 [here](https://github.com/gridbugs/dune-completion-scripts), and that page has

--- a/data/changelog/posts/dune-developer-preview/2024-11-15-installing-developer-tools-with-dune.md
+++ b/data/changelog/posts/dune-developer-preview/2024-11-15-installing-developer-tools-with-dune.md
@@ -7,7 +7,7 @@ _Discuss this post on [Discuss](https://discuss.ocaml.org/t/installing-developer
 
 Dune can install and run developer tools in the context of a project. This
 feature is available in the [Dune Developer
-Preview](https://preview.dune.build/) and in the upcoming release of Dune 3.17.
+Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog) and in the upcoming release of Dune 3.17.
 As with all of Dune's package management features, consider this feature to be unstable as
 its UI and semantics may change without notice.
 
@@ -93,7 +93,7 @@ to OCaml's editor integration and it has a couple of quirks that are worth
 mentioning here.
 
 TL;DR: Install Dune with the install script on the [Developer Preview
-page](https://preview.dune.build/) and you'll get an [`ocamllsp` shell
+page](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog) and you'll get an [`ocamllsp` shell
 script](https://github.com/ocaml-dune/binary-distribution/blob/main/tool-wrappers/ocamllsp)
 that will install and run the correct version of `ocamllsp` for your project.
 
@@ -184,7 +184,7 @@ if it doesn't detect a Dune lockdir so the same script should work for non-Dune
 projects. Because the script is named the same as the `ocamllsp` executable,
 most editors don't require special configuration to run it. See the "Editor
 Configuration" section of the [Dune Developer
-Preview page](https://preview.dune.build/) for more information about setting up
+Preview page](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog) for more information about setting up
 your editor.
 
 

--- a/data/changelog/posts/dune-developer-preview/2025-05-19-portable-lock-directories-for-dune-package-management.md
+++ b/data/changelog/posts/dune-developer-preview/2025-05-19-portable-lock-directories-for-dune-package-management.md
@@ -6,7 +6,7 @@ tags: [dune, developer-preview]
 _Discuss this post on [Discuss](https://discuss.ocaml.org/t/portable-lock-directories-for-dune-package-management/16669)!_
 
 We've recently made a change to how lock directories work in the [Dune Developer
-Preview](https://preview.dune.build/).
+Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog).
 
 Previously when Dune would solve dependencies for a project and generate a lock
 directory, the lock directory would be specialized for the computer where it was
@@ -125,7 +125,7 @@ filename.
 ## How do I get it?
 
 This feature is live in the latest version of the [Dune Developer
-Preview](https://preview.dune.build/). Follow the instructions on that page to
+Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog). Follow the instructions on that page to
 install a version of Dune with this feature. With portable lock directories
 enabled, Dune will temporarily remain backwards compatible with the original
 lock directory format, though support will likely be dropped at some point.

--- a/data/changelog/posts/dune-developer-preview/2025-06-05-portable-external-dependencies-for-dune-package-management.md
+++ b/data/changelog/posts/dune-developer-preview/2025-06-05-portable-external-dependencies-for-dune-package-management.md
@@ -11,7 +11,7 @@ projects or their dependencies. Currently this information is not portable
 because Dune only stores the names of system packages within the package
 repository on the machine where the lock directory is generated. We've recently
 changed how Dune stores the names of system packages in the [Dune Developer
-Preview](https://preview.dune.build/) so that the names of packages in all
+Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog) so that the names of packages in all
 known package repositories are stored. This allows a lock directory generated
 on one machine to be used on a different machine.
 
@@ -231,4 +231,4 @@ be computed on demand rather than just at solve time.
 This bring us a step closer to a world where Dune users can check their lock
 directories into version control with confidence that their builds are
 reproducible across different platforms. To try out the latest version of the
-Dune Developer Preview, go to [preview.dune.build](https://preview.dune.build/).
+Dune Developer Preview, go to [preview.dune.build](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=changelog).

--- a/data/news/platform/platform-2024-12.md
+++ b/data/news/platform/platform-2024-12.md
@@ -50,7 +50,7 @@ Recent updates across the platform focus on performance and reliability. Dune op
 
 [Dune 3.17 was released](https://discuss.ocaml.org/t/ann-dune-3-17/15770) with significant improvements to package management. Key features include binary distribution support, better error messages for missing packages, and Windows support without requiring OPAM.
 
-The [Dune Developer Preview website](https://preview.dune.build) now provides editor setup instructions and package management tutorials.
+The [Dune Developer Preview website](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=news) now provides editor setup instructions and package management tutorials.
 
 Dune's package management features [were tested across hundreds of packages](https://dune.check.ci.dev/) in the opam repository, and a coverage tool was developed to track build success rates. For local development, Dune added support for building dependencies via `@pkg-install`, caching for package builds, and automated binary builds of development tools. The system supports both monorepo and polyrepo workflows, with options for installing individual dependencies or complete development environments.
 

--- a/data/news/platform/platform-2025-04.md
+++ b/data/news/platform/platform-2025-04.md
@@ -72,7 +72,7 @@ Technical barriers have been and are being systematically addressed, e.g. improv
 
 ### **Dune Developer Preview**
 
-[Dune Developer Preview](https://preview.dune.build/) is an experimental channel that introduces cutting-edge features to streamline OCaml development workflows. Building upon Dune's foundation as OCaml's official build system, this initiative allows us to iterate quickly on ideas and experiment with improving the developer experience and with experimental features. For example, one feature that came out of Dune Developer Preview and made it into the upstream codebase is package management: by enabling Dune to deal with project dependencies, we eliminate the need to juggle multiple tools.
+[Dune Developer Preview](https://preview.dune.build?utm_source=ocaml.org&utm_medium=referral&utm_campaign=news) is an experimental channel that introduces cutting-edge features to streamline OCaml development workflows. Building upon Dune's foundation as OCaml's official build system, this initiative allows us to iterate quickly on ideas and experiment with improving the developer experience and with experimental features. For example, one feature that came out of Dune Developer Preview and made it into the upstream codebase is package management: by enabling Dune to deal with project dependencies, we eliminate the need to juggle multiple tools.
 
 The tooling includes built-in LSP support, formatting capabilities, and a shared cache that dramatically improves build performance. Early adopters are encouraged to [provide feedback](https://docs.google.com/forms/u/2/d/e/1FAIpQLSda-mOTHIdATTt_e9dFmNgUCy-fD55Qzr3bGGsxpfY_Ecfyxw/viewform?usp=send_form) as these experimental features mature toward stable releases.
 


### PR DESCRIPTION
Doing this manually to get more visibility on traffic on preview.dune.build's Plausible instance. Could be automated through a middleware, if it proves useful.