### PR TITLE
doc: fix several typos in tutorials/language

### DIFF
--- a/data/tutorials/language/3ds_02_maps.md
+++ b/data/tutorials/language/3ds_02_maps.md
@@ -10,11 +10,11 @@ category: "Data Structures"
 
 In the most general sense, the [`Map`](/manual/api/Map.html) module lets you create _immutable_ key-value
 [associative array](https://en.wikipedia.org/wiki/Associative_array) for your types. More concretely, 
-OCaml's `Map` module is implemented using a binary search tree alogorithm to support fast lookups (of O(Log n)). 
+OCaml's `Map` module is implemented using a binary search tree algorithm to support fast lookups (of O(Log n)). 
 
 **Note**: The concept of a `Map` in this tutorial refers to a data structure that stores a
 set of key-value pairs. It is sometimes called a dictionary or an association table. This
-is a disinct concept from the maps we've explored in previous lessons, such as `List.map`,
+is a distinct concept from the maps we've explored in previous lessons, such as `List.map`,
 `Array.map`, and `Option.map`, which are functions that operate over data rather than
 being data themselves.
 

--- a/data/tutorials/language/3ds_03_sets.md
+++ b/data/tutorials/language/3ds_03_sets.md
@@ -50,7 +50,7 @@ This module also defines two types:
 
 For `StringSet.empty`, you can see that the OCaml toplevel displays the placeholder `<abstr>` instead of the actual value. However, converting the string set to a list using `StringSet.to_list` results in an empty list.
 
-(Remember, for OCaml versions before 5.1, it will be `StringeSet.empty |> StringSet.elements;;`)
+(Remember, for OCaml versions before 5.1, it will be `StringSet.empty |> StringSet.elements;;`)
 
 2. A set with a single element is created using `StringSet.singleton`:
 


### PR DESCRIPTION
This PR fixes three minor typos in [tutorials/language](https://github.com/ocaml/ocaml.org/tree/main/data/tutorials/language).