### PR TITLE
Fix incorrect plural feets → feet

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -123,8 +123,8 @@ Bindings can be given special comments (sometimes called "docstrings") that edit
 
 ```ocaml
 (** Feet in a mile *)
-let feets = 5280;;
-val feets : int = 5280
+let feet = 5280;;
+val feet : int = 5280
 ```
 
 This is discussed further in [`odoc` for Authors: Special Comments](https://ocaml.github.io/odoc/odoc/odoc_for_authors.html#special_comments).


### PR DESCRIPTION
Fixes a spelling error in the documentation where "feets" was used instead of the correct plural "feet".

### Changes
- `data/tutorials/getting-started/1_01_a_tour_of_ocaml.md`: corrected "feets" → "feet"