### PR TITLE
Cleanup Blog Syndication

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -1,6 +1,7 @@
 - id: practicalocaml
   name: Practical OCaml
   url: https://practicalocaml.com/rss/
+  disabled: true
 - id: ocamlpro
   name: OCamlPro
   url: https://ocamlpro.com/blog/feed
@@ -213,6 +214,7 @@
   name: Debajyati's Blog
   url: https://debajyatidey.hashnode.dev/rss.xml
   publish_all: false
+  disabled: true
 - id: bbatsov
   name: Bozhidar Batsov
   url: https://batsov.com/feeds/OCaml.xml
@@ -242,4 +244,3 @@
   name: Tim McGilchrist
   url: https://lambdafoo.com/rss.xml
   publish_all: false
-

--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -10,9 +10,11 @@
 - id: tarides
   name: Tarides
   url: https://tarides.com/feed.xml
+  publish_all: false
 - id: janestreet
   name: Jane Street Tech Blog
   url: https://blog.janestreet.com/feed.xml
+  publish_all: false
 - id: hannes
   name: Hannes Mehnert
   url: https://hannes.robur.coop/atom
@@ -22,6 +24,7 @@
 - id: andrej
   name: Andrej Bauer
   url: http://math.andrej.com/feed.xml
+  publish_all: false
 - id: ujamjar
   name: Andy Ray
   url: http://www.ujamjar.com/ocaml.xml
@@ -40,12 +43,14 @@
 - id: coq
   name: Coq
   url: https://coq.inria.fr/rss.xml
+  publish_all: false
 - id: cburnout
   name: Cranial Burnout
   url: http://www.blogger.com/feeds/9108979482982930820/posts/default/-/OCaml
 - id: erratique
   name: Daniel Bünzli
   url: https://erratique.ch/feeds/news.atom
+  publish_all: false
 - id: dbaelde
   name: David Baelde
   url: http://www.blogger.com/feeds/17133288/posts/default/-/ocaml
@@ -55,12 +60,14 @@
 - id: mega-nerd
   name: Erik de Castro Lopo
   url: http://www.mega-nerd.com/erikd/Blog/index.rss20
+  publish_all: false
 - id: emillon
   name: Etienne Millon
   url: http://blog.emillon.org/feeds/ocaml.xml
 - id: frama-c
   name: Frama-C
   url: http://frama-c.com/rss.xml
+  publish_all: false
 - id: gallium
   name: GaGallium
   url: http://gallium.inria.fr/blog/index.rss
@@ -78,33 +85,39 @@
 - id: hongboz
   name: Hong bo Zhang
   url: https://hongboz.wordpress.com/feed/
+  publish_all: false
 - id: ambassadortothecomputers
   name: Jake Donham
   url: http://ambassadortothecomputers.blogspot.com/feeds/posts/default?alt=rss
+  publish_all: false
 - id: kcsrk
   name: KC Sivaramakrishnan
   url: https://kcsrk.info/atom-ocaml.xml
 - id: lpw25
   name: Leo White
   url: http://lpw25.net/rss.xml
+  publish_all: false
 - id: skjegstad
   name: Magnus Skjegstad
   url: http://www.skjegstad.com/feeds/ocaml.tag.atom.xml
 - id: 0branch
   name: Marc Simpson
   url: https://blog.0branch.com/rss.xml
+  publish_all: false
 - id: syntaxexclamation
   name: Matthias Puech
   url: https://syntaxexclamation.wordpress.com/tag/ocaml/feed/
 - id: mgiovannini
   name: Matías Giovannini
   url: http://www.blogger.com/feeds/5888658295182480819/posts/default
+  publish_all: false
 - id: mlin
   name: Mike Lin
   url: http://www.blogger.com/feeds/3693082774051755513/posts/default/-/OCaml
 - id: mcclurmc
   name: Mike McClurg
   url: https://mcclurmc.wordpress.com/feed/
+  publish_all: false
 - id: mirage
   name: MirageOS
   url: https://mirage.io/feed.xml
@@ -135,6 +148,7 @@
 - id: rgrinberg
   name: Rudi Grinberg
   url: http://rgrinberg.com/blog/atom.xml
+  publish_all: false
 - id: smondet
   name: Sebastien Mondet
   url: https://seb.mondet.org/b/OCaml.rss
@@ -150,6 +164,7 @@
 - id: tvaroquaux
   name: Till Varoquaux
   url: http://www.blogger.com/feeds/6115529230232389198/posts/default
+  publish_all: false
 - id: yansnotes
   name: Yan Shvartzshnaider
   url: http://yansnotes.blogspot.com/feeds/posts/default/-/ocaml
@@ -165,19 +180,21 @@
 - id: bap
   name: The BAP Blog
   url: https://binaryanalysisplatform.github.io/feed.xml
+  publish_all: false
 - id: baturin
   name: Daniil Baturin
   url: https://baturin.org/blog/atom-ocaml.xml
 - id: signalsandthreads
   name: Signals and Threads
   url: https://feeds.simplecast.com/L9810DOa
+  publish_all: false
 - id: robur.coop
   name: Robur Cooperative
   url: https://blog.robur.coop/feed.xml
