### PR TITLE
Update planet-sources.yml

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -247,3 +247,7 @@
   name: Tim McGilchrist
   url: https://lambdafoo.com/rss.xml
   publish_all: false
+- id: aguluman
+  name: Chukwuma Akunyili
+  url: https://fearful-odds.rocks/feed.xml
+  publish_all: false


### PR DESCRIPTION
This pull request adds a new OCaml-focused blog source to the `data/planet-sources.yml` file.

New blog source added:

* Added Chukwuma Akunyili's blog (`aguluman`) with its RSS feed to the OCaml-only sources list.
* Added RSS feed from blog posts and journal entries at https://fearful-odds.rocks