### PR TITLE
Disable Markdown linter's rule wrt space around code bl0cks and lists

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,6 +14,10 @@
         "MD024": {
             "allow_different_nesting": true
         },
+        // Don't require code blocks to be surrounded by blank space
+        "MD031": false,
+        // Don't require lists to be surrounded by blank space
+        "MD032": false,
         // Allow inline HTML
         "MD033": false,
         // First line in a file doesn't need to be a top-level header


### PR DESCRIPTION
I want the markdown linter to be actually useful and less annoying, so we're disabling these two rules.