### PR TITLE
Fix typos and grammar across tutorials

### DIFF
--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -256,8 +256,8 @@ The name of this function begins with `List.` because it is part of the predefin
 
 The function `List.map` can be applied on any kind of list. Here it is given a list of integers, but it could be a list of floats, strings, or anything. This is known as _polymorphism_. The `List.map` function is polymorphic, meaning it has two implicit _type variables_: `'a` and `'b` (pronounced “alpha” and “beta”). They both can be anything; however, in regard to the function passed to `List.map`:
 
-1. Input list elements have the same type of its input.
-2. Output list elements have the same type of its output.
+1. Input list elements have the same type as its input.
+2. Output list elements have the same type as its output.
 
 ### Side-Effects and the `unit` Type
 
@@ -683,7 +683,7 @@ The standard library provides several predefined exceptions. It is possible to d
 
 ### Using the `result` Type
 
-Another way to deal with errors in OCaml is by returning value of type `result`,
+Another way to deal with errors in OCaml is by returning a value of type `result`,
 which can represent either the correct result or an error. Here is how it is defined:
 
 ```ocaml

--- a/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
+++ b/data/tutorials/getting-started/1_02_your_first_ocaml_program.md
@@ -261,7 +261,7 @@ opam install sexplib
 ```
 
 Next, define a string containing a valid S-expression in `bin/main.ml`. Parse
-it into a S-expression with  the  `Sexplib.Sexp.of_string` function, and then
+it into an S-expression with the `Sexplib.Sexp.of_string` function, and then
 convert it back into a string with `Sexplib.Sexp.to_string` and print it.
 
 ```ocaml

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -29,13 +29,13 @@ If your editor is setup correctly, here are some important features you can begi
 
 ![VSCode Hovering](/media/tutorials/vscode-hover.gif)
 
-This is a great feature that let's you see type information of any OCaml variable or function. All you have to do is place your cursor over the code and it will be displayed in the tooltip.
+This is a great feature that lets you see type information of any OCaml variable or function. All you have to do is place your cursor over the code and it will be displayed in the tooltip.
 
 #### 2) Jump to Definitions With `Ctrl + Click`
 
 ![VSCode Ctrl click](/media/tutorials/vscode-ctrl-click.gif)
 
-If you hold down the <kbd>Ctrl</kbd> key while hovering, the code appears as a clickable link which if clicked takes you to the file where the implementation is. This can be great if you want to understand how a piece of code works under the hood. In this example, hovering and `Ctrl + Clicking` over the `peek` method of the `Queue` module will take you to the definiton of the `peek` method itself and how it is implemented.
+If you hold down the <kbd>Ctrl</kbd> key while hovering, the code appears as a clickable link which if clicked takes you to the file where the implementation is. This can be great if you want to understand how a piece of code works under the hood. In this example, hovering and `Ctrl + Clicking` over the `peek` method of the `Queue` module will take you to the definition of the `peek` method itself and how it is implemented.
 
 #### 3) OCaml Commands With `Ctrl + Shift + P`
 
@@ -98,7 +98,7 @@ Next, we need to bridge the gap between our major mode (in this case, `tuareg`) 
   (ocaml-eglot . eglot-ensure))
 ```
 
-And that's all there is to it! Now all you need to do is install `ocaml-lsp-server` and `ocamlformat` in our [switch](/docs/opam-switch-introduction):
+And that's all there is to it! Now all you need to do is install `ocaml-lsp-server` and `ocamlformat` in your [switch](/docs/opam-switch-introduction):
 
 ```shell
 opam install ocaml-lsp-server ocamlformat
@@ -140,7 +140,7 @@ opam user-setup install
 
 ![Vim Type information](/media/tutorials/vim-type-info.gif)
 
-- In the Vim editor, press the <kbd>Esc</kbd> to enter command mode.
+- In the Vim editor, press <kbd>Esc</kbd> to enter command mode.
 - Place the cursor over the variable.
 - Type `:MerlinTypeOf` and press <kbd>Enter</kbd>.
 - The type information will be displayed in the command bar.
@@ -150,7 +150,7 @@ Other Merlin commands for Vim are available and you can checkout their usage on 
 
 Neovim comes with an LSP client.
 
-One note here is that is that `ocaml-lsp-server` is sensitive to versioning, and often does not play well with the sometimes outdated sources in Mason, a popular package manager for language services. We recommend you install the LSP server directly in the switch, and pointing your Neovim config to use that.
+One note here is that `ocaml-lsp-server` is sensitive to versioning, and often does not play well with the sometimes outdated sources in Mason, a popular package manager for language services. We recommend you install the LSP server directly in the switch, and point your Neovim config to use that.
 
 To install the LSP server and the formatter, run the following.
 ```shell

--- a/data/tutorials/getting-started/2_01_toplevel.md
+++ b/data/tutorials/getting-started/2_01_toplevel.md
@@ -57,7 +57,7 @@ If you want to use a library from a package installed in the current opam switch
 # #require "<LIBRARY_NAME>";;
 ```
 
-into the toplevel to make all definitions from the library available. For, example, try
+into the toplevel to make all definitions from the library available. For example, try
 
 ```ocaml
 # Str.quote {|"hello"|};;

--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -30,7 +30,7 @@ opam switch create my_project <compiler-version>
 
 Replace `<compiler-version>` with the version of the OCaml compiler you want to use, e.g. `5.2.0` (see `opam switch list-available` for a list of available OCaml compilers versions).
 
-If you don't specify a compiler, and `my_project` is a directory, opam will choose the default version. If `my_project` is not a directory, opam will consider it as a plain name and tries to install a compiler version with the same name.
+If you don't specify a compiler, and `my_project` is a directory, opam will choose the default version. If `my_project` is not a directory, opam will consider it as a plain name and try to install a compiler version with the same name.
 
 Next, **activate** your new switch. This will set it as the currently selected switch, so any OCaml-related operations will use this switch. You can activate it by running:
 

--- a/data/tutorials/getting-started/3_01_ocaml_on_windows.md
+++ b/data/tutorials/getting-started/3_01_ocaml_on_windows.md
@@ -148,7 +148,7 @@ The installation procedure will print instructions on how to link Merlin with
 your editor.
 
 **If you use Vim**, the default Cygwin Vim will not work with
-Merlin. You will need install Vim separately. In addition to the usual
+Merlin. You will need to install Vim separately. In addition to the usual
 instructions printed when installing Merlin, you may need to set the PATH in
 Vim:
 

--- a/data/tutorials/getting-started/3_03_ocaml_playground.md
+++ b/data/tutorials/getting-started/3_03_ocaml_playground.md
@@ -96,8 +96,8 @@ The playground also supports code completion. It helps users by suggesting and c
 
 As you can see from the above code samples, you don't need to use `;;` at the end of definitions.
 