-  only_ocaml: false
 - id: dinosaure
   name: Romain Calascibetta
   url: https://blog.osau.re/feed.xml
+  publish_all: false
 - id: emilpriver
   name: Emil Privér
   url: https://priver.dev/tags/ocaml/index.xml
@@ -187,41 +204,42 @@
 - id: chshersh
   name: Dmitrii Kovanikov
   url: https://chshersh.com/atom.xml
+  publish_all: false
 - id: lthms
   name: "Thomas Letan’s Blog"
   url: https://soap.coffee/~lthms/posts/index.xml
-  only_ocaml: true
+  publish_all: false
 - id: debajyatidey
   name: Debajyati's Blog
   url: https://debajyatidey.hashnode.dev/rss.xml
-  only_ocaml: true
+  publish_all: false
 - id: bbatsov
   name: Bozhidar Batsov
   url: https://batsov.com/feeds/OCaml.xml
-  only_ocaml: true
 - id: jonludlam
   name: Jon Ludlam's Blog at recoil.org
   url: https://jon.recoil.org/atom.xml
+  publish_all: false
 - id: patricoferris
   name: Patrick Ferris' OCaml Blog
   url: https://patrick.sirref.org/ocaml-blog/atom.xml
 - id: dra27
   name: David Allsopp's Blog
   url: https://www.dra27.uk/feed.xml
+  publish_all: false
 - id: anil
   name: Anil Madhavapeddy's Blog
   url: https://anil.recoil.org/news.xml
-  only_ocaml: true
+  publish_all: false
 - id: xvw
   name: "Xavier Van de Woestyne's Blog"
   url: https://xvw.lol/tags/en/ocaml.xml
-  only_ocaml: true
 - id: yawaramin
   name: Yawar Amin
   url: https://dev.to/feed/yawaramin
-  only_ocaml: true
+  publish_all: false
 - id: tsmc
   name: Tim McGilchrist
   url: https://lambdafoo.com/rss.xml
-  only_ocaml: true
+  publish_all: false
 

--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -35,6 +35,7 @@
 - id: cameleon
   name: Cameleon news
   url: http://www.blogger.com/feeds/7617521785419311079/posts/default
+  publish_all: false
 - id: inria
   name: Caml INRIA
   url: http://caml.inria.fr/news.en.rss
@@ -70,8 +71,9 @@
   url: http://frama-c.com/rss.xml
   publish_all: false
 - id: gallium
-  name: GaGallium
+  name: Gagallium
   url: http://gallium.inria.fr/blog/index.rss
+  publish_all: false
 - id: gaius
   name: Gaius Hammond
   url: https://gaius.tech/category/ocaml/feed/
@@ -143,6 +145,7 @@
 - id: psellos
   name: Psellos
   url: http://psellos.com/atom.xml
+  publish_all: false
 - id: rjones
   name: Richard Jones
   url: https://rwmj.wordpress.com/tag/ocaml/feed/

--- a/data/video-youtube.yml
+++ b/data/video-youtube.yml
@@ -19,6 +19,62 @@
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
   source_title: Jane Street - Tech Talks
+- title: WAYBAR
+  url: https://www.youtube.com/watch/fGhkRiUsTpc?version=3
+  thumbnail: https://i3.ytimg.com/vi/fGhkRiUsTpc/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-05-08T19:38:16+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: I Tried Golf.Vim
+  url: https://www.youtube.com/watch/AoMfifC6QyI?version=3
+  thumbnail: https://i2.ytimg.com/vi/AoMfifC6QyI/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-05-07T15:00:30+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: HEAVY ARCH RICING Part 2
+  url: https://www.youtube.com/watch/J4xU2rOMh3I?version=3
+  thumbnail: https://i3.ytimg.com/vi/J4xU2rOMh3I/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-05-07T04:12:22+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: Ricing Arch Part 1
+  url: https://www.youtube.com/watch/UzUu77RZGSE?version=3
+  thumbnail: https://i2.ytimg.com/vi/UzUu77RZGSE/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-05-05T23:18:54+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
 - title: Making OCaml Safe for Performance Engineering
   url: https://www.youtube.com/watch/g3qd4zpm1LA?version=3
   thumbnail: https://i4.ytimg.com/vi/g3qd4zpm1LA/hqdefault.jpg
@@ -40,6 +96,95 @@
     problems that they help us solve, and the place in the design space of programming
     languages that this leaves us in.\n\nRead the full transcript here: https://www.janestreet.com/tech-talks/making-ocaml-safe-for-performance-engineering/"
   published: 2025-04-03T20:44:20+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: Building A Copilot Like AutoComplete!!
