### PR TITLE
Changelog: add release announcement for opam-publish 2.6.0

### DIFF
--- a/data/platform_tools_releases/opam-publish/2025-09-19-opam-publish-2.6.0.md
+++ b/data/platform_tools_releases/opam-publish/2025-09-19-opam-publish-2.6.0.md
@@ -1,0 +1,28 @@
+---
+title: 2.6.0
+tags:
+- opam-publish
+- platform
+authors:
+- kit-ty-kate
+contributors:
+changelog: |
+ * Add a new --token argument (also accessible through the OPAM_PUBLISH_GH_TOKEN environment variable) which accepts GitHub tokens to simplify non-interactive usages \[[#174](https://github.com/ocaml-opam/opam-publish/pull/174) [@filipeom](https://github.com/filipeom)\]
+ * Add a message after the PR is open, to notify users that they can re-run opam-publish to update the PR \[[#172](https://github.com/ocaml-opam/opam-publish/pull/172) [@punchagan](https://github.com/punchagan)\]
+ * Remove the use of the deprecated github.unix in favour of github-unix (added in ocaml-github 3.1.0) \[[@kit-ty-kate](https://github.com/kit-ty-kate)\]
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- 2.6.0
+---
+
+We're pleased to announce the release of `opam-publish` 2.6.0! This update brings improvements for automation and better user experience.
+
+## What's New
+
+**Enhanced automation support**: A new `--token` argument (also available via the `OPAM_PUBLISH_GH_TOKEN` environment variable) now accepts GitHub tokens, making it easier to use opam-publish in CI/CD pipelines and other non-interactive environments.
+
+**Re-run to update existing PR**: After opening a pull request, opam-publish now displays a helpful message letting you know that you can re-run the command to update your existing PR. This addresses a common workflow issue where package authors would close PRs and open new ones, often unaware that opam-publish can update existing PRs.
+
+Thanks to @filipeom and @punchagan for their contributions to this release!

--- a/data/platform_tools_releases/opam-publish/2025-09-19-opam-publish-2.6.0.md
+++ b/data/platform_tools_releases/opam-publish/2025-09-19-opam-publish-2.6.0.md
@@ -1,5 +1,5 @@
 ---
-title: 2.6.0
+title: Opam-publish 2.6.0
 tags:
 - opam-publish
 - platform

--- a/data/platform_tools_releases/opam-publish/2025-10-06-opam-publish-2.7.0.md
+++ b/data/platform_tools_releases/opam-publish/2025-10-06-opam-publish-2.7.0.md
@@ -1,0 +1,44 @@
+---
+title: Opam-publish 2.7.0
+tags:
+- opam-publish
+- platform
+authors:
+- kit-ty-kate
+contributors:
+changelog: |
+    *   Use a token to push commits instead of SSH keys \[[#175](https://github.com/ocaml-opam/opam-publish/pull/175) [@filipeom](https://github.com/filipeom)\]
+    *   Switch from lwt\_ssl to tls-lwt which avoid one dependency \[[#176](https://github.com/ocaml-opam/opam-publish/pull/176) [@kit-ty-kate](https://github.com/kit-ty-kate)\]
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- 2.7.0
+---
+
+We are pleased to announce the release of `opam-publish` 2.7.0!
+
+This release builds on the automation improvements introduced in version 2.6.0, making it even easier to publish your OCaml packages automatically in CI/CD environments.
+
+## Enhanced Token-Based Authentication
+
+Building on the `--token` argument and `OPAM_PUBLISH_GH_TOKEN` environment variable introduced in 2.6.0, this release takes automation further with improvements by [@filipeom](https://github.com/filipeom):
+
+- **Token-based pushing**: SSH keys are no longer required for pushing branches to your fork—the GitHub token now handles everything, eliminating the need to manage SSH credentials in CI environments. This closes two long-standing feature requests (#109 and #170) for better non-interactive and CI support.
+- **Automatic git configuration**: If `user.name` and `user.email` aren't set in your git config, they'll be automatically populated with your GitHub username and a default email address as a fallback
+
+These token-based features work alongside the traditional SSH-based authentication, so you can choose whichever method works best for your workflow. For CI/CD pipelines, the token-based approach is significantly simpler.
+
+Check out [this example CI workflow](https://github.com/formalsec/smtml/commit/3c98cc024583e69b87c6d63a233abff149471399) and the [automated publish script](https://github.com/formalsec/smtml/blob/3c98cc024583e69b87c6d63a233abff149471399/scripts/publish.sh) to see the complete automated setup in action, including the use of `--no-confirmation` and `--no-browser` flags for fully automated publishing.
+
+## Additional Improvements
+
+- **Dependency improvements**: Switched from `lwt_ssl` to `tls-lwt`, moving from a C binding to libssl to a pure OCaml implementation of TLS. This reduces dependencies by eliminating the `conf-libssl` opam dependency and its associated depext, which can be problematic on some platforms.
+
+As a reminder from 2.6.0, opam-publish also displays a helpful message after opening a pull request, letting you know you can re-run the tool to update the same PR rather than opening a new one—addressing a common workflow issue where package authors would unnecessarily close and recreate PRs.
+
+---
+
+Happy publishing!
+
+The opam team 🐫


### PR DESCRIPTION
@kit-ty-kate would that work as an announcement for `opam-publish.2.6.0` for the OCaml Changelog?

I saw there was no release announcement on Discuss I could copy from. Maybe we want to post this on Discuss as well?

Feel free to update / change as needed, or just give me a thumbs up for publication. :heart: 