### PR TITLE
(data) clarify difference between utop prompt and commands

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -162,7 +162,7 @@ You're now in an OCaml toplevel, and you can start typing OCaml expressions. For
 
 **Congratulations**! You've installed OCaml! 🎉
 
-Exit UTop by typing `#quit;;` or pressing `Ctrl+D`.
+Exit UTop by typing `#quit;;` (the `#` here is not the prompt, you have to type it) or pressing `Ctrl+D`.
 
 ## Join the Community
 


### PR DESCRIPTION
I've witnessed a beginner confuse the `utop` prompt (`#`) and the prefix for utop commands (like `#quit`). This adds a small clarification that this prefix really has to be typed and is not part of the prompt.