+  url: https://www.youtube.com/watch/GuRiTCX-rT0?version=3
+  thumbnail: https://i4.ytimg.com/vi/GuRiTCX-rT0/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-02-08T17:06:37+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: Nuking A Twitter Community
+  url: https://www.youtube.com/watch/ZWLljD4iwpM?version=3
+  thumbnail: https://i3.ytimg.com/vi/ZWLljD4iwpM/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-01-21T20:00:02+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: how can he be so good?
+  url: https://www.youtube.com/watch/yfIgOMb2jmU?version=3
+  thumbnail: https://i2.ytimg.com/vi/yfIgOMb2jmU/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-01-18T16:00:57+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: I Got Interviewed By An AI
+  url: https://www.youtube.com/watch/9MXlwBi5gLk?version=3
+  thumbnail: https://i2.ytimg.com/vi/9MXlwBi5gLk/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-01-17T14:05:51+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: Building A Project With Devin
+  url: https://www.youtube.com/watch/ZmrHcA5xPT8?version=3
+  thumbnail: https://i3.ytimg.com/vi/ZmrHcA5xPT8/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2025-01-16T23:54:28+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: Building Machine Learning Systems for a Trillion Trillion Floating Point
+    Operations
+  url: https://www.youtube.com/watch/139UPjoq7Kw?version=3
+  thumbnail: https://i2.ytimg.com/vi/139UPjoq7Kw/hqdefault.jpg
+  description: "Over the last 10 years we've seen Machine Learning consume everything,
+    from the tech industry to the Nobel Prize, and yes, even the ML acronym. This
+    rise in ML has also come along with an unprecedented buildout of infra, with Llama
+    3 now reaching 4e25 floating point operations, or 40 yottaflops, or 40 trillion
+    trillion floating point operations.\n\nTo build these ML models, you need ML systems,
+    like PyTorch. In this talk, Horace will (attempt to) answer: \n- How have ML systems
+    evolved over time to meet the training needs of ML models? How does building ML
+    systems differ from regular systems?\n- How do we get the most out of a single
+    GPU? What's the point of compilers if we're just training a single model?\n- And
+    what is the right way to think about scaling to 10s of thousands of GPUs?"
+  published: 2024-12-09T15:32:10+00:00
   author_name: Jane Street
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
@@ -487,6 +632,64 @@
   author_uri: https://www.youtube.com/channel/UC3TI-fmhJ_g3_n9fHaXGZKA
   source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UC3TI-fmhJ_g3_n9fHaXGZKA
   source_title: FUN OCaml
+- title: 'System Jitter and Where to Find It: A Whack-a-Mole Experience'
+  url: https://www.youtube.com/watch/I_TtMk5z0O0?version=3
+  thumbnail: https://i2.ytimg.com/vi/I_TtMk5z0O0/hqdefault.jpg
+  description: "In this Tech Talk, Tudor Brindus, a software engineer at Jane Street,
+    shares his expertise on reducing jitter\u2014deviations from mean input processing
+    times\u2014in low-latency systems. Maintaining consistently low jitter in a trading
+    system allows us to offer tighter markets without incurring additional risk. Using
+    a simple memory ping-pong application as a case study, Tudor will walk through
+    how to identify and resolve common sources of jitter caused by both Linux kernel
+    and microarchitectural conditions."
+  published: 2024-11-15T17:31:27+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: 'uv: An Extremely Fast Python Package Manager'
+  url: https://www.youtube.com/watch/gSKTfG1GXYQ?version=3
+  thumbnail: https://i4.ytimg.com/vi/gSKTfG1GXYQ/hqdefault.jpg
+  description: 'Charlie Marsh is the founder of Astral, which develops uv, a next-generation
+    Python package manager written in Rust. In this talk, Charlie details the unique
+    challenges of the Python packaging ecosystem and how he made uv so fast: allocators,
+    concurrency, zero-copy tricks, and more.
+
+
+    You can find the transcript for this video and other Tech Talks here: https://www.janestreet.com/tech-talks/index.html'
+  published: 2024-10-23T20:57:51+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: ASMR Golang Boxed Jades
+  url: https://www.youtube.com/watch/mLAg5dTF-E4?version=3
+  thumbnail: https://i2.ytimg.com/vi/mLAg5dTF-E4/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2024-10-04T16:32:55+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: i fell for mocks again...
+  url: https://www.youtube.com/watch/rhUwOBg4TyM?version=3
+  thumbnail: https://i3.ytimg.com/vi/rhUwOBg4TyM/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2024-10-02T13:39:42+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
 - title: How to Use OCaml's Coercion Operator
   url: https://www.youtube.com/watch/HNLSyxN-rPE?version=3
   thumbnail: https://i1.ytimg.com/vi/HNLSyxN-rPE/hqdefault.jpg
@@ -500,6 +703,48 @@
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJrgFrWRKn0-1EI3gVZLQJtJ
   source_title: Jane Street - OCaml Unboxed
