### PR TITLE
fix: correct OCaml 5.4.0 release date and wrong link to RFC

### DIFF
--- a/data/releases/5.4.0.md
+++ b/data/releases/5.4.0.md
@@ -156,7 +156,7 @@ The user manual for OCaml can be:
   (Ryan Tjoa and Chris Casinghino, review by Gabriel Scherer, Chris Casinghino,
   and Leo White)
 
-- RFCs[#39](https://github.com/ocaml/ocaml/issues/39), [#13404](https://github.com/ocaml/ocaml/issues/13404): atomic record fields
+- RFC[#39](https://github.com/ocaml/RFCs/pull/39), [#13404](https://github.com/ocaml/ocaml/issues/13404): atomic record fields
     `{ ...; mutable readers : int [@atomic]; ... }`
     `Atomic.Loc.fetch_and_add [%atomic.loc data.readers] 1`
   (Clément Allain and Gabriel Scherer, review by KC Sivaramakrishnan,

--- a/data/releases/5.4.0.md
+++ b/data/releases/5.4.0.md
@@ -5,7 +5,7 @@ date: 2025-10-09
 is_latest: true
 intro: |
   This page describes OCaml version **5.4.0**, released on
-  2025-01-08. Go [here](/releases) for a list of all releases.
+  2025-10-09. Go [here](/releases) for a list of all releases.
 
   This release is available as an [opam](/p/ocaml/5.4.0) package.
 highlights: |


### PR DESCRIPTION
This fixes the incorrect release date for the [OCaml 5.4.0 release](https://ocaml.org/releases/5.4.0) (**October 9, 2025**) and the link to **[RFC 39](https://github.com/ocaml/RFCs/pull/39)**.