### PR TITLE
changelog: release dune.3.20.0

### DIFF
--- a/data/changelog/releases/dune/2025-08-21-dune-3.20.0.md
+++ b/data/changelog/releases/dune/2025-08-21-dune-3.20.0.md
@@ -1,0 +1,95 @@
+---
+title: Dune 3.20.0
+tags:
+- dune
+- platform
+authors:
+contributors:
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- 3.20.0
+changelog: |
+    ### Fixed
+
+    - Stop re-running cram tests after promotion when it's not necessary (#11994,
+      @rgrinberg)
+
+    - fix: `$ dune subst` should not fail when adding the version field in opam
+      files (#11801, fixes #11045, @btjorge)
+
+    - Kill all processes in the process group after the main process has
+      terminated; in particular this avoids background processes in cram tests to
+      stick around after the test finished (#11841, fixes #11820, @Alizter,
+      @Leonidas-from-XIV)
+
+    ### Added
+
+    - `(tests)` stanzas now generate aliases with the test name. To run
+      `(test (name a))` you can do `dune build @runtest-a`. (#11558, grants part of #10239,
+      @Alizter)
+
+    - Inline test libraries now produce aliases `runtest-name_of_lib`
+      allowing users to run specific inline tests as `dune build
+      @runtest-name_of_lib`. (#11109, partially fixes #10239, @Alizter)
+
+    - feature: `$ dune subst` use version from `dune-project` when no version
+      control repository has been detected (#11801, @btjorge)
+
+    - Allow `dune exec` to run concurrently with another instance of dune in watch
+      mode (#11840, @gridbugs)
+
+    - Introduce `%{os}`, `%{os_version}`, `%{os_distribution}`, and `%{os_family}`
+      percent forms. These have the same values as their opam counterparts.
+      (#11863, @rgrinberg)
+
+    - Introduce option `(implicit_transitive_deps false-if-hidden-includes-supported)`
+      that is equivalent to `(implicit_transitive_deps false)` when `-H` is
+      supported by the compiler (OCaml >= 5.2) and equivalent to
+      `(implicit_transitive_deps true)` otherwise. (#11866, fixes #11212, @nojb)
+
+    - Add `dune describe location` for printing the path to the executable that
+      would be run (#11905, @gridbugs)
+
+    - `dune runtest` can now understand absolute paths as well as run tests in
+      specific build contexts (#11936, @Alizter).
+
+    - Added 'empty' alias which contains no targets. (#11556 #11952 #11955 #11956,
+      grants #4161, @Alizter and @rgrinberg)
+
+    - Allow `dune promote` to properly run while a watch mode server is running
+      (#12010, @ElectreAAS)
+
+    - Add `--alias` and `--alias-rec` flags as an alternative to the `@@` and `@`
+      syntax in the command line (#12043, fixes #5775, @rgrinberg)
+
+    - Added a `(timeout <float>)` field to the `(cram)` stanza to specify per-test
+      time limits. Tests exceeding the timeout are terminated with an error.
+      (#12041, @Alizter)
+
+    ### Changed
+
+    - Format long lists in s-expressions to fill the line instead of
+      formatting them in a vertical way (#10892, fixes #10860, @nojb)
+
+    - Switch from MD5 to BLAKE3 for digesting targets and rules. BLAKE3 is both more
+      performant and difficult to break than MD5 (#11735, @rgrinberg, @Alizter)
+
+    - Print a warning when `dune build` runs over RPC (#11833, @gridbugs)
+
+    - Stop emitting empty module group wrapper `.js` file in `melange.emit`
+      (#11987, fixes #11986, @anmonteiro)
+---
+
+The Dune Team is happy to announce the release of Dune `3.20.0`.
+
+This release contains some important bug fixes. It contains new features for
+tests, such as the possibility to use an alias and the possibility to declare a
+timeout for cram tests. This release also provides new possibilities for the
+watch mode, like the ability to run an executable or promote files while the
+watch mode is running.
+
+A significant change in this release is how the dune file formatter
+acts. It will now try to fill the line instead of using the vertical format.
+


### PR DESCRIPTION
This PR adds the changelog for the already released `dune.3.20.0`.
