### PR TITLE
doc: remove unnecessary information in PPX tutorial

### DIFF
--- a/data/tutorials/language/4ad_00_metaprogramming.md
+++ b/data/tutorials/language/4ad_00_metaprogramming.md
@@ -21,15 +21,14 @@ preprocessor](https://github.com/ocaml-ppx/ppxlib/tree/main/examples/simple-exte
 Printf.printf "This program has been compiled by user: %s" [%get_env "USER"]
 ```
 
-When you compile the code with the preprocessor, it will replace [%get_env "USER"] with the content of the USER environment variable. If the USER environment variable is set to "JohnDoe" for example, the line would become:
+The preprocessor will replace [%get_env "USER"] with the content of the USER 
+environment variable at compile time. This environment variable has no effect at 
+runtime. For example, if USER is set to "JohnDoe", the line would become:
 
 <!-- $MDX skip -->
 ```ocaml
 Printf.printf "This program has been compiled by user: %s" "JohnDoe"
 ```
-
-
-With this modification, the preprocessor will replace [%get_env "USER"] with the content of the USER environment variable during compile time, and this code should work on most systems without any additional configuration. At compile time, the preprocessor would replace [%get_env "USER"] by a string with the content of the USER environment variable, which usually contains the username of the person compiling the program. This happens at compile time, so at runtime, the value of the USER variable would have no effect, as it's used purely for informational purposes in the compiled program.
 
 In this guide, we explain the different mechanisms behind preprocessors in OCaml,
 with as few prerequisites as possible. If you are only interested in how to use a


### PR DESCRIPTION
I got a little tripped up by this description of environment variables in the PPX tutorial. PPXs are tagged as an advanced topic and I don't think we need to repeat that the preprocessor runs at compile time three times. Also, I don't think USER is defined on Windows so this statement that "this code should work on most systems without configuration" isn't true.
