### PR TITLE
Announce opam-publish 2.6.0 and 2.7.0

### DIFF
--- a/data/platform_tools_releases/opam-publish/2025-09-19-opam-publish-2-6-0.md
+++ b/data/platform_tools_releases/opam-publish/2025-09-19-opam-publish-2-6-0.md
@@ -1,0 +1,19 @@
+---
+title: "opam-publish 2.6.0"
+authors: [
+  "Raja Boujbel",
+  "Kate Deplaix",
+  "David Allsopp",
+]
+versions: ["2.6.0"]
+tags: [opam, platform]
+github_release_tags: [2.6.0]
+---
+
+We are happy to announce the release of opam-publish 2.6.0, which brings opam-publish closer to the ability to more easily publish your releases automatically.
+This release brings:
+- A new `OPAM_PUBLISH_GH_TOKEN` environment variable and `--token` argument are now available to pass the GitHub token, thanks to [@filipeom](https://github.com/filipeom)
+- The addition of a message after the PR is open, to notify users that they can re-run opam-publish to update the PR, thanks to [@punchagan](https://github.com/punchagan)
+
+Happy publishing!
+<> <> The opam team <> <> :camel:

--- a/data/platform_tools_releases/opam-publish/2025-10-07-opam-publish-2-7-0.md
+++ b/data/platform_tools_releases/opam-publish/2025-10-07-opam-publish-2-7-0.md
@@ -1,0 +1,25 @@
+---
+title: "opam-publish 2.7.0"
+authors: [
+  "Raja Boujbel",
+  "Kate Deplaix",
+  "David Allsopp",
+]
+versions: ["2.7.0"]
+tags: [opam, platform]
+github_release_tags: [2.7.0]
+---
+
+_Feedback on this post is welcomed on [Discuss](https://discuss.ocaml.org/t/ann-opam-publish-2-7-0/17358)!_
+
+We are happy to announce the release of opam-publish 2.7.0 which brings the ability to more easily publish your releases automatically, thanks to [@filipeom](https://github.com/filipeom):
+- SSH keys aren't used to push the branch to the user's fork anymore. Instead the token we already require is used.
+- If undefined, the git config variables `user.name` and `user.email` are automatically filled with the github username and username@opam-publish as a backup
+
+An example of the new automated setup can be found in [this CI job](https://github.com/formalsec/smtml/commit/3c98cc024583e69b87c6d63a233abff149471399).
+
+Other minor changes include:
+- The switch from `lwt_ssl` to `tls-lwt` which avoid one dependency and avoid depending on the system libssl
+
+Happy publishing!
+<> <> The opam team <> <> :camel:


### PR DESCRIPTION
As a replacement for https://github.com/ocaml/ocaml.org/pull/3343