### PR TITLE
release page and changelog for the release of OCaml 5.4.0

### DIFF
--- a/data/changelog/releases/ocaml/2025-10-09-ocaml-5.4.0.md
+++ b/data/changelog/releases/ocaml/2025-10-09-ocaml-5.4.0.md
@@ -754,7 +754,7 @@ We have the pleasure of celebrating the birthday of Claude Gaspar Bachet de
 Méziriac and the anniversary of the Kepler's supernova by announcing the release
 of OCaml version 5.4.0.
 
-Some of the highlights in OCaml 5.4.0 are:
+Some of the highlights of OCaml 5.4.0 are:
 
 ### Labelled tuples
 
@@ -762,30 +762,39 @@ Some of the highlights in OCaml 5.4.0 are:
 ```ocaml
       let ( * ) (x,~dx) (y,~dx:dy) = x*.y, ~dx:(x *. dy +. y *. dx )
 ```
-  This labeled tuples are equivalent to SML records, they are an order-dependent and structurally-typed variants of records. They are mostly intended for local types.
+  Those labeled tuples are equivalent to SML records: they are an order-dependent and structurally-typed variants of records. They are mostly intended for local types.
 
 ### Array literal syntax support for immutable arrays and `floatarray`s
 
-    The array literal syntax is now shared by array-like primitive datatypes,
-    like `'a array`, `floatarray` and immutable array `iarray`.
-    For instance, this code
+  The array literal syntax is now shared by array-like primitive datatypes,
+like `'a array`, `floatarray` and immutable array `iarray`.
+For instance, this code
+
 ```ocaml
-    let x = Array.Flotarray.create 3;
-    Array.Flotarray.set x 0 1.;
-    Array.Flotarray.set x 1 2.;
-    Array.Flotarray.set x 2 3.;
+let x =
+  let x = Array.Flotarray.create 3 in
+  Array.Flotarray.set x 0 1.;
+  Array.Flotarray.set x 1 2.;
+  Array.Flotarray.set x 2 3.;
+  x
 ```
-    can now be written
+
+can now be written
+
 ```ocaml
     let x : floatarray = [|0.; 1.; 2.|]
 ```
-    This also supported in patterns
+
+This also supported in patterns
+
 ```ocaml
     let one = match x with
     | [|_;y;_|] -> Some y
     | _ -> None
 ```
-    However array indexing still needs to go through user-defined indexing operator
+
+However array indexing still needs to go through user-defined indexing operator
+
 ```ocaml
     let (.$()) = Array.Floatarray.get
     let (.$()<-) = Array.Floatarray.set
@@ -794,15 +803,19 @@ Some of the highlights in OCaml 5.4.0 are:
 
 ### Immutable arrays
 
-  Along with extended array literal, OCaml 5.4 adds support for immutable arrays.
+Along with shared array literals, OCaml 5.4 adds support for immutable arrays.
+  
  ```ocaml
- let v: float iarray = [| 0; 1; 2 |]
+ let v: int iarray = [| 0; 1; 2 |]
  ```
-  In particular, this makes it possible to use coercion on immutable arrays without
-  a functional wrapper
-  ```ocaml
-  let w = ([|object method m = 0 end|]:<m:int> iarray_ :> < > iarray)
-  ```
+ 
+Immutable arrays are covariant in the type of their elements, it is thus possible to coerce 
+immutable arrays with no costs at runtime:
+
+```ocaml
+let i1: _ iarray = [|object method m = 0 end|]
+let i2 = ( i1 :> < > iarray)
+```
   
 ### Atomic record fields
   
@@ -821,13 +834,27 @@ let rec push t x =
     push t x
   ...
 ```
+Moreover, it is forbidden to pattern match on atomic fields:
+
+```ocaml
+let f { head; tail } = tail;;
+```
+
+>```bash
+>Error: Atomic fields (here tail) are forbidden in patterns,
+>       as it is difficult to reason about when the atomic read
+>       will happen during pattern matching: the field may be read
+>       zero, one or several times depending on the patterns around it.
+>```
+
+in order to make access to atomic fields more explicit.
 
 ### Four new standard library modules: Pair, Pqueue, Repr, and Iarray
 
 The standard library has been extended with four new modules:
 
 - Pair: functions for working on pairs
-- Pqueue: priority queue, generic or not
+- Pqueue: priority queues, generic or not
 - Repr: physical and structural equality, comparison function, 
   more generically all functions dependent on the memory representation
   of values.
@@ -840,7 +867,7 @@ tracking memory leaks in C code running the OCaml runtime. To get around
 cancellation issues, the restored mode currently assume that all domains are
 joined before exiting the OCaml runtime.
 
