### PR TITLE
changelog: add github_release_tags on alpha/beta releases

### DIFF
--- a/data/changelog/releases/ocaml/2024-09-20-ocaml-5.3.0.alpha1.md
+++ b/data/changelog/releases/ocaml/2024-09-20-ocaml-5.3.0.alpha1.md
@@ -2,6 +2,8 @@
 title: OCaml 5.3.0 - First Alpha
 tags: [ocaml]
 unstable: true
+github_release_tags:
+- 5.3.0-alpha1
 ---
 
 Four months after the release of OCaml 5.2.0, the set of new features for the

--- a/data/changelog/releases/ocaml/2024-10-31-ocaml-5.3.0.beta1.md
+++ b/data/changelog/releases/ocaml/2024-10-31-ocaml-5.3.0.beta1.md
@@ -2,6 +2,8 @@
 title: OCaml 5.3.0 - First Beta
 tags: [ocaml]
 unstable: true
+github_release_tags:
+- 5.3.0-beta1
 changelog: |
   ### Runtime fixes
   

--- a/data/changelog/releases/ocaml/2024-11-07-ocaml-5.2.1-rc1.md
+++ b/data/changelog/releases/ocaml/2024-11-07-ocaml-5.2.1-rc1.md
@@ -2,6 +2,8 @@
 title: OCaml 5.2.1 - Release Candidate
 tags: [ocaml]
 unstable: true
+github_release_tags:
+- 5.2.1-rc1
 changelog: |
   ## Changes Since OCaml 5.2.0
   ### Runtime System:

--- a/data/changelog/releases/ocaml/2024-11-28-ocaml-5.3.0-beta2.md
+++ b/data/changelog/releases/ocaml/2024-11-28-ocaml-5.3.0-beta2.md
@@ -2,6 +2,8 @@
 title: OCaml 5.3.0 - Second Beta
 tags: [ocaml]
 unstable: true
+github_release_tags:
+- 5.3.0-beta2
 changelog: |
   # Changes Since The First Beta
   ## Type system fixes

--- a/data/changelog/releases/ocaml/2024-12-19-ocaml-5.3.0-rc1.md
+++ b/data/changelog/releases/ocaml/2024-12-19-ocaml-5.3.0-rc1.md
@@ -2,6 +2,8 @@
 title: OCaml 5.3.0 - First Release Candidate
 tags: [ocaml]
 unstable: true
+github_release_tags:
+- 5.3.0-rc1
 changelog: |
   ## Changes since the second beta
   

--- a/data/changelog/releases/ocp-indent/2019-09-18-ocp-indent-1.8.0.md
+++ b/data/changelog/releases/ocp-indent/2019-09-18-ocp-indent-1.8.0.md
@@ -1,6 +1,8 @@
 ---
 title: Ocp-indent 1.8.0
 tags: [ocp-indent, platform]
+github_release_tags:
+- 1.8.0
 changelog: |
   * compatibility with OCaml 4.08.0 (new attributes, monadic lets...)
   * lots of smaller indentation fixes (module types, empty variants...)

--- a/data/changelog/releases/ocp-indent/2019-10-24-ocp-indent-1.8.1.md
+++ b/data/changelog/releases/ocp-indent/2019-10-24-ocp-indent-1.8.1.md
@@ -1,6 +1,8 @@
 ---
 title: Ocp-indent 1.8.1
 tags: [ocp-indent, platform]
+github_release_tags:
+- 1.8.1
 changelog: |
   * tiny API change to help with the detection of top-level phrase boundaries
   * fixed a bug with end of comment detection in some cases (esp. related to cinaps)

--- a/data/changelog/releases/opam/2024-10-15-opam-2-3-0-beta1.md
+++ b/data/changelog/releases/opam/2024-10-15-opam-2-3-0-beta1.md
@@ -6,6 +6,8 @@ authors: [
   "David Allsopp",
 ]
 unstable: true
+github_release_tags:
+- 2.3.0-beta1
 tags: [opam, platform]
 ---
 

--- a/data/changelog/releases/opam/2024-10-24-opam-2-3-0-beta2.md
+++ b/data/changelog/releases/opam/2024-10-24-opam-2-3-0-beta2.md
@@ -6,6 +6,8 @@ authors: [
   "David Allsopp",
 ]
 unstable: true
+github_release_tags:
+- 2.3.0-beta2
 tags: [opam, platform]
 ---
 

--- a/data/changelog/releases/opam/2024-10-30-opam-2-3-0-rc1.md
+++ b/data/changelog/releases/opam/2024-10-30-opam-2-3-0-rc1.md
@@ -6,6 +6,8 @@ authors: [
   "David Allsopp",
 ]
 unstable: true
+github_release_tags:
+- 2.3.0-rc1
 tags: [opam, platform]
 ---
 

--- a/data/changelog/releases/ppxlib/2023-02-14-ppxlib-0.29.1.md
+++ b/data/changelog/releases/ppxlib/2023-02-14-ppxlib-0.29.1.md
@@ -1,6 +1,8 @@
 ---
 title: Ppxlib 0.29.1
 tags: [ppxlib]
+github_release_tags:
+- 0.29.1
 changelog: |
   - Allow users to vendor `ppxlib` as-is, as well as `ppx_sexp_conv` in the same project (#386, @kit-ty-kate)
 ---

--- a/data/changelog/releases/ppxlib/2023-06-20-ppxlib-0.30.0.md
+++ b/data/changelog/releases/ppxlib/2023-06-20-ppxlib-0.30.0.md
@@ -1,6 +1,8 @@
 ---
 title: Ppxlib 0.30.0
 tags: [ppxlib]
+github_release_tags:
+- 0.30.0
 changelog: |
   * Adopt the OCaml Code of Conduct on the repo ([ocaml-ppx/ppxlib#426](https://github.com/ocaml-ppx/ppxlib/pull/426), @pitag-ha)
   * Clean up misleading attribute hints when declared for proper context. ([ocaml-ppx/ppxlib#425](https://github.com/ocaml-ppx/ppxlib/pull/425), @ceastlund)


### PR DESCRIPTION
Add github_release_tags on alpha/beta releases to ensure GitHub Actions OCaml Platform releases scraper workflow recognizes these releases