+- title: why am i building this?
+  url: https://www.youtube.com/watch/qpu_iOGYC-g?version=3
+  thumbnail: https://i2.ytimg.com/vi/qpu_iOGYC-g/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2024-09-30T19:45:26+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: if you dont like it, make your own
+  url: https://www.youtube.com/watch/-sPYTEt49nw?version=3
+  thumbnail: https://i2.ytimg.com/vi/-sPYTEt49nw/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2024-09-26T00:53:44+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
+- title: The Greatest Vim Website
+  url: https://www.youtube.com/watch/eRxo3kER5is?version=3
+  thumbnail: https://i2.ytimg.com/vi/eRxo3kER5is/hqdefault.jpg
+  description: "LIVE ON TWITCH: https://twitch.tv/ThePrimeagen\n\nBecome a backend
+    engineer.  Its my favorite site\nhttps://boot.dev/?promo=PRIMEYT\n\nThis is also
+    the best way to support me is to support yourself becoming a better backend engineer.
+    \ \n\nGet in on Discord: https://discord.gg/ThePrimeagen\n\nGet in on Twitter:
+    https://twitter.com/ThePrimeagen\n\n### Got Something For Me to Read or Watch??:
+    \nhttps://www.reddit.com/r/ThePrimeagenReact/"
+  published: 2024-09-21T14:00:39+00:00
+  author_name: TheVimeagen
+  author_uri: https://www.youtube.com/channel/UCVk4b-svNJoeytrrlOixebQ
+  source_link: https://www.youtube.com/feeds/videos.xml?channel_id=UCVk4b-svNJoeytrrlOixebQ
+  source_title: The Vimeagen
 - title: OCaml's New Proposed "include functor" Syntax | OCaml Unboxed
   url: https://www.youtube.com/watch/SWURUDr_i3w?version=3
   thumbnail: https://i4.ytimg.com/vi/SWURUDr_i3w/hqdefault.jpg
@@ -2781,6 +3026,19 @@
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
   source_title: Jane Street - Signal & Threads
+- title: More Signals & Threads coming soon!
+  url: https://www.youtube.com/watch/KAg9DYqAThw?version=3
+  thumbnail: https://i4.ytimg.com/vi/KAg9DYqAThw/hqdefault.jpg
+  description: "Signals & Threads is back, and we have a fun season of topics lined
+    up, including: Building better abstractions for design and user interfaces, the
+    role of writing in a technical organization, the approach that different languages
+    take to memory management\u2026and more. We hope you\u2019ll join us. The first
+    episode drops September 1st."
+  published: 2021-08-25T16:54:57+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
+  source_title: Jane Street - Signal & Threads
 - title: Let Definitions | OCaml Programming | Chapter 2 Video 4
   url: https://www.youtube.com/watch/eRnG4gwOTlI
   thumbnail: https://i2.ytimg.com/vi/eRnG4gwOTlI/hqdefault.jpg
@@ -3129,6 +3387,24 @@
   author_uri: https://www.youtube.com/channel/UCX3XfA9qjWjymue2I_hcW1A
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLre5AT9JnKShBOPeuiD9b-I4XROIJhkIU
   source_title: 'OCaml Programming: Correct + Efficient + Beautiful'
+- title: "An Inside Look at Jane Street\u2019s Tech Internship with Jeanne Van Briesen,
+    Matt Else, and Grace Zhang"
+  url: https://www.youtube.com/watch/V06-rpAllKg?version=3
+  thumbnail: https://i3.ytimg.com/vi/V06-rpAllKg/hqdefault.jpg
+  description: 'In this week''s episode, the season 1 finale, Ron speaks with Jeanne,
+    Matt, and Grace, three former tech interns at Jane Street who have returned as
+    full-timers. They talk about the experience of being an intern at Jane Street,
+    the types of projects that interns work on, and how they''ve found the transition
+    to full-time work.
+
+
+    You can find the transcript for this episode along with links to things we discussed
+    at signalsandthreads.com.'
+  published: 2020-11-06T16:51:47+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
+  source_title: Jane Street - Signal & Threads
 - title: Building a Functional Email Server with Dominick LoBraico
   url: https://www.youtube.com/watch/cM6mRLvFw54
   thumbnail: https://i4.ytimg.com/vi/cM6mRLvFw54/hqdefault.jpg
@@ -3199,6 +3475,22 @@
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
   source_title: Jane Street - Signal & Threads
+- title: Clock Synchronization with Chris Perl
+  url: https://www.youtube.com/watch/p1CewOuvKmg?version=3
+  thumbnail: https://i1.ytimg.com/vi/p1CewOuvKmg/hqdefault.jpg
+  description: "Clock synchronization, keeping all of the clocks on your network set
+    to the \u201Ccorrect\u201D time, sounds straightforward: our smartphones sure
+    don\u2019t seem to have trouble with it. Next, keep them all accurate to within
+    100 microseconds, and prove that you did -- now things start to get tricky. In
+    this episode, Ron talks with Chris Perl, a systems engineer at Jane Street about
+    the fundamental difficulty of solving this problem at scale and how we solved
+    it.\n\nYou can find the transcript for this podcast episode along with links to
+    things we discussed at signalsandthreads.com."
+  published: 2020-10-14T16:29:51+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
+  source_title: Jane Street - Signal & Threads
 - title: Python, OCaml, and Machine Learning with Laurent Mazare
   url: https://www.youtube.com/watch/d4SoT7rP28k
   thumbnail: https://i1.ytimg.com/vi/d4SoT7rP28k/hqdefault.jpg
@@ -3233,6 +3525,59 @@
     You can find the transcript for this podcast episode along with links to things
     we discussed at signalsandthreads.com.'
   published: 2020-10-07T15:45:03+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
