### PR TITLE
(data) Fix malformed YAML in ocaml-lsp 1.25.0 platform release

### DIFF
--- a/data/platform_releases/ocaml-lsp/2025-12-20-ocaml-lsp-1.25.0.md
+++ b/data/platform_releases/ocaml-lsp/2025-12-20-ocaml-lsp-1.25.0.md
@@ -20,13 +20,13 @@ changelog: |
 
 This release of `ocaml-lsp-server` introduces support for `.mlx` files, new custom requests, and configuration updates for `code-lens`.
 
-### Features
+## Features
 
 * **`.mlx` Support:** Added support for `.mlx` files, including diagnostics, code actions, hover, and formatting via `ocamlformat-mlx`.
 * **New Custom Requests:** Added `typeExpression`, `locate`, and `phrase` requests to the server.
 * **Code-Lens Configuration:** `code-lens` for nested `let` bindings is now configurable.
 
-### Fixes and Improvements
+## Fixes and Improvements
 
 * **Configuration Fallback:** The server now falls back to `.merlin` configuration if a `dune-project` file is missing, provided `dot-merlin-reader` is installed.
 * **Metrics:** Improved the precision of timestamps for collected metrics.

--- a/data/platform_releases/ocaml-lsp/2025-12-20-ocaml-lsp-1.25.0.md
+++ b/data/platform_releases/ocaml-lsp/2025-12-20-ocaml-lsp-1.25.0.md
@@ -1,32 +1,21 @@
 ---
-title: 1.25.0
-tags:
-- ocaml-lsp
-- platform
-- editors
-authors: []
-contributors:
-changelog: |
-CHANGES:
-    ## Features
-
-    *   Make `code-lens` for nested let bindings configurable ([#1567](https://github.com/ocaml/ocaml-lsp/pull/1567))
-    *   Add support for `.mlx` files, including formatting via `ocamlformat-mlx` and most OCaml LSP features (diagnostics, code actions, hover, etc.) ([#1528](https://github.com/ocaml/ocaml-lsp/pull/1528))
-    *   Add `typeExpression` custom request ([#1576](https://github.com/ocaml/ocaml-lsp/pull/1576))
-    *   Add `locate` custom request ([#1576](https://github.com/ocaml/ocaml-lsp/pull/1576))
-    *   Add `phrase` custom request ([#1576](https://github.com/ocaml/ocaml-lsp/pull/1576))
-
-    ## Fixes
-
-    *   Improve precision of collected metrics timestamps. ([#1565](https://github.com/ocaml/ocaml-lsp/pull/1565))
-    *   Fallback on `.merlin` configuration if no `dune-project` file is found and if  
-        `dot-merlin-reader` is installed. ([#1563](https://github.com/ocaml/ocaml-lsp/pull/1563), fixes [#1522](https://github.com/ocaml/ocaml-lsp/issues/1522))
-versions:
-experimental: false
-ignore: false
-released_on_github_by: voodoos
+title: OCaml-LSP 1.25.0
+tags: [ocaml-lsp, platform, editors]
+versions: ["1.25.0"]
 github_release_tags:
 - 1.25.0
+
+changelog: |
+    ## Features
+    - Make `code-lens` for nested let bindings configurable ([#1567](https://github.com/ocaml/ocaml-lsp/pull/1567))
+    - Add support for `.mlx` files, including formatting via `ocamlformat-mlx` and most OCaml LSP features (diagnostics, code actions, hover, etc.) ([#1528](https://github.com/ocaml/ocaml-lsp/pull/1528))
+    - Add `typeExpression` custom request ([#1576](https://github.com/ocaml/ocaml-lsp/pull/1576))
+    - Add `locate` custom request ([#1576](https://github.com/ocaml/ocaml-lsp/pull/1576))
+    - Add `phrase` custom request ([#1576](https://github.com/ocaml/ocaml-lsp/pull/1576))
+
+    ## Fixes
+    - Improve precision of collected metrics timestamps. ([#1565](https://github.com/ocaml/ocaml-lsp/pull/1565))
+    - Fallback on `.merlin` configuration if no `dune-project` file is found and if `dot-merlin-reader` is installed. ([#1563](https://github.com/ocaml/ocaml-lsp/pull/1563), fixes [#1522](https://github.com/ocaml/ocaml-lsp/issues/1522))
 ---
 
 This release of `ocaml-lsp-server` introduces support for `.mlx` files, new custom requests, and configuration updates for `code-lens`.


### PR DESCRIPTION
The file had several YAML issues preventing the build:
- Missing title prefix "OCaml-LSP"
- Empty versions field
- Malformed changelog block with unindented CHANGES: line
- Unsupported fields (authors, contributors, experimental, etc.)