### PR TITLE
Add opam env instructions for nushell

### DIFF
--- a/data/tutorials/getting-started/3_01_ocaml_on_windows.md
+++ b/data/tutorials/getting-started/3_01_ocaml_on_windows.md
@@ -87,6 +87,12 @@ On PowerShell:
 > (& opam env --switch=default) -split '\\r?\\n' | ForEach-Object { Invoke-Expression $_ }
 ```
 
+On [Nushell](https://www.nushell.sh/):
+
+```
+> opam env --shell=powershell | parse "$env:{key} = '{val}'" | transpose -rd | load-env
+```
+
 Opam will display the shell update command each time it is needed.
 
 You can verify your installation with


### PR DESCRIPTION
The powershell syntax is pretty close to what nushell wants. It'd be cool if `opam env` natively supported nushell but this is not too bad in the mean time.

I added this to the Windows page since I think it's one of the only shells Windows users are likely to be using other than cmd, Powershell, and Bash (which is trivial).