### PR TITLE
Changelog: add merlin 5.6-503 5.6-504 and ocaml-lsp 1.23.1 1.24.0

### DIFF
--- a/data/changelog/releases/merlin/2025-10-04-merlin-v5.6-503-and-504.md
+++ b/data/changelog/releases/merlin/2025-10-04-merlin-v5.6-503-and-504.md
@@ -1,0 +1,53 @@
+---
+title: Merlin 5.6-503 and 5.6-504
+tags:
+- merlin
+- platform
+authors:
+- voodoos
+contributors:
+changelog: |
+    ## CHANGES:
+
+    *   merlin binary
+        *   Add `locate-types` command ([#1951](https://github.com/ocaml/merlin/pull/1951))
+    *   merlin library
+        *   Fix `merlin_reader` for OpenBSD ([#1956](https://github.com/ocaml/merlin/pull/1956))
+        *   Improve recovery of mutually recursive definitions ([#1962](https://github.com/ocaml/merlin/pull/1962), [#1963](https://github.com/ocaml/merlin/pull/1963), fixes [#1953](https://github.com/ocaml/merlin/issues/1953))
+        *   Support for OCaml 5.4 ([#1974](https://github.com/ocaml/merlin/pull/1974))
+    *   vim plugin
+        *   Fix error when `:MerlinOccurrencesProjectWide` fails to gather code previews ([#1970](https://github.com/ocaml/merlin/pull/1970))
+        *   Add more short-paths tests cases ([#1904](https://github.com/ocaml/merlin/pull/1904))
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- v5.6-503
+- v5.6-504
+---
+
+Merlin 5.6 is now available with support for OCaml 5.4, a new type navigation command, and several bug fixes!
+
+### Key Changes
+
+**New `locate-types` command**
+
+The new `locate-types` command returns all locatable type identifiers in an expression as a tree structure. Unlike `locate-type`, which only handles simple type constructors and ignores type arguments, `locate-types` works on complex types like `(int, Foo.t) result`. You can now navigate to `int`, `Foo.t`, or `result` individually. This enables better "Go to Type Definition" functionality in editors that support it.
+
+**OCaml 5.4 support**
+
+This release supports OCaml 5.4.
+
+**Improved error recovery**
+
+Type checking now handles mutually recursive definitions better when they contain errors, providing more useful feedback during development.
+
+**OpenBSD support**
+
+Fixed `merlin_reader` to work correctly on OpenBSD.
+
+**Vim plugin fix**
+
+`:MerlinOccurrencesProjectWide` no longer errors when it can't gather code previews.
+
+See the [GitHub repository](https://github.com/ocaml/merlin) and the related [announcement on the Discuss forums](https://discuss.ocaml.org/t/ann-new-releases-of-merlin-5-6-and-ocaml-lsp-1-24-0/) for more details.

--- a/data/changelog/releases/ocaml-lsp/2025-10-03-ocaml-lsp-1.23.1.md
+++ b/data/changelog/releases/ocaml-lsp/2025-10-03-ocaml-lsp-1.23.1.md
@@ -1,0 +1,32 @@
+---
+title: OCaml-LSP 1.23.1
+tags:
+- ocaml-lsp
+- platform
+authors:
+- voodoos
+contributors:
+changelog: |
+    ## Fixes
+
+    *   Fix hover on method calls not showing the type. ([#1553](https://github.com/ocaml/ocaml-lsp/pull/1553), fixes [#1552](https://github.com/ocaml/ocaml-lsp/issues/1552))
+    *   Fix error on opening `.mll` files ([#1557](https://github.com/ocaml/ocaml-lsp/pull/1557))
+    *   Ensure compatibility with both yojson 2.0 and 3.0. ([#1534](https://github.com/ocaml/ocaml-lsp/pull/1534))
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- 1.23.1
+---
+
+We're happy to announce the release of `ocaml-lsp-server` 1.23.1!
+
+This maintenance release fixes three key issues:
+
+- **Method hover now works**: Hovering over object method calls now correctly displays type information instead of showing "No information available"
+- **OCamllex files open without errors**: Fixed an error that occurred when opening `.mll` (OCamllex lexer) files in editors like NeoVim
+- **Yojson compatibility**: Ensures the language server works with both yojson 2.0 and 3.0
+
+Update via opam: `opam update && opam upgrade ocaml-lsp-server`
+
+For more details, see the related [announcement on the Discuss forums](https://discuss.ocaml.org/t/ann-new-releases-of-merlin-5-6-and-ocaml-lsp-1-24-0/)!

--- a/data/changelog/releases/ocaml-lsp/2025-10-04-ocaml-lsp-1.24.0.md
+++ b/data/changelog/releases/ocaml-lsp/2025-10-04-ocaml-lsp-1.24.0.md
@@ -1,0 +1,22 @@
+---
+title: OCaml-LSP 1.24.0
+tags:
+- ocaml-lsp
+- platform
+authors:
+- voodoos
+contributors:
+changelog: |
+    ## Features
+
+    *   Support for OCaml 5.4 ([#1559](https://github.com/ocaml/ocaml-lsp/pull/1559))
+versions:
+unstable: false
+ignore: false
+github_release_tags:
+- 1.24.0
+---
+
+We're happy to announce the release of ocaml-lsp-server `1.24.0`, which brings support for OCaml 5.4!
+
+For more details, see the related [announcement on the Discuss forums](https://discuss.ocaml.org/t/ann-new-releases-of-merlin-5-6-and-ocaml-lsp-1-24-0/)!


### PR DESCRIPTION
@xvw Thanks for making an announcement on Discuss.

Since the current structure of the OCaml Changelog (with automated scraping of releases from GitHub) can't yet accomodate joint announcements of multiple tools, I split the content up like this.