-###  A new chapter in the reference manual on profiling OCaml programs on Linux and macOS
+###  A new section in the reference manual on profiling OCaml programs on Linux and macOS
 
 A new section in the [reference manual](https://ocaml.org/manual/profil.html) explains
 how to use OS specific profiling tools to profile native OCaml programs.
@@ -848,16 +875,14 @@ how to use OS specific profiling tools to profile native OCaml programs.
 
 ### A lot of incremental changes:
 
-  - Many runtime improvements
+  - Many runtime and code generation improvements
   - More than thirty new standard library functions
-  - A dozen of improved error messages
-  - Improved support for Merlin's renaming feature.
+  - Nearly a dozen improved error messages
   - Around fifty bug fixes
 
-
-Please report any unexpected behaviours on the [OCaml issue tracker](https://github.com/ocaml/ocaml/issues)
-and post any questions or comments you might have on our
-[discussion forums](https://discuss.ocaml.org).
+Please report any unexpected behaviours on the [OCaml issue
+tracker](https://github.com/ocaml/ocaml/issues) and post any questions or
+comments you might have on our [discussion forums](https://discuss.ocaml.org).
 
 
 The full list of changes can be found in the full changelog.

--- a/data/changelog/releases/ocaml/2025-10-09-ocaml-5.4.0.md
+++ b/data/changelog/releases/ocaml/2025-10-09-ocaml-5.4.0.md
@@ -750,9 +750,8 @@ changelog: |
     (Antonin Décimo, review by Nicolás Ojeda Bär)
 ---
 
-We have the pleasure of celebrating the birthday of Claude Gaspar Bachet de
-Méziriac and the anniversary of the Kepler's supernova by announcing the release
-of OCaml version 5.4.0.
+We have the pleasure of celebrating the birthdays of Camille Saint-Saëns and
+Karl Schwarzschild by announcing the release of OCaml version 5.4.0.
 
 Some of the highlights of OCaml 5.4.0 are:
 
@@ -760,7 +759,7 @@ Some of the highlights of OCaml 5.4.0 are:
 
   It is now possible to put labels on tuple fields
 ```ocaml
-      let ( * ) (x,~dx) (y,~dx:dy) = x*.y, ~dx:(x *. dy +. y *. dx )
+let ( * ) (x,~dx) (y,~dx:dy) = x*.y, ~dx:(x *. dy +. y *. dx )
 ```
   Those labeled tuples are equivalent to SML records: they are an order-dependent and structurally-typed variants of records. They are mostly intended for local types.
 
@@ -782,23 +781,23 @@ let x =
 can now be written
 
 ```ocaml
-    let x : floatarray = [|0.; 1.; 2.|]
+let x : floatarray = [|0.; 1.; 2.|]
 ```
 
 This also supported in patterns
 
 ```ocaml
-    let one = match x with
-    | [|_;y;_|] -> Some y
-    | _ -> None
+let one = match x with
+  | [|_;y;_|] -> Some y
+  | _ -> None
 ```
 
 However array indexing still needs to go through user-defined indexing operator
 
 ```ocaml
-    let (.$()) = Array.Floatarray.get
-    let (.$()<-) = Array.Floatarray.set
-    let () = x.$(0) <- x.$(1)
+let (.$()) = Array.Floatarray.get
+let (.$()<-) = Array.Floatarray.set
+let () = x.$(0) <- x.$(1)
 ```
 
 ### Immutable arrays
@@ -819,9 +818,9 @@ let i2 = ( i1 :> < > iarray)
   
 ### Atomic record fields
   
-  It is now possible to mark specific of record as atomic. Atomic operations on
+  It is now possible to mark a field of a record as atomic. Atomic operations on
 those fields require to use the new `Atomic.Loc` submodule after accessing the
-location of those fields with the new extension `[%atomic.loc ...]`. For
+location of those fields with the `[%atomic.loc ...]` builtin extension. For
 instance,
 
 ```ocaml
@@ -847,17 +846,40 @@ let f { head; tail } = tail;;
 >       zero, one or several times depending on the patterns around it.
 >```
 
-in order to make access to atomic fields more explicit.
+in order to make all reads explicit.
 
 ### Four new standard library modules: Pair, Pqueue, Repr, and Iarray
 
 The standard library has been extended with four new modules:
 
 - Pair: functions for working on pairs
+
+```ocaml
+let ones = Pair.map_fst succ (0,1)
+```
+
 - Pqueue: priority queues, generic or not
+
+```ocaml
+module Int_pqueue = Pqueue.MakeMin(Int)
+let q = Int_pqueue.of_list [4;0;5;7]
+let some_zero = Int_pqueue.pop_min q
+```
+
 - Repr: physical and structural equality, comparison function, 
   more generically all functions dependent on the memory representation
   of values.
+  
+```ocaml
+let f = Repr.phys_equal (ref 0) (ref 0)
+```
+
+- Iarray: functions on immutable arrays
+
+```ocaml
+let a = Iarray.init 10 Fun.id
+let b = Iarray.map succ a
+```
 
 ###  Restored "memory cleanup upon exit" mode
 
@@ -884,7 +906,6 @@ Please report any unexpected behaviours on the [OCaml issue
 tracker](https://github.com/ocaml/ocaml/issues) and post any questions or
 comments you might have on our [discussion forums](https://discuss.ocaml.org).
 
-
 The full list of changes can be found in the full changelog.
 
 ---
@@ -892,6 +913,7 @@ The full list of changes can be found in the full changelog.
 ## Installation Instructions
 
 The base compiler can be installed as an opam switch with the following commands:
+
 ```bash
 opam update
 opam switch create 5.4.0
@@ -899,17 +921,20 @@ opam switch create 5.4.0
 
 The source code for the release is also directly available on:
 
-* [GitHub](https://github.com/ocaml/ocaml/releases/download/5.4.0/ocaml-5.4.0.tar.gz)
-* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.4/ocaml-5.4.0.tar.gz)
+- [GitHub](https://github.com/ocaml/ocaml/releases/download/5.4.0/ocaml-5.4.0.tar.gz)
+- [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.4/ocaml-5.4.0.tar.gz)
 
 ### Fine-Tuned Compiler Configuration
 
 If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+
 ```bash
 opam update
 opam switch create <switch_name> ocaml-variants.5.4.0+options <option_list>
 ```
+
 where `<option_list>` is a space separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+
 ```bash
 opam switch create 5.4.0+flambda+nffa ocaml-variants.5.4.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
 ```

--- a/data/changelog/releases/ocaml/2025-10-09-ocaml-5.4.0.md
+++ b/data/changelog/releases/ocaml/2025-10-09-ocaml-5.4.0.md
@@ -1,0 +1,890 @@
+---
+title: Release of OCaml 5.4.0
+tags: [ocaml]
+versions: ["OCaml 5.4.0"]
+github_release_tags: [5.4.0]
+changelog: |
+  ### Language features:
+  
+  - [#13097](https://github.com/ocaml/ocaml/issues/13097): added immutable arrays (`'a iarray` type, Iarray stdlib module)
+    (Antal Spector-Zabusky and Olivier Nicole, review by Gabriel Scherer,
+    Jeremy Yallop and Vincent Laviron)
+  
+  - [#13340](https://github.com/ocaml/ocaml/issues/13340): Array literal syntax [| e1; ...; en |] can now be used to
+    denote values of type `'a array` and `'a iarray` and `floatarray`,
+    both in expressions and patterns. The compiler disambiguates each
+    case by using contextual type information (assuming `'a array`
+    by default).
+    (Nicolás Ojeda Bär, review by Richard Eisenberg, Jeremy Yallop, Jacques
+    Garrigue, and Gabriel Scherer)
+  
+  - [#13498](https://github.com/ocaml/ocaml/issues/13498): Tuple fields are now optionally labeled:
+    `(x:42, y:0)` and `let (~x, ~y) = ... in ...`.
+    (Ryan Tjoa and Chris Casinghino, review by Gabriel Scherer, Chris Casinghino,
+    and Leo White)
+  
+  - RFCs[#39](https://github.com/ocaml/ocaml/issues/39), [#13404](https://github.com/ocaml/ocaml/issues/13404): atomic record fields
+      `{ ...; mutable readers : int [@atomic]; ... }`
+      `Atomic.Loc.fetch_and_add [%atomic.loc data.readers] 1`
+    (Clément Allain and Gabriel Scherer, review by KC Sivaramakrishnan,
+     Basile Clément and Olivier Nicole)
+  
+  ### Standard library:
+  
+  * (*breaking change*) [#14124](https://github.com/ocaml/ocaml/issues/14124): Do not raise Invalid_argument on negative List.{drop,take}.
+    (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+  
+  - [#13696](https://github.com/ocaml/ocaml/issues/13696): Add Result.product and Result.Syntax:
+    `let open Result.Syntax in let* x = ... in ...`
+    (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+  
+  - [#12871](https://github.com/ocaml/ocaml/issues/12871): Add the Pqueue module to the stdlib. It implements priority queues.
+    (Jean-Christophe Filliâtre, review by Daniel Bünzli, Léo Andrès and
+    Gabriel Scherer)
+  
+  - [#13760](https://github.com/ocaml/ocaml/issues/13760): Add String.{edit_distance,spellcheck}
+    (Daniel Bünzli, review by wikku, Nicolás Ojeda Bär, Gabriel Scherer and
+     Florian Angeletti)
+  
+  - [#13753](https://github.com/ocaml/ocaml/issues/13753), [#13755](https://github.com/ocaml/ocaml/issues/13755): Add Stdlib.Repr:
+    Repr.phys_equal and Repr.compare are more explicit than (==) and `compare`.
+    (Kate Deplaix, Thomas Blanc and Léo Andrès, review by Gabriel Scherer,
+     Florian Angeletti, Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
+  
+  - [#13695](https://github.com/ocaml/ocaml/issues/13695): Add Stdlib.Char.Ascii
+    (Daniel Bünzli, review by by Nicolás Ojeda Bär and Jeremy Yallop)
+  
+  
+  - [#13720](https://github.com/ocaml/ocaml/issues/13720): Add Result.{get_ok',error_to_failure}
+   (Daniel Bünzli, review by wikku, Gabriel Scherer, Nicolás Ojeda Bär,
+    Vincent Laviron and hirrolot)
+  
+  - [#13885](https://github.com/ocaml/ocaml/issues/13885): Add Dynarray.{exists2, for_all2}.
+    (T. Kinsart, review by Daniel Bünzli, Gabriel Scherer, and Nicolás Ojeda Bär)
+  
+  * (*breaking change*) [#13862](https://github.com/ocaml/ocaml/issues/13862): Make List.sort_uniq keep the first occurrences of duplicates.
+    (Benoît Jubin, review by Nicolás Ojeda Bär, Gabriel Scherer)
+  
+  - [#13836](https://github.com/ocaml/ocaml/issues/13836): Add [Float.]Array.{equal,compare}.
+    (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
+  
+  - [#13796](https://github.com/ocaml/ocaml/issues/13796): Add Uchar.utf_8_decode_length_of_byte and
+    Uchar.max_utf_8_decode_length.
+    (Daniel Bünzli, review by Nicolás Ojeda Bär and Florian Angeletti)
+  
+  - [#13768](https://github.com/ocaml/ocaml/issues/13768): Add Either.get_left and Either.get_right
+    (T. Kinsart, review by Nicolás Ojeda Bär and Florian Angeletti)
+  
+  * (*breaking change*) [#13570](https://github.com/ocaml/ocaml/issues/13570), [#13794](https://github.com/ocaml/ocaml/issues/13794): Format, add an out_width function to Format device for
+     approximating unicode width.
+    (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
+     and Gabriel Scherer)
+  
+  - [#13731](https://github.com/ocaml/ocaml/issues/13731): Add Either.retract
+    (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
+  
+  - [#13729](https://github.com/ocaml/ocaml/issues/13729): Add Seq.filteri
+    (T. Kinsart, review by Nicolás Ojeda Bär and Daniel Bünzli)
+  
+  - [#13721](https://github.com/ocaml/ocaml/issues/13721): Add Result.retract
+    (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär and
+     David Allsopp)
+  
+  - [#13310](https://github.com/ocaml/ocaml/issues/13310): Add Stdlib.Pair
+    (Victoire Noizet, review by Nicolás Ojeda Bär, Daniel Bünzli, Xavier Van de
+     Woestyne, Jeremy Yallop and Florian Angeletti)
+  
+  - [#13662](https://github.com/ocaml/ocaml/issues/13662): Add eager boolean operations Bool.logand, Bool.logor, Bool.logxor
+    (Jeremy Yallop, review by Nicolás Ojeda Bär)
+  
+  - [#13463](https://github.com/ocaml/ocaml/issues/13463), [#13572](https://github.com/ocaml/ocaml/issues/13572): Avoid raising Queue.empty in Format when it is used
+    concurrently, raise a specific exception instead.
+    (Chritophe Raffalli, review by Gabriel Scherer and Daniel Bünzli)
+  
+  - [#13620](https://github.com/ocaml/ocaml/issues/13620): Avoid copying the string in String.concat, String.sub and
+    String.split_on_char when the full string is returned.
+    (Christophe Raffalli, review by Nicolás Ojeda Bär and Gabriel Scherer and
+     Hugo Heuzard)
+  
+  - [#13727](https://github.com/ocaml/ocaml/issues/13727): Reimplement Sys.getenv_opt not to use exceptions internally, meaning
+    that the current backtrace is preserved when Sys.getenv_opt returns None.
+    (David Allsopp, review by Nicolás Ojeda Bär, Josh Berdine and Gabriel Scherer)
+  
+  - [#13737](https://github.com/ocaml/ocaml/issues/13737): Avoid closure allocations in Weak.Make.add when resizing the
+    table
+    (Vincent Laviron, review by Gabriel Scherer and Daniel Bünzli)
+  
+  - [#13740](https://github.com/ocaml/ocaml/issues/13740): Improve performance of Weak.find_aux
+    (Josh Berdine, review by Gabriel Scherer)
+  
+  - [#13782](https://github.com/ocaml/ocaml/issues/13782): Improve performance and type safety of Type.Id by using
+    [%extension_constructor] instead of Obj.Extension_constructor.of_val.
+    (Basile Clément, review by Vincent Laviron and Nicolás Ojeda Bär)
+  
+  - [#13589](https://github.com/ocaml/ocaml/issues/13589): Expose Sys.io_buffer_size, the size of internal buffers used by the
+    runtime system and the `unix` library.
+    (Yves Ndiaye and Nicolás Ojeda Bär, review by Daniel Bünzli and Nicolás Ojeda
+    Bär)
+  
+  - [#13569](https://github.com/ocaml/ocaml/issues/13569): add a `Format.format_text` which adds break hints to format literals.
+    (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
+     and Gabriel Scherer)
+  
+  - [#13578](https://github.com/ocaml/ocaml/issues/13578): On Windows, use the OS CSPRNG to seed the Stdlib.Random generator.
+    (Antonin Décimo, review by Miod Vallat, Nicolás Ojeda Bär, and Xavier Leroy)
+  
+  - [#13859](https://github.com/ocaml/ocaml/issues/13859): Fix Weak.get_copy not darkening custom blocks
+    (Josh Berdine, review by Stephen Dolan)
+  
+  - [#13909](https://github.com/ocaml/ocaml/issues/13909): Add `Dynarray.unsafe_to_iarray`
+    (Olivier Nicole, review by Daniel Bünzli, Stefan Muenzel and Gabriel Scherer,
+    request by Daniel Bünzli)
+  
+  - [#13932](https://github.com/ocaml/ocaml/issues/13932): Add List.singleton and Seq.singleton
+    (David Allsopp, tariffs applied by Nicolás Ojeda Bär and Gabriel Scherer)
+  
+  * (*breaking change*) [#13843](https://github.com/ocaml/ocaml/issues/13843): Add signal definitions for SIGIO and SIGWINCH. Introduces a
+    type alias for signal int, signal_to_string to convert OCaml signal numbers
+    to their POSIX equivalent names, and signal_of_int/signal_to_int for
+    converting between OCaml and platform signal numbers. (Reported in [#13825](https://github.com/ocaml/ocaml/issues/13825))
+    (Tim McGilchrist, review by David Allsopp, Nicolás Ojeda Bär, Daniel Bünzli
+     Jan Midtgaard and Miod Vallat)
+  
+  ### Runtime system:
+  
+  - [#13500](https://github.com/ocaml/ocaml/issues/13500): Add frame pointers support for ARM64 on Linux and macOS.
+    (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
+     and Miod Vallat)
+  
+  - [#12964](https://github.com/ocaml/ocaml/issues/12964): Reintroduce "memory cleanup upon exit" mode. The cleanup will
+    however be incomplete if not all domains have been joined when the main
+    domain terminates.
+    (Miod Vallat, review by KC Sivaramakrishnan, feedback from Nick Barnes
+     and Gabriel Scherer)
+  
+  - [#13582](https://github.com/ocaml/ocaml/issues/13582): Enable software prefetching support for ARM64, s390x, PPC64 and RiscV.
+    Used during GC marking and sweeping to speed up both operations by
+    prefetching data.
+    (Tim McGilchrist, review by Nick Barnes, Antonin Décimo,
+     Stephen Dolan and Miod Vallat)
+  
+  
+  - [#13675](https://github.com/ocaml/ocaml/issues/13675): Make Unix.map_file memory show up in Gc.Memprof.
+    (Stephen Dolan, review by Guillaume Munch-Maccagnoni and Gabriel Scherer)
+  
+  - [#13785](https://github.com/ocaml/ocaml/issues/13785): Add `Runtime_events.Timestamp.get_current`.
+    (Simon Cruanes)
+  
+  - [#13774](https://github.com/ocaml/ocaml/issues/13774): Fix for inaccurate live blocks/words stats in compaction.
+    (Sadiq Jaffer, report by KC Sivaramakrishnan and Jan Midtgaard, review by
+    Gabriel Scherer)
+  
+  - [#13773](https://github.com/ocaml/ocaml/issues/13773): Ensure that shared pool owners are correctly set on pool adoption.
+    (Stephen Dolan, review by Sadiq Jaffer and Gabriel Scherer)
+  
+  * (*breaking change*) [#11449](https://github.com/ocaml/ocaml/issues/11449), [#13497](https://github.com/ocaml/ocaml/issues/13497): Add caml_stat_char_array_{to,of}_os functions allowing
+    conversion of string data which may contain NUL characters. Correct
+    implementation of caml_stat_strdup_to_utf16 to raise Out_of_memory instead of
+    returning of NULL (the behaviour of caml_stat_strdup_to_os was inconsistent
+    between Unix/Windows).
+    (David Allsopp, review by Nick Barnes, Antonin Décimo and Miod Vallat)
+  
+  - [#13352](https://github.com/ocaml/ocaml/issues/13352): Concurrency refactors and cleanups.
+    (Antonin Décimo, review by Gabriel Scherer, David Allsopp, and Miod Vallat)
+  
+  - [#13437](https://github.com/ocaml/ocaml/issues/13437): Stop using GetProcAddress to load functions that were not
+    available in older, now unsupported Windows versions.
+    (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
+  
+  - [#13470](https://github.com/ocaml/ocaml/issues/13470): Constify some function parameters, flags tables, and some
+    pointers in C code (take 3).
+    (Antonin Décimo, review by Stephen Dolan and Miod Vallat)
+  
+  - [#13492](https://github.com/ocaml/ocaml/issues/13492): Parse the CAML_LD_LIBRARY_PATH environment variable for the
+    shared_libs_path item in `ocamlrun -config` in addition to displaying the
+    entries found in ld.conf.
+    (David Allsopp, review by Stephen Dolan)
+  
+  - [#13496](https://github.com/ocaml/ocaml/issues/13496): Add missing .type and .size directives to main frametable to silence
+    warnings from the linker when using libasmrun_shared on amd64 and power. The
+    other backends already carried these directives.
+    (David Allsopp, review by Tim McGilchrist and Miod Vallat)
+  
+  - [#13354](https://github.com/ocaml/ocaml/issues/13354): Use C99 flexible array member syntax everywhere.
+    (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and Xavier Leroy)
+  
+  - [#11865](https://github.com/ocaml/ocaml/issues/11865), [#13584](https://github.com/ocaml/ocaml/issues/13584): Fix a deadlock triggered by deleting C roots from C finalisers
+    (Stephen Dolan, report by Timothy Bourke, review by Mark Shinwell and Damien
+    Doligez)
+  
+  - [#13613](https://github.com/ocaml/ocaml/issues/13613): Functions from caml/skiplist.h and caml/lf_skiplist.h no longer raise
+    Out_of_memory exceptions that the runtime could not handle.
+    (Guillaume Munch-Maccagnoni, review by Stephen Dolan)
+  
+  - [#13575](https://github.com/ocaml/ocaml/issues/13575), [#13635](https://github.com/ocaml/ocaml/issues/13635): Maintain OCaml frame pointers correctly even when using
+     C libraries that do not support them.
+    (Stephen Dolan and David Allsopp, report by Thomas Leonard, review by Tim
+     McGilchrist and Fabrice Buoro)
+  
+  - [#13643](https://github.com/ocaml/ocaml/issues/13643): Allow values reachable from ephemeron keys to be collected by minor GC
+    (Stephen Dolan, review by François Bobot)
+  
+  - [#13701](https://github.com/ocaml/ocaml/issues/13701): optimize `caml_continuation_use` based on [#12735](https://github.com/ocaml/ocaml/issues/12735)
+    (Hugo Heuzard, review by KC Sivaramakrishnan)
+  
+  - [#13227](https://github.com/ocaml/ocaml/issues/13227), [#13714](https://github.com/ocaml/ocaml/issues/13714): Review of locking in the multicore runtime. Fix
+    deadlocks in runtime events and potential deadlocks with named
+    values.
+    (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, tests by
+    Jan Midtgaard)
+  
+  - [#13736](https://github.com/ocaml/ocaml/issues/13736): Fix major GC pacing bug triggered by synchronous collections.
+    (Nick Barnes, review by Damien Doligez and Tim McGilchrist)
+  
+  - [#13827](https://github.com/ocaml/ocaml/issues/13827): Avoid re-marking ephemerons with trivial data.
+    (Stephen Dolan, review by Nick Barnes and Josh Berdine, benchmarking by
+     Nicolás Ojeda Bär)
+  
+  - [#13300](https://github.com/ocaml/ocaml/issues/13300), [#13861](https://github.com/ocaml/ocaml/issues/13861): introduce `Gc.ramp_up` to explicitly mark ramp-up
+    phases of memory consumption and avoid GC overwork. Ramp-up behaviors
+    are worse with OCaml 5 than with OCaml 4 due to higher sensitivity
+    to excessive pacing computations. Indicating ramp-up explicitly eliminates
+    the main known slowdown of OCaml 5 (relative to OCaml 4) for Coq/Rocq.
+    (Gabriel Scherer, review by Damien Doligez and Guillaume Munch-Maccagnoni,
+     report by Emilio Jesús Gallego Arias and Olivier Nicole)
+  
+  - [#14057](https://github.com/ocaml/ocaml/issues/14057): Don't update memprof too early at the end of a minor GC.
+    (Nick Barnes, review by Damien Doligez).
+  
+  ### Code generation and optimizations:
+  
+  - [#13262](https://github.com/ocaml/ocaml/issues/13262), [#14074](https://github.com/ocaml/ocaml/issues/14074): fix performance issue on Apple Silicon macOS by emitting
+    `stlr` instead of `dmb ishld; str`.
+    (KC Sivaramakrishnan, report by François Pottier, analysis by Frédéric Bour,
+    Xavier Leroy, Miod Vallat, Gabriel Scherer and Stephen Dolan, review by Miod
+    Vallat, Vincent Laviron and Xavier Leroy)
+  
+  * (*breaking change*) [#13050](https://github.com/ocaml/ocaml/issues/13050), [#14104](https://github.com/ocaml/ocaml/issues/14104), [#14143](https://github.com/ocaml/ocaml/issues/14143): Use '$' instead of '.' to separate module names
+    in symbol names on macOS and Windows (including the Cygwin backend).
+    This changes mangling of OCaml identifiers on those operating systems from
+    `camlModule.name_NNN` to `camlModule$name_NNN`. Additionally it
+    changes the encoding of special characters from $xx (two hex digits)
+    to $$xx (two dollar signs followed by two hex digits).
+    (Tim McGilchrist, with contributions from Xavier Leroy,
+     reviewed by Xavier Leroy, Miod Vallat, Gabriel Scherer,
+     Nick Barnes and Hugo Heuzard)
+  
+  - [#13807](https://github.com/ocaml/ocaml/issues/13807): Allow unaligned memory accesses on ARM64.
+    (Matthew Else, review by Xavier Leroy)
+  
+  
+  - [#13565](https://github.com/ocaml/ocaml/issues/13565): less tagging in switches compiled to affine transformations
+    by ocamlopt.
+    (Gabriel Scherer and Clément Allain, review by Vincent Laviron,
+     report by Vesa Karvonen)
+  
+  - [#13672](https://github.com/ocaml/ocaml/issues/13672) Avoid register stall on conversion instructions on amd64.
+    (Pierre Chambart, review by Gabriel Scherer and Xavier Leroy,
+     report by Patrick Nicodemus)
+  
+  - [#13667](https://github.com/ocaml/ocaml/issues/13667): (originally [#11162](https://github.com/ocaml/ocaml/issues/11162)) Fix instr_size computation on arm64.
+    (Stephen Dolan and Tim McGilchrist, review by Xavier Leroy
+    and David Allsopp)
+  
+  - [#13758](https://github.com/ocaml/ocaml/issues/13758): Propagate more value kinds in Flambda to allow more unboxing
+    (Vincent Laviron, review by Pierre Chambart)
+  
+  - [#13759](https://github.com/ocaml/ocaml/issues/13759): Propagate more type information from clambda to cmm.
+    (Pierre Chambart, review by Gabriel Scherer)
+  
+  - [#13735](https://github.com/ocaml/ocaml/issues/13735): Follow the behaviour of the C compiler to decide whether to emit the
+    `.size` and `.type` directives and the `.note.GNU-stack` section
+    (Samuel Hym, review by Miod Vallat, Antonin Décimo and Gabriel Scherer)
+  
+  ### Other libraries:
+  
+  * (*breaking change*) [#13435](https://github.com/ocaml/ocaml/issues/13435): On Windows, use system calls for `Filename.get_temp_dir_name` instead
+    of directly reading the environment, which in particular improves the security
+    of OCaml processes running in the SYSTEM security context by mitigating
+    privileged file operation attacks. For all other processes running with the
+    default environment (where `TEMP` is set), there is no discernible change.
+    (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
+  
+  - [#13504](https://github.com/ocaml/ocaml/issues/13504), [#13625](https://github.com/ocaml/ocaml/issues/13625), [#14223](https://github.com/ocaml/ocaml/issues/14223): Add `Thread.set_current_thread_name`.
+    (Romain Beauxis, review by Gabriel Scherer and Antonin Décimo)
+  
+  * (*breaking change*) [#13376](https://github.com/ocaml/ocaml/issues/13376): Allow Dynlink.loadfile_private to load bytecode libraries with
+    internal dependencies
+    (Vincent Laviron, report by Stéphane Glondu, review by Nicolás Ojeda Bär
+     and Xavier Leroy)
+  
+  - [#13429](https://github.com/ocaml/ocaml/issues/13429): add `Unix.sigwait`, a binding to the `sigwait` system call;
+    implement `Thread.wait_signal` using `Unix.sigwait`, and
+    `Thread.sigmask` using `Unix.sigprocmask`.
+    (Xavier Leroy, review by Antonin Décimo, Gabriel Scherer, Miod Vallat)
+  
+  - [#13442](https://github.com/ocaml/ocaml/issues/13442), [#13452](https://github.com/ocaml/ocaml/issues/13452): Fix Unix.getgroups for users belonging to more than 32 groups
+    when using musl
+    (Kate Deplaix, review by Gabriel Scherer, Antonin Décimo, Anil Madhavapeddy)
+  
+  - [#13576](https://github.com/ocaml/ocaml/issues/13576): Introduce internal helpers to convert between time representations.
+    On Windows, prevent erroneously waiting for an unbounded time in Unix.select
+    if more than 64 file descriptors per lists are watched, or if watching
+    non-socket file descriptors, and a timeout longer than $2^{32}$ milliseconds
+    is used. Cap the timeout to $2^{32}$ milliseconds.
+    (Antonin Décimo, review by Gabriel Scherer and Miod Vallat)
+  
+  - [#13921](https://github.com/ocaml/ocaml/issues/13921): Set cloexec correctly on CRT file descriptors created by the Unix
+    library on Windows. The inheritance on the underlying Win32 handles was
+    correctly set, but the book-keeping for the CRT was leaking the value of
+    non-inherited handles which combined with re-use of HANDLE values within
+    processes could appear to make a CRT file descriptor "re-open".
+    (David Allsopp, review by Nicolás Ojeda Bär)
+  
+  ### Tools:
+  
+  - [#13686](https://github.com/ocaml/ocaml/issues/13686): Fix Python debugger extensions (for LLDB and GDB) to restore
+    functionality broken by [#13272](https://github.com/ocaml/ocaml/issues/13272) in 5.3.
+    (Nick Barnes, review by Tim McGilchrist Gabriel Scherer)
+  
+  - [#12019](https://github.com/ocaml/ocaml/issues/12019): ocamlc: add `align_double` and `align_int64` to `ocamlc -config`
+    output.
+    (Romain Beauxis, review by David Allsopp)
+  
+  - [#12642](https://github.com/ocaml/ocaml/issues/12642), [#13536](https://github.com/ocaml/ocaml/issues/13536), [#14184](https://github.com/ocaml/ocaml/issues/14184), [#14192](https://github.com/ocaml/ocaml/issues/14192): in the toplevel, print shorter paths for
+    constructors and labels when only some modules along their path are open.
+    (Gabriel Scherer, review by Florian Angeletti)
+  
+  - [#13199](https://github.com/ocaml/ocaml/issues/13199), [#13485](https://github.com/ocaml/ocaml/issues/13485), [#13665](https://github.com/ocaml/ocaml/issues/13665), [#13762](https://github.com/ocaml/ocaml/issues/13762), [#13965](https://github.com/ocaml/ocaml/issues/13965): Support running native debuggers in
+    ocamltest.
+    (Tim McGilchrist, Sebastien Hinderer, David Allsopp, Antonin Décimo, review by
+    Sebastien Hinderer, Gabriel Scherer, Antonin Décimo, and Tim McGilchrist)
+  
+  - [#13764](https://github.com/ocaml/ocaml/issues/13764), [#13779](https://github.com/ocaml/ocaml/issues/13779): add missing "-keywords" flag to ocamldep and ocamlprof
+    (Florian Angeletti, report by Prashanth Mundkur, review by Gabriel Scherer)
+  
+  - [#13877](https://github.com/ocaml/ocaml/issues/13877): ocamldoc, add a `-latex-escape-underscore` flag to control the
+    escaping of `_` underscore in latex references (in order to be able to match
+    odoc behaviour).
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#13906](https://github.com/ocaml/ocaml/issues/13906): Add support for a `multicore` tag in ocamltest and use it for
+    tests that fail on mono-core systems.
+    (Stéphane Glondu, review by Nicolás Ojeda Bär)
+  
+  ### Manual and documentation:
+  
+  - [#13751](https://github.com/ocaml/ocaml/issues/13751): Document support for profiling with Linux perf and frame pointers.
+    (Tim McGilchrist, review by Gabriel Scherer and Miod Vallat)
+  
+  - [#12452](https://github.com/ocaml/ocaml/issues/12452): Add examples to Stdlib.Fun documentation.
+    (Hazem ElMasry, review by Florian Angeletti and Gabriel Scherer)
+  
+  - [#13924](https://github.com/ocaml/ocaml/issues/13924): Document how to put [@deprecated] on let bindings, constructors, etc
+    in the manual
+    (Valentin Gatien-Baron, review by Florian Angeletti)
+  
+  
+  - [#13694](https://github.com/ocaml/ocaml/issues/13694): Fix name for caml_hash_variant in the C interface.
+    (Michael Hendricks)
+  
+  - [#13732](https://github.com/ocaml/ocaml/issues/13732): Document that custom finalizers must not access the OCaml heap, etc.
+    (Josh Berdine, review by Stephen Dolan and Guillaume Munch-Maccagnoni)
+  
+  ### Type system
+  
+  * (*breaking change*) [#13830](https://github.com/ocaml/ocaml/issues/13830): fail rather than silently create abstract module types when avoiding
+    (i.e. hiding) signature items, as in:
+    ```ocaml
+      module N = struct
+        open (struct type t = A | B end)
+        module type T = sig type u = t * int end
+      end
+    ```
+    Before, it was succeeding with `module N : sig module type T end`, now it
+    fails. Similarly for anonymous functor calls (of the form `F(struct ... end))
+    (Clement Blaudeau, review by Gabriel Scherer)
+  
+  ### Compiler user-interface and warnings:
+  
+  - [#13817](https://github.com/ocaml/ocaml/issues/13817): align spellchecking hints with the possibly misspelled identifier/
+                Error: Unbound type constructor "aray"
+                Hint:              Did you mean "array"?
+    (Florian Angeletti, suggestion by Daniel Bünzli, review by Gabriel Scherer)
+  
+  - [#13587](https://github.com/ocaml/ocaml/issues/13587): Enable native backend on x86_64 GNU/Hurd.
+    (Samuel Thibault, review by Antonin Décimo, Sébastien Hinderer and Miod
+     Vallat)
+  
+  - [#13663](https://github.com/ocaml/ocaml/issues/13663): Improve the error message when GADT parameter variance cannot be
+    checked.
+    (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
+  
+  - [#13646](https://github.com/ocaml/ocaml/issues/13646): Improve the error messages when a recursive module type
+    references another recursive module type.
+    (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
+  
+  - [#13702](https://github.com/ocaml/ocaml/issues/13702), [#13865](https://github.com/ocaml/ocaml/issues/13865): Specialized error messages for functors appearing in contexts
+    where non-functors were expected `module A: sig ... end = Set.Make`
+    (and the reverse)
+    (Florian Angeletti, report by Jeremy Yallop, review by Gabriel Scherer)
+  
+  - [#13788](https://github.com/ocaml/ocaml/issues/13788), [#13813](https://github.com/ocaml/ocaml/issues/13813): Keep the module context in spellchecking hints.
+    `Fun.protact` now prompts `Did you mean "Fun.protect?"` rather than
+    `Did you mean "protect?"`.
+    (Florian Angeletti, suggestion by Daniel Bünzli, review by Gabriel Scherer)
+  
+  
+  - [#13428](https://github.com/ocaml/ocaml/issues/13428): support dump=[source | parsetree | lambda | ... | cmm | ...]
+    in OCAMLRUNPARAM
+    (Gabriel Scherer, review by Vincent Laviron)
+  
+  - [#13493](https://github.com/ocaml/ocaml/issues/13493): Clearer error message in ocamlc for conflicting link options for
+    C stubs when shared libraries are not available.
+    (David Allsopp, review by Gabriel Scherer)
+  
+  - [#13563](https://github.com/ocaml/ocaml/issues/13563), lighter inline code styling for output without bold support: inline
+    code is no longer printed as "..." to avoid confusion with OCaml strings.
+    (Florian Angeletti, review by Richard Eisenberg)
+  
+  - [#13568](https://github.com/ocaml/ocaml/issues/13568), composable formatting for warning and alert messages
+    (Florian Angeletti, review by Richard Eisenberg)
+  
+  - [#13601](https://github.com/ocaml/ocaml/issues/13601): Enable natdynlink on x86_64 GNU/Hurd
+    (Samuel Thibault, review by Sébastien Hinderer)
+  
+  - [#13809](https://github.com/ocaml/ocaml/issues/13809): Distinguish `(module M : S)` and `(module M) : (module S)` and
+    change locations of error messages when `S` is ill-typed in `(module S)`
+    (Samuel Vivien, review by Florian Angeletti and Gabriel Scherer)
+  
+  - [#13814](https://github.com/ocaml/ocaml/issues/13814), 13898: Add an `unused-type-declaration` warning when using
+    a `t as 'a` with no other occurences of `'a`
+    (Samuel Vivien, review by Florian Angeletti, Kate Deplaix)
+  
+  - [#13818](https://github.com/ocaml/ocaml/issues/13818): better delimited hints in error message
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  ### Internal/compiler-libs changes:
+  
+  - [#13539](https://github.com/ocaml/ocaml/issues/13539), [#13776](https://github.com/ocaml/ocaml/issues/13776): Use nanosleep instead of usleep or select, if available.
+    (Antonin Décimo, review by Miod Vallat and Gabriel Scherer)
+  
+  - [#13748](https://github.com/ocaml/ocaml/issues/13748): Add a .editorconfig file for basic editor auto-configuration.
+    (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
+  
+  - [#13302](https://github.com/ocaml/ocaml/issues/13302), [#14236](https://github.com/ocaml/ocaml/issues/14236): Store locations of longidents components
+    (Ulysse Gérard and Jules Aguillon, review by Jules Aguillon
+     and Florian Angeletti)
+  
+  
+  - [#13314](https://github.com/ocaml/ocaml/issues/13314): Comment the code of Translclass
+    (Vincent Laviron and Nathanaëlle Courant, review by Olivier Nicole)
+  
+  - [#13362](https://github.com/ocaml/ocaml/issues/13362): reimplement Floatarray.concat in C (`caml_floatarray_concat`),
+    matching the implementation of Array.concat.
+    (Gabriel Scherer, review by Nicolás Ojeda Bär)
+  
+  - [#13624](https://github.com/ocaml/ocaml/issues/13624): Added location to exception definitions and type extensions
+    (Samuel Vivien, review by Gabriel Scherer)
+  
+  - [#13425](https://github.com/ocaml/ocaml/issues/13425): undocumented -dmatchcomp flag for the debug
+    output of the pattern-matching compiler
+    (Gabriel Scherer, review by Vincent Laviron and Nicolás Ojeda Bär)
+  
+  - [#13460](https://github.com/ocaml/ocaml/issues/13460): introduce a variant of all predefined types
+    (Gabriel Scherer, review by Ulysse Gérard and Florian Angeletti)
+  
+  - [#13457](https://github.com/ocaml/ocaml/issues/13457), [#13537](https://github.com/ocaml/ocaml/issues/13537): Annotate alloc/free open/close pairs of functions
+    with compiler attributes for static analysis.
+    (Antonin Décimo, review by Gabriel Scherer and Florian Angeletti)
+  
+  - [#13464](https://github.com/ocaml/ocaml/issues/13464): Use generic types in call to `subtype`. This improves
+    inference of type-directed disambiguation in principal mode.
+    (Richard Eisenberg, review by Jacques Garrigue)
+  
+  - [#13606](https://github.com/ocaml/ocaml/issues/13606): Fix Numbers.Int_base.compare
+    (Mark Shinwell, review by Vincent Laviron)
+  
+  - [#13612](https://github.com/ocaml/ocaml/issues/13612): Refactor `type_application`
+    (Ulysse Gérard, Leo White, review by Antonin Décimo, Gabriel Scherer,
+     Samuel Vivien, Florian Angeletti and Jacques Garrigue)
+  
+  - [#13744](https://github.com/ocaml/ocaml/issues/13744): Refactor in `collect_apply_args`
+    (Samuel Vivien, review by Florian Angeletti and Gabriel Scherer)
+  
+  - [#13787](https://github.com/ocaml/ocaml/issues/13787): a new -dcanonical-ids option to show canonicalized identifier stamps
+    in -d{lambda,cmm,...} outputs.
+    (Gabriel Scherer, review by Vincent Laviron and David Allsopp,
+     suggested by David Allsopp)
+  
+  - [#13820](https://github.com/ocaml/ocaml/issues/13820): Add a new option -i-variance to print the variance of every
+    type parameter; bivariance is printed as `+-`, and for consistency,
+    parser is modified too to accept `+-` and `-+` as `type_variance`.
+    (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
+  
+  - [#13828](https://github.com/ocaml/ocaml/issues/13828): Apply BUILD_PATH_PREFIX_MAP to Sys.argv.(0) before storing it in .cmt
+    and .cmti files.
+    (David Allsopp, review by Daniel Bünzli and Gabriel Scherer)
+  
+  - [#13848](https://github.com/ocaml/ocaml/issues/13848): Add all paths components to the cmt files indexes
+    (Ulysse Gérard, review by Florian Angeletti)
+  
+  - [#13854](https://github.com/ocaml/ocaml/issues/13854): Make the parser set loc_ghost more correctly, for `keyword%extension`
+    syntax
+    (Valentin Gatien-Baron, review by Florian Angeletti)
+  
+  - [#13856](https://github.com/ocaml/ocaml/issues/13856): Add a new indirection in types AST called `package` that stores the
+    content of a `Tpackage` node
+    (Samuel Vivien, review by Florian Angeletti)
+  
+  - [#13866](https://github.com/ocaml/ocaml/issues/13866): Modified occurence check that prevents recursive types for it to see
+    the checked type as a graph rather than a tree
+    (Samuel Vivien, report by Didier Remy, review by Florian Angeletti
+     and Jacques Garrigue)
+  
+  - [#13884](https://github.com/ocaml/ocaml/issues/13884) Correctly index modules in constructors and labels paths
+    (Ulysse Gérard, review by Florian Angeletti)
+  
+  - [#13946](https://github.com/ocaml/ocaml/issues/13946): refactor the #install_printer code in the debugger and toplevel
+    (Pierre Boutillier, review by Gabriel Scherer and Florian Angeletti)
+  
+  - [#13952](https://github.com/ocaml/ocaml/issues/13952): check and document the correctness of `caml_domain_alone ()`.
+    (Gabriel Scherer, review by KC Sivaramakrishnan, report by Olivier Nicole)
+  
+  - [#13971](https://github.com/ocaml/ocaml/issues/13971): Keep generalized structure from patterns when typing `let`
+    (Leo White, review by Samuel Vivien and Florian Angeletti)
+  
+  * (*breaking change*) [#13972](https://github.com/ocaml/ocaml/issues/13972): Renamed the `-no-alias-deps` flag internal representation to
+    `no_alias_deps` instead of `transparent_modules`.
+    (Clement Blaudeau, review by Gabriel Scherer)
+  
+  ### Build system:
+  
+  * (*breaking change*) [#13526](https://github.com/ocaml/ocaml/issues/13526), [#13789](https://github.com/ocaml/ocaml/issues/13789), [#13804](https://github.com/ocaml/ocaml/issues/13804): Simplify the build of cross compilers
+    This replaces the configure `--with-target-bindir` option by an equivalent
+    `TARGET_BINDIR` variable
+    (Samuel Hym, review by Miod Vallat, Xavier Leroy, Antonin Décimo and Sébastien
+    Hinderer)
+  
+  
+  - [#13431](https://github.com/ocaml/ocaml/issues/13431): Simplify github action responsible for flagging PRs with
+    the `parsetree-changes` label and extend it to mention the @ppxlib-dev
+    team.
+    (Nathan Rebours, review by Florian Angeletti)
+  
+  - [#13494](https://github.com/ocaml/ocaml/issues/13494): Use native symlinks on Windows for the OCaml installation, reducing
+    disk usage considerably.
+    (David Allsopp, review by Nicolás Ojeda Bär and Gabriel Scherer)
+  
+  - [#13789](https://github.com/ocaml/ocaml/issues/13789): Strictly validate the host and target triplets when building for the
+    Windows ports to be *-*-cygwin, *-w64-mingw32* or *-pc-windows. Other Cygwin
+    variants used to be rejected - other MSVC and mingw-w64 variants are now
+    rejected too.
+    (David Allsopp, review by Antonin Décimo and Gabriel Scherer)
+  
+  ### Bug fixes:
+  
+  - [#13819](https://github.com/ocaml/ocaml/issues/13819): Fix field initialisation bug in runtime events subsystem.
+    (Nick Barnes, review by Gabriel Scherer).
+  
+  - [#13977](https://github.com/ocaml/ocaml/issues/13977): Pass `-fPIC` when compiling C files using `ocamlopt`. This was a
+    regression in OCaml 5.3.
+    (Nicolás Ojeda Bär, review by Daniel Bünzli and Gabriel Scherer)
+  
+  - [#13957](https://github.com/ocaml/ocaml/issues/13957): Allow 'effect' as attribute id.
+    (Pieter Goetschalckx, review by Nicolás Ojeda Bär and Florian Angeletti)
+  
+  - [#13691](https://github.com/ocaml/ocaml/issues/13691) [#13895](https://github.com/ocaml/ocaml/issues/13895): Make four globals underlying Gc.control atomic to avoid C data
+    races against them.
+    (Jan Midtgaard, review by Miod Vallat, Sadiq Jaffer and Antonin Décimo)
+  
+  - [#13454](https://github.com/ocaml/ocaml/issues/13454): Output a correct trace of the C_CALLN bytecode.
+    (Miod Vallat, review by Antonin Décimo)
+  
+  - [#13595](https://github.com/ocaml/ocaml/issues/13595): Use x19 as Canonical Frame Address (CFA) register. This would cause
+    backtraces to be truncated when calling no alloc C code.
+    (Tim McGilchrist, report by Nick Barnes, review by Nick Barnes)
+  
+  * (*breaking change*) [#13605](https://github.com/ocaml/ocaml/issues/13605): Fix ungenerated constraints when they where impossible due to polyvars
+    issues
+    (Samuel Vivien, review by Florian Angeletti, Richard Eisenberg
+     and Jacques Garrigue)
+  
+  - [#13677](https://github.com/ocaml/ocaml/issues/13677), [#13679](https://github.com/ocaml/ocaml/issues/13679): domain.c: remove backup_thread_running to simplify
+    concurrent state updates to the backup thread status.
+    (Gabriel Scherer, review by Jan Midtgaard and Miod Vallat,
+     report by Jan Midtgaard)
+  
+  - [#13896](https://github.com/ocaml/ocaml/issues/13896), [#14098](https://github.com/ocaml/ocaml/issues/14098): ocamldoc, do not wrap module description in a paragraph tag
+    inside the table of modules
+    (Florian Angeletti, report by John Whitington, review by Gabriel Scherer)
+  
+  - [#13703](https://github.com/ocaml/ocaml/issues/13703): wrong explanation for some polymorphic-variant subtyping errors
+    (Gabriel Scherer, review by Jacques Garrigue,
+     report by Wiktor Kuchta and Richard Eisenberg)
+  
+  - [#13710](https://github.com/ocaml/ocaml/issues/13710): Support unicode identifiers in comments.
+    (Pieter Goetschalckx, review by Florian Angeletti and Gabriel Scherer)
+  
+  - [#13763](https://github.com/ocaml/ocaml/issues/13763): Track type of variables bound by as-patterns
+    (Leo White, review by Gabriel Scherer, port by Vincent Laviron)
+  
+  - [#13778](https://github.com/ocaml/ocaml/issues/13778), [#13811](https://github.com/ocaml/ocaml/issues/13811): do not warn for unused type declarations when the type is used
+    in a first-class module type (`module S with type t = int)`.
+    (Florian Angeletti, report by Nicolás Ojeda Bär, review by Gabriel Scherer)
+  
+  - [#13790](https://github.com/ocaml/ocaml/issues/13790): Fix bytecode-only build of Cygwin when flexlink is being bootstrapped
+    with the compiler.
+    (David Allsopp, review by Antonin Décimo and Miod Vallat)
+  
+  - [#13812](https://github.com/ocaml/ocaml/issues/13812): Add forgotten check about the validity of the type variable name on
+    the right-hand side of `_ as _`.
+    (Samuel Vivien, review by Gabriel Scherer)
+  
+  - [#13845](https://github.com/ocaml/ocaml/issues/13845): Fix bug in untypeast/pprintast for value bindings with polymorphic
+    type annotations.
+    (Chris Casinghino, review by Florian Angeletti and Gabriel Scherer)
+  
+  - [#13930](https://github.com/ocaml/ocaml/issues/13930), [#13933](https://github.com/ocaml/ocaml/issues/13933): Fix bugs in recursive values definitions involving
+    lazy values that have already been evaluated.
+    (Gabriel Scherer, review by Vincent Laviron, report by Vincent Laviron)
+  
+  - [#13867](https://github.com/ocaml/ocaml/issues/13867): Fix bug with some recursive bindings of lazy values.
+    (Guillaume Bury and Vincent Laviron, review by Stefan Muenzel
+     and Gabriel Scherer)
+  
+  - [#13931](https://github.com/ocaml/ocaml/issues/13931): fix bugs in nested recursive value definitions.
+    (Gabriel Scherer, review by Vincent Laviron,
+     report by Vincent Laviron)
+  
+  - [#13875](https://github.com/ocaml/ocaml/issues/13875), [#13878](https://github.com/ocaml/ocaml/issues/13878): Add dedicated constructor for mutable variable access in
+    Cmm to prevent bugs linked to incorrect handling of coeffects.
+    (Vincent Laviron, review by Gabriel Scherer)
+  
+  - [#13880](https://github.com/ocaml/ocaml/issues/13880): Make object stat counters atomic
+    (Dimitris Mostrous, review by Gabriel Scherer and Nicolás Ojeda Bär)
+  
+  - [#13172](https://github.com/ocaml/ocaml/issues/13172), [#13829](https://github.com/ocaml/ocaml/issues/13829): Fix a missing check of illegal recursive module-type
+    definitions
+    (Clement Blaudeau, review by Florian Angeletti)
+  
+  - [#13541](https://github.com/ocaml/ocaml/issues/13541), [#13777](https://github.com/ocaml/ocaml/issues/13777): Using C++11 `thread_local` causes name-mangling
+    issues when linking with flexlink on Cygwin.
+    (Antonin Décimo and David Allsopp, report by Kate Deplaix)
+  
+  * (*breaking change*) [#13874](https://github.com/ocaml/ocaml/issues/13874), [#13882](https://github.com/ocaml/ocaml/issues/13882): Make evaluation order consistent for applications when using
+    the non-flambda native compiler
+    (Vincent Laviron, report by Jean-Marie Madiot, review by Gabriel Scherer)
+  
+  - [#13942](https://github.com/ocaml/ocaml/issues/13942): Fix assertion on empty array case
+    (Olivier Nicole, review by Gabriel Scherer)
+  
+  - [#13950](https://github.com/ocaml/ocaml/issues/13950): Avoid tearing in `Array.sub`
+    (Gabriel Scherer and Olivier Nicole, report by Jan Midtgaard, review by
+     Gabriel Scherer)
+  
+  - [#13928](https://github.com/ocaml/ocaml/issues/13928), [#13944](https://github.com/ocaml/ocaml/issues/13944): Fix handling of excessively nested unboxed types
+    (Vincent Laviron, review by Gabriel Scherer)
+  
+  - [#13987](https://github.com/ocaml/ocaml/issues/13987): Remove a spurious TSan report in case of benign data race between
+    major GC read and write from the mutator (fixes [#13427](https://github.com/ocaml/ocaml/issues/13427))
+    (Olivier Nicole, report by Thomas Leonard, review by Gabriel Scherer)
+  
+  - [#14007](https://github.com/ocaml/ocaml/issues/14007), [#14015](https://github.com/ocaml/ocaml/issues/14015): Fix memory corruption when an exception is raised during
+    demarshaling.
+    (Benoît Vaugon, review by David Allsopp and Gabriel Scherer)
+  
+  - [#14025](https://github.com/ocaml/ocaml/issues/14025): fix data race between compaction and domain termination
+    (Gabriel Scherer, review by Jan Midtgaard,
+     report by Jan Midtgaard)
+  
+  - [#13956](https://github.com/ocaml/ocaml/issues/13956) Fix a regression introduced in [#13308](https://github.com/ocaml/ocaml/issues/13308) triggering wrong unused warnings.
+    (Ulysse Gérard, review by Florian Angeletti)
+  
+  - [#14070](https://github.com/ocaml/ocaml/issues/14070): also point to label mismatches in error messages for labelled tuples
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#14088](https://github.com/ocaml/ocaml/issues/14088), [#14091](https://github.com/ocaml/ocaml/issues/14091): fix non-deterministic code generation in
+    matching.ml (backport of rescript-lang/rescript[#7557](https://github.com/ocaml/ocaml/issues/7557))
+    (Christiano Calgano, review by Gabriel Scherer and Vincent Laviron)
+  
+  - [#14105](https://github.com/ocaml/ocaml/issues/14105): Fix a loop in Pprintast that could result in a hang when printing
+    constructor `(::)` in isolation.
+    (Ulysse Gérard, review by Nicolás Ojeda Bär and Florian Angeletti)
+  
+  - [#14108](https://github.com/ocaml/ocaml/issues/14108): toplevel, fix a typo in directive type mismatch
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#13586](https://github.com/ocaml/ocaml/issues/13586), [#14093](https://github.com/ocaml/ocaml/issues/14093): Fix closing an out_channel during flush
+    (Stephen Dolan, report by Jan Midtgaard, investigation by Nick Roberts,
+     review by Antonin Décimo and Miod Vallat)
+  
+  - [#14101](https://github.com/ocaml/ocaml/issues/14101), [#14139](https://github.com/ocaml/ocaml/issues/14139): define atomic helper types inside `caml/misc.h` to improve
+    header compatibility with C++
+    (Florian Angeletti, report by Kate Deplaix, review by Gabriel Scherer)
+  
+  - [#14135](https://github.com/ocaml/ocaml/issues/14135): Fix a rare internal typechecker error when combining recursive
+    modules, polymorphic fields or methods, and constrained type parameters.
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#14169](https://github.com/ocaml/ocaml/issues/14169): runtime, fix cache miss within the stack fragments cache
+    (Florian Angeletti, review by Gabriel Scherer)
+  
+  - [#14196](https://github.com/ocaml/ocaml/issues/14196), [#14197](https://github.com/ocaml/ocaml/issues/14197): ocamlprof: do not instrument unreachable clauses
+    (Gabriel Scherer, review by Nicolás Ojeda Bär, report by Ali Caglayan)
+  
+  - [#14200](https://github.com/ocaml/ocaml/issues/14200), [#14202](https://github.com/ocaml/ocaml/issues/14202) : bad variance check with private aliases
+    (Jacques Garrigue, report and review by Stephen Dolan)
+  
+  - [#14061](https://github.com/ocaml/ocaml/issues/14061), [#14209](https://github.com/ocaml/ocaml/issues/14209): fix a memory-ordering bug in Weak.set that could
+    result in uninitialized memory seen by Weak.get on another domain.
+    (Damien Doligez, review by Gabriel Scherer)
+  
+  - [#14214](https://github.com/ocaml/ocaml/issues/14214), [#14221](https://github.com/ocaml/ocaml/issues/14221): fix a confused error message for module inclusions,
+    functor error messages were missing some type equalities potentially leading
+    to nonsensical "type t is not compatible with type t" submessage
+    (Florian Angeletti, report by Basile Clément, review by Gabriel Scherer)
+  
+  - [#14238](https://github.com/ocaml/ocaml/issues/14238): Fix certain variadic macros in misc.h which could trigger C warnings
+    under certain conditions in prerelease versions of OCaml 5.4.
+    (Antonin Décimo, review by Nicolás Ojeda Bär)
+---
+
+We have the pleasure of celebrating the birthday of Claude Gaspar Bachet de
+Méziriac and the anniversary of the Kepler's supernova by announcing the release
+of OCaml version 5.4.0.
+
+Some of the highlights in OCaml 5.4.0 are:
+
+### Labelled tuples
+
+  It is now possible to put labels on tuple fields
+```ocaml
+      let ( * ) (x,~dx) (y,~dx:dy) = x*.y, ~dx:(x *. dy +. y *. dx )
+```
+  This labeled tuples are equivalent to SML records, they are an order-dependent and structurally-typed variants of records. They are mostly intended for local types.
+
+### Array literal syntax support for immutable arrays and `floatarray`s
+
+    The array literal syntax is now shared by array-like primitive datatypes,
+    like `'a array`, `floatarray` and immutable array `iarray`.
+    For instance, this code
+```ocaml
+    let x = Array.Flotarray.create 3;
+    Array.Flotarray.set x 0 1.;
+    Array.Flotarray.set x 1 2.;
+    Array.Flotarray.set x 2 3.;
+```
+    can now be written
+```ocaml
+    let x : floatarray = [|0.; 1.; 2.|]
+```
+    This also supported in patterns
+```ocaml
+    let one = match x with
+    | [|_;y;_|] -> Some y
+    | _ -> None
+```
+    However array indexing still needs to go through user-defined indexing operator
+```ocaml
+    let (.$()) = Array.Floatarray.get
+    let (.$()<-) = Array.Floatarray.set
+    let () = x.$(0) <- x.$(1)
+```
+
+### Immutable arrays
+
+  Along with extended array literal, OCaml 5.4 adds support for immutable arrays.
+ ```ocaml
+ let v: float iarray = [| 0; 1; 2 |]
+ ```
+  In particular, this makes it possible to use coercion on immutable arrays without
+  a functional wrapper
+  ```ocaml
+  let w = ([|object method m = 0 end|]:<m:int> iarray_ :> < > iarray)
+  ```
+  
+### Atomic record fields
+  
+  It is now possible to mark specific of record as atomic. Atomic operations on
+those fields require to use the new `Atomic.Loc` submodule after accessing the
+location of those fields with the new extension `[%atomic.loc ...]`. For
+instance,
+
+```ocaml
+type 'a mpsc_list = { mutable head:'a list; mutable tail: 'a list [@atomic] }
+
+let rec push t x =
+  let before = Atomic.Loc.get [%atomic.loc t.tail] in
+  let after = x :: before in
+  if not (Atomic.Loc.compare_and_set [%atomic.loc t.tail] before after) then
+    push t x
+  ...
+```
+
+### Four new standard library modules: Pair, Pqueue, Repr, and Iarray
+
+The standard library has been extended with four new modules:
+
+- Pair: functions for working on pairs
+- Pqueue: priority queue, generic or not
+- Repr: physical and structural equality, comparison function, 
+  more generically all functions dependent on the memory representation
+  of values.
+
+###  Restored "memory cleanup upon exit" mode
+
+This mode allows to restart many time the OCaml runtime in C-driven programs
+that interact with OCaml libraries. It is also useful to reduce noise when
+tracking memory leaks in C code running the OCaml runtime. To get around
+cancellation issues, the restored mode currently assume that all domains are
+joined before exiting the OCaml runtime.
+
+###  A new chapter in the reference manual on profiling OCaml programs on Linux and macOS
+
+A new section in the [reference manual](https://ocaml.org/manual/profil.html) explains
+how to use OS specific profiling tools to profile native OCaml programs.
+
+
+### A lot of incremental changes:
+
+  - Many runtime improvements
+  - More than thirty new standard library functions
+  - A dozen of improved error messages
+  - Improved support for Merlin's renaming feature.
+  - Around fifty bug fixes
+
+
+Please report any unexpected behaviours on the [OCaml issue tracker](https://github.com/ocaml/ocaml/issues)
+and post any questions or comments you might have on our
+[discussion forums](https://discuss.ocaml.org).
+
+
+The full list of changes can be found in the full changelog.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 5.4.0
+```
+
+The source code for the release is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/releases/download/5.4.0/ocaml-5.4.0.tar.gz)
+* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.4/ocaml-5.4.0.tar.gz)
+
+### Fine-Tuned Compiler Configuration
+
+If you want to tweak the configuration of the compiler, you can switch to the option variant with:
+```bash
+opam update
+opam switch create <switch_name> ocaml-variants.5.4.0+options <option_list>
+```
+where `<option_list>` is a space separated list of `ocaml-option-*` packages. For instance, for a `flambda` and `no-flat-float-array` switch:
+```bash
+opam switch create 5.4.0+flambda+nffa ocaml-variants.5.4.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```

--- a/data/releases/5.3.0.md
+++ b/data/releases/5.3.0.md
@@ -43,13 +43,14 @@ type clashes.
 
 For a comprehensive list of changes and details on all new features,
 bug fixes, optimisations, etc., please consult the
-[changelog](#Changes).
+[changelog](#changes).
 
 ---
 
 ## Installation Instructions
 
 The base compiler can be installed as an opam switch with the following commands:
+
 ```bash
 opam update
 opam switch create 5.3.0
@@ -57,9 +58,8 @@ opam switch create 5.3.0
 
 The source code for OCaml 5.3.0 is also directly available on:
 
-* [GitHub](https://github.com/ocaml/ocaml/archive/5.3.0.tar.gz)
-* [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3.0.tar.gz)
-
+- [GitHub](https://github.com/ocaml/ocaml/archive/5.3.0.tar.gz)
+- [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3.0.tar.gz)
 
 ### Configuration Options
 
@@ -79,14 +79,11 @@ following options:
 
 For instance, one can install a switch with both `flambda` and the `--disable-flat-float-array` option with
 
-
-```
+```bash
 opam switch create 5.3.0+flambda+nffa ocaml-variants.5.3.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
 ```
 
-
-Source Distribution
--------------------
+## Source Distribution
 
 - [Source
   tarball](https://github.com/ocaml/ocaml/archive/5.3.0.tar.gz)
@@ -108,17 +105,15 @@ instructions. See also the [Windows release
 notes](https://ocaml.org/releases/5.3/notes/README.win32.adoc) for
 instructions on how to build under Windows.
 
-Alternative Compilers
----------------------
+## Alternative Compilers
 
 Additionally, the following projects allow you to compile OCaml code to
 targets traditionally associated with other languages:
 
-* [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
+- [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
   to JavaScript compiler.
 
-User Manual
--------------
+## User Manual
 
 The user manual for OCaml can be:
 
@@ -137,12 +132,9 @@ The user manual for OCaml can be:
   [tarball](https://ocaml.org/releases/5.3/ocaml-5.3-refman.info.tar.gz)
   of Emacs info files
 
-
 ## Changes
 
-(Changes that can break existing programs are marked with a "*")
-
-### Restored backend:
+### Restored backend
 
 - [#12954](https://github.com/ocaml/ocaml/issues/12954): Restore the MSVC port
   (David Allsopp, Antonin Décimo, Samuel Hym, and Miod Vallat, review by Nicolás
@@ -152,7 +144,7 @@ The user manual for OCaml can be:
   (Antonin Décimo, review by Nicolás Ojeda Bär, Samuel Hym,
    David Allsopp and Sébastien Hinderer)
 
-### Language features:
+### Language features
 
 - [#12309](https://github.com/ocaml/ocaml/issues/12309), [#13158](https://github.com/ocaml/ocaml/issues/13158): Add syntax support for deep effect handlers
   (Leo White, Tom Kelly, Anil Madhavapeddy, KC Sivaramakrishnan, Xavier Leroy
@@ -163,7 +155,6 @@ The user manual for OCaml can be:
   (Xavier Leroy and Florian Angeletti, review by Daniel Bünzli and
    Jules Aguillon)
 
-
 - [#12828](https://github.com/ocaml/ocaml/issues/12828), [#13283](https://github.com/ocaml/ocaml/issues/13283): Add short syntax for dependent functor types `(X:A) -> ...`
   (Jeremy Yallop, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
@@ -173,14 +164,13 @@ The user manual for OCaml can be:
   annotations.
   (Jacques Garrigue, report and review by Gabriel Scherer and Florian Angeletti)
 
-### Runtime system:
+### Runtime system
 
 - [#11911](https://github.com/ocaml/ocaml/issues/11911), [#12923](https://github.com/ocaml/ocaml/issues/12923): Multicore statistical memory profiling.
   This restores a notable OCaml 4 feature that was missing
   in OCaml 5.
   (Nick Barnes, review by Stephen Dolan, Jacques-Henri Jourdan
    and Guillaume Munch-Maccagnoni).
-
 
 - [#13419](https://github.com/ocaml/ocaml/issues/13419): Fix memory bugs in runtime events system.
   (B. Szilvasy and Nick Barnes, review by Miod Vallat, Nick Barnes,
@@ -242,7 +232,7 @@ The user manual for OCaml can be:
   Now these tables will go in the readonly segment, where they belong.
   (Antonin Décimo, review by David Allsopp)
 
-- [#10696](https://github.com/ocaml/ocaml/issues/10696): Introduce __has_attribute and __has_c_attributes in
+- [#10696](https://github.com/ocaml/ocaml/issues/10696): Introduce `__has_attribute` and `__has_c_attributes` in
   <caml/misc.h> to test the support of specific attributes in C
   code. Introduce fallthrough as a wrapper around the fallthrough
   attribute.
@@ -298,7 +288,7 @@ The user manual for OCaml can be:
 - [#13529](https://github.com/ocaml/ocaml/issues/13529): Do not write to event ring after going out of stw participant set.
   (KC Sivaramakrishnan, review by Sadiq Jaffer)
 
-### Code generation and optimizations:
+### Code generation and optimizations
 
 - [#13014](https://github.com/ocaml/ocaml/issues/13014): Enable compile-time option -function-sections on all previously
   unsupported native backends (POWER, riscv64 and s390x)
@@ -325,12 +315,11 @@ The user manual for OCaml can be:
   with js_of_ocaml
   (Hugo Heuzard, review by Gabriel Scherer)
 
-### Standard library:
+### Standard library
 
 - [#12885](https://github.com/ocaml/ocaml/issues/12885): move Dynarray to an unboxed representation
   (Gabriel Scherer, suggestions by Vincent Laviron,
    review by Olivier Nicole and Simon Cruanes, Yann Leray, Alain Frisch)
-
 
 - [#12884](https://github.com/ocaml/ocaml/issues/12884): Add `Queue.drop`
   (Léo Andrès, review by Nicolás Ojeda Bär and Gabriel Scherer)
@@ -370,15 +359,17 @@ The user manual for OCaml can be:
   (Gabriel Scherer, report by Hazem Elmasry,
    review by Olivier Nicole, Hazem Elmasry and Nicolás Ojeda Bär)
 
-* (*breaking change*) [#13240](https://github.com/ocaml/ocaml/issues/13240): Add Uchar.seeded_hash, Change Uchar.hash implementation.
+- (*breaking change*) [#13240](https://github.com/ocaml/ocaml/issues/13240): Add Uchar.seeded_hash, Change Uchar.hash implementation.
   Previously, Uchar.hash was aliased to Uchar.to_int. If you need that behavior,
   change your module instantiation from eg `module HT = Hashtbl.Make(Uchar)` to
-  ```
+  
+  ```ocaml
     module HT = Hashtbl.Make(struct
       ...
       let hash = Uchar.to_int
     end)
   ```
+
   If the current implementation is desired, and you have a hashtable module `HT`
   (produced with the `Make` functor) in persistent storage, use `HT.rebuild` to
   ensure it doesn't break when reading from or writing to buckets.
@@ -392,7 +383,7 @@ The user manual for OCaml can be:
   to Dynarray.
   (Jake H, review by Gabriel Scherer and Florian Angeletti)
 
-### Other libraries:
+### Other libraries
 
 - [#11996](https://github.com/ocaml/ocaml/issues/11996): release the dependency of dynlink on compilerlibs.
   (Sébastien Hinderer and Stephen Dolan, review by Damien Doligez and
@@ -401,7 +392,7 @@ The user manual for OCaml can be:
 - [#13326](https://github.com/ocaml/ocaml/issues/13326): Implement Unix.O_APPEND on windows.
   (Romain Beauxis, review by Miod Vallat, Gabriel Scherer and Antonin Décimo)
 
-### Tools:
+### Tools
 
 - [#11716](https://github.com/ocaml/ocaml/issues/11716): ocamllex: mismatched parentheses and curly brackets are now caught
   by ocamllex, instead of causing invalid OCaml code to be generated.
@@ -412,7 +403,7 @@ The user manual for OCaml can be:
   (Olivier Nicole, suggested by Sébastien Hinderer and David Allsopp, review by
    Gabriel Scherer)
 
-* (*breaking change*) [#13114](https://github.com/ocaml/ocaml/issues/13114): Support ocamldebug remote debugging over IPv6 on all
+- (*breaking change*) [#13114](https://github.com/ocaml/ocaml/issues/13114): Support ocamldebug remote debugging over IPv6 on all
   platforms, and over Unix domain sockets on Windows.
   (Antonin Décimo, review by Gabriel Scherer and Miod Vallat)
 
@@ -420,7 +411,7 @@ The user manual for OCaml can be:
   LLDB support for them.
   (Nick Barnes, review by Tim McGilchrist and Gabriel Scherer)
 
-### Toplevel:
+### Toplevel
 
 - [#12891](https://github.com/ocaml/ocaml/issues/12891): Improved styling for initial prompt
   (Florian Angeletti, review by Gabriel Scherer)
@@ -428,7 +419,7 @@ The user manual for OCaml can be:
 - [#13053](https://github.com/ocaml/ocaml/issues/13053): Improved display of builtin types such as `_ list` when aliased.
   (Samuel Vivien, review by Florian Angeletti)
 
-### Manual and documentation:
+### Manual and documentation
 
 - [#13370](https://github.com/ocaml/ocaml/issues/13370): Document that that temporary variables holding GCd pointers must
   not be live across a GC.
@@ -491,9 +482,9 @@ The user manual for OCaml can be:
    UTF-8 encoded Unicode text for OCaml source file
   (Florian Angeletti, review by Nicolás Ojeda Bär and Daniel Bünzli)
 
-### Compiler user-interface and warnings:
+### Compiler user-interface and warnings
 
-* (*breaking change*) [#12084](https://github.com/ocaml/ocaml/issues/12084), [#13669](https://github.com/ocaml/ocaml/issues/13669), [#13673](https://github.com/ocaml/ocaml/issues/13673): Check link order when creating archive and when using
+- (*breaking change*) [#12084](https://github.com/ocaml/ocaml/issues/12084), [#13669](https://github.com/ocaml/ocaml/issues/13669), [#13673](https://github.com/ocaml/ocaml/issues/13673): Check link order when creating archive and when using
    ocamlopt.
   (Hugo Heuzard, review by Stefan Muenzel and Sébastien Hinderer)
 
@@ -539,7 +530,7 @@ The user manual for OCaml can be:
   keyword.
   (Florian Angeletti, review by Gabriel Scherer)
 
-### Internal/compiler-libs changes:
+### Internal/compiler-libs changes
 
 - [#13286](https://github.com/ocaml/ocaml/issues/13286): Distinguish unique identifiers `Shape.Uid.t` according to their
   provenance: either an implementation or an interface.
@@ -549,7 +540,6 @@ The user manual for OCaml can be:
   useful information for external tools for navigation and analysis purposis.
   (Ulysse Gérard, Florian Angeletti, review by Florian Angeletti and Gabriel
   Scherer)
-
 
 - [#11129](https://github.com/ocaml/ocaml/issues/11129), [#11148](https://github.com/ocaml/ocaml/issues/11148): enforce that ppxs do not produce `parsetree`s with
   an empty list of universally quantified type variables
@@ -635,7 +625,7 @@ The user manual for OCaml can be:
   by not allocating a list when the list is not necessary.
   (Richard Eisenberg, review by Jacques Garrigue)
 
-### Build system:
+### Build system
 
 - [#12909](https://github.com/ocaml/ocaml/issues/12909): Reorganise how MKEXE_VIA_CC is built to make it correct for MSVC by
   grouping all the linker flags at the end of the C compiler commandline
@@ -648,7 +638,7 @@ The user manual for OCaml can be:
 - [#12996](https://github.com/ocaml/ocaml/issues/12996): Only link with -lgcc_eh when available.
   (Romain Beauxis, review by David Allsopp and Miod Vallat)
 
-* (*breaking change*) [#13200](https://github.com/ocaml/ocaml/issues/13200): Do not use CFLAGS for linking.
+- (*breaking change*) [#13200](https://github.com/ocaml/ocaml/issues/13200): Do not use CFLAGS for linking.
   (Sébastien Hinderer, review by Gabriel Scherer, Antonin Décimo,
   Miod Vallat and Samuel Hym)
 
@@ -656,7 +646,7 @@ The user manual for OCaml can be:
   (Sébastien Hinderer, review by Miod Vallat, Gabriel Scherer and
   Olivier Nicole)
 
-* (*breaking change*) [#12578](https://github.com/ocaml/ocaml/issues/12578), [#12589](https://github.com/ocaml/ocaml/issues/12589), [#13322](https://github.com/ocaml/ocaml/issues/13322), [#13519](https://github.com/ocaml/ocaml/issues/13519): Use configured CFLAGS and CPPFLAGS *only*
+- (*breaking change*) [#12578](https://github.com/ocaml/ocaml/issues/12578), [#12589](https://github.com/ocaml/ocaml/issues/12589), [#13322](https://github.com/ocaml/ocaml/issues/13322), [#13519](https://github.com/ocaml/ocaml/issues/13519): Use configured CFLAGS and CPPFLAGS *only*
   during the build of the compiler itself. Do not use them when
   compiling third-party C sources through the compiler. Flags for
   compiling third-party C sources can still be specified at configure
@@ -669,7 +659,7 @@ The user manual for OCaml can be:
   [#12198](https://github.com/ocaml/ocaml/issues/12198), [#12321](https://github.com/ocaml/ocaml/issues/12321), [#12586](https://github.com/ocaml/ocaml/issues/12586), [#12616](https://github.com/ocaml/ocaml/issues/12616), [#12706](https://github.com/ocaml/ocaml/issues/12706) and [#13048](https://github.com/ocaml/ocaml/issues/13048).
   (Sébastien Hinderer, review by David Allsopp and Florian Angeletti)
 
-### Bug fixes:
+### Bug fixes
 
 - [#12854](https://github.com/ocaml/ocaml/issues/12854): Add a test in the regression suite that flags the bug [#12825](https://github.com/ocaml/ocaml/issues/12825).
   (Luc Maranget)
@@ -694,7 +684,7 @@ The user manual for OCaml can be:
   The syntax '-(1 [@foo])' was incorrectly parsed as '-1'.
   (Jules Aguillon, reviewed by Gabriel Scherer, report by Gabriel Scherer)
 
-* (*breaking change*) [#13070](https://github.com/ocaml/ocaml/issues/13070): On Windows, when configured with bootstrapped flexdll, don't add
+- (*breaking change*) [#13070](https://github.com/ocaml/ocaml/issues/13070): On Windows, when configured with bootstrapped flexdll, don't add
   +flexdll to the search path when -nostdlib is specified (which then means
   -L <path-to-flexdll> no longer gets passed to the system linker).
   (David Allsopp, review by Florian Angeletti)
@@ -816,7 +806,7 @@ The user manual for OCaml can be:
 
 - [#13391](https://github.com/ocaml/ocaml/issues/13391), [#13551](https://github.com/ocaml/ocaml/issues/13551): fix a printing bug with `-dsource` when using
   raw literal inside a locally abstract type constraint
-  (i.e. `let f: type \#for. ... `)
+  (i.e. `let f: type \#for. ...`)
   (Florian Angeletti, report by Nick Roberts, review by Richard Eisenberg)
 
 - [#13520](https://github.com/ocaml/ocaml/issues/13520): Fix compilation of native-code version of systhreads. Bytecode fields

--- a/data/releases/5.3.0.md
+++ b/data/releases/5.3.0.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 5.3.0
 date: 2025-01-08
-is_latest: true
+is_latest: false
 intro: |
   This page describes OCaml version **5.3.0**, released on
   2025-01-08. Go [here](/releases) for a list of all releases.

--- a/data/releases/5.4.0.md
+++ b/data/releases/5.4.0.md
@@ -1,0 +1,879 @@
+---
+kind: compiler
+version: 5.4.0
+date: 2025-10-09
+is_latest: true
+intro: |
+  This page describes OCaml version **5.4.0**, released on
+  2025-01-08. Go [here](/releases) for a list of all releases.
+
+  This release is available as an [opam](/p/ocaml/5.4.0) package.
+highlights: |
+  - Labelled tuples
+  - Immutable arrays
+  - Array literal syntax support for immutable arrays and `floatarray`s
+  - Atomic record fields
+  - Four new standard library modules: Pair, Pqueue, Repr, and Iarray
+  - Restored "memory cleanup upon exit" mode
+  - New section in the manual on native code profiling on Linux and macOS
+  - Many runtime improvements
+  - More than thirty new standard library functions
+  - A dozen of improved error messages
+  - Improved support for Merlin's renaming feature.
+  - Around fifty bug fixes
+---
+
+## What's New
+
+Some of the highlights in OCaml 5.4.0 are:
+
+- Labelled tuples
+- Immutable arrays
+- Array literal syntax support for immutable arrays and `floatarray`s
+  (through type-directed disambiguation)
+- Atomic record fields
+- Four new standard library modules: Pair, Pqueue, Repr, and Iarray
+- Restored "memory cleanup upon exit" mode
+- New section in the manual on native code profiling on Linux and macOS
+
+And a lot of incremental changes:
+
+- Many runtime improvements
+- More than thirty new standard library functions
+- A dozen of improved error messages
+- Improved support for Merlin's renaming feature.
+- Around fifty bug fixes
+For a comprehensive list of changes and details on all new features,
+bug fixes, optimisations, etc., please consult the
+[changelog](#changes).
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+
+```bash
+opam update
+opam switch create 5.4.0
+```
+
+The source code for OCaml 5.4.0 is also directly available on:
+
+- [GitHub](https://github.com/ocaml/ocaml/archive/5.4.0.tar.gz)
+- [OCaml archives at Inria](https://caml.inria.fr/pub/distrib/ocaml-5.4/ocaml-5.4.0.tar.gz)
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: Set OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: Compile OCaml without the native-code compiler
+- `ocaml-option-flambda`: Set OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: Set OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: Set OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: Set OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-tsan` : Set OCaml to be compiled with thread sanitiser support
+- `ocaml-option-address-sanitizer`: Set OCaml to be compiled with address sanitiser
+- `ocaml-option-leak-sanitizer`: Set OCaml to be compiled with leak sanitiser
+- `ocaml-option-fp`: Set OCaml to be compiled with frame pointers
+
+For instance, one can install a switch with both `flambda` and the `--disable-flat-float-array` option with
+
+```bash
+opam switch create 5.4.0+flambda+nffa ocaml-variants.5.4.0+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+## Source Distribution
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/5.4.0.tar.gz)
+  (`.tar.gz`) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin)
+- Also available in
+  [`.zip`](https://github.com/ocaml/ocaml/archive/5.4.0.zip)
+  format
+- [Opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://ocaml.org/releases/5.4/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions. See also the [Windows release
+notes](https://ocaml.org/releases/5.4/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+## Alternative Compilers
+
+Additionally, the following projects allow you to compile OCaml code to
+targets traditionally associated with other languages:
+
+- [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
+  to JavaScript compiler.
+- [wasm_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
+  to WebAssembly compiler.
+
+## User Manual
+
+The user manual for OCaml can be:
+
+- [Browsed online](https://ocaml.org/releases/5.4/manual/index.html)
+- Downloaded as a single
+  [PDF](https://ocaml.org/releases/5.4/ocaml-5.4-refman.pdf)
+  or [plain
+  text](https://ocaml.org/releases/5.4/ocaml-5.4-refman.txt)
+  document
+- Downloaded as a single
+  [TAR](https://ocaml.org/releases/5.4/ocaml-5.4-refman-html.tar.gz)
+  or
+  [ZIP](https://ocaml.org/releases/5.4/ocaml-5.4-refman-html.zip)
+  archive of HTML files
+- Downloaded as a single
+  [tarball](https://ocaml.org/releases/5.4/ocaml-5.4-refman.info.tar.gz)
+  of Emacs info files
+
+## Changes
+
+### Language features
+
+- [#13097](https://github.com/ocaml/ocaml/issues/13097): added immutable arrays (`'a iarray` type, Iarray stdlib module)
+  (Antal Spector-Zabusky and Olivier Nicole, review by Gabriel Scherer,
+  Jeremy Yallop and Vincent Laviron)
+
+- [#13340](https://github.com/ocaml/ocaml/issues/13340): Array literal syntax [| e1; ...; en |] can now be used to
+  denote values of type `'a array` and `'a iarray` and `floatarray`,
+  both in expressions and patterns. The compiler disambiguates each
+  case by using contextual type information (assuming `'a array`
+  by default).
+  (Nicolás Ojeda Bär, review by Richard Eisenberg, Jeremy Yallop, Jacques
+  Garrigue, and Gabriel Scherer)
+
+- [#13498](https://github.com/ocaml/ocaml/issues/13498): Tuple fields are now optionally labeled:
+  `(x:42, y:0)` and `let (~x, ~y) = ... in ...`.
+  (Ryan Tjoa and Chris Casinghino, review by Gabriel Scherer, Chris Casinghino,
+  and Leo White)
+
+- RFCs[#39](https://github.com/ocaml/ocaml/issues/39), [#13404](https://github.com/ocaml/ocaml/issues/13404): atomic record fields
+    `{ ...; mutable readers : int [@atomic]; ... }`
+    `Atomic.Loc.fetch_and_add [%atomic.loc data.readers] 1`
+  (Clément Allain and Gabriel Scherer, review by KC Sivaramakrishnan,
+   Basile Clément and Olivier Nicole)
+
+### Standard library
+
+- (*breaking change*) [#14124](https://github.com/ocaml/ocaml/issues/14124): Do not raise Invalid_argument on negative List.{drop,take}.
+  (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+
+- [#13696](https://github.com/ocaml/ocaml/issues/13696): Add Result.product and Result.Syntax:
+  `let open Result.Syntax in let* x = ... in ...`
+  (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+
+- [#12871](https://github.com/ocaml/ocaml/issues/12871): Add the Pqueue module to the stdlib. It implements priority queues.
+  (Jean-Christophe Filliâtre, review by Daniel Bünzli, Léo Andrès and
+  Gabriel Scherer)
+
+- [#13760](https://github.com/ocaml/ocaml/issues/13760): Add String.{edit_distance,spellcheck}
+  (Daniel Bünzli, review by wikku, Nicolás Ojeda Bär, Gabriel Scherer and
+   Florian Angeletti)
+
+- [#13753](https://github.com/ocaml/ocaml/issues/13753), [#13755](https://github.com/ocaml/ocaml/issues/13755): Add Stdlib.Repr:
+  Repr.phys_equal and Repr.compare are more explicit than (==) and `compare`.
+  (Kate Deplaix, Thomas Blanc and Léo Andrès, review by Gabriel Scherer,
+   Florian Angeletti, Nicolás Ojeda Bär, Daniel Bünzli and Jeremy Yallop)
+
+- [#13695](https://github.com/ocaml/ocaml/issues/13695): Add Stdlib.Char.Ascii
+  (Daniel Bünzli, review by by Nicolás Ojeda Bär and Jeremy Yallop)
+
+- [#13720](https://github.com/ocaml/ocaml/issues/13720): Add Result.{get_ok',error_to_failure}
+ (Daniel Bünzli, review by wikku, Gabriel Scherer, Nicolás Ojeda Bär,
+  Vincent Laviron and hirrolot)
+
+- [#13885](https://github.com/ocaml/ocaml/issues/13885): Add Dynarray.{exists2, for_all2}.
+  (T. Kinsart, review by Daniel Bünzli, Gabriel Scherer, and Nicolás Ojeda Bär)
+
+- (*breaking change*) [#13862](https://github.com/ocaml/ocaml/issues/13862): Make List.sort_uniq keep the first occurrences of duplicates.
+  (Benoît Jubin, review by Nicolás Ojeda Bär, Gabriel Scherer)
+
+- [#13836](https://github.com/ocaml/ocaml/issues/13836): Add [Float.]Array.{equal,compare}.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
+- [#13796](https://github.com/ocaml/ocaml/issues/13796): Add Uchar.utf_8_decode_length_of_byte and
+  Uchar.max_utf_8_decode_length.
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#13768](https://github.com/ocaml/ocaml/issues/13768): Add Either.get_left and Either.get_right
+  (T. Kinsart, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- (*breaking change*) [#13570](https://github.com/ocaml/ocaml/issues/13570), [#13794](https://github.com/ocaml/ocaml/issues/13794): Format, add an out_width function to Format device for
+   approximating unicode width.
+  (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
+   and Gabriel Scherer)
+
+- [#13731](https://github.com/ocaml/ocaml/issues/13731): Add Either.retract
+  (Daniel Bünzli, review by Nicolás Ojeda Bär and David Allsopp)
+
+- [#13729](https://github.com/ocaml/ocaml/issues/13729): Add Seq.filteri
+  (T. Kinsart, review by Nicolás Ojeda Bär and Daniel Bünzli)
+
+- [#13721](https://github.com/ocaml/ocaml/issues/13721): Add Result.retract
+  (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär and
+   David Allsopp)
+
+- [#13310](https://github.com/ocaml/ocaml/issues/13310): Add Stdlib.Pair
+  (Victoire Noizet, review by Nicolás Ojeda Bär, Daniel Bünzli, Xavier Van de
+   Woestyne, Jeremy Yallop and Florian Angeletti)
+
+- [#13662](https://github.com/ocaml/ocaml/issues/13662): Add eager boolean operations Bool.logand, Bool.logor, Bool.logxor
+  (Jeremy Yallop, review by Nicolás Ojeda Bär)
+
+- [#13463](https://github.com/ocaml/ocaml/issues/13463), [#13572](https://github.com/ocaml/ocaml/issues/13572): Avoid raising Queue.empty in Format when it is used
+  concurrently, raise a specific exception instead.
+  (Chritophe Raffalli, review by Gabriel Scherer and Daniel Bünzli)
+
+- [#13620](https://github.com/ocaml/ocaml/issues/13620): Avoid copying the string in String.concat, String.sub and
+  String.split_on_char when the full string is returned.
+  (Christophe Raffalli, review by Nicolás Ojeda Bär and Gabriel Scherer and
+   Hugo Heuzard)
+
+- [#13727](https://github.com/ocaml/ocaml/issues/13727): Reimplement Sys.getenv_opt not to use exceptions internally, meaning
+  that the current backtrace is preserved when Sys.getenv_opt returns None.
+  (David Allsopp, review by Nicolás Ojeda Bär, Josh Berdine and Gabriel Scherer)
+
+- [#13737](https://github.com/ocaml/ocaml/issues/13737): Avoid closure allocations in Weak.Make.add when resizing the
+  table
+  (Vincent Laviron, review by Gabriel Scherer and Daniel Bünzli)
+
+- [#13740](https://github.com/ocaml/ocaml/issues/13740): Improve performance of Weak.find_aux
+  (Josh Berdine, review by Gabriel Scherer)
+
+- [#13782](https://github.com/ocaml/ocaml/issues/13782): Improve performance and type safety of Type.Id by using
+  [%extension_constructor] instead of Obj.Extension_constructor.of_val.
+  (Basile Clément, review by Vincent Laviron and Nicolás Ojeda Bär)
+
+- [#13589](https://github.com/ocaml/ocaml/issues/13589): Expose Sys.io_buffer_size, the size of internal buffers used by the
+  runtime system and the `unix` library.
+  (Yves Ndiaye and Nicolás Ojeda Bär, review by Daniel Bünzli and Nicolás Ojeda
+  Bär)
+
+- [#13569](https://github.com/ocaml/ocaml/issues/13569): add a `Format.format_text` which adds break hints to format literals.
+  (Florian Angeletti, review by Nicolás Ojeda Bär, Daniel Bünzli,
+   and Gabriel Scherer)
+
+- [#13578](https://github.com/ocaml/ocaml/issues/13578): On Windows, use the OS CSPRNG to seed the Stdlib.Random generator.
+  (Antonin Décimo, review by Miod Vallat, Nicolás Ojeda Bär, and Xavier Leroy)
+
+- [#13859](https://github.com/ocaml/ocaml/issues/13859): Fix Weak.get_copy not darkening custom blocks
+  (Josh Berdine, review by Stephen Dolan)
+
+- [#13909](https://github.com/ocaml/ocaml/issues/13909): Add `Dynarray.unsafe_to_iarray`
+  (Olivier Nicole, review by Daniel Bünzli, Stefan Muenzel and Gabriel Scherer,
+  request by Daniel Bünzli)
+
+- [#13932](https://github.com/ocaml/ocaml/issues/13932): Add List.singleton and Seq.singleton
+  (David Allsopp, tariffs applied by Nicolás Ojeda Bär and Gabriel Scherer)
+
+- (*breaking change*) [#13843](https://github.com/ocaml/ocaml/issues/13843): Add signal definitions for SIGIO and SIGWINCH. Introduces a
+  type alias for signal int, signal_to_string to convert OCaml signal numbers
+  to their POSIX equivalent names, and signal_of_int/signal_to_int for
+  converting between OCaml and platform signal numbers. (Reported in [#13825](https://github.com/ocaml/ocaml/issues/13825))
+  (Tim McGilchrist, review by David Allsopp, Nicolás Ojeda Bär, Daniel Bünzli
+   Jan Midtgaard and Miod Vallat)
+
+### Runtime system
+
+- [#13500](https://github.com/ocaml/ocaml/issues/13500): Add frame pointers support for ARM64 on Linux and macOS.
+  (Tim McGilchrist, review by KC Sivaramakrishnan, Fabrice Buoro
+   and Miod Vallat)
+
+- [#12964](https://github.com/ocaml/ocaml/issues/12964): Reintroduce "memory cleanup upon exit" mode. The cleanup will
+  however be incomplete if not all domains have been joined when the main
+  domain terminates.
+  (Miod Vallat, review by KC Sivaramakrishnan, feedback from Nick Barnes
+   and Gabriel Scherer)
+
+- [#13582](https://github.com/ocaml/ocaml/issues/13582): Enable software prefetching support for ARM64, s390x, PPC64 and RiscV.
+  Used during GC marking and sweeping to speed up both operations by
+  prefetching data.
+  (Tim McGilchrist, review by Nick Barnes, Antonin Décimo,
+   Stephen Dolan and Miod Vallat)
+
+- [#13675](https://github.com/ocaml/ocaml/issues/13675): Make Unix.map_file memory show up in Gc.Memprof.
+  (Stephen Dolan, review by Guillaume Munch-Maccagnoni and Gabriel Scherer)
+
+- [#13785](https://github.com/ocaml/ocaml/issues/13785): Add `Runtime_events.Timestamp.get_current`.
+  (Simon Cruanes)
+
+- [#13774](https://github.com/ocaml/ocaml/issues/13774): Fix for inaccurate live blocks/words stats in compaction.
+  (Sadiq Jaffer, report by KC Sivaramakrishnan and Jan Midtgaard, review by
+  Gabriel Scherer)
+
+- [#13773](https://github.com/ocaml/ocaml/issues/13773): Ensure that shared pool owners are correctly set on pool adoption.
+  (Stephen Dolan, review by Sadiq Jaffer and Gabriel Scherer)
+
+- (*breaking change*) [#11449](https://github.com/ocaml/ocaml/issues/11449), [#13497](https://github.com/ocaml/ocaml/issues/13497): Add caml_stat_char_array_{to,of}_os functions allowing
+  conversion of string data which may contain NUL characters. Correct
+  implementation of caml_stat_strdup_to_utf16 to raise Out_of_memory instead of
+  returning of NULL (the behaviour of caml_stat_strdup_to_os was inconsistent
+  between Unix/Windows).
+  (David Allsopp, review by Nick Barnes, Antonin Décimo and Miod Vallat)
+
+- [#13352](https://github.com/ocaml/ocaml/issues/13352): Concurrency refactors and cleanups.
+  (Antonin Décimo, review by Gabriel Scherer, David Allsopp, and Miod Vallat)
+
+- [#13437](https://github.com/ocaml/ocaml/issues/13437): Stop using GetProcAddress to load functions that were not
+  available in older, now unsupported Windows versions.
+  (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
+
+- [#13470](https://github.com/ocaml/ocaml/issues/13470): Constify some function parameters, flags tables, and some
+  pointers in C code (take 3).
+  (Antonin Décimo, review by Stephen Dolan and Miod Vallat)
+
+- [#13492](https://github.com/ocaml/ocaml/issues/13492): Parse the CAML_LD_LIBRARY_PATH environment variable for the
+  shared_libs_path item in `ocamlrun -config` in addition to displaying the
+  entries found in ld.conf.
+  (David Allsopp, review by Stephen Dolan)
+
+- [#13496](https://github.com/ocaml/ocaml/issues/13496): Add missing .type and .size directives to main frametable to silence
+  warnings from the linker when using libasmrun_shared on amd64 and power. The
+  other backends already carried these directives.
+  (David Allsopp, review by Tim McGilchrist and Miod Vallat)
+
+- [#13354](https://github.com/ocaml/ocaml/issues/13354): Use C99 flexible array member syntax everywhere.
+  (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and Xavier Leroy)
+
+- [#11865](https://github.com/ocaml/ocaml/issues/11865), [#13584](https://github.com/ocaml/ocaml/issues/13584): Fix a deadlock triggered by deleting C roots from C finalisers
+  (Stephen Dolan, report by Timothy Bourke, review by Mark Shinwell and Damien
+  Doligez)
+
+- [#13613](https://github.com/ocaml/ocaml/issues/13613): Functions from caml/skiplist.h and caml/lf_skiplist.h no longer raise
+  Out_of_memory exceptions that the runtime could not handle.
+  (Guillaume Munch-Maccagnoni, review by Stephen Dolan)
+
+- [#13575](https://github.com/ocaml/ocaml/issues/13575), [#13635](https://github.com/ocaml/ocaml/issues/13635): Maintain OCaml frame pointers correctly even when using
+   C libraries that do not support them.
+  (Stephen Dolan and David Allsopp, report by Thomas Leonard, review by Tim
+   McGilchrist and Fabrice Buoro)
+
+- [#13643](https://github.com/ocaml/ocaml/issues/13643): Allow values reachable from ephemeron keys to be collected by minor GC
+  (Stephen Dolan, review by François Bobot)
+
+- [#13701](https://github.com/ocaml/ocaml/issues/13701): optimize `caml_continuation_use` based on [#12735](https://github.com/ocaml/ocaml/issues/12735)
+  (Hugo Heuzard, review by KC Sivaramakrishnan)
+
+- [#13227](https://github.com/ocaml/ocaml/issues/13227), [#13714](https://github.com/ocaml/ocaml/issues/13714): Review of locking in the multicore runtime. Fix
+  deadlocks in runtime events and potential deadlocks with named
+  values.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, tests by
+  Jan Midtgaard)
+
+- [#13736](https://github.com/ocaml/ocaml/issues/13736): Fix major GC pacing bug triggered by synchronous collections.
+  (Nick Barnes, review by Damien Doligez and Tim McGilchrist)
+
+- [#13827](https://github.com/ocaml/ocaml/issues/13827): Avoid re-marking ephemerons with trivial data.
+  (Stephen Dolan, review by Nick Barnes and Josh Berdine, benchmarking by
+   Nicolás Ojeda Bär)
+
+- [#13300](https://github.com/ocaml/ocaml/issues/13300), [#13861](https://github.com/ocaml/ocaml/issues/13861): introduce `Gc.ramp_up` to explicitly mark ramp-up
+  phases of memory consumption and avoid GC overwork. Ramp-up behaviors
+  are worse with OCaml 5 than with OCaml 4 due to higher sensitivity
+  to excessive pacing computations. Indicating ramp-up explicitly eliminates
+  the main known slowdown of OCaml 5 (relative to OCaml 4) for Coq/Rocq.
+  (Gabriel Scherer, review by Damien Doligez and Guillaume Munch-Maccagnoni,
+   report by Emilio Jesús Gallego Arias and Olivier Nicole)
+
+- [#14057](https://github.com/ocaml/ocaml/issues/14057): Don't update memprof too early at the end of a minor GC.
+  (Nick Barnes, review by Damien Doligez).
+
+### Code generation and optimizations
+
+- [#13262](https://github.com/ocaml/ocaml/issues/13262), [#14074](https://github.com/ocaml/ocaml/issues/14074): fix performance issue on Apple Silicon macOS by emitting
+  `stlr` instead of `dmb ishld; str`.
+  (KC Sivaramakrishnan, report by François Pottier, analysis by Frédéric Bour,
+  Xavier Leroy, Miod Vallat, Gabriel Scherer and Stephen Dolan, review by Miod
+  Vallat, Vincent Laviron and Xavier Leroy)
+
+- (*breaking change*) [#13050](https://github.com/ocaml/ocaml/issues/13050), [#14104](https://github.com/ocaml/ocaml/issues/14104), [#14143](https://github.com/ocaml/ocaml/issues/14143): Use '$' instead of '.' to separate module names
+  in symbol names on macOS and Windows (including the Cygwin backend).
+  This changes mangling of OCaml identifiers on those operating systems from
+  `camlModule.name_NNN` to `camlModule$name_NNN`. Additionally it
+  changes the encoding of special characters from $xx (two hex digits)
+  to $$xx (two dollar signs followed by two hex digits).
+  (Tim McGilchrist, with contributions from Xavier Leroy,
+   reviewed by Xavier Leroy, Miod Vallat, Gabriel Scherer,
+   Nick Barnes and Hugo Heuzard)
+
+- [#13807](https://github.com/ocaml/ocaml/issues/13807): Allow unaligned memory accesses on ARM64.
+  (Matthew Else, review by Xavier Leroy)
+
+- [#13565](https://github.com/ocaml/ocaml/issues/13565): less tagging in switches compiled to affine transformations
+  by ocamlopt.
+  (Gabriel Scherer and Clément Allain, review by Vincent Laviron,
+   report by Vesa Karvonen)
+
+- [#13672](https://github.com/ocaml/ocaml/issues/13672) Avoid register stall on conversion instructions on amd64.
+  (Pierre Chambart, review by Gabriel Scherer and Xavier Leroy,
+   report by Patrick Nicodemus)
+
+- [#13667](https://github.com/ocaml/ocaml/issues/13667): (originally [#11162](https://github.com/ocaml/ocaml/issues/11162)) Fix instr_size computation on arm64.
+  (Stephen Dolan and Tim McGilchrist, review by Xavier Leroy
+  and David Allsopp)
+
+- [#13758](https://github.com/ocaml/ocaml/issues/13758): Propagate more value kinds in Flambda to allow more unboxing
+  (Vincent Laviron, review by Pierre Chambart)
+
+- [#13759](https://github.com/ocaml/ocaml/issues/13759): Propagate more type information from clambda to cmm.
+  (Pierre Chambart, review by Gabriel Scherer)
+
+- [#13735](https://github.com/ocaml/ocaml/issues/13735): Follow the behaviour of the C compiler to decide whether to emit the
+  `.size` and `.type` directives and the `.note.GNU-stack` section
+  (Samuel Hym, review by Miod Vallat, Antonin Décimo and Gabriel Scherer)
+
+### Other libraries
+
+- (*breaking change*) [#13435](https://github.com/ocaml/ocaml/issues/13435): On Windows, use system calls for `Filename.get_temp_dir_name` instead
+  of directly reading the environment, which in particular improves the security
+  of OCaml processes running in the SYSTEM security context by mitigating
+  privileged file operation attacks. For all other processes running with the
+  default environment (where `TEMP` is set), there is no discernible change.
+  (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
+
+- [#13504](https://github.com/ocaml/ocaml/issues/13504), [#13625](https://github.com/ocaml/ocaml/issues/13625), [#14223](https://github.com/ocaml/ocaml/issues/14223): Add `Thread.set_current_thread_name`.
+  (Romain Beauxis, review by Gabriel Scherer and Antonin Décimo)
+
+- (*breaking change*) [#13376](https://github.com/ocaml/ocaml/issues/13376): Allow Dynlink.loadfile_private to load bytecode libraries with
+  internal dependencies
+  (Vincent Laviron, report by Stéphane Glondu, review by Nicolás Ojeda Bär
+   and Xavier Leroy)
+
+- [#13429](https://github.com/ocaml/ocaml/issues/13429): add `Unix.sigwait`, a binding to the `sigwait` system call;
+  implement `Thread.wait_signal` using `Unix.sigwait`, and
+  `Thread.sigmask` using `Unix.sigprocmask`.
+  (Xavier Leroy, review by Antonin Décimo, Gabriel Scherer, Miod Vallat)
+
+- [#13442](https://github.com/ocaml/ocaml/issues/13442), [#13452](https://github.com/ocaml/ocaml/issues/13452): Fix Unix.getgroups for users belonging to more than 32 groups
+  when using musl
+  (Kate Deplaix, review by Gabriel Scherer, Antonin Décimo, Anil Madhavapeddy)
+
+- [#13576](https://github.com/ocaml/ocaml/issues/13576): Introduce internal helpers to convert between time representations.
+  On Windows, prevent erroneously waiting for an unbounded time in Unix.select
+  if more than 64 file descriptors per lists are watched, or if watching
+  non-socket file descriptors, and a timeout longer than $2^{32}$ milliseconds
+  is used. Cap the timeout to $2^{32}$ milliseconds.
+  (Antonin Décimo, review by Gabriel Scherer and Miod Vallat)
+
+- [#13921](https://github.com/ocaml/ocaml/issues/13921): Set cloexec correctly on CRT file descriptors created by the Unix
+  library on Windows. The inheritance on the underlying Win32 handles was
+  correctly set, but the book-keeping for the CRT was leaking the value of
+  non-inherited handles which combined with re-use of HANDLE values within
+  processes could appear to make a CRT file descriptor "re-open".
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
+### Tools
+
+- [#13686](https://github.com/ocaml/ocaml/issues/13686): Fix Python debugger extensions (for LLDB and GDB) to restore
+  functionality broken by [#13272](https://github.com/ocaml/ocaml/issues/13272) in 5.3.
+  (Nick Barnes, review by Tim McGilchrist Gabriel Scherer)
+
+- [#12019](https://github.com/ocaml/ocaml/issues/12019): ocamlc: add `align_double` and `align_int64` to `ocamlc -config`
+  output.
+  (Romain Beauxis, review by David Allsopp)
+
+- [#12642](https://github.com/ocaml/ocaml/issues/12642), [#13536](https://github.com/ocaml/ocaml/issues/13536), [#14184](https://github.com/ocaml/ocaml/issues/14184), [#14192](https://github.com/ocaml/ocaml/issues/14192): in the toplevel, print shorter paths for
+  constructors and labels when only some modules along their path are open.
+  (Gabriel Scherer, review by Florian Angeletti)
+
+- [#13199](https://github.com/ocaml/ocaml/issues/13199), [#13485](https://github.com/ocaml/ocaml/issues/13485), [#13665](https://github.com/ocaml/ocaml/issues/13665), [#13762](https://github.com/ocaml/ocaml/issues/13762), [#13965](https://github.com/ocaml/ocaml/issues/13965): Support running native debuggers in
+  ocamltest.
+  (Tim McGilchrist, Sebastien Hinderer, David Allsopp, Antonin Décimo, review by
+  Sebastien Hinderer, Gabriel Scherer, Antonin Décimo, and Tim McGilchrist)
+
+- [#13764](https://github.com/ocaml/ocaml/issues/13764), [#13779](https://github.com/ocaml/ocaml/issues/13779): add missing "-keywords" flag to ocamldep and ocamlprof
+  (Florian Angeletti, report by Prashanth Mundkur, review by Gabriel Scherer)
+
+- [#13877](https://github.com/ocaml/ocaml/issues/13877): ocamldoc, add a `-latex-escape-underscore` flag to control the
+  escaping of `_` underscore in latex references (in order to be able to match
+  odoc behaviour).
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#13906](https://github.com/ocaml/ocaml/issues/13906): Add support for a `multicore` tag in ocamltest and use it for
+  tests that fail on mono-core systems.
+  (Stéphane Glondu, review by Nicolás Ojeda Bär)
+
+### Manual and documentation
+
+- [#13751](https://github.com/ocaml/ocaml/issues/13751): Document support for profiling with Linux perf and frame pointers.
+  (Tim McGilchrist, review by Gabriel Scherer and Miod Vallat)
+
+- [#12452](https://github.com/ocaml/ocaml/issues/12452): Add examples to Stdlib.Fun documentation.
+  (Hazem ElMasry, review by Florian Angeletti and Gabriel Scherer)
+
+- [#13924](https://github.com/ocaml/ocaml/issues/13924): Document how to put [@deprecated] on let bindings, constructors, etc
+  in the manual
+  (Valentin Gatien-Baron, review by Florian Angeletti)
+
+- [#13694](https://github.com/ocaml/ocaml/issues/13694): Fix name for caml_hash_variant in the C interface.
+  (Michael Hendricks)
+
+- [#13732](https://github.com/ocaml/ocaml/issues/13732): Document that custom finalizers must not access the OCaml heap, etc.
+  (Josh Berdine, review by Stephen Dolan and Guillaume Munch-Maccagnoni)
+
+### Type system
+
+- (*breaking change*) [#13830](https://github.com/ocaml/ocaml/issues/13830): fail rather than silently create abstract module types when avoiding
+  (i.e. hiding) signature items, as in:
+
+```ocaml
+  module N = struct
+    open (struct type t = A | B end)
+    module type T = sig type u = t * int end
+  end
+```
+
+  Before, it was succeeding with `module N : sig module type T end`, now it
+  fails. Similarly for anonymous functor calls (of the form `F(struct ... end))
+  (Clement Blaudeau, review by Gabriel Scherer)
+
+### Compiler user-interface and warnings
+
+- [#13817](https://github.com/ocaml/ocaml/issues/13817): align spellchecking hints with the possibly misspelled identifier/
+              Error: Unbound type constructor "aray"
+              Hint:              Did you mean "array"?
+  (Florian Angeletti, suggestion by Daniel Bünzli, review by Gabriel Scherer)
+
+- [#13587](https://github.com/ocaml/ocaml/issues/13587): Enable native backend on x86_64 GNU/Hurd.
+  (Samuel Thibault, review by Antonin Décimo, Sébastien Hinderer and Miod
+   Vallat)
+
+- [#13663](https://github.com/ocaml/ocaml/issues/13663): Improve the error message when GADT parameter variance cannot be
+  checked.
+  (Stefan Muenzel, review by Gabriel Scherer and Florian Angeletti)
+
+- [#13646](https://github.com/ocaml/ocaml/issues/13646): Improve the error messages when a recursive module type
+  references another recursive module type.
+  (Stefan Muenzel, review by Florian Angeletti and Gabriel Scherer)
+
+- [#13702](https://github.com/ocaml/ocaml/issues/13702), [#13865](https://github.com/ocaml/ocaml/issues/13865): Specialized error messages for functors appearing in contexts
+  where non-functors were expected `module A: sig ... end = Set.Make`
+  (and the reverse)
+  (Florian Angeletti, report by Jeremy Yallop, review by Gabriel Scherer)
+
+- [#13788](https://github.com/ocaml/ocaml/issues/13788), [#13813](https://github.com/ocaml/ocaml/issues/13813): Keep the module context in spellchecking hints.
+  `Fun.protact` now prompts `Did you mean "Fun.protect?"` rather than
+  `Did you mean "protect?"`.
+  (Florian Angeletti, suggestion by Daniel Bünzli, review by Gabriel Scherer)
+
+- [#13428](https://github.com/ocaml/ocaml/issues/13428): support dump=[source | parsetree | lambda | ... | cmm | ...]
+  in OCAMLRUNPARAM
+  (Gabriel Scherer, review by Vincent Laviron)
+
+- [#13493](https://github.com/ocaml/ocaml/issues/13493): Clearer error message in ocamlc for conflicting link options for
+  C stubs when shared libraries are not available.
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#13563](https://github.com/ocaml/ocaml/issues/13563), lighter inline code styling for output without bold support: inline
+  code is no longer printed as "..." to avoid confusion with OCaml strings.
+  (Florian Angeletti, review by Richard Eisenberg)
+
+- [#13568](https://github.com/ocaml/ocaml/issues/13568), composable formatting for warning and alert messages
+  (Florian Angeletti, review by Richard Eisenberg)
+
+- [#13601](https://github.com/ocaml/ocaml/issues/13601): Enable natdynlink on x86_64 GNU/Hurd
+  (Samuel Thibault, review by Sébastien Hinderer)
+
+- [#13809](https://github.com/ocaml/ocaml/issues/13809): Distinguish `(module M : S)` and `(module M) : (module S)` and
+  change locations of error messages when `S` is ill-typed in `(module S)`
+  (Samuel Vivien, review by Florian Angeletti and Gabriel Scherer)
+
+- [#13814](https://github.com/ocaml/ocaml/issues/13814), 13898: Add an `unused-type-declaration` warning when using
+  a `t as 'a` with no other occurences of `'a`
+  (Samuel Vivien, review by Florian Angeletti, Kate Deplaix)
+
+- [#13818](https://github.com/ocaml/ocaml/issues/13818): better delimited hints in error message
+  (Florian Angeletti, review by Gabriel Scherer)
+
+### Internal/compiler-libs changes
+
+- [#13539](https://github.com/ocaml/ocaml/issues/13539), [#13776](https://github.com/ocaml/ocaml/issues/13776): Use nanosleep instead of usleep or select, if available.
+  (Antonin Décimo, review by Miod Vallat and Gabriel Scherer)
+
+- [#13748](https://github.com/ocaml/ocaml/issues/13748): Add a .editorconfig file for basic editor auto-configuration.
+  (Antonin Décimo, review by Gabriel Scherer and David Allsopp)
+
+- [#13302](https://github.com/ocaml/ocaml/issues/13302), [#14236](https://github.com/ocaml/ocaml/issues/14236): Store locations of longidents components
+  (Ulysse Gérard and Jules Aguillon, review by Jules Aguillon
+   and Florian Angeletti)
+
+- [#13314](https://github.com/ocaml/ocaml/issues/13314): Comment the code of Translclass
+  (Vincent Laviron and Nathanaëlle Courant, review by Olivier Nicole)
+
+- [#13362](https://github.com/ocaml/ocaml/issues/13362): reimplement Floatarray.concat in C (`caml_floatarray_concat`),
+  matching the implementation of Array.concat.
+  (Gabriel Scherer, review by Nicolás Ojeda Bär)
+
+- [#13624](https://github.com/ocaml/ocaml/issues/13624): Added location to exception definitions and type extensions
+  (Samuel Vivien, review by Gabriel Scherer)
+
+- [#13425](https://github.com/ocaml/ocaml/issues/13425): undocumented -dmatchcomp flag for the debug
+  output of the pattern-matching compiler
+  (Gabriel Scherer, review by Vincent Laviron and Nicolás Ojeda Bär)
+
+- [#13460](https://github.com/ocaml/ocaml/issues/13460): introduce a variant of all predefined types
+  (Gabriel Scherer, review by Ulysse Gérard and Florian Angeletti)
+
+- [#13457](https://github.com/ocaml/ocaml/issues/13457), [#13537](https://github.com/ocaml/ocaml/issues/13537): Annotate alloc/free open/close pairs of functions
+  with compiler attributes for static analysis.
+  (Antonin Décimo, review by Gabriel Scherer and Florian Angeletti)
+
+- [#13464](https://github.com/ocaml/ocaml/issues/13464): Use generic types in call to `subtype`. This improves
+  inference of type-directed disambiguation in principal mode.
+  (Richard Eisenberg, review by Jacques Garrigue)
+
+- [#13606](https://github.com/ocaml/ocaml/issues/13606): Fix Numbers.Int_base.compare
+  (Mark Shinwell, review by Vincent Laviron)
+
+- [#13612](https://github.com/ocaml/ocaml/issues/13612): Refactor `type_application`
+  (Ulysse Gérard, Leo White, review by Antonin Décimo, Gabriel Scherer,
+   Samuel Vivien, Florian Angeletti and Jacques Garrigue)
+
+- [#13744](https://github.com/ocaml/ocaml/issues/13744): Refactor in `collect_apply_args`
+  (Samuel Vivien, review by Florian Angeletti and Gabriel Scherer)
+
+- [#13787](https://github.com/ocaml/ocaml/issues/13787): a new -dcanonical-ids option to show canonicalized identifier stamps
+  in -d{lambda,cmm,...} outputs.
+  (Gabriel Scherer, review by Vincent Laviron and David Allsopp,
+   suggested by David Allsopp)
+
+- [#13820](https://github.com/ocaml/ocaml/issues/13820): Add a new option -i-variance to print the variance of every
+  type parameter; bivariance is printed as `+-`, and for consistency,
+  parser is modified too to accept `+-` and `-+` as `type_variance`.
+  (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
+
+- [#13828](https://github.com/ocaml/ocaml/issues/13828): Apply BUILD_PATH_PREFIX_MAP to Sys.argv.(0) before storing it in .cmt
+  and .cmti files.
+  (David Allsopp, review by Daniel Bünzli and Gabriel Scherer)
+
+- [#13848](https://github.com/ocaml/ocaml/issues/13848): Add all paths components to the cmt files indexes
+  (Ulysse Gérard, review by Florian Angeletti)
+
+- [#13854](https://github.com/ocaml/ocaml/issues/13854): Make the parser set loc_ghost more correctly, for `keyword%extension`
+  syntax
+  (Valentin Gatien-Baron, review by Florian Angeletti)
+
+- [#13856](https://github.com/ocaml/ocaml/issues/13856): Add a new indirection in types AST called `package` that stores the
+  content of a `Tpackage` node
+  (Samuel Vivien, review by Florian Angeletti)
+
+- [#13866](https://github.com/ocaml/ocaml/issues/13866): Modified occurence check that prevents recursive types for it to see
+  the checked type as a graph rather than a tree
+  (Samuel Vivien, report by Didier Remy, review by Florian Angeletti
+   and Jacques Garrigue)
+
+- [#13884](https://github.com/ocaml/ocaml/issues/13884) Correctly index modules in constructors and labels paths
+  (Ulysse Gérard, review by Florian Angeletti)
+
+- [#13946](https://github.com/ocaml/ocaml/issues/13946): refactor the #install_printer code in the debugger and toplevel
+  (Pierre Boutillier, review by Gabriel Scherer and Florian Angeletti)
+
+- [#13952](https://github.com/ocaml/ocaml/issues/13952): check and document the correctness of `caml_domain_alone ()`.
+  (Gabriel Scherer, review by KC Sivaramakrishnan, report by Olivier Nicole)
+
+- [#13971](https://github.com/ocaml/ocaml/issues/13971): Keep generalized structure from patterns when typing `let`
+  (Leo White, review by Samuel Vivien and Florian Angeletti)
+
+- (*breaking change*) [#13972](https://github.com/ocaml/ocaml/issues/13972): Renamed the `-no-alias-deps` flag internal representation to
+  `no_alias_deps` instead of `transparent_modules`.
+  (Clement Blaudeau, review by Gabriel Scherer)
+
+### Build system
+
+- (*breaking change*) [#13526](https://github.com/ocaml/ocaml/issues/13526), [#13789](https://github.com/ocaml/ocaml/issues/13789), [#13804](https://github.com/ocaml/ocaml/issues/13804): Simplify the build of cross compilers
+  This replaces the configure `--with-target-bindir` option by an equivalent
+  `TARGET_BINDIR` variable
+  (Samuel Hym, review by Miod Vallat, Xavier Leroy, Antonin Décimo and Sébastien
+  Hinderer)
+
+- [#13431](https://github.com/ocaml/ocaml/issues/13431): Simplify github action responsible for flagging PRs with
+  the `parsetree-changes` label and extend it to mention the @ppxlib-dev
+  team.
+  (Nathan Rebours, review by Florian Angeletti)
+
+- [#13494](https://github.com/ocaml/ocaml/issues/13494): Use native symlinks on Windows for the OCaml installation, reducing
+  disk usage considerably.
+  (David Allsopp, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
+- [#13789](https://github.com/ocaml/ocaml/issues/13789): Strictly validate the host and target triplets when building for the
+  Windows ports to be *-*-cygwin, *-w64-mingw32* or *-pc-windows. Other Cygwin
+  variants used to be rejected - other MSVC and mingw-w64 variants are now
+  rejected too.
+  (David Allsopp, review by Antonin Décimo and Gabriel Scherer)
+
+### Bug fixes
+
+- [#13819](https://github.com/ocaml/ocaml/issues/13819): Fix field initialisation bug in runtime events subsystem.
+  (Nick Barnes, review by Gabriel Scherer).
+
+- [#13977](https://github.com/ocaml/ocaml/issues/13977): Pass `-fPIC` when compiling C files using `ocamlopt`. This was a
+  regression in OCaml 5.3.
+  (Nicolás Ojeda Bär, review by Daniel Bünzli and Gabriel Scherer)
+
+- [#13957](https://github.com/ocaml/ocaml/issues/13957): Allow 'effect' as attribute id.
+  (Pieter Goetschalckx, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#13691](https://github.com/ocaml/ocaml/issues/13691) [#13895](https://github.com/ocaml/ocaml/issues/13895): Make four globals underlying Gc.control atomic to avoid C data
+  races against them.
+  (Jan Midtgaard, review by Miod Vallat, Sadiq Jaffer and Antonin Décimo)
+
+- [#13454](https://github.com/ocaml/ocaml/issues/13454): Output a correct trace of the C_CALLN bytecode.
+  (Miod Vallat, review by Antonin Décimo)
+
+- [#13595](https://github.com/ocaml/ocaml/issues/13595): Use x19 as Canonical Frame Address (CFA) register. This would cause
+  backtraces to be truncated when calling no alloc C code.
+  (Tim McGilchrist, report by Nick Barnes, review by Nick Barnes)
+
+- (*breaking change*) [#13605](https://github.com/ocaml/ocaml/issues/13605): Fix ungenerated constraints when they where impossible due to polyvars
+  issues
+  (Samuel Vivien, review by Florian Angeletti, Richard Eisenberg
+   and Jacques Garrigue)
+
+- [#13677](https://github.com/ocaml/ocaml/issues/13677), [#13679](https://github.com/ocaml/ocaml/issues/13679): domain.c: remove backup_thread_running to simplify
+  concurrent state updates to the backup thread status.
+  (Gabriel Scherer, review by Jan Midtgaard and Miod Vallat,
+   report by Jan Midtgaard)
+
+- [#13896](https://github.com/ocaml/ocaml/issues/13896), [#14098](https://github.com/ocaml/ocaml/issues/14098): ocamldoc, do not wrap module description in a paragraph tag
+  inside the table of modules
+  (Florian Angeletti, report by John Whitington, review by Gabriel Scherer)
+
+- [#13703](https://github.com/ocaml/ocaml/issues/13703): wrong explanation for some polymorphic-variant subtyping errors
+  (Gabriel Scherer, review by Jacques Garrigue,
+   report by Wiktor Kuchta and Richard Eisenberg)
+
+- [#13710](https://github.com/ocaml/ocaml/issues/13710): Support unicode identifiers in comments.
+  (Pieter Goetschalckx, review by Florian Angeletti and Gabriel Scherer)
+
+- [#13763](https://github.com/ocaml/ocaml/issues/13763): Track type of variables bound by as-patterns
+  (Leo White, review by Gabriel Scherer, port by Vincent Laviron)
+
+- [#13778](https://github.com/ocaml/ocaml/issues/13778), [#13811](https://github.com/ocaml/ocaml/issues/13811): do not warn for unused type declarations when the type is used
+  in a first-class module type (`module S with type t = int)`.
+  (Florian Angeletti, report by Nicolás Ojeda Bär, review by Gabriel Scherer)
+
+- [#13790](https://github.com/ocaml/ocaml/issues/13790): Fix bytecode-only build of Cygwin when flexlink is being bootstrapped
+  with the compiler.
+  (David Allsopp, review by Antonin Décimo and Miod Vallat)
+
+- [#13812](https://github.com/ocaml/ocaml/issues/13812): Add forgotten check about the validity of the type variable name on
+  the right-hand side of `_ as _`.
+  (Samuel Vivien, review by Gabriel Scherer)
+
+- [#13845](https://github.com/ocaml/ocaml/issues/13845): Fix bug in untypeast/pprintast for value bindings with polymorphic
+  type annotations.
+  (Chris Casinghino, review by Florian Angeletti and Gabriel Scherer)
+
+- [#13930](https://github.com/ocaml/ocaml/issues/13930), [#13933](https://github.com/ocaml/ocaml/issues/13933): Fix bugs in recursive values definitions involving
+  lazy values that have already been evaluated.
+  (Gabriel Scherer, review by Vincent Laviron, report by Vincent Laviron)
+
+- [#13867](https://github.com/ocaml/ocaml/issues/13867): Fix bug with some recursive bindings of lazy values.
+  (Guillaume Bury and Vincent Laviron, review by Stefan Muenzel
+   and Gabriel Scherer)
+
+- [#13931](https://github.com/ocaml/ocaml/issues/13931): fix bugs in nested recursive value definitions.
+  (Gabriel Scherer, review by Vincent Laviron,
+   report by Vincent Laviron)
+
+- [#13875](https://github.com/ocaml/ocaml/issues/13875), [#13878](https://github.com/ocaml/ocaml/issues/13878): Add dedicated constructor for mutable variable access in
+  Cmm to prevent bugs linked to incorrect handling of coeffects.
+  (Vincent Laviron, review by Gabriel Scherer)
+
+- [#13880](https://github.com/ocaml/ocaml/issues/13880): Make object stat counters atomic
+  (Dimitris Mostrous, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
+- [#13172](https://github.com/ocaml/ocaml/issues/13172), [#13829](https://github.com/ocaml/ocaml/issues/13829): Fix a missing check of illegal recursive module-type
+  definitions
+  (Clement Blaudeau, review by Florian Angeletti)
+
+- [#13541](https://github.com/ocaml/ocaml/issues/13541), [#13777](https://github.com/ocaml/ocaml/issues/13777): Using C++11 `thread_local` causes name-mangling
+  issues when linking with flexlink on Cygwin.
+  (Antonin Décimo and David Allsopp, report by Kate Deplaix)
+
+- (*breaking change*) [#13874](https://github.com/ocaml/ocaml/issues/13874), [#13882](https://github.com/ocaml/ocaml/issues/13882): Make evaluation order consistent for applications when using
+  the non-flambda native compiler
+  (Vincent Laviron, report by Jean-Marie Madiot, review by Gabriel Scherer)
+
+- [#13942](https://github.com/ocaml/ocaml/issues/13942): Fix assertion on empty array case
+  (Olivier Nicole, review by Gabriel Scherer)
+
+- [#13950](https://github.com/ocaml/ocaml/issues/13950): Avoid tearing in `Array.sub`
+  (Gabriel Scherer and Olivier Nicole, report by Jan Midtgaard, review by
+   Gabriel Scherer)
+
+- [#13928](https://github.com/ocaml/ocaml/issues/13928), [#13944](https://github.com/ocaml/ocaml/issues/13944): Fix handling of excessively nested unboxed types
+  (Vincent Laviron, review by Gabriel Scherer)
+
+- [#13987](https://github.com/ocaml/ocaml/issues/13987): Remove a spurious TSan report in case of benign data race between
+  major GC read and write from the mutator (fixes [#13427](https://github.com/ocaml/ocaml/issues/13427))
+  (Olivier Nicole, report by Thomas Leonard, review by Gabriel Scherer)
+
+- [#14007](https://github.com/ocaml/ocaml/issues/14007), [#14015](https://github.com/ocaml/ocaml/issues/14015): Fix memory corruption when an exception is raised during
+  demarshaling.
+  (Benoît Vaugon, review by David Allsopp and Gabriel Scherer)
+
+- [#14025](https://github.com/ocaml/ocaml/issues/14025): fix data race between compaction and domain termination
+  (Gabriel Scherer, review by Jan Midtgaard,
+   report by Jan Midtgaard)
+
+- [#13956](https://github.com/ocaml/ocaml/issues/13956) Fix a regression introduced in [#13308](https://github.com/ocaml/ocaml/issues/13308) triggering wrong unused warnings.
+  (Ulysse Gérard, review by Florian Angeletti)
+
+- [#14070](https://github.com/ocaml/ocaml/issues/14070): also point to label mismatches in error messages for labelled tuples
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#14088](https://github.com/ocaml/ocaml/issues/14088), [#14091](https://github.com/ocaml/ocaml/issues/14091): fix non-deterministic code generation in
+  matching.ml (backport of rescript-lang/rescript[#7557](https://github.com/ocaml/ocaml/issues/7557))
+  (Christiano Calgano, review by Gabriel Scherer and Vincent Laviron)
+
+- [#14105](https://github.com/ocaml/ocaml/issues/14105): Fix a loop in Pprintast that could result in a hang when printing
+  constructor `(::)` in isolation.
+  (Ulysse Gérard, review by Nicolás Ojeda Bär and Florian Angeletti)
+
+- [#14108](https://github.com/ocaml/ocaml/issues/14108): toplevel, fix a typo in directive type mismatch
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#13586](https://github.com/ocaml/ocaml/issues/13586), [#14093](https://github.com/ocaml/ocaml/issues/14093): Fix closing an out_channel during flush
+  (Stephen Dolan, report by Jan Midtgaard, investigation by Nick Roberts,
+   review by Antonin Décimo and Miod Vallat)
+
+- [#14101](https://github.com/ocaml/ocaml/issues/14101), [#14139](https://github.com/ocaml/ocaml/issues/14139): define atomic helper types inside `caml/misc.h` to improve
+  header compatibility with C++
+  (Florian Angeletti, report by Kate Deplaix, review by Gabriel Scherer)
+
+- [#14135](https://github.com/ocaml/ocaml/issues/14135): Fix a rare internal typechecker error when combining recursive
+  modules, polymorphic fields or methods, and constrained type parameters.
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#14169](https://github.com/ocaml/ocaml/issues/14169): runtime, fix cache miss within the stack fragments cache
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#14196](https://github.com/ocaml/ocaml/issues/14196), [#14197](https://github.com/ocaml/ocaml/issues/14197): ocamlprof: do not instrument unreachable clauses
+  (Gabriel Scherer, review by Nicolás Ojeda Bär, report by Ali Caglayan)
+
+- [#14200](https://github.com/ocaml/ocaml/issues/14200), [#14202](https://github.com/ocaml/ocaml/issues/14202) : bad variance check with private aliases
+  (Jacques Garrigue, report and review by Stephen Dolan)
+
+- [#14061](https://github.com/ocaml/ocaml/issues/14061), [#14209](https://github.com/ocaml/ocaml/issues/14209): fix a memory-ordering bug in Weak.set that could
+  result in uninitialized memory seen by Weak.get on another domain.
+  (Damien Doligez, review by Gabriel Scherer)
+
+- [#14214](https://github.com/ocaml/ocaml/issues/14214), [#14221](https://github.com/ocaml/ocaml/issues/14221): fix a confused error message for module inclusions,
+  functor error messages were missing some type equalities potentially leading
+  to nonsensical "type t is not compatible with type t" submessage
+  (Florian Angeletti, report by Basile Clément, review by Gabriel Scherer)
+
+- [#14238](https://github.com/ocaml/ocaml/issues/14238): Fix certain variadic macros in misc.h which could trigger C warnings
+  under certain conditions in prerelease versions of OCaml 5.4.
+  (Antonin Décimo, review by Nicolás Ojeda Bär)

--- a/data/releases/5.4.0.md
+++ b/data/releases/5.4.0.md
@@ -18,14 +18,14 @@ highlights: |
   - New section in the manual on native code profiling on Linux and macOS
   - Many runtime improvements
   - More than thirty new standard library functions
-  - A dozen of improved error messages
+  - Nearly a dozen improved error messages
   - Improved support for Merlin's renaming feature.
   - Around fifty bug fixes
 ---
 
 ## What's New
 
-Some of the highlights in OCaml 5.4.0 are:
+Some of the highlights of OCaml 5.4.0 are:
 
 - Labelled tuples
 - Immutable arrays
@@ -38,10 +38,9 @@ Some of the highlights in OCaml 5.4.0 are:
 
 And a lot of incremental changes:
 
-- Many runtime improvements
+- Many runtime  and code generation improvements
 - More than thirty new standard library functions
-- A dozen of improved error messages
-- Improved support for Merlin's renaming feature.
+- Nearly a dozen improved error messages
 - Around fifty bug fixes
 For a comprehensive list of changes and details on all new features,
 bug fixes, optimisations, etc., please consult the


### PR DESCRIPTION
In preparation of the release for OCaml 5.4.0 this week (maybe tomorrow) this PR adds a draft for release page and the changelog entry for OCaml 5.4.0.

I have also edited the 5.3.0 release page to pass the (new?) markdown linter.
I will switch the PR to the non-draft mode once the release is in process.