### PR TITLE
feat: add docs for neovim setup

### DIFF
--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -175,29 +175,30 @@ vim.lsp.config['ocamllsp'] = {
 vim.lsp.enable 'ocamllsp'
 ```
 
-You can also use `vim.lsp` with a modular config.
+See `:h lsp-config` for more detail on configuration options.
 
-Assume that your config has the following structure. The internal structure of `lua` does not matter much.
-```text
-.
-├── init.lua
-└── lua
-    ├── custom
-    │   └── plugins
-    │       └── some-plugin.lua
-    └── kickstart
-        ├── health.lua
-        └── plugins
-            └── some-plugin.lua
-```
+#### Modular Config With Runtimepath
 
-Then run the following at the root of your config.
+You can also use `vim.lsp` with a modular config via `runtimepath`. Putting your config table inside `lsp/<some_name>.lua` or `after/lsp/<some_name>.lua` will allow Neovim to search for them automatically.
+
+See `:h runtimepath` for more detail.
+
+Run the following at the root of your config.
 ```text
 mkdir lsp
 touch lsp/ocamllsp.lua
 ```
 
-We now add our LSP configs to `lsp/ocamllsp.lua`...
+Your Neovim config should have the following structure now.
+```text
+.
+├── init.lua
+├── lsp
+│   └── ocamllsp.lua
+└── ...
+```
+
+Add your LSP config to `lsp/ocamllsp.lua`.
 ```lua
 return {
   cmd = { 'ocamllsp' },
@@ -207,7 +208,7 @@ return {
 }
 ```
 
-...and import them in the toplevel `init.lua`.
+Then enable them in the toplevel `init.lua`.
 ```lua
 vim.lsp.enable 'ocamllsp'
 ```
@@ -226,4 +227,6 @@ Add this to your `nvim-lspconfig` setup.
   end,
 },
 ```
+
+There is no need to pass more settings to `setup` because `nvim-lspconfig` provides reasonable defaults. See [here](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ocamllsp.lua) for more info.
 

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -167,8 +167,19 @@ Add this to your toplevel `init.lua`.
 ```lua
 vim.lsp.config['ocamllsp'] = {
   cmd = { 'ocamllsp' },
-  filetypes = { 'ocaml', 'ocaml.interface', 'ocaml.menhir', 'reason' },
-  root_markers = { { 'dune-project', 'dune-workspace' }, '.git' },
+  filetypes = { 
+    'ocaml',
+    'ocaml.interface',
+    'ocaml.menhir',
+    'ocaml.ocamllex',
+    'dune',
+    'reason'
+  },
+  root_markers = {
+    { 'dune-project', 'dune-workspace' },
+    { "*.opam", "esy.json", "package.json" },
+    '.git'
+  },
   settings = {},
 }
 
@@ -202,8 +213,19 @@ Add your LSP config to `lsp/ocamllsp.lua`.
 ```lua
 return {
   cmd = { 'ocamllsp' },
-  filetypes = { 'ocaml', 'ocaml.interface', 'ocaml.menhir', 'reason' },
-  root_markers = { { 'dune-project', 'dune-workspace' }, '.git' },
+  filetypes = { 
+    'ocaml',
+    'ocaml.interface',
+    'ocaml.menhir',
+    'ocaml.ocamllex',
+    'dune',
+    'reason'
+  },
+  root_markers = {
+    { 'dune-project', 'dune-workspace' },
+    { "*.opam", "esy.json", "package.json" },
+    '.git'
+  },
   settings = {},
 }
 ```

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -177,9 +177,9 @@ vim.lsp.enable 'ocamllsp'
 
 See `:h lsp-config` for more detail on configuration options.
 
-#### Modular Config With Runtimepath
+#### Using vim.lsp With runtimepath
 
-You can also use `vim.lsp` with a modular config via `runtimepath`. Putting your config table inside `lsp/<some_name>.lua` or `after/lsp/<some_name>.lua` will allow Neovim to search for them automatically.
+You can also move your LSP config to a separate file via `runtimepath` if you'd like to keep your `init.lua` minimal. Putting your config table inside `lsp/<some_name>.lua` or `after/lsp/<some_name>.lua` will allow Neovim to search for them automatically.
 
 See `:h runtimepath` for more detail.
 

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -158,33 +158,13 @@ opam install ocaml-lsp-server ocamlformat
 ```
 
 There are two main ways to install and manage LSP servers.
-- A more traditional way is to use `nvim-lspconfig`, which is a package used for this purpose. For more info, `kickstart.nvim` has a great example setup.
-- A newer way is to use the new Neovim LSP API for versions newer than v0.11.0 via `vim.lsp`.
+- A newer, more recommended way is to use the new Neovim LSP API for versions newer than v0.11.0 via `vim.lsp`.
+- A more traditional way is to use `nvim-lspconfig`. For more info, `kickstart.nvim` has a great example setup.
 
-Using the Lazy package manager with `nvim-lspconfig`:
+### Using vim.lsp:
+
+Add this to your toplevel `init.lua`.
 ```lua
-require('lazy').setup({
-  -- other packages...
-  {
-    'neovim/nvim-lspconfig',
-    config = function()
-      vim.api.nvim_create_autocmd('LspAttach', {
-        -- your keybindings here...
-      })
-
-      -- this part may contain your existing LSP setup that play along nicely with Mason...
-
-      -- add this line specifically for OCaml
-      require('lspconfig').ocamllsp.setup {}
-    end,
-  },
-  -- other packages...
-})
-```
-
-Using `vim.lsp`:
-```lua
--- add this to your toplevel init.lua
 vim.lsp.config['ocamllsp'] = {
   cmd = { 'ocamllsp' },
   filetypes = { 'ocaml', 'ocaml.interface', 'ocaml.menhir', 'reason' },
@@ -211,29 +191,39 @@ Assume that your config has the following structure. The internal structure of `
             └── some-plugin.lua
 ```
 
-Then run the following.
+Then run the following at the root of your config.
 ```text
-cd lua
 mkdir lsp
-touch lsp/init.lua
-touch lsp/servers.lua
+touch lsp/ocamllsp.lua
 ```
 
-We now add our LSP configs to `lsp/servers.lua`, export them from `lsp/init.lua`, and import them in the toplevel `init.lua`.
+We now add our LSP configs to `lsp/ocamllsp.lua`...
 ```lua
--- path/to/config/lua/lsp/servers.lua
-vim.lsp.config['ocamllsp'] = {
+return {
   cmd = { 'ocamllsp' },
   filetypes = { 'ocaml', 'ocaml.interface', 'ocaml.menhir', 'reason' },
   root_markers = { { 'dune-project', 'dune-workspace' }, '.git' },
   settings = {},
 }
-
-vim.lsp.enable 'ocamllsp'
-
--- path/to/config/lua/lsp/init.lua
-require("lsp.servers")
-
--- path/to/config/init.lua
-require("lsp")
 ```
+
+...and import them in the toplevel `init.lua`.
+```lua
+vim.lsp.enable 'ocamllsp'
+```
+
+### Using nvim-lspconfig
+
+Add this to your `nvim-lspconfig` setup.
+```lua
+{
+  'neovim/nvim-lspconfig',
+  config = function()
+    -- rest of config...
+
+    -- add this line specifically for OCaml
+    require('lspconfig').ocamllsp.setup {}
+  end,
+},
+```
+


### PR DESCRIPTION
Closes #3319 .

Added docs for setting up the LSP server on Neovim.

Add docs for using `nvim-lspconfig` and `vim.lsp`. Both methods are frequently used, and it's a good idea to add instructions for `nvim-lspconfig` because `vim.lsp` only supports Neovim versions 0.11 and above.