### PR TITLE
Changelog: add ocp-indent 1.9.0

### DIFF
--- a/data/changelog/releases/ocp-indent/2025-10-01-ocp-indent-1.9.0.md
+++ b/data/changelog/releases/ocp-indent/2025-10-01-ocp-indent-1.9.0.md
@@ -1,0 +1,46 @@
+---
+title: ocp-indent 1.9.0
+tags:
+- ocp-indent
+- platform
+authors:
+- NathanReb
+contributors:
+changelog: |
+    CHANGES:
+
+    *   Fix detection of let vs letin after a struct ([#324](https://github.com/OCamlPro/ocp-indent/pull/324), [@Julow](https://github.com/Julow))
+    *   Treat `|>` as a monadic operator ([#322](https://github.com/OCamlPro/ocp-indent/pull/322), [@nberth](https://github.com/nberth))
+    *   Prevent Args out of range error in ocp-indent-buffer ([#327](https://github.com/OCamlPro/ocp-indent/pull/327), [@bcc32](https://github.com/bcc32))
+    *   Fix "Missing ‘lexical-binding’ cookie" warning in Emacs ([#329](https://github.com/OCamlPro/ocp-indent/pull/329), [@nojb](https://github.com/nojb))
+    *   Fix a bug where ocp-indent translate LF to CRLF when run on Windows instead  
+        of preserving the input's newlines. ([#334](https://github.com/OCamlPro/ocp-indent/pull/334), [@nojb](https://github.com/nojb))
+    *   Add `ocp-indent-gen-rules` to support `dune fmt` like workflow with ocp-indent  
+        ([#333](https://github.com/OCamlPro/ocp-indent/pull/333), [@NathanReb](https://github.com/NathanReb))
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- 1.9.0
+---
+
+You can comment on [this announcement on the OCaml discuss forums](https://discuss.ocaml.org/t/ann-ocp-indent-1-9-0/17349).
+
+Here at OCamlPro we’re happy to announce the (long awaited) release of ocp-indent.1.9.0.
+
+The full release notes are available here if you want the detailed version.
+
+1.9.0 contains mostly bug fixes, better and more consistent indentation of fun _ -> and |>, compatibility with cmdliner.1.3.0 and above (it works with 2.0.0) and a new utility tool: ocp-indent-gen-rules for those of you who would like to try ocp-indent in a dune fmt like workflow.
+
+This last bit is documented here. This is a feature that some of us wanted internally at OCamlPro so we decided to ship it with the tool as an experiment. We’d really like to hear if this fits your ocp-indent usage so please don’t hesitate to try it out and give us some feedback.
+
+We’re also interested in hearing how you use ocp-indent in general and what you expect from it. Reach out if you have any request!
+
+We’ve also updated the repo to fit the more recent development standards. We migrated the test suite to dune cram tests and re-enabled them in opam.
+Hopefully this should make contributing to ocp-indent a smoother experience!
+
+Also be aware that we’ll do our best to maintain ocp-indent more actively from now on.
+
+We’d like to thank our external contributors for this release: [@dbuenzli](https://github.com/dbuenzli), [@nojb](https://github.com/nojb), [@bcc32](https://github.com/bcc32) and [@Julow](https://github.com/Julow).
+
+Happy indenting!


### PR DESCRIPTION
@NathanReb Adding the announcement for ocp-indent 1.9.0 that has been made on Discuss, to the OCaml Changelog