+  source_title: Jane Street - Signal & Threads
+- title: Compiler Optimization with Greta Yorsh
+  url: https://www.youtube.com/watch/UZhjIYwwObE?version=3
+  thumbnail: https://i2.ytimg.com/vi/UZhjIYwwObE/hqdefault.jpg
+  description: "It\u2019s a software engineer\u2019s dream: A compiler that can take
+    idiomatic high-level code and output maximally efficient instructions. Ron\u2019s
+    guest this week is Greta Yorsh, who has worked on just that problem in a career
+    spanning both industry and academia. Ron and Greta talk about some  of the tricks
+    that compilers use to make our software faster, ranging from feedback-directed
+    optimization and super-optimization to formal analysis. \n\nYou can find the transcript
+    for this episode along with links to things we discussed at signalsandthreads.com."
+  published: 2020-09-30T17:51:11+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
+  source_title: Jane Street - Signal & Threads
+- title: Multicast and the Markets with Brian Nigito
+  url: https://www.youtube.com/watch/triyiLwqWUI?version=3
+  thumbnail: https://i1.ytimg.com/vi/triyiLwqWUI/hqdefault.jpg
+  description: 'Electronic exchanges like Nasdaq need to handle a staggering number
+    of transactions every second. To keep up, they rely on two deceptively simple-sounding
+    concepts: single-threaded programs and multicast networking. In this episode,
+    Ron speaks with Brian Nigito, a 20-year industry veteran who helped build some
+    of the earliest electronic exchanges, about the tradeoffs that led to the architecture
+    we have today, and how modern exchanges use these straightforward building blocks
+    to achieve blindingly fast performance at scale.
+
+
+    You can find the transcript for this episode along with links to things we discussed
+    at signalsandthreads.com.'
+  published: 2020-09-23T19:37:42+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
+  source_title: Jane Street - Signal & Threads
+- title: Build Systems with Andrey Mokhov
+  url: https://www.youtube.com/watch/V9YA32uV3Ls?version=3
+  thumbnail: https://i3.ytimg.com/vi/V9YA32uV3Ls/hqdefault.jpg
+  description: "Most software engineers only think about their build system when it
+    breaks; and yet, this often unloved piece of software forms the backbone of every
+    serious project. This week, Ron has a conversation with Andrey Mokhov about build
+    systems, from the venerable Make to Bazel and beyond. Andrey has a lot of experience
+    in this field, including significant contributions to the replacement for the
+    Glasgow Haskell Compiler\u2019s Make-based system and Build Systems \xE0 la carte,
+    a paper that untangles the complex ecosystem of existing build systems. Ron and
+    Andrey muse on questions like why every language community seems to have its own
+    purpose-built system and, closer to home, where Andrey and the rest of the build
+    systems team at Jane Street are focusing their efforts.\n\nYou can find the transcript
+    for this episode along with links to related work at signalsandthreads.com."
+  published: 2020-09-17T20:09:29+00:00
   author_name: Jane Street
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
@@ -3279,6 +3624,85 @@
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
   source_title: Jane Street - Signal & Threads
