### PR TITLE
feat: document docs generation process and improve missing docs UX

### DIFF
--- a/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation_not_found.eml
@@ -14,21 +14,33 @@ Package_layout.render
 ~left_sidebar_html:""
 ~right_sidebar_html:"" @@
   let version = Package.url_version package in
+  let docs_ci_issue_url =
+    Printf.sprintf "https://github.com/ocurrent/ocaml-docs-ci/issues/new?title=Missing+documentation+for+%s+%s&body=Documentation+is+missing+for+package+[%s](https://ocaml.org/p/%s/%s)+version+%s"
+      package.name (Package.render_version package)
+      package.name package.name (Package.render_version package) (Package.render_version package)
+  in
   <div class="sm:flex max-w-max mx-auto">
     <p class="text-4xl font-extrabold text-primary sm:text-5xl">404</p>
     <div class="sm:ml-6">
       <div class="sm:border-l sm:border-gray-200 sm:pl-6">
-        <h1 class="text-4xl font-extrabold text-title dark:text-dark-title tracking-tight sm:text-5xl">Page not found</h1>
-        <p class="mt-1 text-base text-content dark:text-dark-content">We're sorry, for some reason we don't have the documentation for this package.</p>
+        <h1 class="text-4xl font-extrabold text-title dark:text-dark-title tracking-tight sm:text-5xl">Documentation not found</h1>
+        <p class="mt-1 text-base text-content dark:text-dark-content">We're sorry, the documentation for this package version is not available.</p>
+        <p class="mt-3 text-sm text-content dark:text-dark-content">
+          Package documentation is generated automatically by
+          <a href="https://github.com/ocurrent/ocaml-docs-ci" class="text-primary dark:text-dark-primary hover:underline">ocaml-docs-ci</a>.
+          If you believe this is an error, please report it to the documentation CI project.
+        </p>
       </div>
-      <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
+      <div class="mt-10 flex flex-wrap gap-3 sm:border-l sm:border-transparent sm:pl-6">
         <a href="<%s Url.Package.overview package.name ?version %>"
           class="btn">
           Go To Package Overview
         </a>
-        <a href="https://github.com/ocaml/ocaml.org/issues"
-          class="btn btn-ghost">
-          Open an Issue
+        <a href="<%s docs_ci_issue_url %>"
+          class="btn btn-ghost"
+          target="_blank"
+          rel="noopener noreferrer">
+          Report Missing Docs
         </a>
       </div>
     </div>

--- a/src/ocamlorg_frontend/pages/packages.eml
+++ b/src/ocamlorg_frontend/pages/packages.eml
@@ -156,6 +156,39 @@ in
         </div>
     </div>
 </div>
+<div class="w-full">
+    <div class="container-fluid pt-6 pb-12">
+        <p class="uppercase text-sm text-content dark:text-dark-content tracking-widest font-medium mb-2">documentation</p>
+        <h2 class="font-bold text-2xl text-title dark:text-dark-title mb-2">Automatic Documentation Generation</h2>
+        <p class="text-xl text-content dark:text-dark-content mb-6">Every package published to opam gets its documentation built and hosted automatically on this website.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
+            <div class="text-left">
+                <h3 class="text-xl text-title dark:text-dark-title font-semibold mb-2">How It Works</h3>
+                <p class="text-base text-content dark:text-dark-content mb-4">
+                    Documentation is generated using <a href="https://github.com/ocaml/odoc" class="text-primary dark:text-dark-primary hover:underline">odoc</a>,
+                    the OCaml documentation tool. When you publish a package, a continuous integration pipeline called
+                    <a href="https://github.com/ocurrent/ocaml-docs-ci" class="text-primary dark:text-dark-primary hover:underline">ocaml-docs-ci</a>
+                    automatically picks it up, builds the documentation for all versions, and makes it available here.
+                </p>
+                <p class="text-base text-content dark:text-dark-content">
+                    The pipeline is built with <a href="https://github.com/ocurrent/ocurrent" class="text-primary dark:text-dark-primary hover:underline">OCurrent</a>,
+                    a workflow specification language written in OCaml that powers much of the OCaml ecosystem's CI infrastructure.
+                </p>
+            </div>
+            <div class="text-left">
+                <h3 class="text-xl text-title dark:text-dark-title font-semibold mb-2">Writing Good Documentation</h3>
+                <p class="text-base text-content dark:text-dark-content mb-4">
+                    To make the most of automatic documentation generation, add doc-comments to your <code class="bg-code_background dark:bg-dark-code_background px-1 rounded">.mli</code> files
+                    using the odoc syntax. These comments will be rendered as formatted documentation with cross-references to other modules and packages.
+                </p>
+                <p class="text-base text-content dark:text-dark-content">
+                    Learn more about writing documentation in the
+                    <a href="https://ocaml.github.io/odoc/" class="text-primary dark:text-dark-primary hover:underline">odoc documentation</a>.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
 <div class="w-full section-blue-gradient dark:dark-section-blue-gradient">
     <div class="container-fluid flex items-center justify-between py-7 px-8">
         <div class="flex flex-col w-full md:max-w-[50%]">


### PR DESCRIPTION
## Summary

- Add "Automatic Documentation Generation" section to the `/packages` page explaining how package documentation is generated
- Improve the "documentation not found" error page with better guidance

## Changes

### /packages page
Added a new section explaining:
- How documentation is generated using [odoc](https://github.com/ocaml/odoc)
- The role of [ocaml-docs-ci](https://github.com/ocurrent/ocaml-docs-ci) in automatically building docs
- Brief mention of [OCurrent](https://github.com/ocurrent/ocurrent) as the underlying technology
- Tips for writing good documentation

### Documentation not found page
- Changed title from "Page not found" to "Documentation not found" (more specific)
- Added explanation that docs are generated by ocaml-docs-ci
- Changed "Open an Issue" button to "Report Missing Docs" linking to ocaml-docs-ci issues
- Pre-fills the issue with package name and version for easier reporting

## Screenshots

Would be helpful to add screenshots after testing locally.

## Test plan

- [ ] Build locally with `make build`
- [ ] Visit `/packages` and verify the new section renders correctly
- [ ] Navigate to a package with missing docs and verify:
  - [ ] The error message is clear
  - [ ] The "Report Missing Docs" button opens a pre-filled GitHub issue

🤖 Generated with [Claude Code](https://claude.ai/code)