### PR TITLE
Prevent changelog scrape to create GA errors

### DIFF
--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -280,9 +280,7 @@ module Scraper = struct
   module SSet = Set.Make (String)
 
   let warn fmt =
-    let flush out =
-      Printf.fprintf out "\n%!";
-    in
+    let flush out = Printf.fprintf out "\n%!" in
     Printf.kfprintf flush stderr fmt
 
   let fetch_github repo =

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -279,12 +279,9 @@ module Scraper = struct
   module SMap = Map.Make (String)
   module SSet = Set.Make (String)
 
-  let warning_count = ref 0
-
   let warn fmt =
     let flush out =
       Printf.fprintf out "\n%!";
-      incr warning_count
     in
     Printf.kfprintf flush stderr fmt
 
@@ -322,6 +319,5 @@ module Scraper = struct
   (** This does not generate any file. Instead, it exits with an error if a
       changelog entry is missing. *)
   let scrape_platform_releases () =
-    Releases.all () |> group_releases_by_project |> SMap.iter check_if_uptodate;
-    if !warning_count > 0 then exit 1
+    Releases.all () |> group_releases_by_project |> SMap.iter check_if_uptodate
 end

--- a/tool/ood-gen/lib/changelog.ml
+++ b/tool/ood-gen/lib/changelog.ml
@@ -316,8 +316,7 @@ module Scraper = struct
            %!"
           project
 
-  (** This does not generate any file. Instead, it exits with an error if a
-      changelog entry is missing. *)
+  (** This does not generate any file. *)
   let scrape_platform_releases () =
     Releases.all () |> group_releases_by_project |> SMap.iter check_if_uptodate
 end


### PR DESCRIPTION
#2949 is creating GA errors. See: https://github.com/ocaml/ocaml.org/actions/workflows/scrape_changelog.yml