+- title: A Taste of GPU Compute
+  url: https://www.youtube.com/watch/eqkAaplKBc4?version=3
+  thumbnail: https://i2.ytimg.com/vi/eqkAaplKBc4/hqdefault.jpg
+  description: "Presented by: Raph Levien\n\nThe GPU in a modern computer (desktop
+    or mobile) has about an order of magnitude more raw general purpose computing
+    throughput than the CPU, but is barely used except for games, machine learning,
+    and cryptocurrency mining, largely because it\u2019s hard to program. Getting
+    good performance entails massive parallelism (thousands of threads) and careful
+    attention to an explicit memory hierarchy. While GPU compute programming may seem
+    to many like a black art, techniques from functional programming, including immutable
+    data structures and an emphasis on associative operations (monoids) adapt very
+    well to this space. This talk will present techniques used in piet-metal, a new
+    2D graphics rendering engine optimized for the modern GPU compute, and hopefully
+    will serve as an invitation for the curious to explore this strange but powerful
+    computing environment.\n\nRaph Levien is currently an independent researcher exploring
+    2D graphics, font technology, and GUI, doing most of his work in Rust. Previously
+    he was at Google for 11 years, including on the Android UI toolkit team, mostly
+    working on fonts and text, and before that was the maintainer of Ghostscript.
+    He has a PhD in Computer Science from UC Berkeley, on the topic of curve design
+    tools."
+  published: 2020-04-15T17:03:28+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: The Algorithm for Precision Medicine
+  url: https://www.youtube.com/watch/Rt3XyeFHvt4?version=3
+  thumbnail: https://i3.ytimg.com/vi/Rt3XyeFHvt4/hqdefault.jpg
+  description: "Presented by: Matt Might\n\nPrecision medicine promises to deliver
+    ultra-personalized care by casting medicine as an optimization problem: identifying
+    the best possible treatment with respect to all available data.\n\nA slew of recent
+    advances in biology, starting with the ability to sequence the human genome, have
+    caused an explosion in the amount of data one can collect on a single patient
+    and a similar explosion in the complexity of reasoning about this data in order
+    to solve this optimization problem. Computational support for the practicing physician
+    is no longer an option.\n\nThis talk covers precision medicine from the ground
+    up for computer scientists \u2014 through a personal journey from programming
+    languages research into academic medicine.  It will demonstrate progress to date,
+    including the now-routine use of relational programming in miniKanren to identify
+    personalized treatments for patients with some of the rarest and most challenging
+    diseases in the world."
+  published: 2020-02-18T17:22:52+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: 'State of the Shell: PowerShell7'
+  url: https://www.youtube.com/watch/2gJgL8a0YGA?version=3
+  thumbnail: https://i3.ytimg.com/vi/2gJgL8a0YGA/hqdefault.jpg
+  description: Steve Lee from Microsoft discusses the Powershell roadmap, what's new
+    in Powershell 7, and the differences it has from Windows Powershell.
+  published: 2020-01-31T16:54:01+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: Dude, Where Are My Files? Reverse Engineering Ransomware
+  url: https://www.youtube.com/watch/gjCKKLuDoP8?version=3
+  thumbnail: https://i4.ytimg.com/vi/gjCKKLuDoP8/hqdefault.jpg
+  description: "Presented by: Michael Sikorski\n\nJoin Michael Sikorski, author of
+    \"Practical Malware Analysis\", as he introduces you to malware analysis and reverse
+    engineering by dissecting Ransomware. Mike will review some of the most famous
+    ransomware attacks in recent memory such as WannaCry and Petya. In multiple demonstrations,
+    he\u2019ll show exactly how to reverse engineer malware using real-world samples.\n\nMichael
+    Sikorski is an expert in reverse engineering and malware analysis. He is the Senior
+    Director and Founder of the FireEye Labs Advanced Reverse Engineering (FLARE)
+    Team. Mike provides oversight to research projects and manages the analysis process
+    used by the team. He created a series of courses in malware analysis and teaches
+    them to a variety of audiences including the FBI, NSA, and Black Hat. Mike is
+    the co-author of the book \"Practical Malware Analysis,\" which is published by
+    No Starch Press. He came to FireEye through its acquisition of Mandiant, where
+    he worked for seven years. Prior to Mandiant, he worked for MIT Lincoln Laboratory
+    and the National Security Agency. Mike is also an Adjunct Assistant Professor
+    at Columbia University's Department of Computer Science."
+  published: 2019-12-09T19:17:08+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
 - title: Unboxed Types for OCaml
   url: https://www.youtube.com/watch/RV-4Xddk0Yc
   thumbnail: https://i3.ytimg.com/vi/RV-4Xddk0Yc/hqdefault.jpg
@@ -3377,6 +3801,129 @@
     Laurent holds a PhD in theoretical computer science from Institut National Polytechnique
     de Grenoble.'
   published: 2019-08-13T18:00:45+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: '13 Years in a Shell: Lessons, Practices, and Achievements in PowerShell'
