### PR TITLE
changelog: release Dune 3.20.1

### DIFF
--- a/data/changelog/releases/dune/2025-08-26-dune.3.20.1.md
+++ b/data/changelog/releases/dune/2025-08-26-dune.3.20.1.md
@@ -1,0 +1,32 @@
+---
+title: Dune 3.20.1
+tags:
+  - dune
+  - platform
+authors:
+contributors:
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+  - 3.20.1
+changelog: |
+  ### Fixed
+
+  - Fix `runtest-js` mistakenly depending on `byte` (fixes #12243, #12242,
+    @vouillon and @Alizter)
+
+  - Fix the interpretation of paths in `dune runtest` when running from within a
+    subdirectory. (#12251, fixes #12250, @Alizter)
+
+  ### Changed
+
+  - Revert formatting change introduced in 3.20.0 making long lists in
+    s-expressions fill the line instead of formatting them in a vertical way
+    (#12245, reverts #10892, @nojb)
+---
+
+The Dune Team is happy to announce the release of Dune `3.20.1`.
+
+This release introduces some minor fixes and reverts the dune file formatter
+change.


### PR DESCRIPTION
This PR adds the `3.20.1` `dune` changelog.