-A little caveat here is that the playground behaves different from the OCaml toplevel.
-All expressions and definitions all evaluated in order, every time you click the "Run" button.
+A little caveat here is that the playground behaves differently from the OCaml toplevel.
+All expressions and definitions are evaluated in order, every time you click the "Run" button.
 When you write `2+3` and in the next line write a string `"this is a string"` ([see here](/play#code=MiszCiJ0aGlzIGlzIGEgc3RyaW5nIg%3D%3D)), you will see an error saying:
 
 ```

--- a/data/tutorials/guides/0tt_00_formatting_text.md
+++ b/data/tutorials/guides/0tt_00_formatting_text.md
@@ -24,11 +24,11 @@ Line breaking is based on three concepts:
 * **break hints**: a break hint is a directive to the pretty-printing
  engine that proposes to break the line here, if it is necessary to
  properly print the rest of the material. Otherwise, the
- pretty-printing engine never break lines (except “in case of
+ pretty-printing engine never breaks lines (except “in case of
  emergency” to avoid very bad output). In short, a break hint tells
  the pretty printer that a line break here may be appropriate.
 * **Indentation rules**: When a line break occurs, the pretty-printing
- engines fixes the indentation (or amount of leading spaces) of the
+ engine fixes the indentation (or amount of leading spaces) of the
  new line using indentation rules, as follows:
   * A box can state the extra indentation of every new line opened
  in its scope. This extra indentation is named **box breaking
@@ -50,7 +50,7 @@ so skip the rest at first reading).
 * **horizontal box** (*h* box, as obtained by the `open_hbox`
  procedure): within this box, break hints do not lead to line breaks.
 * **vertical box** (*v* box, as obtained by the `open_vbox`
- procedure): within this box, every break hint lead to a new line.
+ procedure): within this box, every break hint leads to a new line.
 * **vertical/horizontal box** (*hv* box, as obtained by the
  `open_hvbox` procedure): if it is possible, the entire box is
  written on a single line; otherwise, every break hint within the box
@@ -65,7 +65,7 @@ so skip the rest at first reading).
 
 Let me give an example. Suppose we can write 10 chars before the right
 margin (that indicates no more room). We represent any char as a `-`
-sign; characters `[` and `]` indicates the opening and closing of a box
+sign; characters `[` and `]` indicate the opening and closing of a box
 and `b` stands for a break hint given to the pretty-printing engine.
 
 The output "--b--b--" is displayed like this (the b symbol stands for
@@ -295,12 +295,12 @@ When writing a pretty-printing routine, follow these simple rules:
  most of the time a space should be considered a break hint.
 1. Do not try to force new lines, let the pretty-printer do it for you:
  that's its only job. In particular, do not use `force_newline`: this
- procedure effectively leads to a newline, but it also as the
+ procedure effectively leads to a newline, but it also has the
  unfortunate side effect to partially reinitialise the
  pretty-printing engine, so that the rest of the printing material is
  noticeably messed up.
 1. Never put newline characters directly in the strings to be printed:
- pretty printing engine will consider this newline character as any
+ the pretty printing engine will consider this newline character as any
  other character written on the current line and this will completely
  mess up the output. Instead of new line characters use line break
  hints: if those break hints must always result in new lines, it just

--- a/data/tutorials/guides/0tt_01_command_line_arguments.md
+++ b/data/tutorials/guides/0tt_01_command_line_arguments.md
@@ -95,7 +95,7 @@ function simply adds the file name to the reference defined earlier.
 let anon_fun filename = input_files := filename :: !input_files
 ```
 
-Finally we build the list of command line flag specifcations. Each is a tuple
+Finally we build the list of command line flag specifications. Each is a tuple
 of the flag name, the action to be taken when it is encountered, and the help
 string.
 
@@ -187,7 +187,7 @@ built-in `Arg` module:
   parser.
 
 * [Minicli](https://opam.ocaml.org/packages/minicli/) has good support for
-  rejecting malformed command lines which others might sliently accept.
+  rejecting malformed command lines which others might silently accept.
 
 * [Getopt](https://opam.ocaml.org/packages/getopt/) for OCaml is similar to
   [GNU getopt](https://www.gnu.org/software/libc/manual/html_node/Getopt.html).

--- a/data/tutorials/guides/0tt_04_calling_fortran_libraries.md
+++ b/data/tutorials/guides/0tt_04_calling_fortran_libraries.md
@@ -6,7 +6,7 @@ description: >
 category: "Tutorials"
 ---
 
-Fortran isn't a language the many people write new code in but it still
+Fortran isn't a language that many people write new code in but it still
 is in extensive use in the scientific communities. Many, many libraries
 exist for doing numerical calculation that will never be written in C or
 C++. It is quite possible though to call Fortran routines from OCaml as
@@ -68,7 +68,7 @@ corresponding C prototype for our gtd6 function is
 
 `int gtd6_(integer *iyd, real* sec, real* alt, real* glat, real* glong, real* dens, real* temp);`
 
-Note that its up to the caller to know that `dens` and `temp` are
+Note that it's up to the caller to know that `dens` and `temp` are
 actually arrays. Failure to pass an array will cause a segmentation
 violation since the gtd6_ function is using them as arrays (yet another
 reason OCaml shines).
@@ -113,7 +113,7 @@ A few points of interest
 ### Step 3: Compile the Shared Library
 
 Now having the two source files funcs.f and wrapper.c we need to create
-a shared library that can be loaded by OCaml. Its easier to do this as a
+a shared library that can be loaded by OCaml. It's easier to do this as a
 multistep process, so here are the commands:
 
 `prompt> g77 -c funcs.f`
@@ -146,7 +146,7 @@ single floating point and calls the C function gtd6_t.
 
 At this point, the steps that are given are to compile this into
 bytecode. I don't yet have much experience compiling to native so I'll
-let some else help out (or wait until I learn how to do it).
+let someone else help out (or wait until I learn how to do it).
 
 `prompt> ocamlc -c gtd6.ml`
 

--- a/data/tutorials/guides/1wf_01_debugging.md
+++ b/data/tutorials/guides/1wf_01_debugging.md
@@ -563,7 +563,7 @@ v is 11
 The TSan instrumentation benefits from compiling programs with debug
 information, which happens by default under `dune`. To manually invoke
 the `ocamlopt` compiler under our `5.2.0+tsan` switch it is thus
-suffient to pass it the `-g` flag:
+sufficient to pass it the `-g` flag:
 
 ```
 ocamlopt -g -o race.exe -I +unix unix.cmxa race.ml

--- a/data/tutorials/guides/1wf_02_error_handling.md
+++ b/data/tutorials/guides/1wf_02_error_handling.md
@@ -204,7 +204,7 @@ exceptions are called asynchronous. These include:
 
 The latter is thrown when the user interrupts an interactive execution. Because
 they are loosely or not at all related with the program logic, it mostly doesn't
-make sense to track the place where an asynchronous exceptions was thrown, as it
+make sense to track the place where an asynchronous exception was thrown, as it
 could be anywhere. Deciding if an application needs to catch those exceptions
 and how it should be done is beyond the scope of this tutorial. Interested
 readers may refer to Guillaume Munch-Maccagnoni's [A Guide to recover from
@@ -491,7 +491,7 @@ Here is a questionable but straightforward implementation using exceptions:
 val host : string -> string = <fun>
 ```
 
-This may fail by raising `Not_found` if the first the call to `String.index`
+This may fail by raising `Not_found` if the first call to `String.index`
 does, which could happen if there is no `@` character in the input string,
 signifying that it's not an email address. However, if the second call to
 `String.index` fails, meaning no dot character was found, we may return the
@@ -599,7 +599,7 @@ robustness. A couple of observations:
   as a fallback
 
 When used to handling errors with catch statements, it requires some time to get
-used the latter style. The key idea is avoiding or deferring looking directly
+used to the latter style. The key idea is avoiding or deferring looking directly
 into option values. Instead, pass them along using ad hoc pipes (such as `map`
 and `bind`). Erik Meijer calls that style “following the happy path.” Visually,
 it also resembles the “early return“ pattern often found in C.
@@ -747,7 +747,7 @@ Note that some say the types **`result`** and `Either.t` are
 [isomorphic](https://en.wikipedia.org/wiki/Isomorphism). Concretely, it means
 it's always possible to replace one by the other, like in a completely neutral
 refactoring. Values of type **`result`** and `Either.t` can be translated back and
-forth, and appling both translations one after the other, in any order, returns
+forth, and applying both translations one after the other, in any order, returns
 to the starting value. Nevertheless, this doesn't mean **`result`** should be used
 in place of `Either.t`, or vice versa. Naming things matters, as punned by Phil
 Karlton's famous quote:
@@ -764,7 +764,7 @@ behavior with minimal loss of clarity. Use them.
 
 When `Option.bind` or `Result.bind` are used, they are often aliased into a
 custom binding operator, such as `let*`. However, it is also possible to use it
-as a binary operator, which is very often writen `>>=`. Using `bind` this way
+as a binary operator, which is very often written `>>=`. Using `bind` this way
 must be detailed because it is extremely popular in other functional programming
 languages, especially in Haskell.
 
@@ -826,7 +826,7 @@ Go, Rust, Swift, or even modern Java, where it would look like:
 `x.bind(f)`.
 
 Here is the same code as presented at the end of the previous section, rewritten
-using `Result.bind` as a binary opeator:
+using `Result.bind` as a binary operator:
 
 ```ocaml
 File.read_opt path
@@ -844,7 +844,7 @@ expression extends beyond a single line.
 
 OCaml has a strict typing discipline, not a strict styling discipline;
 therefore, picking the right style is left to the author's decision. That
-applies error handling, so pick a style knowingly. See the [OCaml Programming
+applies to error handling, so pick a style knowingly. See the [OCaml Programming
 Guidelines](/docs/guidelines) for more details on those matters.
 
 ## Conversions Between Errors
@@ -958,7 +958,7 @@ is catastrophic!
 
 # Concluding Remarks
 
-Properly handling errors is a complex matter. It is [cross-cutting
+Properly handling errors is a complex matter. It is a [cross-cutting
 concern](https://en.wikipedia.org/wiki/Cross-cutting_concern), touches all parts
 of an application, and can't be isolated in a dedicated module. In contrast to
 several other mainstream languages, OCaml provides several mechanisms to handle
@@ -974,10 +974,10 @@ fine, so it's a balance.
 
 * [“Exceptions”](/manual/coreexamples.html#s%3Aexceptions) in ”The OCaml Manual, The Core Language”, chapter 1, section 6, December 2022
 * [Module **`option`**](/manual/api/Option.html) in OCaml Library
-* [Module **`result`**](/manual/api/Result.html) in Ocaml Library
+* [Module **`result`**](/manual/api/Result.html) in OCaml Library
 * [“Error Handling”](https://dev.realworldocaml.org/error-handling.html) in “Real World OCaml”, part 7, Yaron Minsky and Anil Madhavapeddy, 2ⁿᵈ edition, Cambridge University Press, October 2022
 * “Add "finally" function to Pervasives”, Marcello Seri, GitHub PR, [ocaml/ocaml/pull/1855](https://github.com/ocaml/ocaml/pull/1855)
-* “A guide to recover from interrupts”, Guillaume Munch-Maccagnoni, parf the [`memprof-limits`](https://gitlab.com/gadmm/memprof-limits/) documentation
+* “A guide to recover from interrupts”, Guillaume Munch-Maccagnoni, part of the [`memprof-limits`](https://gitlab.com/gadmm/memprof-limits/) documentation
 
 <!--
 Acknowledgements

--- a/data/tutorials/guides/1wf_03_profiling.md
+++ b/data/tutorials/guides/1wf_03_profiling.md
@@ -902,7 +902,7 @@ Each sample counts as 0.01 seconds.
 
 ### Using `perf` on Linux
 
-Assuming `perf`is installed and your program is compiled into
+Assuming `perf` is installed and your program is compiled into
 native code with `-g` (or ocamlbuild tag `debug`), you just need to type
 
 <!-- $MDX skip -->

--- a/data/tutorials/guides/1wf_04_multicore_ready.md
+++ b/data/tutorials/guides/1wf_04_multicore_ready.md
@@ -136,7 +136,7 @@ let _ =
 The runner creates a bank with 7 accounts containing $100
 each and then runs two loops in parallel with:
 
-- One transfering money with `money_shuffle`
+- One transferring money with `money_shuffle`
 - Another one repeatedly printing the account balances with `print_balances`:
 
 ``` shell
@@ -301,7 +301,7 @@ ready for OCaml 5.x parallelism, hurrah!
 
 The programming pattern of 'always-having-to-do-something-at-the-end'
 that we encountered with the missing `Mutex.unlock` is a recurring
-one for which OCaml offers a dedicate function:
+one for which OCaml offers a dedicated function:
 
 ```ocaml
  Fun.protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a

--- a/data/tutorials/guides/1wf_05_garbage_collection.md
+++ b/data/tutorials/guides/1wf_05_garbage_collection.md
@@ -6,7 +6,7 @@ description: >
 category: "Guides"
 ---
 
-In [Understanding the Garbage Collector](/docs/garbage-collector), discussed how Garbage Collection in OCaml works.
+In [Understanding the Garbage Collector](/docs/garbage-collector), we discussed how Garbage Collection in OCaml works.
 In this tutorial, we look at how to use the `Gc` module and how to write your own finalisers.
 At the end of the tutorial, we give some exercises you might try in order to develop a better understanding.
 

--- a/data/tutorials/guides/rs_00_guidelines.md
+++ b/data/tutorials/guides/rs_00_guidelines.md
@@ -376,7 +376,7 @@ own work!
 
 #### Pattern-matching warnings
 
-Warnings about pattern-matching must be treated with the upmost care.
+Warnings about pattern-matching must be treated with the utmost care.
 
 * Those with useless clauses should be eliminated, of course.
 * For nonexhaustive pattern-matching, you must complete the
@@ -420,7 +420,7 @@ can use it with more complex or simpler patterns. For instance:
  `let [x; y] as l = ...`<br />
  simultaneously defines a list `l` and its two elements `x` and `y`.
 * `let` with simple pattern:<br />
- `let _ = ...` does not define anything, it just evaluate the
+ `let _ = ...` does not define anything, it just evaluates the
  expression on the right hand side of the `=` symbol.
 
 #### The destructuring `let` must be exhaustive
@@ -879,7 +879,7 @@ versions, see the [note below](#imperative-and-functional-versions-of-listlength
  with recursive functions, using lists in contexts where
  imperative data structures seem to be mandatory to anyone,
  passing numerous global parameters of the problem to every
- function, even when a global reference perfectly avoid
+ function, even when a global reference perfectly avoids
  these spurious parameters that are mainly invariants that must
  be repeatedly passed.
   * This programmer feels that the `mutable` keyword in record-type
@@ -996,7 +996,7 @@ subsequent `ESC-/` proposes an alternate completion.
 
 Under Unix, the `CTRL-C-CTRL-C` or `Meta-X     compile` combination,
 followed by `` CTRL-X-` ``, is also used to find all occurrences of a
-certain string in a OCaml program. Instead of launching `make` to
+certain string in an OCaml program. Instead of launching `make` to
 recompile, launch the `grep` command. Then all the “error
 messages” from `grep` are compatible with the `` CTRL-X-` `` usage,
 which automatically takes you to the file and the place where the string
@@ -1008,7 +1008,7 @@ Under Unix: use the line editor `ledit`, which offers great editing
 capabilities “à la Emacs” (including `ESC-/`!) as well as a history
 mechanism that lets you retrieve previously-typed commands and even
 retrieve commands from one session to another. `ledit` is written in
-OCaml and can be freely downnloaded
+OCaml and can be freely downloaded
 [here](ftp://ftp.inria.fr/INRIA/Projects/cristal/caml-light/bazar-ocaml/ledit.tar.gz).
 
 ### How to Compile
@@ -1298,7 +1298,7 @@ recommended.
 ### How to Indent Operations
 
 When an operator takes complex arguments, or in the presence of multiple
-calls to the same operator, start the next the line with the operator,
+calls to the same operator, start the next line with the operator,
 and don't indent the rest of the operation. For example:
 
 <!-- $MDX skip -->
@@ -1779,7 +1779,7 @@ let rec size_lambda accu = function
 | Var v -> succ accu
 ```
 
-### Bad Indentation of Pattern-Catching constructs
+### Bad Indentation of Pattern-Matching Constructs
 
 #### No *beastly* indentation of functions and case analyses
 
@@ -1831,7 +1831,7 @@ let f = function
 
 No problem arises except for functions with many arguments&mdash;or very
 complicated arguments&mdash;which can't fit on the same line. You
-must indent the expressions with respect to the fucntion's name (1
+must indent the expressions with respect to the function's name (1
 or 2 spaces according to the chosen convention). Write small arguments
 on the same line, and change lines at the start of an argument.
 

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -263,7 +263,7 @@ val jane : person =
 
 The following examples demonstrate two methods by which we can extract Jane's `email` and `phone` number data in the nested `contact` tuple. We will do so first by using nested deconstruction, then demonstrate another approach by first extracting `content` followed by accessing the `email` and `phone` by deconstructing `contact`. 
 
-First, lets use nested deconstruction to access the contents of the `contact` tuple directly:
+First, let's use nested deconstruction to access the contents of the `contact` tuple directly:
 
 ```ocaml
 # let { name; street; city; zip; contact = (email, phone) } = jane;;
@@ -457,7 +457,7 @@ There are two alternative ways to apply functions.
 
 ### The Application Operator
 
-The application operator `@@` operator.
+The application operator is `@@`.
 ```ocaml
 # sqrt 9.0;;
 - : float = 3.
@@ -668,7 +668,7 @@ The way `sweet_cat` is written is an abbreviated version of `sour_cat`. Such a w
 
 ### Partial Application and Closures
 
-We want to define functions of type `string -> string` that appends `"kitty "` in front of its arguments. This can be done using `sour_cat` and `sweet_cat`
+We want to define functions of type `string -> string` that append `"kitty "` in front of its arguments. This can be done using `sour_cat` and `sweet_cat`
 ```ocaml
 # let sour_kitty x = sour_cat "kitty" x;;
 val sour_kitty : string -> string = <fun>

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -39,7 +39,7 @@ The `int` type is the default and basic integer type in OCaml. When you enter a 
 - : int = 42
 ```
 
-The `int` type represents platform-dependent signed integers. This means `int` does not always have same the number of bits. It depends on underlying platform characteristics, such as processor architecture or operating system. Operations on `int` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Int`](/manual/api/Int.html) modules.
+The `int` type represents platform-dependent signed integers. This means `int` does not always have the same number of bits. It depends on underlying platform characteristics, such as processor architecture or operating system. Operations on `int` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Int`](/manual/api/Int.html) modules.
 
 Usually, `int` has 31 bits in 32-bit architectures and 63 in 64-bit architectures, because one bit is reserved for OCaml's runtime operation. The standard library also provides [`Int32`](/manual/api/Int32.html) and [`Int64`](/manual/api/Int64.html) modules, which support platform-independent operations on 32- and 64-bit signed integers. These modules are not detailed in this tutorial.
 
@@ -160,7 +160,7 @@ Like strings, byte sequences are finite and fixed-sized. Each individual byte is
 
 Operations on `bytes` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Bytes`](/manual/api/Bytes.html) modules. Only the function `Bytes.get` allows direct access to the characters contained in a byte sequence. Unlike arrays, there is no direct access operator on byte sequences.
 
-The memory representation of `bytes` is four times more compact that `char array`.
+The memory representation of `bytes` is four times more compact than `char array`.
 ### Arrays & Lists
 
 #### Arrays

--- a/data/tutorials/language/0it_03_lists.md
+++ b/data/tutorials/language/0it_03_lists.md
@@ -2,7 +2,7 @@
 id: lists
 title: Lists
 description: >
-  Learn about one of OCaml's must used, built-in data types
+  Learn about one of OCaml's most used, built-in data types
 category: "Introduction"
 ---
 

--- a/data/tutorials/language/0it_04_higher_order_functions.md
+++ b/data/tutorials/language/0it_04_higher_order_functions.md
@@ -98,7 +98,7 @@ But what would happen if we wanted to say "hi" 2 times? Or 4 or 12 times?
 
 When this happens, it usually means that the function is making certain decision that it shouldn't. In other words, the function **knows something** (like the number of times).
 
-So instead, we will create a function that **let's the caller decide** how many times to say "hi." We do this by requiring a new argument, in this case, `times`:
+So instead, we will create a function that **lets the caller decide** how many times to say "hi." We do this by requiring a new argument, in this case, `times`:
 
 ```ocaml
 # let rec say_many_hi times name =
@@ -332,7 +332,7 @@ On the other hand, sometimes we have functions that already work with tuples, an
 
 For that we can define a little `curry` helper that will take a function as input, and return another function as output. It is essentially a wrapper.
 
-The input function must have type: `('a * 'b) -> 'c` – this is the type of any function that one tuple with 2 parameters.
+The input function must have type: `('a * 'b) -> 'c` – this is the type of any function that takes one tuple with 2 parameters.
 
 The output function will have type `'a -> 'b -> 'c` – notice how the arguments `'a` and `'b` are now unbundled!
 
@@ -819,7 +819,7 @@ let asc = List.sort (fun a b -> a - b) list ;;
 let desc = List.sort (fun a b -> b - a) list ;;
 ```
 
-Most OCaml modules include a `compare` function that can be pass in to `sort`:
+Most OCaml modules include a `compare` function that can be passed in to `sort`:
 
 ```ocaml
 let int_array = [|3;0;100|];;

--- a/data/tutorials/language/0it_06_imperative.md
+++ b/data/tutorials/language/0it_06_imperative.md
@@ -579,7 +579,7 @@ val c1 : unit -> int = <fun>
 val c2 : unit -> int = <fun>
 ```
 
-Now, using partial application, we create two closure `c1` and `c2` that encapsulates a counter. Calling `c1 ()` will increment the counter associated with `c1` and return its current value. Similarly, calling `c2 ()` will update its own independent counter.
+Now, using partial application, we create two closures `c1` and `c2` that encapsulate a counter. Calling `c1 ()` will increment the counter associated with `c1` and return its current value. Similarly, calling `c2 ()` will update its own independent counter.
 
 ```ocaml
 # c1 ();;
@@ -829,7 +829,7 @@ This issue also arises when applying arguments to variant constructors, building
 - : int * int = (0, -1)
 ```
 
-The value of this expression depends on the order of subexpression evaluation. Since this order is not specified, there is no reliable way to know what this value is. At the time of writing this tutorial, the evaluation produced `(0, -1)`, but if you see something else, it is not a bug. Such an unreliable value must a avoided.
+The value of this expression depends on the order of subexpression evaluation. Since this order is not specified, there is no reliable way to know what this value is. At the time of writing this tutorial, the evaluation produced `(0, -1)`, but if you see something else, it is not a bug. Such an unreliable value must be avoided.
 
 To ensure that evaluation takes place in a specific order, use the means to put expressions in sequences using either `let … in` expressions or the semi-colon sequence operator (`;`). Check the [Evaluating Expressions in Sequence](#evaluating-expressions-in-sequence) section.
 

--- a/data/tutorials/language/1ms_00_modules.md
+++ b/data/tutorials/language/1ms_00_modules.md
@@ -471,7 +471,7 @@ reset.
 
 ## Conclusion
 
-OCaml, modules are the basic means of organising software. To sum up, a
+In OCaml, modules are the basic means of organising software. To sum up, a
 module is a collection of definitions wrapped under a name. These definitions
 can be submodules, which allows the creation of hierarchies of modules.
 Top-level modules must be files and are the units of compilation. Every module

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -106,7 +106,7 @@ The module expression `struct ... end` is inlined in the `Set.Make` call.
 
 However, since the module `String` already defines
 - Type name `t`, which is an alias for `string`
-- Function `compare` of type `t -> t -> bool` compares two strings
+- Function `compare` of type `t -> t -> int` compares two strings
 
 This can be simplified even further into this:
 

--- a/data/tutorials/language/1ms_03_dune.md
+++ b/data/tutorials/language/1ms_03_dune.md
@@ -284,12 +284,12 @@ Here `foo` is the project name and `foo.dir` is its container directory, the nam
 
 In the previous stages, interfaces were duplicated. In the
 “[Libraries](#libraries)” section of this tutorial, two files are the same:
-`lib/cumulus.mli` and `lib/status.mli`. Later, in the “[Include
-Subdirectories](#include-subdirectories)” section, the files `lib/cumulus/m.mli`
-and `lib/status/m.mli` are also the same.
+`lib/cumulus.mli` and `lib/stratus.mli`. Later, in the "[Include
+Subdirectories](#include-subdirectories)" section, the files `lib/cumulus/m.mli`
+and `lib/stratus/m.mli` are also the same.
 
 Here is a possible way to fix this using named module types (also known as
-signatures). First, delete the files `lib/cumulus/m.mli` and `lib/status/m.mli`.
+signatures). First, delete the files `lib/cumulus/m.mli` and `lib/stratus/m.mli`.
 Then modify module `Wmo` interface and implementation.
 
 **`wmo.mli`**

--- a/data/tutorials/language/3ds_00_options.md
+++ b/data/tutorials/language/3ds_00_options.md
@@ -52,7 +52,7 @@ Most of the functions in this section, as well as other useful ones, are provide
 
 ### Map Over an Option
 
-Using pattern matching, it is possible to define functions, allowing us to work with option values. For example, lets define a custom `map` function of type `('a -> 'b) -> 'a option -> 'b option` that allows us to apply a function to the wrapped value inside an `option` (if present):
+Using pattern matching, it is possible to define functions, allowing us to work with option values. For example, let's define a custom `map` function of type `('a -> 'b) -> 'a option -> 'b option` that allows us to apply a function to the wrapped value inside an `option` (if present):
 
 ```ocaml
 let map f = function
@@ -60,7 +60,7 @@ let map f = function
   | Some v -> Some (f v)
 ```
 
-Our custom `map` function is the same a the standard library's `Option.map`:
+Our custom `map` function is the same as the standard library's `Option.map`:
 
 ```ocaml
 # Option.map (fun x -> x * x) (Some 3);;
@@ -110,7 +110,7 @@ Here, `map` is applied to a list inside `Some`, doubling each number. If `None`,
 
 ### Peel Off Doubly Wrapped Options
 
-Sometimes we may encounter a value that is wrapped in multiple options. Lets define a custom `join` function of type `'a option option -> 'a option` that peels off one layer from a doubly wrapped option:
+Sometimes we may encounter a value that is wrapped in multiple options. Let's define a custom `join` function of type `'a option option -> 'a option` that peels off one layer from a doubly wrapped option:
 
 ```ocaml
 let join = function
@@ -119,7 +119,7 @@ let join = function
   | None -> None
 ```
 
-Our custom `join` function is the same a the standard library's `Option.join`:
+Our custom `join` function is the same as the standard library's `Option.join`:
 
 ```ocaml
 # Option.join (Some (Some 42));;
@@ -169,7 +169,7 @@ val safe_divide : int -> int -> int option = <fun>
 
 ### Extract the Content of an Option
 
-We will also want to extract the contents of a value wrapped in an option. Lets define a custom `get` function of type `'a option -> 'a` that allows us to access to the value contained inside an `option`:
+We will also want to extract the contents of a value wrapped in an option. Let's define a custom `get` function of type `'a option -> 'a` that allows us to access the value contained inside an `option`:
 
 ```ocaml
 # let get = function
@@ -251,7 +251,7 @@ The function `fold` of type `none:'a -> some:('b -> 'a) -> 'b option -> 'a` can 
 let fold ~none ~some o = o |> Option.map some |> Option.value ~default:none
 ```
 
-In the standard library, this function is `Option.fold`.
+In the standard library, this function is `Option.bind`.
 
 The `Option.fold` function can be used to implement a fall-back logic without writing pattern matching. For instance, here is a function that turns the contents of the `$PATH` environment variable into a list of strings, or the empty list if undefined. This version uses pattern matching:
 
@@ -333,7 +333,7 @@ val greet : string option -> string = <fun>
 
 The `bind` function of type `'a option -> ('a -> 'b option) -> 'b option` works a bit like `map`. But whilst `map` expects a function parameter `f` that returns an unwrapped value of type `b`, `bind` expects a function `f` that returns a value already wrapped in an option `'b option`.
 
-Lets try to implement a custom `bind` function:
+Let's try to implement a custom `bind` function:
 
 ```ocaml
 # let bind o f =
@@ -342,7 +342,7 @@ Lets try to implement a custom `bind` function:
   | None -> None;;
 val bind : 'a option -> ('a -> 'b option) -> 'b option = <fun>
 ```
-In the standard library, this function is `Option.fold`.
+In the standard library, this function is `Option.bind`.
 
 The following are simple examples demonstrating the use of `Option.bind`:
 

--- a/data/tutorials/language/3ds_02_maps.md
+++ b/data/tutorials/language/3ds_02_maps.md
@@ -23,7 +23,7 @@ create our custom map module. Refer to the [Functors](/docs/functors) for more i
 on functors. This functor has a module parameter that defines the keys' type to be used in
 the maps, and a function for comparing them.
 
-For an different implementation of an association table in OCaml's Standard Library, see the tutorial
+For a different implementation of an association table in OCaml's Standard Library, see the tutorial
 on [Hash Tables](/docs/hash-tables).
 
 ```ocaml
@@ -100,13 +100,13 @@ To find entries in a map, use the `find_opt` or `find` functions:
 - : int = 2112
 ```
 
-When the searched key is present from the map:
+When the searched key is present in the map:
 - `find_opt` returns the associated value, wrapped in an option
 - `find` returns the associated value
 
 When the searched key is absent from the map:
 - `find_opt` returns `None`
-- `find` throws the `Not_found` exceptions
+- `find` throws the `Not_found` exception
 
 We can also use `find_first_opt` and `find_last_opt` if we want to use a
 predicate function:
@@ -299,11 +299,11 @@ If you need to create a map with a custom key type, you can call the `Map.Make`
 functor with a module of your own, provided that it implements two things:
 
 1. A type `t` exposing the type of the map's key
-2. A function `compare : t -> t -> int` function that compares `t` values
+2. A function `compare : t -> t -> int` that compares `t` values
 
 Let's define our custom map below for non-negative numbers.
 
-We'll start by defining a module for strings that compares them in case-insensitive way.
+We'll start by defining a module for strings that compares them in a case-insensitive way.
 
 ```ocaml
 # module Istring = struct

--- a/data/tutorials/language/3ds_03_sets.md
+++ b/data/tutorials/language/3ds_03_sets.md
@@ -10,7 +10,7 @@ category: "Data Structures"
 
 `Set` provides the functor `Set.Make`. You must start by passing `Set.Make` a module. It specifies the element type for your set. In return, you get another module with those elements' set operations.
 
-**Disclaimer:** The examples in this tutorial require OCaml 5.1. If you're running a previous version of OCaml , you can either use `elements` instead of `to_list`, which is a new function in OCaml 5.1, or upgrade OCaml by running `opam update`, then `opam upgrade ocaml`. Check your current version with `ocaml --version`. 
+**Disclaimer:** The examples in this tutorial require OCaml 5.1. If you're running a previous version of OCaml, you can either use `elements` instead of `to_list`, which is a new function in OCaml 5.1, or upgrade OCaml by running `opam update`, then `opam upgrade ocaml`. Check your current version with `ocaml --version`. 
 
 If you need to work with string sets, you must invoke `Set.Make(String)`. That returns a new module.
 

--- a/data/tutorials/language/3ds_04_hashtbl.md
+++ b/data/tutorials/language/3ds_04_hashtbl.md
@@ -22,7 +22,7 @@ information at a nearly instantaneous linear time complexity (O(1)).
 A hash table data structure achieves efficient reads and writes by employing a
 hashing function that converts the key of a key/value pair into an
 algorithmically unique "fingerprint" known as a hash. OCaml has a built-in
-hashing function within the `Hashtabl` module that is available for each key
+hashing function within the `Hashtbl` module that is available for each key.
 The `Hashtbl` module implements an efficient, mutable lookup table.
 
 ## Creating a Polymorphic Hash Table
@@ -54,7 +54,7 @@ and then later use a string as a key in that same hash table.
 
 ### Adding Data to a Hash Table
 
-Lets add some data to `my_hash`. Lets say I am working on a cross word
+Let's add some data to `my_hash`. Let's say I am working on a crossword
 solving program and I want to find all words that start with a certain
 letter. First I need to enter the data into `my_hash`.
 
@@ -77,7 +77,7 @@ something like this:
 
 The return type is `unit`, indicating that `Hashtbl.add` produces a side effect.
 
-Now that we put data into `my_hash`, lets look at its type:
+Now that we put data into `my_hash`, let's look at its type:
 
 ```ocaml
 # my_hash;;
@@ -127,7 +127,7 @@ associated to the key.
 
 This behavior is interesting for the above example or when, say, the
 keys represent variables that can be temporarily masked by a local
-variables of the same name.
+variable of the same name.
 
 ### Replacing Data in Hash Tables
 

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -2,7 +2,7 @@
 id: sequences
 title: Sequences
 description: >
-  Learn about sequences, of OCaml's most-used, built-in data types
+  Learn about sequences, one of OCaml's most-used, built-in data types
 category: "Data Structures"
 prerequisite_tutorials:
   - "lists"
@@ -59,7 +59,7 @@ may see as forcing evaluation to retrieve the first element of the list.
 However, this only gives access to the tip of the
 sequence, since the second argument of `Seq.Cons` is a function too.
 
-This explain why sequences may be considered potentially
+This explains why sequences may be considered potentially
 infinite: Until a `Seq.Nil` value has been found in the sequence, one can't say
 for sure if some will ever appear. The sequence could be a stream of incoming
 requests in a server, readings from an embedded sensor, or system logs. All have
@@ -227,7 +227,7 @@ filtered sequence beginning with `Seq.Nil`.
 colloquially be called a recursive, is an example of a kind of recursion called
 [corecursion](https://en.wikipedia.org/wiki/Corecursion). Corecursion differs
 from recursion in that it constructs results incrementally rather than consuming
-it's input incrementally. Unlike traditional recursion, which works towards a
+its input incrementally. Unlike traditional recursion, which works towards a
 base case, corecursive functions must indefinitely produce values as a stream. The `trial_div` function is corecursive
 because it does not immediately compute the complete sequence of primes. Instead, it
 produces prime numbers on-demand, filtering and deferring further computation until
@@ -371,7 +371,7 @@ This application of `Seq.unfold` has type  `unit -> int Seq.node`, making it a f
 
 ## Be Aware of Seq.Cons vs Seq.cons
 
-The `Seq` module in the OCaml Standard Library contains two version of
+The `Seq` module in the OCaml Standard Library contains two versions of
 "cons-ing" that warrant special attention due to their similar names and distinct
 behavior.
 
@@ -420,7 +420,7 @@ val ints_b : int Seq.t = <fun>
 Now that we have seen these two versions of "cons-ing" can construct the same
 sequence, it begs the question: what makes `Seq.cons` and `Seq.Cons` different?
 
-Lets look at how confusing `Seq.Cons` and `Seq.con` can lead to unintended
+Let's look at how confusing `Seq.Cons` and `Seq.cons` can lead to unintended
 behavior.
 
 ### Fibs with `Seq.cons`
@@ -452,7 +452,7 @@ This produces a never-ending recursion that leads to a stack overflow.
 
 ### Fibs with `Seq.Cons`
 
-Next, lets define `fibs_v2` using the constructor `Seq.Cons`:
+Next, let's define `fibs_v2` using the constructor `Seq.Cons`:
 
 ```ocaml
 # let rec fibs_v2 m n () = Seq.Cons (m, fibs_v2 n (n + m));;
@@ -504,7 +504,7 @@ arguments of `'a` and `'a t`.
 
 ### A Mental Model for `Seq.Cons` vs `Seq.cons`
 
-It useful to think of `Seq.Cons` and `Seq.cons` as accomplishing different
+It is useful to think of `Seq.Cons` and `Seq.cons` as accomplishing different
 tasks. `Seq.Cons` provides a convenient means of recursively defining a sequence
 generator and a clumsy means to prepend a value to a sequence.  Conversely,
 `Seq.cons` provides a convenient means to prepend a value to a sequence and an

--- a/data/tutorials/language/3ds_06_memoization.md
+++ b/data/tutorials/language/3ds_06_memoization.md
@@ -41,7 +41,7 @@ golden ratio, (1 + &Sqrt;5)/2.
 
 If we record Fibonacci numbers as they are computed, we can avoid this redundant
 work. The idea is that whenever we compute `f n`, we store it in a table indexed
-by `n`. In this case the indexing keys are integers, so we can use implement
+by `n`. In this case the indexing keys are integers, so we can implement
 this table using an array:
 
 ```ocaml

--- a/data/tutorials/language/3ds_07_monads.md
+++ b/data/tutorials/language/3ds_07_monads.md
@@ -658,7 +658,7 @@ That notion of *sequential order* is part of what the monad laws stipulate. We
 will state those laws below. But first, let's pause to consider sequential order
 in imperative languages.
 
-**Sequential Order.* In languages like Java and C, there is a semicolon that
+**Sequential Order.** In languages like Java and C, there is a semicolon that
 imposes a sequential order on statements, e.g.:
 
 ```java

--- a/data/tutorials/language/4ad_00_metaprogramming.md
+++ b/data/tutorials/language/4ad_00_metaprogramming.md
@@ -136,7 +136,7 @@ module files using our previously written `preprocessor.sh`:
 
 ### The Limits of Manipulating Text Files
 
-The complexities of a programming language syntax makes it very hard to
+The complexities of a programming language's syntax make it very hard to
 manipulate text in a way that is tied to the syntax. Suppose for instance that,
 similarly to the previous example, you want to rewrite all occurrences of "World"
 by "Universe," but _inside the OCaml strings of the program_ only. It is quite
@@ -297,7 +297,7 @@ files](#the-limits-of-manipulating-text-files)). Indeed, exactly the right amoun
 of information is passed to the PPX, and we also know that the PPX won't modify
 any part of the source.
 
-Example of derivers are:
+Examples of derivers are:
 - [`ppx_show`](https://github.com/thierry-martinez/ppx_show) generates a pretty printer
   from a type for values of this type.
 - Derivers that derive serializers from OCaml types to other formats, such as

--- a/data/tutorials/language/4ad_01_operators.md
+++ b/data/tutorials/language/4ad_01_operators.md
@@ -214,7 +214,7 @@ This function is using `Option.bind` as a custom binder over the calls to `rinde
 
 The `let open String in` construct allows calling functions `rindex_opt`, `rindex_from_opt`, `length`, `ends_with` and `sub` from module `String` without prefixing each of them with `String.` within the scope of the definition of `doi_parts`.
 
-The rest of the function applies if relevant delimiting characters have been found. It does performs additional checks and extracts registrant and identifier form the string `s`, if possible.
+The rest of the function applies if relevant delimiting characters have been found. It performs additional checks and extracts registrant and identifier from the string `s`, if possible.
 
  <!-- TODO: move this into the list tutorial
  In the following example, we use that mechanism to write a function which produces the list of Friday 13th dates between two years.

--- a/data/tutorials/language/4ad_02_objects.md
+++ b/data/tutorials/language/4ad_02_objects.md
@@ -59,7 +59,7 @@ list `[]` has type `'a list`, meaning a list of any type. However we
 want a stack of `int`, not anything else, so in this case we want to
 tell the type inference engine that this list isn't the general "list of
 anything" but is in fact the narrower "list of `int`." The syntax
-`( expression : type )` means `expression`, which is a of type
+`( expression : type )` means `expression`, which is of type
 `type`. This *isn't* a general type cast because you can't use it to
 overrule the type inference engine, only to narrow a general type to
 make it more specific. So you can't write, for example, `( 1 : float )`:
@@ -615,7 +615,7 @@ canonical way of creating objects is to first define a class, then use
 this class to create individual objects. This can be cumbersome in some
 situations because class definitions are more than a type definition and
 cannot be defined recursively with types. However, objects have a type
-that is very analog to a record type, and it can be used in type
+that is very analogous to a record type, and it can be used in type
 definitions. In addition, objects can be created without a class. They
 are called *immediate objects*. Here is the definition of an immediate
 object:

--- a/data/tutorials/language/5rt_02_compiler_frontend.md
+++ b/data/tutorials/language/5rt_02_compiler_frontend.md
@@ -94,7 +94,7 @@ of:
 : Command-line interfaces for the compiler tools.
 
 `file_formats/`
-: Serializer and deserializers for on-disk files used by the compiler driver.
+: Serializers and deserializers for on-disk files used by the compiler driver.
 
 `lambda/`
 : The lambda conversion pass.

--- a/data/tutorials/platform/0_01_managing_deps.md
+++ b/data/tutorials/platform/0_01_managing_deps.md
@@ -60,7 +60,7 @@ If the project generates the opam file from the `dune-project` (you can tell by 
 (package
  (name demo)
  (synopsis "A short, but powerful statement about your project")
- (description "An complete and exhaustive description everything your project does.")
+ (description "A complete and exhaustive description of everything your project does.")
  (depends
   (ocaml
    (>= 4.08.0))
@@ -201,7 +201,7 @@ And for the `*.opam` file, it looks like:
 "alcotest" {with-test}
 ```
 
-The available flags for each dependencies are:
+The available flags for each dependency are:
 
 - Normal: no flag
 - Build: `build`

--- a/data/tutorials/platform/0_02_install_compiler.md
+++ b/data/tutorials/platform/0_02_install_compiler.md
@@ -9,7 +9,7 @@ category: "Projects"
 
 > **TL;DR**
 > 
-> Use `opam switch set` to manually select the switch to use and use `dune-workspace` to automatically run commands in different environment.
+> Use `opam switch set` to manually select the switch to use and use `dune-workspace` to automatically run commands in different environments.
 
 Compilation environments are managed with opam switches. The typical workflow is to have a local opam switch for the project, but you may need to select a different compilation environment (i.e. a different compiler version) sometimes. For instance, to run unit tests on an older/newer version of OCaml.
 
@@ -21,13 +21,13 @@ opam switch create 4.14.0 ocaml-base-compiler.4.14.0
 
 This will create a new switch called `4.14.0` with the compiler version `4.14.0`.
 
-The list of available compiler version can be retrieved with:
+The list of available compiler versions can be retrieved with:
 
 ```
 opam switch list-available
 ```
 
-This will list the available compiler version for all of the configured Opam repositories.
+This will list the available compiler versions for all of the configured Opam repositories.
 
 Once you've created a switch (or you already have a switch you'd like to use), you can run:
 
@@ -50,7 +50,7 @@ Alternatively, you may want to automatically run commands in a given set of comp
 (context (opam (switch 4.13.0)))
 ```
 
-All the Dune commands you will run, will be run on all of the switches listed. For instance with the definition above:
+All the Dune commands you run will be run on all of the switches listed. For instance with the definition above:
 
 ```
 dune runtest --workspace dune-workspace

--- a/data/tutorials/platform/0_03_run_executables_and_tests.md
+++ b/data/tutorials/platform/0_03_run_executables_and_tests.md
@@ -78,7 +78,7 @@ Running `dune test` will fail with the following output:
 
 This means that the test failed because the executable exited with the status code `1`.
 
-The output is not very descriptive. If we want to create suites of unit tests, with several tests per files, and different kind of assertions, we will want to use a test framework such as Alcotest.
+The output is not very descriptive. If we want to create suites of unit tests, with several tests per files, and different kinds of assertions, we will want to use a test framework such as Alcotest.
 
 Let's modify our dummy test to link to Alcotest:
 

--- a/data/tutorials/platform/0_09_opam_path.md
+++ b/data/tutorials/platform/0_09_opam_path.md
@@ -73,7 +73,7 @@ Now, whenever you navigate to your OCaml project directory, `direnv` will automa
 
 6. Example
 
-Suppose you have an OCaml project in directory `disco` and local opam switch is associated to it, and a `.envrc` file in that directory containing the following:
+Suppose you have an OCaml project in directory `disco` and a local opam switch is associated with it, and a `.envrc` file in that directory containing the following:
 ```bash
 eval $(opam env)
 ```
@@ -81,7 +81,7 @@ After running `direnv allow`, `direnv` will handle the opam switch activation fo
 
 7. Messages from `direnv`
 
-Whenever entering or leaving a `direnv` managed directory, you will be informed of the the actions performed.
+Whenever entering or leaving a `direnv` managed directory, you will be informed of the actions performed.
 
 On entrance:
 ```

--- a/data/tutorials/platform/2_08_odoc.md
+++ b/data/tutorials/platform/2_08_odoc.md
@@ -9,7 +9,7 @@ category: "Additional Tooling"
 
 The documentation rendering tool `odoc` generates documentation
 in the form of HTML, LaTeX, or man pages,
-from the docstrings and interfaces of the project's modules
+from the docstrings and interfaces of the project's modules.
 
 Dune can run `odoc` on your project to generate HTML documentation with this command:
 

--- a/data/tutorials/platform/3_04_create_libraries.md
+++ b/data/tutorials/platform/3_04_create_libraries.md
@@ -20,6 +20,6 @@ Creating a library with dune is as simple as adding a `library` stanza in your d
  (libraries <libraries...>))
 ```
 
-Where `<name>` is the name of the library used inside internally, `<public_name>` is the name of the library used by users of the package and `<libaries...>` is the list of libraries to link to your library.
+Where `<name>` is the name of the library used internally, `<public_name>` is the name of the library used by users of the package and `<libraries...>` is the list of libraries to link to your library.
 
 Note that if the library does not have a `public_name`, it will not be installed when installing the package through opam. As a consequence, you cannot use an internal library that does not have a `public_name` in a library or executable that has one.


### PR DESCRIPTION
I went through all the tutorials and fixed the typos and grammar issues I spotted. About 100 fixes across 41 files covering all four tutorial sections (getting-started, guides, language, platform).

Here's the gist of what's fixed:

- Misspellings: "specifcations", "suffient", "downnloaded", "fucntion's", "libaries", "Hashtabl", etc.
- Wrong words: "must" instead of "most", "status" instead of "stratus", "that" instead of "than", "form" instead of "from"
- Subject-verb disagreement: "engines fixes", "break hint lead", "syntax makes" (with plural subject), etc.
- Missing words: missing articles, prepositions, subjects ("In OCaml, modules...", "a local opam switch", etc.)
- Doubled words: "the the", "operator operator", "function function"
- Wrong function references: `Option.fold` should be `Option.bind` in the options tutorial
- Wrong type: `String.compare` returns `int`, not `bool` (functors tutorial)
- Punctuation: missing periods, extra commas, spacing issues