+  url: https://www.youtube.com/watch/_RbsYJxONww?version=3
+  thumbnail: https://i4.ytimg.com/vi/_RbsYJxONww/hqdefault.jpg
+  description: "Do something for long enough and you\u2019re bound to make a lot of
+    the mistakes that can be made. If you can learn from those, and share them with
+    others, then you\u2019re on the right path. So that\u2019s what this session is
+    about: the technical best practices and lessons Don\u2019s learned in 13 years
+    of working with PowerShell, his observations on making DevOps \u201Cactually work\u201D
+    in business environments, and his own personal life lessons and career achievements
+    that have come along the way. You\u2019ll learn the write way to design a PowerShell
+    advanced function, what a truly functional DevOps team actually looks like, and
+    the biggest \u201Cunlocks\u201D Don\u2019s cobbled together in over two decades
+    in the IT industry. In-person attendees will also get a free collection of Don\u2019s
+    most popular ebooks.\n\n\u2014\n\nDon Jones is the co-founder of The DevOps Collective,
+    which runs PowerShell.org, PowerShell + DevOps Global Summit, and provides technology
+    education funding to underprivileged and underrepresented individuals throughout
+    the US. Don has been a Microsoft MVP Award recipient for 15 years, and has worked
+    with PowerShell since before its launch in 2006. PowerShell\u2019s inventor, Jeffrey
+    Snover, named Don the \u201CFirst Follower\u201D of PowerShell. Today, Don is
+    a Vice President in the Content organization at Pluralsight, the technology skills
+    platform. Over his 25-year career, Don has authored literally dozens of IT books,
+    including the first-published book on PowerShell and the bestselling Learn Windows
+    PowerShell in a Month of Lunches. Don\u2019s current projects include fiction
+    and other genre novels, and can be found at http://leanpub.com/u/donjones. Don
+    also posts regularly to his site, DonJones.com, and holds occasional workshops
+    around Be the Master, his book on achieving success and helping others do the
+    same (BeTheMaster.com)."
+  published: 2019-06-27T19:50:17+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: 'Safe at Any Speed: Building a Performant, Safe, Maintainable Packet Processor'
+  url: https://www.youtube.com/watch/BysBMdx9w6k?version=3
+  thumbnail: https://i3.ytimg.com/vi/BysBMdx9w6k/hqdefault.jpg
+  description: "Presented by: Sebastian Funk\n\nAt Jane Street, we\u2019ve been building
+    systems to trade electronically for over a decade. As technology advances and
+    the scale of the markets grows, we need our systems to be able to process ever
+    growing amounts of data in ever shorter time windows.\n\nIn this talk, we explore
+    how to build a highly optimized single-core packet processing system that is capable
+    of processing millions of messages per second. We see how to bridge the gap between
+    the high-level abstractions we\u2019ve come to love when structuring code, and
+    efficient machine-level execution necessary to process messages at line-rate."
+  published: 2019-05-08T19:56:09+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: A Language-Oriented System Design
+  url: https://www.youtube.com/watch/5ZjmjdErEC0?version=3
+  thumbnail: https://i2.ytimg.com/vi/5ZjmjdErEC0/hqdefault.jpg
+  description: 'This talk explores the design of Ontology, a permissions management
+    service developed at Jane Street. The design of the system is language-oriented
+    in two different ways:
+
+
+    Internally, the state of the system is represented as a sequence of declarations
+    in a dependently-typed language lifted straight out of type theory. This language
+    is the unifying principle behind a deductive database, its query language, and
+    the representation of requested state changes that together form the core of the
+    system.
+
+
+    Externally, in the user interface for the system, the internal language is hidden
+    everywhere, having been rendered in natural language (English). Because of this
+    rendering strategy, key elements of the user interface are at once structure-editors
+    for the internal language as well as natural language forms that allow even technically
+    unsophisticated users to construct permissions requests and queries.
+
+
+    Presented by: Nathan Linger
+
+    Nathan has been a developer at Jane Street since 2008, working on a variety of
+    software projects. He holds a PhD in Computer Science from Portland State University.'
+  published: 2019-03-08T23:00:40+00:00
+  author_name: Jane Street
+  author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
+  source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
+  source_title: Jane Street - Tech Talks
+- title: Abstractions for Expressive, Efficient Parallel and Distributed Computing
+  url: https://www.youtube.com/watch/4h7YBUXiCZE?version=3
+  thumbnail: https://i1.ytimg.com/vi/4h7YBUXiCZE/hqdefault.jpg
+  description: 'Presented by: Lindsey Kuper
+
+    Parallel and distributed systems are notoriously difficult to build correctly
+    or efficiently. In parallel systems, the manipulation of shared state can cause
+    unintended behavior in the presence of unpredictable task scheduling, while in
+    distributed systems, the manipulation of replicated state can cause unintended
+    behavior in the presence of an unreliable network. Meanwhile, decades of research
+    have not yet produced a general solution to the problem of automatic program parallelization.
+
+
+    In this talk, I discuss how my research addresses these challenges from both theoretical
+    and applied points of view. My work on lattice-based data structures, or LVars,
+    proposes new foundations for expressive deterministic-by-construction parallel
+    and distributed programming models. My work on non-invasive domain-specific languages
+    for parallelism gives programmers language-based tools for safe, deterministic
+    parallelization. The guiding principle and goal of both of these lines of work
+    is to find the right high-level abstractions to express computation in a way that
+    not only does not compromise efficiency, but actually enables it. I conclude by
+    discussing the role that this principle of finding the right efficiency-enabling
+    abstractions can play in my ongoing investigation into SMT-based verification
+    of neural networks.
+
+
+
+    Lindsey Kuper
+
+    Lindsey Kuper (https://users.soe.ucsc.edu/~lkuper/) is an Assistant Professor
+    of Computer Science and Engineering at the University of California, Santa Cruz,
+    where she works on language-based approaches to building software systems that
+    are correct and efficient. She holds a Ph.D. in computer science from Indiana
+    University and a BA in computer science and music from Grinnell College. Prior
+    to joining UC Santa Cruz, she was a Research Scientist in the Parallel Computing
+    Lab at Intel Labs. During her Ph.D. years, she contributed to the Rust programming
+    language at Mozilla Research, served several residencies at the Recurse Center,
+    and co-founded !!Con (http://bangbangcon.com), the annual conference of ten-minute
+    talks about the joy, excitement, and surprise of computing.'
+  published: 2019-02-11T16:51:52+00:00
   author_name: Jane Street
   author_uri: https://www.youtube.com/channel/UCDsVC_ewpcEW_AQcO-H-RDQ
   source_link: https://www.youtube.com/feeds/videos.xml?playlist_id=PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs

--- a/data/youtube.yml
+++ b/data/youtube.yml
@@ -1,21 +1,21 @@
 - name: Jane Street - Tech Talks
   kind: playlist
   id: PLCiAikFFaMJoWyXnJ2BWpse5HuiYibNYs
-  only_ocaml: true
+  publish_all: true
 - name: Jane Street - OCaml Unboxed
   kind: playlist
   id: PLCiAikFFaMJrgFrWRKn0-1EI3gVZLQJtJ
 - name: Jane Street - Signal & Threads
   kind: playlist
   id: PLCiAikFFaMJouorRXDSfS2UoKV4BfKyQm
-  only_ocaml: true
+  publish_all: true
 - name: Emelle TV
   kind: channel
   id: UCvVVfCa7-nzSuCdMKXnNJNQ
 - name: The Vimeagen
   kind: channel
   id: UCVk4b-svNJoeytrrlOixebQ
-  only_ocaml: true
+  publish_all: true
 - name: FUN OCaml
   kind: channel
   id: UC3TI-fmhJ_g3_n9fHaXGZKA

--- a/src/ocamlorg_data/data_intf.ml
+++ b/src/ocamlorg_data/data_intf.ml
@@ -48,7 +48,7 @@ module Blog = struct
     name : string;
     url : string;
     description : string;
-    only_ocaml : bool;
+    publish_all : bool;
     disabled : bool;
   }
 

--- a/tool/ood-gen/lib/blog.ml
+++ b/tool/ood-gen/lib/blog.ml
@@ -150,7 +150,7 @@ module Scraper = struct
     let slug = Utils.slugify title in
     let source_path = "data/planet/" ^ source.Data_intf.Blog.id in
     print_string
-      (Printf.sprintf "\nprocesing %s/%s " source.Data_intf.Blog.id slug);
+      (Printf.sprintf "\nprocessing %s/%s " source.Data_intf.Blog.id slug);
     let output_file = source_path ^ "/" ^ slug ^ ".md" in
     if not (Sys.file_exists output_file) then
       let url = River.link post in

--- a/tool/ood-gen/lib/blog.ml
+++ b/tool/ood-gen/lib/blog.ml
@@ -10,7 +10,7 @@ module Source = struct
     id : string;
     name : string;
     url : string;
-    only_ocaml : bool option;
+    publish_all : bool option;
     disabled : bool option;
   }
   [@@deriving yaml]
