### PR TITLE
Cookbook: "Start a Web Server and render HTML template" with dream and cohttp

### DIFF
--- a/data/cookbook/start-a-web-server-html-template/00-cohttp-server.ml
+++ b/data/cookbook/start-a-web-server-html-template/00-cohttp-server.ml
@@ -8,8 +8,12 @@ packages:
   tested_version: "6.1.0"
   used_libraries:
   - cohttp
+- name: "tyxml"
+  tested_version: "4.6.0"
+  used_libraries:
+  - tyxml
 discussion: |
-  This example shows how to use `cohttp-lwt-unix` to start an HTTP server and render a HTML template in OCaml
+  This example demonstrates how to build an HTTP server using `cohttp-lwt-unix` and safely render an HTML template with `Tyxml` in OCaml
 ---
 (* The server:
   - Handles any incoming request on port 8080
@@ -21,24 +25,18 @@ discussion: |
 
 open Cohttp
 open Cohttp_lwt_unix
+open Tyxml.Html
 
-let template = {|
-  <!DOCTYPE html>
-  <html lang="en">
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Template Page</title>
-    </head>
-    <body>
-      <h1>Hello World!</h1>
-    </body>
-  </html>
-|}
+let html_template =
+  html
+    (head (title (txt "Template Page")) [meta ~a:[a_charset "UTF-8"] ()])
+    (body [h1 [txt "Hello World!"]])
+
+let response_body = Format.asprintf "%a" (pp ()) html_template
 
 let () =
   let callback _conn _req _body =
-    Server.respond_string ~status:`OK ~body:template 
+    Server.respond_string ~status:`OK ~body:response_body 
       ~headers:(Header.init_with "Content-Type" "text/html") ()
   in
   let server = Server.make ~callback () in

--- a/data/cookbook/start-a-web-server-html-template/00-cohttp-server.ml
+++ b/data/cookbook/start-a-web-server-html-template/00-cohttp-server.ml
@@ -1,0 +1,48 @@
+---
+packages:
+- name: "cohttp-lwt-unix"
+  tested_version: "5.3.0"
+  used_libraries:
+  - cohttp-lwt-unix
+- name: "cohttp"
+  tested_version: "6.1.0"
+  used_libraries:
+  - cohttp
+discussion: |
+  This example shows how to use `cohttp-lwt-unix` to start an HTTP server and render a HTML template in OCaml
+---
+(* The server:
+  - Handles any incoming request on port 8080
+  - Responds with a static HTML template that displays "Hello World!"
+  - Uses Server.respond_string to return the template with headers set as html/text
+  - Uses Cohttp_lwt_unix for asynchronous operations
+  - Uses Cohttp for HTTP handling
+  *)
+
+open Cohttp
+open Cohttp_lwt_unix
+
+let template = {|
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Template Page</title>
+    </head>
+    <body>
+      <h1>Hello World!</h1>
+    </body>
+  </html>
+|}
+
+let () =
+  let callback _conn _req _body =
+    Server.respond_string ~status:`OK ~body:template 
+      ~headers:(Header.init_with "Content-Type" "text/html") ()
+  in
+  let server = Server.make ~callback () in
+  let port = 8080 in
+  let mode = `TCP (`Port port) in
+  Format.printf "listening on http://localhost:%d\n%!" port;
+  Server.create ~mode server |> Lwt_main.run

--- a/data/cookbook/start-a-web-server-html-template/01-dream-server.ml
+++ b/data/cookbook/start-a-web-server-html-template/01-dream-server.ml
@@ -35,5 +35,4 @@ let () =
   @@ Dream.logger
   @@ Dream.router [
     Dream.get "/" (fun _ -> Dream.html template);
-    Dream.any "/" (fun _ -> Dream.empty `Not_Found);
   ]

--- a/data/cookbook/start-a-web-server-html-template/01-dream-server.ml
+++ b/data/cookbook/start-a-web-server-html-template/01-dream-server.ml
@@ -1,0 +1,39 @@
+---
+packages:
+- name: "dream"
+  tested_version: "1.0.0~alpha8"
+  used_libraries:
+  - dream
+discussion: |
+  This example uses Dream, a simple and type-safe web framework for OCaml.
+  To avoid errors, the file name should end with `.eml.ml`.
+  Set the dune file following the guide here:
+  [Dream Template](https://aantron.github.io/dream/#templates)
+---
+
+(* The server:
+  - Handles any incoming request on port 8080
+  - Logs requests
+  - Responds with a static HTML template that displays "Hello World!"
+  - Returns 404 error for other routes *)
+
+let template =
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Template Page</title>
+    </head>
+    <body>
+      <h1>Hello World!</h1>
+    </body>
+  </html>
+
+let () =
+  Dream.run
+  @@ Dream.logger
+  @@ Dream.router [
+    Dream.get "/" (fun _ -> Dream.html template);
+    Dream.any "/" (fun _ -> Dream.empty `Not_Found);
+  ]


### PR DESCRIPTION
Cookbook for - [Start a Web Server That Serves an HTML Template](https://ocaml.org/cookbook/start-a-web-server-html-template)

- Dream 
- Cohttp 