@@ -27,13 +27,13 @@ module Source = struct
       in
       Ok
         (sources
-        |> List.map (fun { id; name; url; only_ocaml; disabled } ->
+        |> List.map (fun { id; name; url; publish_all; disabled } ->
                {
                  Data_intf.Blog.id;
                  name;
                  url;
                  description = "";
-                 only_ocaml = Option.value ~default:true only_ocaml;
+                 publish_all = Option.value ~default:true publish_all;
                  disabled = Option.value ~default:false disabled;
                }))
     in
@@ -79,7 +79,7 @@ module Post = struct
                       name;
                       url;
                       description = "";
-                      only_ocaml = false;
+                      publish_all = true;
                       disabled = false;
                     }
                 | None ->
@@ -162,7 +162,7 @@ module Scraper = struct
           if not (Sys.file_exists source_path) then Sys.mkdir source_path 0o775;
           let content = River.content post in
           if
-            (not source.only_ocaml)
+            source.publish_all
             || String.(
                  is_sub_ignore_case "caml" content
                  || is_sub_ignore_case "caml" title)

--- a/tool/ood-gen/lib/youtube.ml
+++ b/tool/ood-gen/lib/youtube.ml
@@ -31,18 +31,18 @@ type source_metadata = {
   name : string;
   kind : kind;
   id : string;
-  only_ocaml : bool option;
+  publish_all : bool option;
 }
 [@@deriving of_yaml]
 
-type source = { name : string; kind : kind; id : string; only_ocaml : bool }
-[@@deriving stable_record ~version:source_metadata ~modify:[ only_ocaml ]]
+type source = { name : string; kind : kind; id : string; publish_all : bool }
+[@@deriving stable_record ~version:source_metadata ~modify:[ publish_all ]]
 
 let source_of_yaml x =
   x |> source_metadata_of_yaml
   |> Result.map
        (source_of_source_metadata
-          ~modify_only_ocaml:(Option.value ~default:false))
+          ~modify_publish_all:(Option.value ~default:false))
 
 type source_list = source list [@@deriving of_yaml]
 
@@ -179,7 +179,7 @@ let scrape yaml_file =
            |> walk_mrss
            |> Seq.unfold (feed_entry src [])
            |> Seq.filter (fun video ->
-                  (not src.only_ocaml)
+                  (not src.publish_all)
                   || String.(
                        is_sub_ignore_case "caml" video.Vid.title
                        || is_sub_ignore_case "caml" video.Vid.description)))

--- a/tool/ood-gen/lib/youtube.ml
+++ b/tool/ood-gen/lib/youtube.ml
@@ -42,7 +42,7 @@ let source_of_yaml x =
   x |> source_metadata_of_yaml
   |> Result.map
        (source_of_source_metadata
-          ~modify_publish_all:(Option.value ~default:false))
+          ~modify_publish_all:(Option.value ~default:true))
 
 type source_list = source list [@@deriving of_yaml]
 
@@ -179,7 +179,7 @@ let scrape yaml_file =
            |> walk_mrss
            |> Seq.unfold (feed_entry src [])
            |> Seq.filter (fun video ->
-                  (not src.publish_all)
+                  src.publish_all
                   || String.(
                        is_sub_ignore_case "caml" video.Vid.title
                        || is_sub_ignore_case "caml" video.Vid.description)))


### PR DESCRIPTION
Rename the filter, now `publish_all, ' meaning all posts from the feed will be published.

Make publish_all default to true.

Fix data/planet-source.yml
* Specify publish_all when set to false
* Do not specify publish_all when the name or the URL contains "caml"
* Disable some always error feeds

