### PR TITLE
Fix markdown lint issues across all tutorials

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -7,7 +7,7 @@ description: |
 category: "First Steps"
 ---
 
-This guide will walk you through a minimum installation of OCaml. That includes installing a package manager and [the compiler](#installation-on-unix-and-macos) itself. We'll also install some platform tools like a build system, support for your editor, and a few other important ones.
+This guide will walk you through a minimum installation of OCaml. That includes installing a package manager and [the compiler](#initialise-opam) itself. We'll also install some platform tools like a build system, support for your editor, and a few other important ones.
 
 On this page, you'll find installation instructions for Linux, macOS, Windows, and &ast;BSD for recent OCaml versions. For Docker, Linux instructions apply, except when setting up opam.
 
@@ -21,7 +21,7 @@ Opam also installs the OCaml compiler. Alternatives exist, but opam is the best 
 
 To install opam, you can [use your system package manager](https://opam.ocaml.org/doc/Install.html#Using-your-distribution-39-s-package-system) or download the [binary distribution](https://opam.ocaml.org/doc/Install.html#Binary-distribution). The details are available in these links, but for convenience, we use package distributions:
 
-**For macOS**
+### For macOS
 
 If you're installing with [Homebrew](https://brew.sh/):
 
@@ -37,7 +37,7 @@ port install opam
 
 **Note**: While it's rather straightforward to install opam using macOS, it's possible you'll run into problems later with Homebrew because it has changed the way it installs. The executable files cannot be found in ARM64, the M1 processor used in newer Macs. Addressing this can be a rather complicated procedure, so we've made [a short ARM64 Fix doc](/docs/arm64-fix) explaining this so as not to derail this installation guide.
 
-**For Linux**
+### For Linux
 
 It's preferable to install opam with your system's package manager on Linux, as superuser. On the opam site, find [details of all installation methods](https://opam.ocaml.org/doc/Install.html). A version of opam above 2.0 is packaged in all supported Linux distributions. If you are using an unsupported Linux distribution, please either download a precompiled binary or build opam from sources.
 
@@ -59,7 +59,7 @@ sudo pacman -S opam
 sudo apt-get install --no-install-recommends opam
 ```
 
-**For Windows**
+### For Windows
 
 It's easiest to install opam with [WinGet](https://github.com/microsoft/winget-cli):
 
@@ -67,7 +67,7 @@ It's easiest to install opam with [WinGet](https://github.com/microsoft/winget-c
 PS C:\> winget install Git.Git OCaml.opam
 ```
 
-**Binary Distribution**
+### Binary Distribution
 
 If you want the latest release of opam, install it through the binary distribution. On Unix and macOS, you'll need to install the following system packages first: `gcc`, `build-essential`, `curl`, `bubblewrap`, and `unzip`. Note that they might have different names depending on your operating system or distribution. Also, note this script internally calls `sudo`.
 
@@ -97,13 +97,13 @@ opam init -y
 
 Make sure you follow the instructions provided at the end of the output of `opam init` to complete the initialisation. Typically, this is:
 
-```
+```shell
 eval $(opam env)
 ```
 
 on Unix, and from the Windows Command Prompt:
 
-```
+```shell
 for /f \"tokens=*\" %i in ('opam env') do @%i
 ```
 

--- a/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
+++ b/data/tutorials/getting-started/1_01_a_tour_of_ocaml.md
@@ -305,7 +305,7 @@ val range : int -> int -> int list = <fun>
 
 As indicated by its type `int -> int -> int list`, the function `range` takes two integers as arguments and returns a list of integers as result. The first `int` parameter, `lo`, is the range's lower bound; the second `int` parameter, `hi`, is the higher bound. If `lo > hi`, the empty range is returned. That's the first branch of the `if … then … else` expression. Otherwise, the `lo` value is prepended to the list created by calling `range` itself; this is recursion. Prepending is achieved using `::`, the cons operator in OCaml. It constructs a new list by adding an element at the front of an existing list. Progress is made at each call; since `lo` has just been prepended at the head of the list, `range` is called with `lo + 1`. This can be visualised this way (this is not OCaml syntax):
 
-```
+```text
    range 2 5
 => 2 :: range 3 5
 => 2 :: 3 :: range 4 5

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -49,7 +49,7 @@ If you used the DkML distribution, you will need to:
     1. Go to `File` > `Preferences` > `Settings` view (or press `Ctrl ,`)
     2. Select `User` > `Extensions` > `OCaml Platform`
     3. Uncheck `OCaml: Use OCaml Env`. That's it!
-    
+
 ## Emacs
 
 Using Emacs to work with OCaml requires at least two modes:
@@ -72,7 +72,6 @@ For the purposes of this tutorial, we are going to focus on the use of `tuareg` 
   :ensure t
   :mode (("\\.ocamlinit\\'" . tuareg-mode)))
 ```
-
 
 #### Melpa and `use-package`
 
@@ -110,7 +109,6 @@ You are now ready to edit OCaml code _productively_ with Emacs!
 
 OCaml-eglot can be finely configured, the project [README](https://github.com/tarides/ocaml-eglot/blob/main/README.md) gives several configuration paths to adapt perfectly to your workflow. You will also find there an exhaustive presentation of the different functions offered by the mode.
 
-
 #### Getting Type Information
 
 Opening an OCaml file should launch an `ocaml-lsp` server, and you can convince yourself that it's working by using, for example, the `ocaml-eglot-type-enclosing` command (or using the `C-c C-t` binding) on an expression of your choice:
@@ -118,7 +116,6 @@ Opening an OCaml file should launch an `ocaml-lsp` server, and you can convince 
 ![Emacs Type information](/media/tutorials/emacs-type-info.gif)
 
 OCaml-eglot [README](https://github.com/tarides/ocaml-eglot/blob/main/README.md) provides a comprehensive overview of all the functions available in this mode!
-
 
 ## Vim
 
@@ -136,7 +133,7 @@ opam user-setup install
 
 ### Talking to Merlin
 
-#### Getting Type Information
+#### Getting Type Information in Vim
 
 ![Vim Type information](/media/tutorials/vim-type-info.gif)
 
@@ -161,7 +158,7 @@ There are two main ways to install and manage LSP servers.
 - A newer, more recommended way is to use the new Neovim LSP API for versions newer than v0.11.0 via `vim.lsp`.
 - A more traditional way is to use `nvim-lspconfig`. For more info, `kickstart.nvim` has a great example setup.
 
-### Using vim.lsp:
+### Using vim.lsp
 
 Add this to your toplevel `init.lua`.
 ```lua
@@ -250,5 +247,4 @@ Add this to your `nvim-lspconfig` setup.
 },
 ```
 
-There is no need to pass more settings to `setup` because `nvim-lspconfig` provides reasonable defaults. See [here](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ocamllsp.lua) for more info.
-
+There is no need to pass more settings to `setup` because `nvim-lspconfig` provides reasonable defaults. See [the nvim-lspconfig OCaml LSP configuration](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/ocamllsp.lua) for more info.

--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -24,7 +24,7 @@ $ opam switch list
 
 To create a new opam switch, you can use the `opam switch` command followed by the desired switch name and an optional OCaml compiler version. For example, to create a switch named "my_project" with a specific OCaml compiler version, use:
 
-```
+```shell
 opam switch create my_project <compiler-version>
 ```
 
@@ -34,7 +34,7 @@ If you don't specify a compiler, and `my_project` is a directory, opam will choo
 
 Next, **activate** your new switch. This will set it as the currently selected switch, so any OCaml-related operations will use this switch. You can activate it by running:
 
-```
+```shell
 opam switch my_project
 ```
 
@@ -42,7 +42,7 @@ Replace `my_project` with the name of your new switch.
 
 **Confirm** you've activated it by running:
 
-```
+```shell
 opam switch
 ```
 

--- a/data/tutorials/getting-started/3_02_arm_fix.md
+++ b/data/tutorials/getting-started/3_02_arm_fix.md
@@ -16,7 +16,7 @@ where brew
 
 If the response is `/usr/local/bin/brew`, we'll need to make the changes. It needs to be `/opt/homebrew/bin/brew`.
 
-### Install CLT
+## Install CLT
 
 First, ensure the Command Line Tools (CLT) are installed by running
 
@@ -27,7 +27,7 @@ Library SDKs usr
 
 If they're not installed, let's install them now. You don't have to install all of XCode; you can install just the CLT by [downloading them directly from Apple's Developer](https://developer.apple.com/download/all/). Look for a non-beta version for stability, like "Command Line Tools for XCode 14.3.1"
 
-### Disable Rosetta
+## Disable Rosetta
 
 Next, it's necessary to disable Rosetta if you have it installed. This [Apple Support article](https://support.apple.com/en-us/HT211861) tells you how to check. If it's installed, please follow the steps below.
 
@@ -38,20 +38,20 @@ Next, it's necessary to disable Rosetta if you have it installed. This [Apple Su
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 ```
 
-2. Reinstall Homebrew:
+1. Reinstall Homebrew:
 
 ```Shell
 brew install /Users/tarides/Library/Caches/Homebrew/downloads/9e6d2a225119ad88cde6474d39696e66e4f87dc4a4d101243b91986843df691e--libev--4.33.arm64_monterey.bottle.tar.gz
 ```
 
-3. Check to see if Homebrew is in the correct location now. It should return what's shown below:
+1. Check to see if Homebrew is in the correct location now. It should return what's shown below:
 
 ```shell
 $ which brew
 /opt/homebrew/bin/brew
 ```
 
-4. Close Terminal
+1. Close Terminal
 
 It's essential to close your current Terminal window and open a new one for it to work properly. Then run the following command. If you get the output shown, you're ready to brew!
 
@@ -60,7 +60,7 @@ $ brew doctor
 Your system is ready to brew.
 ```
 
-### Return to Install Tutorial
+## Return to Install Tutorial
 
 Now that's all sorted, you can return to the [Install OCaml tutorial](/docs/installing-ocaml) to install and initialise opam.
 

--- a/data/tutorials/getting-started/3_03_ocaml_playground.md
+++ b/data/tutorials/getting-started/3_03_ocaml_playground.md
@@ -35,7 +35,7 @@ You can clear the editor panel by simply pressing Ctrl+A and Backspace and start
 
 Let's start with something simple. Type the following on your editor panel and click Run.
 
-```
+```ocaml
 2+3
 ```
 
@@ -45,7 +45,7 @@ You should see the following output.
 
 Now, clear the output and also delete the things on the editor panel. Let's try out some strings. Go ahead and type the following editor panel and click Run.
 
-```
+```ocaml
 "OCaml is amazing"
 ```
 
@@ -55,7 +55,7 @@ You should see the following output.
 
 That's amazing! You are doing great. Now let's write a short program. I'll be using the code sample that we saw when we entered the playground.
 
-```
+```ocaml
 let num_domains = 2
 let n = 20
 
@@ -77,7 +77,7 @@ let () =
 
 The output will be the following.
 
-```
+```text
 fib(20) = 10946
 
 val num_domains : int = 2
@@ -100,7 +100,7 @@ A little caveat here is that the playground behaves differently from the OCaml t
 All expressions and definitions are evaluated in order, every time you click the "Run" button.
 When you write `2+3` and in the next line write a string `"this is a string"` ([see here](/play#code=MiszCiJ0aGlzIGlzIGEgc3RyaW5nIg%3D%3D)), you will see an error saying:
 
-```
+```text
 Line 1, characters 2-3:
 Error: This expression has type int
        This is not a function; it cannot be applied.

--- a/data/tutorials/guides/0tt_03_calling_c_libraries.md
+++ b/data/tutorials/guides/0tt_03_calling_c_libraries.md
@@ -291,7 +291,7 @@ base class from which other classes can be derived, and is also a
 non-virtual class of which the user should be allowed to create
 instances?)
 
-#### Wrapping Calls to C Libraries
+### Wrapping Calls to C Libraries
 
 Now we'll look in more detail at actually wrapping up calls to C library
 functions. Here's a simple example:

--- a/data/tutorials/guides/0tt_04_calling_fortran_libraries.md
+++ b/data/tutorials/guides/0tt_04_calling_fortran_libraries.md
@@ -30,7 +30,7 @@ All of the examples below use the GNU Fortran 77 compiler (g77). None of
 these have been tested with the GNU fortran 90 compiler (gfort) and will
 not be until it has proven itself through some time.
 
-### Step 1: Compile the Fortran Routine
+## Step 1: Compile the Fortran Routine
 
 Where C/C++ have only one category of subroutine (the function), Fortran
 has two: the function and the subroutine. The function is the equivalent
@@ -73,7 +73,7 @@ actually arrays. Failure to pass an array will cause a segmentation
 violation since the gtd6_ function is using them as arrays (yet another
 reason OCaml shines).
 
-### Step 2: Create the C Wrapper
+## Step 2: Create the C Wrapper
 
 Because OCaml's foreign function interface is C based, it is necessary
 to create a C wrapper. To avoid difficulties in passing back arrays of
@@ -110,7 +110,7 @@ A few points of interest
  macro to create a new value containing the return value and to
  return it respectively.
 
-### Step 3: Compile the Shared Library
+## Step 3: Compile the Shared Library
 
 Now having the two source files funcs.f and wrapper.c we need to create
 a shared library that can be loaded by OCaml. It's easier to do this as a
@@ -127,7 +127,7 @@ the fortran function and the wrapper function. The -lg2c option is
 required to provide the implementations of the built in fortran
 functions that are used.
 
-### Step 4: Now to OCaml
+## Step 4: Now to OCaml
 
 Now in an OCaml file (gtd6.ml) we have to define the external reference
 to the function and a function to call it.

--- a/data/tutorials/guides/1wf_01_debugging.md
+++ b/data/tutorials/guides/1wf_01_debugging.md
@@ -221,19 +221,19 @@ At runtime, the program raises an uncaught exception `Not_found`.  Suppose we
 want to find where and why this exception has been raised, we can proceed as
 follows. First, we compile the program in debug mode:
 
-```
+```shell
 ocamlc -g uncaught.ml
 ```
 
 We launch the debugger:
 
-```
+```shell
 ocamldebug a.out
 ```
 
 Then the debugger answers with a banner and a prompt:
 
-```
+```text
 OCaml Debugger version 4.14.0
 
 (ocd)
@@ -243,7 +243,7 @@ OCaml Debugger version 4.14.0
 
 Type `r` (for *run*); you get
 
-```
+```text
 (ocd) r
 Loading program... done.
 Time : 27
@@ -256,7 +256,7 @@ Self-explanatory, isn't it? So, you want to step backward to set the program
 counter before the time the exception is raised; hence type in `b` as
 *backstep*, and you get
 
-```
+```text
 (ocd) b
 Time: 26 - pc: 0:29628 - module Stdlib__List
 191     [] -> raise Not_found<|a|>
@@ -271,7 +271,7 @@ But, as you know, you want the debugger to tell you which procedure calls the
 one from `List`, and also who calls the procedure that calls the one from
 `List`; hence, you want a backtrace of the execution stack:
 
-```
+```text
 (ocd) bt
 Backtrace:
 #0 Stdlib__List list.ml:191:26
@@ -307,7 +307,7 @@ spurious exception you just need to type `ocamldebug a.out`, then `r`, `b`, and
 To get more info about the current status of the debugger you can ask it
 directly at the toplevel prompt of the debugger; for instance:
 
-```
+```text
 (ocd) info breakpoints
 No breakpoint.
 
@@ -327,7 +327,7 @@ Syntax: break
 Let's set up a breakpoint and rerun the entire program from the
 beginning (`(g)oto 0` then `(r)un`):
 
-```
+```text
 (ocd) break @Uncaught 7
 Breakpoint 1 at 0:42856: file uncaught.ml, line 7, characters 3-36
 
@@ -344,7 +344,7 @@ Breakpoint: 1
 Then, we can step and find what happens just before (`<|b|>`)
 `List.assoc` is about to be called in `find_address`:
 
-```
+```text
 (ocd) s
 Time: 21 - pc: 0:42756 - module Uncaught
 3 let find_address name = <|b|>List.assoc name !l
@@ -372,7 +372,7 @@ Getting a back trace for an uncaught exception can be informative to
 understand in which context a problem occurs. However, by default,
 programs compiled with both `ocamlc` and `ocamlopt` will not print it:
 
-```
+```shell
 ocamlc -g uncaught.ml
 ./a.out
 Fatal error: exception Not_found
@@ -384,7 +384,7 @@ Fatal error: exception Not_found
 By running with the environment variable `OCAMLRUNPARAM` set to `b`
 (for back trace) we get something more informative:
 
-```
+```shell
 OCAMLRUNPARAM=b ./a.out
 Fatal error: exception Not_found
 Raised at Stdlib__List.assoc in file "list.ml", line 191, characters 10-25
@@ -399,7 +399,7 @@ exception in `List.assoc` from the `Stdlib` when calling
 The environment variable `OCAMLRUNPARAM` also works when working on a
 program built with `dune`:
 
-```
+```dune
 ;; file dune
 (executable
  (name uncaught)
@@ -407,7 +407,7 @@ program built with `dune`:
 )
 ```
 
-```
+```shell
 OCAMLRUNPARAM=b dune exec ./uncaught.exe
 Fatal error: exception Not_found
 Raised at Stdlib__List.assoc in file "list.ml", line 191, characters 10-25
@@ -427,7 +427,7 @@ report these.
 To install the TSan mode, create a dedicated TSan switch by running the
 following command (here we create a 5.2.0 switch):
 
-```
+```shell
 opam switch create 5.2.0+tsan ocaml-variants.5.2.0+options ocaml-option-tsan
 ```
 
@@ -483,7 +483,7 @@ Here is a corresponding `dune` file:
 If we compile and run the program using `dune` under a regular `5.2.0` switch the
 program appears to work:
 
-```
+```shell
 $ opam exec -- dune build ./race.exe
 $ opam exec -- dune exec ./race.exe
 v.x is 11
@@ -492,7 +492,7 @@ v.x is 11
 However, if we compile and run the program with Dune from the new
 `5.2.0+tsan` switch TSan warns us of a data race:
 
-```
+```text
 $ opam switch 5.2.0+tsan
 $ opam exec -- dune build ./race.exe
 $ opam exec -- dune exec ./race.exe
@@ -554,7 +554,7 @@ let () =
 If we recompile and run our program with this change, it now completes
 without TSan warnings:
 
-```
+```shell
 $ opam exec -- dune build ./race.exe
 $ opam exec -- dune exec ./race.exe
 v is 11
@@ -565,6 +565,6 @@ information, which happens by default under `dune`. To manually invoke
 the `ocamlopt` compiler under our `5.2.0+tsan` switch it is thus
 sufficient to pass it the `-g` flag:
 
-```
+```shell
 ocamlopt -g -o race.exe -I +unix unix.cmxa race.ml
 ```

--- a/data/tutorials/guides/1wf_02_error_handling.md
+++ b/data/tutorials/guides/1wf_02_error_handling.md
@@ -956,7 +956,7 @@ system or the compiler to be bugged for the second code path to be executed.
 Breakage of the language semantics qualifies as extraordinary circumstances. It
 is catastrophic!
 
-# Concluding Remarks
+## Concluding Remarks
 
 Properly handling errors is a complex matter. It is a [cross-cutting
 concern](https://en.wikipedia.org/wiki/Cross-cutting_concern), touches all parts
@@ -970,7 +970,7 @@ always better than the others, and choosing one to use should be a matter of
 fitting the context rather than that of taste. But opinionated OCaml code is also
 fine, so it's a balance.
 
-# External Resources
+## External Resources
 
 * [“Exceptions”](/manual/coreexamples.html#s%3Aexceptions) in ”The OCaml Manual, The Core Language”, chapter 1, section 6, December 2022
 * [Module **`option`**](/manual/api/Option.html) in OCaml Library

--- a/data/tutorials/guides/1wf_03_profiling.md
+++ b/data/tutorials/guides/1wf_03_profiling.md
@@ -178,7 +178,7 @@ by a trailing NUL (`\0`) character. OCaml stores strings in a different
 way, as we can see from the data segment above. This string is stored
 like this:
 
-```
+```text
 4 byte header: 4348
 the string:    h e l l o , SP w o r l d \n
 padding:       \0 \0 \002
@@ -203,7 +203,7 @@ a header which tells the garbage collector about how large the object is
 in words, and something about what the object contains. Writing the
 number 4348 in binary:
 
-```
+```text
 length of the object in words:  0000 0000 0000 0000 0001 00 (4 words)
 color (used by GC):             00
 tag:                            1111 1100 (String_tag)
@@ -587,7 +587,7 @@ Note the structure of the floating point number: it has a header (2301),
 followed by the 8 byte (2 word) representation of the number itself. The
 header can be decoded by writing it as binary:
 
-```
+```text
 Length of the object in words:  0000 0000 0000 0000 0000 10 (8 bytes)
 Color:                          00
 Tag:                            1111 1101 (Double_tag)
@@ -779,7 +779,7 @@ the OCaml representation for integers. Let's represent them as:
 where `a` and `b` are the actual integer arguments. So this function
 returns:
 
-```
+```text
 %eax + %ebx - 1
 = 2 * a + 1 + 2 * b + 1 - 1
 = 2 * a + 2 * b + 1
@@ -849,7 +849,7 @@ let () =
 And can be run and compiled with
 
 <!-- $MDX skip -->
-```
+```shell
 ocamlcp -p a graphics.cma graphtest.ml -o graphtest
 ./graphtest
 ocamlprof graphtest.ml
@@ -868,7 +868,7 @@ compiler to include profiling information for `gprof`:
 After running the program as normal, the profiling code dumps out a file
 `gmon.out` which we can interpret with `gprof`:
 
-```
+```text
 $ gprof ./a.out
 Flat profile:
 

--- a/data/tutorials/guides/1wf_05_garbage_collection.md
+++ b/data/tutorials/guides/1wf_05_garbage_collection.md
@@ -45,7 +45,7 @@ let () =
 
 Here is what it printed out for me:
 
-```
+```text
 minor_words: 115926165     # Total number of words allocated
 promoted_words: 31217      # Promoted from minor -> major
 major_words: 31902         # Large objects allocated in major directly

--- a/data/tutorials/guides/rs_00_guidelines.md
+++ b/data/tutorials/guides/rs_00_guidelines.md
@@ -858,7 +858,7 @@ let rec list_length = function
 ```
 
 (For those that would contest the equivalence of those two
-versions, see the [note below](#imperative-and-functional-versions-of-listlength)).
+versions, see the [note below](#imperative-and-functional-versions-of-list_length)).
 
 * Another common “over-imperative error” in the imperative world is
   not to systematically choose the simple `for` loop to iterate on a vector's
@@ -1008,8 +1008,8 @@ Under Unix: use the line editor `ledit`, which offers great editing
 capabilities “à la Emacs” (including `ESC-/`!) as well as a history
 mechanism that lets you retrieve previously-typed commands and even
 retrieve commands from one session to another. `ledit` is written in
-OCaml and can be freely downloaded
-[here](ftp://ftp.inria.fr/INRIA/Projects/cristal/caml-light/bazar-ocaml/ledit.tar.gz).
+OCaml and can be freely downloaded from the
+[ledit archive](ftp://ftp.inria.fr/INRIA/Projects/cristal/caml-light/bazar-ocaml/ledit.tar.gz).
 
 ### How to Compile
 
@@ -1069,10 +1069,12 @@ followed by a space: `(1, 2)`, `let triplet = (x, y, z)`...
   parentheses around n-tuples when matching several values
   simultaneously.
 
-        match x, y with
-        | 1, _ -> ...
-        | x, 1 -> ...
-        | x, y -> ...
+    ```ocaml
+    match x, y with
+    | 1, _ -> ...
+    | x, 1 -> ...
+    | x, y -> ...
+    ```
 
     > **Justification**: The point is to match several values in
     > parallel, not to construct a tuple. Moreover, the expressions
@@ -1157,7 +1159,7 @@ know a little mathematics or strive to follow the following rules:
 
 For example: `1 + 2 * x` means `1 + (2 * x)`.
 
-#### Function application: the same rules as those in mathematics for usage of *trigonometric functions*
+#### Function application: same rules as for *trigonometric functions*
 
 In mathematics you write `sin x` to mean `sin (x)`. In the same way
 `sin x + cos x` means `(sin x) + (cos x)` not `sin (x + (cos x))`. Use

--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -13,7 +13,7 @@ prerequisite_tutorials:
 
 In OCaml, functions are treated as values, so you can use functions as arguments to functions and return them from functions. This tutorial introduces the relationship between expressions, values, and names. The first four sections address non-function values. The following sections, starting at [Function as Values](#function-as-values), address functions.
 
-We use UTop to understand these concepts by example. You are encouraged to modify the examples to gain a better understanding. 
+We use UTop to understand these concepts by example. You are encouraged to modify the examples to gain a better understanding.
 
 ## What is a Value?
 
@@ -47,7 +47,7 @@ An expression's type (before evaluation) and its resulting value's type (after c
 
 ## Global Definitions
 
-Every value can be named. This is the purpose of the `let … = … ` statement. The name is on the left; the expression is on the right.
+Every value can be named. This is the purpose of the `let … = …` statement. The name is on the left; the expression is on the right.
 * If the expression can be evaluated, it is.
 * Otherwise, the expression is turned into a value as-is. That's the case of function definition.
 
@@ -73,8 +73,8 @@ Error: Unbound value d
 Local definitions are introduced by the `let … = … in …` expression. The name bound before the `in` keyword is only bound in the expression after the `in` keyword. Here, the name `d` is bound to `6` inside the expression `d * 7`.
 
 A couple of remarks:
-- No global definition is introduced in this example, which is why we get an error.
-- Computation of `2 * 3` will always take place before `d * 7`.
+* No global definition is introduced in this example, which is why we get an error.
+* Computation of `2 * 3` will always take place before `d * 7`.
 
 Local definitions can be chained (one after another) or nested (one inside another). Here is an example of chaining:
 ```ocaml
@@ -90,8 +90,8 @@ Error: Unbound value e
 ```
 
 Here is how scoping works:
-- `d` is bound to `6` inside `let e = d * 7 in d * e`
-- `e` is bound to `42` inside `d * e`
+* `d` is bound to `6` inside `let e = d * 7 in d * e`
+* `e` is bound to `42` inside `d * e`
 
 Here is an example of nesting:
 ```ocaml
@@ -107,8 +107,8 @@ Error: Unbound value d
 Error: Unbound value e
 ```
 Here is how scoping works:
-- `e` is bound to `6` inside `e * 5`
-- `d` is bound to `30` inside `d * 7`
+* `e` is bound to `6` inside `e * 5`
+* `d` is bound to `30` inside `d * 7`
 
 Arbitrary combinations of chaining or nesting are allowed.
 
@@ -116,7 +116,7 @@ In both examples, `d` and `e` are local definitions.
 
 ## Forms of Pattern Matching
 
-[Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a programming language construct that generalizes case analysis, it makes subexpression inspection possible and applies to values of any type. 
+[Pattern matching](https://en.wikipedia.org/wiki/Pattern_matching) is a programming language construct that generalizes case analysis, it makes subexpression inspection possible and applies to values of any type.
 
 In the following sections, we explore matching inside `let` bindings, which is a special case. In the next chapter on [Basic Data Types and Pattern Matching](/docs/basic-data-types), we examine pattern matching in general cases using `match...with`. The chapter on [Error Handling](/docs/error-handling) explores how destructuring values aids in error handling when using `try...with`.
 
@@ -183,7 +183,6 @@ val introduce : name -> string = <fun>
 # let get_meaning _ = 42;;
 val get_meaning : 'a -> int = <fun>
 ```
-
 
 ### Pattern Matching on `unit`
 <!--Unit example-->
@@ -261,7 +260,7 @@ val jane : person =
    contact = ("jane@example.com", 1234567890)}
 ```
 
-The following examples demonstrate two methods by which we can extract Jane's `email` and `phone` number data in the nested `contact` tuple. We will do so first by using nested deconstruction, then demonstrate another approach by first extracting `content` followed by accessing the `email` and `phone` by deconstructing `contact`. 
+The following examples demonstrate two methods by which we can extract Jane's `email` and `phone` number data in the nested `contact` tuple. We will do so first by using nested deconstruction, then demonstrate another approach by first extracting `content` followed by accessing the `email` and `phone` by deconstructing `contact`.
 
 First, let's use nested deconstruction to access the contents of the `contact` tuple directly:
 
@@ -340,7 +339,7 @@ Without oversimplifying, an OCaml program is a sequence of expressions or global
 
 Execution evaluates each item from top to bottom.
 
-At any time during evaluation, the _environment_ is the ordered sequence of available definitions. The *environment* is also known as *context* in other languages.
+At any time during evaluation, the _environment_ is the ordered sequence of available definitions. The _environment_ is also known as _context_ in other languages.
 
 Here, the name `twenty` is added to the top-level environment.
 ```ocaml
@@ -361,7 +360,7 @@ Error: Unbound value ten
 
 Evaluating `ten` results in an error because it hasn't been added to the global environment. However, in the expression `2 * ten`, the local environment contains the definition of `ten`.
 
-Although OCaml is an expression-oriented language, it has a few statements. The global `let` modifies the global environment by adding a name-value *binding*.
+Although OCaml is an expression-oriented language, it has a few statements. The global `let` modifies the global environment by adding a name-value _binding_.
 
 Top-level expressions are also statements because they are equivalent to `let _ =` definitions.
 ```ocaml
@@ -392,7 +391,7 @@ val i : int = 21
 - : int = 21
 ```
 
-The second definition [*shadows*](https://en.wikipedia.org/wiki/Variable_shadowing) the first. Inner shadowing is limited to the local definition's scope. Therefore, anything written after will still take the previous definition, as shown above. Here, the value of `i` hasn't changed. It's still `21`, as defined in the first expression. The second expression binds `i` locally, inside `i * 2`, not globally.
+The second definition [_shadows_](https://en.wikipedia.org/wiki/Variable_shadowing) the first. Inner shadowing is limited to the local definition's scope. Therefore, anything written after will still take the previous definition, as shown above. Here, the value of `i` hasn't changed. It's still `21`, as defined in the first expression. The second expression binds `i` locally, inside `i * 2`, not globally.
 
 <!--
 A name-value pair in a local expression *shadows* a binding with the same name in the global environment. In other words, the local binding temporarily hides the global one, making it inaccessible, but it doesn't change it.
@@ -434,8 +433,8 @@ When several expressions are written side by side, the leftmost one should be a 
 ```
 
 The `max` function returns the largest of its two arguments, which are:
-- `42`, the result of `21 * 2`
-- `713`, the result of `int_of_string "713"`
+* `42`, the result of `21 * 2`
+* `713`, the result of `int_of_string "713"`
 
 When creating subexpressions, using `begin ... end` is also possible. This is the same as using brackets `( ... )`. As such, the above could also be rewritten and get the same result:
 
@@ -504,10 +503,10 @@ Functions don't have to be bound to a name unless they are [recursive](#recursiv
 Function values not bound to names are called _[anonymous functions](https://en.wikipedia.org/wiki/Anonymous_function)_.
 
 In order, here is what they are:
-- The identity function, which takes anything and returns it unchanged
-- The square function, which takes an integer and returns it squared
-- The function that takes two strings and returns their concatenation with a space character in between
-- The function that takes a list and either returns `None`, if the list is empty, or returns its first element.
+* The identity function, which takes anything and returns it unchanged
+* The square function, which takes an integer and returns it squared
+* The function that takes two strings and returns their concatenation with a space character in between
+* The function that takes a list and either returns `None`, if the list is empty, or returns its first element.
 
 Anonymous functions are often passed as arguments to other functions.
 ```ocaml
@@ -549,7 +548,7 @@ Although local functions are often defined inside the function's scope, this is 
 
 ## Closures
 
-This example illustrates a [*closure*](https://en.wikipedia.org/wiki/Closure_(computer_programming)) using [Same-Level Shadowing](#same-level-shadowing)
+This example illustrates a [_closure_](https://en.wikipedia.org/wiki/Closure_(computer_programming)) using [Same-Level Shadowing](#same-level-shadowing)
 ```ocaml
 # let j = 2 * 3;;
 val j : int = 6
@@ -574,7 +573,7 @@ Here is how this makes sense:
 1. Create a new definition `j`, shadowing the first one
 1. Compute `k` of 7 again, the result is the same: 42
 
-Although the new definition of `j` *shadows* the first one, the original remains the one the function `k` uses. The `k` function's environment captures the first value of `j`, so every time you apply `k` (even after the second definition of `j`), you can be confident the function will behave the same.
+Although the new definition of `j` _shadows_ the first one, the original remains the one the function `k` uses. The `k` function's environment captures the first value of `j`, so every time you apply `k` (even after the second definition of `j`), you can be confident the function will behave the same.
 
 However, all future expressions will use the new value of `j` (`7`), as shown here:
 ```ocaml
@@ -694,12 +693,12 @@ val sweet_kitty : string -> string = <fun>
 
 Since a multiple-parameter function is a series of nested single-argument functions, you don't have to pass all arguments at once.
 
-Passing a single argument to `sour_kitty` or `sweet_kitty` returns a function of type `string -> string`. 
+Passing a single argument to `sour_kitty` or `sweet_kitty` returns a function of type `string -> string`.
  The first argument, here `"kitty"`, is captured and the result is a [closure](#closures).
 
 These expressions have the same value:
-- `fun x -> sweet_cat "kitty" x`
-- `sweet_cat "kitty"`
+* `fun x -> sweet_cat "kitty" x`
+* `sweet_cat "kitty"`
 
 ### Types of Functions of Multiple Parameters
 
@@ -729,7 +728,7 @@ The type arrow operator [_associates to the right_](https://en.wikipedia.org/wik
 
 ### Tuples as Function Parameters
 
-In OCaml, a *tuple* is a data structure used to group a fixed number of values, which can be of different types. Tuples are surrounded by parentheses, and the elements are separated by commas. Here's the basic syntax to create and work with tuples in OCaml:
+In OCaml, a _tuple_ is a data structure used to group a fixed number of values, which can be of different types. Tuples are surrounded by parentheses, and the elements are separated by commas. Here's the basic syntax to create and work with tuples in OCaml:
 ```ocaml
 # ("felix", 1920);;
 - : string * int = ("felix", 1920)
@@ -748,12 +747,11 @@ It looks like two arguments have been passed: `"hello"` and `"world"`. However, 
 
 In many imperative languages, the `spicy_cat ("hello", "world")` syntax reads as a function call with two arguments; but in OCaml, it denotes applying the function `spicy_cat` to a tuple containing `"hello"` and `"world"`.
 
-
 ### Currying and Uncurrying
 
 In the previous sections, two kinds of multiple-parameter functions have been presented.
-- Functions returning a function, such as `sweet_cat` and `sour_cat`
-- Functions taking a tuple as a parameter, such as `spicy_cat`
+* Functions returning a function, such as `sweet_cat` and `sour_cat`
+* Functions taking a tuple as a parameter, such as `spicy_cat`
 
 Interestingly, both kinds of functions provide a way to pass several pieces of data while being functions with a single parameter. From this perspective, it makes sense to say: “All functions have a single argument.”
 
@@ -766,8 +764,8 @@ These translations have names:
 It also said that `sweet_cat` and `sour_cat` are _curried_ functions whilst `spicy_cat` is _uncurried_.
 
 Functions with the following types can be translated back and forth:
-- `string -> (string -> string)` &mdash; curried function type
-- `string * string -> string` &mdash; uncurried function type
+* `string -> (string -> string)` &mdash; curried function type
+* `string * string -> string` &mdash; uncurried function type
 
 These translations are attributed to the 20th-century logician [Haskell Curry](https://en.wikipedia.org/wiki/Haskell_Curry).
 
@@ -787,22 +785,22 @@ val curried_cat : string -> string -> string = <fun>
 <!-- Currying and uncurrying can be understood as operations acting on functions the same way addition and subtraction are operations acting on numbers. -->
 
 In practice, curried functions are the default because:
-- They allow partial application
-- No parentheses or commas
-- No pattern matching over a tuple takes place
+* They allow partial application
+* No parentheses or commas
+* No pattern matching over a tuple takes place
 
 ## Functions With Side Effects
 
-To explain side effects, we need to define what *domain* and *codomain* are. Let's look at an example:
+To explain side effects, we need to define what _domain_ and _codomain_ are. Let's look at an example:
 ```ocaml
 # string_of_int;;
 - : int -> string = <fun>
 ```
 For the function `string_of_int`:
-- Its *domain* is `int`, the type of its parameters
-- The *codomain* is `string`, the type of its results
+* Its _domain_ is `int`, the type of its parameters
+* The _codomain_ is `string`, the type of its results
 
-In other words, the *domain* is left of the `->` and the *codomain* is on the right. These terms help avoid saying the "type at the right" or "type at the left" of a function's type arrow.
+In other words, the _domain_ is left of the `->` and the _codomain_ is on the right. These terms help avoid saying the "type at the right" or "type at the left" of a function's type arrow.
 
 Some functions operate on data outside of their domain or codomain.
 This behaviour is called an effect, or a side effect.
@@ -844,7 +842,7 @@ Functions are like other values; however, there are restrictions:
 - : float -> float = <fun>
 ```
 
-2. Equality between functions can't be tested.
+1. Equality between functions can't be tested.
 ```ocaml
 # pred;;
 - : int -> int = <fun>
@@ -857,8 +855,8 @@ Exception: Invalid_argument "compare: functional value".
 ```
 
 There are two main reasons explaining this:
-- There is no algorithm that takes two functions and determines if they return the same output when provided the same input.
-- Assuming it was possible, such an algorithm would declare that implementations of quicksort and bubble sort are equal. That would mean one could replace the other, and that may not be wise.
+* There is no algorithm that takes two functions and determines if they return the same output when provided the same input.
+* Assuming it was possible, such an algorithm would declare that implementations of quicksort and bubble sort are equal. That would mean one could replace the other, and that may not be wise.
 <!--
 It may seem counterintuitive that classes of objects of the same kind (i.e., having the same type) exist where equality between objects does not make sense. High school mathematics does not provide examples of those classes. But in the case of computing procedures seen as functions, equality isn't the right tool to compare them.
 -->

--- a/data/tutorials/language/0it_01_basic_datatypes.md
+++ b/data/tutorials/language/0it_01_basic_datatypes.md
@@ -161,6 +161,7 @@ Like strings, byte sequences are finite and fixed-sized. Each individual byte is
 Operations on `bytes` values are provided by the [`Stdlib`](/manual/api/Stdlib.html) and the [`Bytes`](/manual/api/Bytes.html) modules. Only the function `Bytes.get` allows direct access to the characters contained in a byte sequence. Unlike arrays, there is no direct access operator on byte sequences.
 
 The memory representation of `bytes` is four times more compact than `char array`.
+
 ### Arrays & Lists
 
 #### Arrays
@@ -704,7 +705,7 @@ Here is how the map function can be defined in this type:
 val map : ('a -> 'b) -> 'a tree -> 'b tree = <fun>
 ```
 
-In the OCaml community, as well as in the larger functional programming community, the word *polymorphism* is used loosely. It is applied to things working in a similar fashion with various types. In this broad sense, several features of OCaml are polymorphic. Each uses a particular form of polymorphism and has a name. In summary, OCaml has several forms of polymorphism. In most cases, the distinction between those concepts is blurred, but it is sometimes necessary to distinguish them.
+In the OCaml community, as well as in the larger functional programming community, the word _polymorphism_ is used loosely. It is applied to things working in a similar fashion with various types. In this broad sense, several features of OCaml are polymorphic. Each uses a particular form of polymorphism and has a name. In summary, OCaml has several forms of polymorphism. In most cases, the distinction between those concepts is blurred, but it is sometimes necessary to distinguish them.
 
 Here are the terms applicable to data types:
 1. `'a list`, `'a option`, and `'a tree` are very often said to be polymorphic types. Formally, `bool list` or `int option` are the types, whilst `list` and `option` are [type operators](https://en.wikipedia.org/wiki/Type_constructor) that take a type parameter and result in a type. This is a form of [parametric polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism). `'a list` and `'a option` denote [type families](https://en.wikipedia.org/wiki/Type_family), which are all the types created by applying type parameters to the operators.
@@ -924,7 +925,7 @@ val top_factorise : expr -> expr = <fun>
 - : expr = Times (Var "n", Plus (Var "x", Var "y"))
 ```
 
-The factorise function above introduces another feature: *guards* to each
+The factorise function above introduces another feature: _guards_ to each
 pattern. The conditional follows the `when`, and it means that
 the return code is executed only if the pattern matches and the condition in the
 `when` clause is satisfied.

--- a/data/tutorials/language/0it_02_loops_and_recursion.md
+++ b/data/tutorials/language/0it_02_loops_and_recursion.md
@@ -7,12 +7,13 @@ category: "Introduction"
 ---
 
 As in other OCaml.org documentation, the code examples will either be something you can test or
-an example of code. Code snippets that begin with the CLI prompt `#`, end with `;;`, and have a 
-clear output can be tested in the OCaml toplevel (`ocaml` or `utop`) 
-or pasted into the OCaml playground. If the code doesn't start with `#` and end in `;;`, 
-it's an example of how to write the code. 
+an example of code. Code snippets that begin with the CLI prompt `#`, end with `;;`, and have a
+clear output can be tested in the OCaml toplevel (`ocaml` or `utop`)
+or pasted into the OCaml playground. If the code doesn't start with `#` and end in `;;`,
+it's an example of how to write the code.
 
 ## For Loops and While Loops
+
 OCaml supports a rather limited form of the familiar `for` loop:
 
 <!-- $MDX skip -->
@@ -125,6 +126,7 @@ let quit_loop = ref false in
 ```
 
 ## Looping Over Lists
+
 If you want to loop over a list, don't be an imperative programmer and
 reach for your trusty six-shooter Mr. `For` Loop! OCaml has some better
 and faster ways to loop over lists, and they are all located in the
@@ -251,6 +253,7 @@ overflows the integers and gives wrong answers even for quite small
 values of `n`.)
 
 ## Looping Over Strings
+
 The `String` module also contains dozens of useful string-related
 functions, and some of them are concerned with looping over strings.
 
@@ -259,6 +262,7 @@ function which works like `List.iter`, except over the characters of the
 string.
 
 ## Recursion
+
 Now we come to a hard topic: recursion. Functional programmers are
 defined by their love of recursive functions, and in many ways recursive
 functions in functional programming are the equivalent of loops in imperative programming.
@@ -274,21 +278,24 @@ In the first example, we'll read the whole file into memory
 this:
 
 ### Approach 1
+
 Get the length of the file and read it all at once using the
 [`really_input`](https://ocaml.org/manual/api/Stdlib.html#VALreally_input) method. This is the simplest, but it might not work on
 channels that are not really files (e.g., reading keyboard input), which
 is why we have two other approaches.
 
 ### Approach 2
+
 The imperative approach uses a `while` loop that is broken out of using
 an exception.
 
 ### Approach 3
+
 A recursive loop breaks out of the recursion again using an
 exception.
 
 We're going to introduce a few new concepts here. Our second two
-approaches will use the `Buffer` module, an expandable buffer. 
+approaches will use the `Buffer` module, an expandable buffer.
 Think of it like a string onto which you can efficiently append more
 text at the end. We're also going to be catching the `End_of_file`
 exception, which the input functions throw when they reach the end of the
@@ -332,7 +339,7 @@ let read_whole_chan chan =
         Buffer.add_char buf '\n'
     done;
     assert false (* This is never executed
-	                (always raises Assert_failure). *)
+                 (always raises Assert_failure). *)
   with
     End_of_file -> Buffer.contents buf
 
@@ -455,7 +462,7 @@ Note the use of `fold_left` and `map`. The `map` is used to
 Then the `fold_left (^) ""` concatenates the list together into one big
 string. Notice also the use of pattern matching. (The library defines a
 function called `String.concat`, which is essentially equivalent to
-`fold_left (^) `, but implemented more efficiently).
+`fold_left (^)`, but implemented more efficiently).
 
 Now let's define a function to read a directory structure, recursively,
 and return a recursive `filesystem` data structure. I'm going to show
@@ -601,6 +608,7 @@ print_endline (string_of_filesystem fs)
 ```
 
 ### Recursion Example: Maximum Element in a List
+
 Remember the basic recursion pattern for lists:
 
 <!-- $MDX skip -->
@@ -640,7 +648,7 @@ Think about this for a while. Suppose you know the maximum element of
 bigger than `y`, then the overall maximum is `x`, whereas conversely if
 `x` is less than `y`, then the overall maximum is `y`.
 
-Does this really work? 
+Does this really work?
 
 Consider `[1; 2; 3; 4; 1]` again. This is
 `1 :: [2; 3; 4; 1]`. Now the maximum element of the remainder,
@@ -690,6 +698,7 @@ to say that a program is provably bug-free, useful for space shuttles,
 nuclear power plants and higher quality software in general).
 
 ### Tail Recursion
+
 Let's look at the `range` function again for about the twentieth time:
 
 ```ocaml
@@ -822,18 +831,19 @@ val range : int -> int -> int list = <fun>
 
 That was a brief overview of tail recursion, but in real world
 situations, determining if a function is tail-recursive can be quite
-hard. 
+hard.
 
-What did we really learn here? 
+What did we really learn here?
 
 One thing is that recursive
 functions have a dangerous trap for inexperienced programmers. Your
 function can appear to work for small inputs (during testing), but then fail
 catastrophically in the field when exposed to large inputs. This is one
-argument *against* using recursive functions; instead, use explicit `while` 
+argument *against* using recursive functions; instead, use explicit `while`
 loops when possible.
 
 ## Mutable Records, References (Again!) and Arrays
+
 Previously we mentioned records in passing. These are like C `struct`s:
 
 ```ocaml
@@ -848,7 +858,7 @@ Error: Some record fields are undefined: b
 
 Let's move on to another interesting feature: OCaml records can have mutable fields.
 Normally an expression like `{a = 3; b = 5}` is an immutable, constant
-object. However if the record has **mutable fields**, 
+object. However if the record has **mutable fields**,
 there is a way to change those fields in the record. This is an
 imperative feature of OCaml, because functional languages don't normally
 allow mutable objects (or references or mutable arrays, which we'll look
@@ -1012,6 +1022,7 @@ Exception: Failure "int_of_string".
 ```
 
 ## Mutually Recursive Functions
+
 Suppose I want to define two functions that call each other. This is
 actually not a very common thing to do, but it can sometimes be useful.
 Here's a contrived example (thanks to Ryan Tarpine): The number 0 is

--- a/data/tutorials/language/0it_03_lists.md
+++ b/data/tutorials/language/0it_03_lists.md
@@ -99,7 +99,6 @@ val append : 'a list -> 'a list -> 'a list = <fun>
 Notice that the memory for the second list is shared, but the first list is
 effectively copied.
 
-
 ## Higher Order Functions on Lists
 
 We might wish to apply a function to each element in a list, yielding a new
@@ -233,7 +232,6 @@ The function [`find`](/manual/api/List.html#VALfind) returns the
 first element of a list matching a given predicate (a predicate is a testing
 function which returns either true or false when given an element). It raises
 an exception if such an element is not found:
-
 
 ```ocaml
 # List.find (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
@@ -445,7 +443,7 @@ The `length` function [previously
 defined](https://ocaml.org/docs/lists#functions-on-lists) builds up an
 intermediate expression of a size proportional to its input list:
 
-```
+```text
    length [1; 2; 3]
 => 1 + length [2; 3]
 => 1 + (1 + length [3])
@@ -476,7 +474,7 @@ val l : int = 3
 
 This function now uses a constant amount of space on the stack:
 
-```
+```text
    length 0 [1; 2; 3]
 => length 1 [2; 3]
 => length 2 [3]

--- a/data/tutorials/language/0it_04_higher_order_functions.md
+++ b/data/tutorials/language/0it_04_higher_order_functions.md
@@ -161,7 +161,7 @@ Hello, Camel!
 
 But our program only outputs one salutation:
 
-```
+```text
 Hello, Camel!
 ```
 
@@ -425,7 +425,6 @@ names
 ;;
 ```
 
-
 ### Pipelines, Composition, and Chaining
 
 In OCaml we use functions a lot, so values go from one function to the other forming what we like to call _pipelines_.
@@ -506,7 +505,6 @@ email
 <!--
 NOTE(@leostera): this example kinda sucks, i'd like one where the use of labels greatly improves the readability but since `ListLabels.nth_opt` doesn't take an argument then we still need that nasty fun flip :( will get back t othis)
 -->
-
 
 ### Iterating
 
@@ -850,7 +848,7 @@ double [1;2;3];; (* [1;1;2;2;3;3] *)
 
 This same pattern is useful to build chains of functions that _short circuit_ on specific values.
 
-For example, if you had to retrieve a user from a database, and *only if there is a user* try access the user's email, you could use `Option.bind` to short-circuit on the first operation:
+For example, if you had to retrieve a user from a database, and _only if there is a user_ try access the user's email, you could use `Option.bind` to short-circuit on the first operation:
 
 ```ocaml
 type user = {
@@ -909,7 +907,6 @@ This has the advantage of making code a lot more readable, without changing the 
 #### Async code
 
 Async libraries for OCaml that implement Promises/Futures usually also have a `bind` function that allows you to chain computations.
-
 
 <!-- ## Recipes
 

--- a/data/tutorials/language/0it_05_labels.md
+++ b/data/tutorials/language/0it_05_labels.md
@@ -146,9 +146,9 @@ val sub : ?pos:int -> ?len:int -> string -> string = <fun>
 ```
 
 Here, we're defining a variant of the function `String.sub` from the standard library.
-* `s` is the string from which we are extracting a substring.
-* `pos` is the substring's starting position. It defaults to `0`.
-* `len` is the substring's length. If missing, it defaults to `String.length s - pos`.
+- `s` is the string from which we are extracting a substring.
+- `pos` is the substring's starting position. It defaults to `0`.
+- `len` is the substring's length. If missing, it defaults to `String.length s - pos`.
 
 When an optional parameter isn't given a default value, its type inside the function is made an `option`. Here, `len` appears as `?len:int` in the function signature. However, inside the body of the function, `len_opt` is an `int option`.
 
@@ -227,7 +227,6 @@ Most often, `concat` is needed. Therefore a function's last declared parameter s
 
 **Note**: Optional parameters make it difficult for the compiler to know if a function is partially applied or not. This is why at least one positional parameter is required after the optional ones. If present at application, it means the function is fully applied, if missing, it means the function is partially applied.
 
-
 ### Passing Labelled Arguments Using the Pipe Operator
 
 Declaring a function's unlabelled argument as the first one simplifies reading the function's type and does not prevent passing this argument using the pipe operator.
@@ -273,7 +272,7 @@ Without the unit parameter, the `optional argument cannot be erased` warning wou
 
 ## Forwarding an Optional Argument
 
-Passing an optional argument with a question mark sign `?` allows forwarding it without unwrapping. These examples reuse the `sub` function defined in the [Optional Arguments Without Default Values](#optional-arguments-without-default-values) section.
+Passing an optional argument with a question mark sign `?` allows forwarding it without unwrapping. These examples reuse the `sub` function defined in the [Defining Optional Parameters Without Default Values](#defining-optional-parameters-without-default-values) section.
 
 ```ocaml
 # let take ?len s = sub ?len s;;

--- a/data/tutorials/language/0it_06_imperative.md
+++ b/data/tutorials/language/0it_06_imperative.md
@@ -54,14 +54,14 @@ val d : int ref = {contents = 0}
 
 Here is what happens in this example:
 1. The value `{ contents = 0 }` is bound to the name `d`. This is a normal definition. Like any other definition, it is immutable. However, the value `0` in the `contents` field of `d` is _mutable_, so it can be updated.
-3. The _assignment_ operator `:=` is used to update the mutable value inside `d` from `0` to `1`.
-4. The _dereference_ operator `!` reads the contents of the mutable value inside `d`.
+2. The _assignment_ operator `:=` is used to update the mutable value inside `d` from `0` to `1`.
+3. The _dereference_ operator `!` reads the contents of the mutable value inside `d`.
 
 The `ref` identifier above refers to two different things:
 * The function `ref : 'a -> 'a ref` that creates a reference
 * The type of mutable references: `'a ref`
 
-**Assignment Operator**
+### Assignment Operator
 
 ```ocaml
 # ( := );;
@@ -74,7 +74,7 @@ The assignment operator `:=` is just a function. It takes
 
 The update takes place as a [side effect](https://en.wikipedia.org/wiki/Side_effect_(computer_science)), and the value `()` is returned.
 
-**Dereference Operator**
+### Dereference Operator
 
 ```ocaml
 # ( ! );;
@@ -147,7 +147,7 @@ Mutable record fields are updated using the left arrow symbol `<-`. In the expre
 
 In contrast to references, there is no special syntax to dereference a mutable record field.
 
-**Remark**: the left arrow symbol `<-` for mutating mutable record field values is not an operator function, like the assignment operator `( := )` is for `refs`. It is rather a _construct_ of the language, it has no type. 
+**Remark**: the left arrow symbol `<-` for mutating mutable record field values is not an operator function, like the assignment operator `( := )` is for `refs`. It is rather a _construct_ of the language, it has no type.
 
 ### Remark: References Are Single Field Records
 
@@ -319,7 +319,7 @@ Using the `let … in` construct means two things:
 * Names may be bound. In the example, no name is bound since `()` is used.
 * Side effects take place in sequence. The bound expression (`print_string "This is"`) is evaluated first, and the referring expression (`print_endline " really Disco!"`) is evaluated second.
 
-**Semicolon**
+#### Semicolon
 
 The single semicolon `;` operator is known as the _sequence_ operator. It allows you to evaluate multiple expressions in order, with the last expression's value as the entire sequence's value.
 
@@ -414,7 +414,7 @@ The `unit` value `()` can serve as a [no-op](https://en.wikipedia.org/wiki/Noop)
 - : unit = ()
 ```
 
-But OCaml also allows writing `if … then … ` expressions without an `else` branch, which is the same as the above.
+But OCaml also allows writing `if … then …` expressions without an `else` branch, which is the same as the above.
 
 ```ocaml
 # if 0 = 1 then print_endline "foo";;
@@ -456,7 +456,7 @@ Here is an error you might encounter:
 Error: Syntax error
 ```
 
-Failing to group in the first branch results in a syntax error. What's before the semicolon is parsed as an `if … then … ` without an `else` expression. What's after the semicolon appears as a [dangling](https://en.wikipedia.org/wiki/Dangling_else) `else`.
+Failing to group in the first branch results in a syntax error. What's before the semicolon is parsed as an `if … then …` without an `else` expression. What's after the semicolon appears as a [dangling](https://en.wikipedia.org/wiki/Dangling_else) `else`.
 
 ### For Loop
 
@@ -474,10 +474,10 @@ A `for` loop is an expression of type `unit`. Here, `for`, `to`, `do`, and `done
 ```
 
 Here:
- - `i` is the loop counter; it is incremented after every iteration.
- - `0` is the first value of `i`.
- - `5` is the last value of `i`.
- - The expression `Printf.printf "%i\n" i` is the body of the loop.
+* `i` is the loop counter; it is incremented after every iteration.
+* `0` is the first value of `i`.
+* `5` is the last value of `i`.
+* The expression `Printf.printf "%i\n" i` is the body of the loop.
 
 The iteration evaluates the body expression (which may contain `i`) until `i` reaches `5`.
 
@@ -531,8 +531,8 @@ A `while` loop is an expression of type `unit`. Here, `while`, `do`, and `done` 
 ```
 
 Here:
-- `!i <= 5` is the condition.
-- The expression ` Printf.printf "%i\n" !i; i := !i + 1;` is the body of the loop.
+* `!i <= 5` is the condition.
+* The expression `Printf.printf "%i\n" !i; i := !i + 1;` is the body of the loop.
 
 The iteration executes the body expression as long as the condition remains true.
 
@@ -622,12 +622,12 @@ The function `sum` is written in an imperative style, using mutable data structu
 ### Good: Application-Wide State
 
 Some applications maintain some state while they are running. Here are a couple of examples:
-- A Read-Eval-Print-Loop (REPL). The state is the environment where values are bound to names. In OCaml, the environment is append-only, but some other languages allow replacing or removing name-value bindings.
-- A server for a stateful protocol. Each session has a state. The global state consists of all the session states.
-- A text editor. The state includes the most recent commands (to allow undo), the state of any open files, the settings, and the state of the UI.
-- A cache.
+* A Read-Eval-Print-Loop (REPL). The state is the environment where values are bound to names. In OCaml, the environment is append-only, but some other languages allow replacing or removing name-value bindings.
+* A server for a stateful protocol. Each session has a state. The global state consists of all the session states.
+* A text editor. The state includes the most recent commands (to allow undo), the state of any open files, the settings, and the state of the UI.
+* A cache.
 
-The following is a toy line editor, using the `get_char` function [defined earlier](#example-getchar-function). It waits for characters on standard input and exits on end-of-file, carriage return, or newline. Otherwise, if the character is printable, it prints it and records it in a mutable list used as a stack. If the character is the delete code, the stack is popped and the last printed character is erased.
+The following is a toy line editor, using the `get_char` function [defined earlier](#example-get_char-function). It waits for characters on standard input and exits on end-of-file, carriage return, or newline. Otherwise, if the character is printable, it prints it and records it in a mutable list used as a stack. If the character is the delete code, the stack is popped and the last printed character is erased.
 
 ```ocaml
 # let record_char state c =
@@ -661,9 +661,9 @@ val loop : char list ref -> 'a = <fun>
 After this last command, you can type and edit any single line of text. Then, press return to get back to the REPL.
 
 This example illustrates the following:
-- The functions `record_char` and `remove_char` neither update the state nor produce side effects. Instead, they each return a pair of values consisting of a string to print and the next state, `new_state`.
-- I/O and state-update side effects happen inside the `loop` function.
-- The state is passed as argument to the `loop` function.
+* The functions `record_char` and `remove_char` neither update the state nor produce side effects. Instead, they each return a pair of values consisting of a string to print and the next state, `new_state`.
+* I/O and state-update side effects happen inside the `loop` function.
+* The state is passed as argument to the `loop` function.
 
 This is a possible way to handle an application-wide state. As in the [Function-Encapsulated Mutability](#good-function-encapsulated-mutability) example, state-aware code is contained in a narrow scope; the rest of the code is purely functional.
 
@@ -707,7 +707,7 @@ It is possible to use an imperative programming style without losing the benefit
 
 Most existing modules provide an interface meant to be used in a functional way. Some require the development and maintenance of [wrapper libraries](https://en.wikipedia.org/wiki/Wrapper_library) to be used in an imperative setting and such use results in inefficient code.
 
-###  It Depends: Module State
+### It Depends: Module State
 
 A module may expose or encapsulate a state in several different ways:
 1. Good: expose a type representing a state, with state creation or reset functions
@@ -755,7 +755,6 @@ Here's an example of bad code:
     (Array.truncate k_len k, Array.truncate m_len m);;
 Error: Unbound value Array.truncate
 ```
-
 
 To understand why this is bad code, assume that the function `Array.truncate` has type `int -> 'a array -> 'a array`. It behaves such that `Array.truncate 3 [5; 6; 7; 8; 9]` returns `[5; 6; 7]`, and the returned array physically corresponds to the 3 first cells of the input array.
 

--- a/data/tutorials/language/1ms_00_modules.md
+++ b/data/tutorials/language/1ms_00_modules.md
@@ -141,8 +141,8 @@ Values, functions, types, or submodules, everything is public. This can be
 restricted to avoid exposing definitions that are not relevant from the outside.
 
 For this, we must distinguish:
-- The definitions inside a module (the module implementation)
-- The public declarations of a module (the module interface)
+* The definitions inside a module (the module implementation)
+* The public declarations of a module (the module interface)
 
 An `.ml` file contains a module implementation; an `.mli` file contains a module
 interface. By default, when no corresponding `.mli` file is provided, an
@@ -480,6 +480,6 @@ a module's interface exposes all its definitions, but this can be restricted
 using the interface syntax.
 
 Going further, here are the other means to handle OCaml software components:
-- Functors, which act like functions from modules to modules
-- Libraries, which are compiled modules bundled together
-- Packages, which are installation and distribution units
+* Functors, which act like functions from modules to modules
+* Libraries, which are compiled modules bundled together
+* Packages, which are installation and distribution units

--- a/data/tutorials/language/1ms_01_functors.md
+++ b/data/tutorials/language/1ms_01_functors.md
@@ -21,7 +21,7 @@ As suggested by the name, a _functor_ is almost like a function. However, while 
 This tutorial uses the [Dune](https://dune.build) build tool. Make sure you have installed version 3.7 or later. We start by creating a fresh project. We need a directory named `funkt` with files `dune-project`, `dune`, and `funkt.ml`.
 
 ```shell
-$ mkdir funkt; cd funkt
+mkdir funkt; cd funkt
 ```
 
 Place the following in the file **`dune-project`**:
@@ -61,8 +61,8 @@ module Make : functor (Ord : OrderedType) -> Set.S
 
 Here is how this reads (starting from the bottom, then going up):
 * Like a function (indicated by the arrow `->`), the functor `Set.Make`
-  - takes a module with signature `OrderedType` and
-  - returns a module with signature [`Set.S`](/manual/api/Set.S.html)
+  * takes a module with signature `OrderedType` and
+  * returns a module with signature [`Set.S`](/manual/api/Set.S.html)
 * The module type `OrderedType` requires a type `t` and a function `compare`, which are used to perform the comparisons between elements of the set.
 
 **Note**: Most set operations need to compare elements to check if they are the same. To allow using a user-defined comparison algorithm, the `Set.Make` functor takes a module that specifies both the element type `t` and the `compare` function. Passing the comparison function as a higher-order parameter, as done in `Array.sort`, for example, would add a lot of boilerplate code. Providing set operations as a functor allows specifying the comparison function only once.
@@ -80,8 +80,8 @@ module StringSet = Set.Make(StringCompare)
 ```
 
 This defines a module `Funkt.StringSet`. What `Set.Make` needs are:
-- Type `t`, here `string`
-- Function allowing to compare two values of type `t`, here `String.compare`
+* Type `t`, here `string`
+* Function allowing to compare two values of type `t`, here `String.compare`
 
 **Note**: A type `t` must be defined in the parameter module, here
 `StringCompare`. Most often, as shown in this example, `t` is an alias for
@@ -105,8 +105,8 @@ end)
 The module expression `struct ... end` is inlined in the `Set.Make` call.
 
 However, since the module `String` already defines
-- Type name `t`, which is an alias for `string`
-- Function `compare` of type `t -> t -> int` compares two strings
+* Type name `t`, which is an alias for `string`
+* Function `compare` of type `t -> t -> int` compares two strings
 
 This can be simplified even further into this:
 
@@ -132,10 +132,10 @@ let _ =
 ```
 
 Here is how this code works:
-- `In_channel.input_lines` : reads lines of text from standard input
-- `List.concat_map` : splits lines into words and produces a word list
-- `StringSet.of_list : string list -> StringSet.t` : converts the word list into a set
-- `StringSet.iter : StringSet.t -> unit` : displays the set's elements
+* `In_channel.input_lines` : reads lines of text from standard input
+* `List.concat_map` : splits lines into words and produces a word list
+* `StringSet.of_list : string list -> StringSet.t` : converts the word list into a set
+* `StringSet.iter : StringSet.t -> unit` : displays the set's elements
 
 The functions `StringSet.of_list` and `StringSet.iter` are available in the functor's application result.
 
@@ -242,7 +242,8 @@ Heap implementations can be represented as functors from `OrderedType` into `Hea
 
 Here is the skeleton of a possible implementation:
 
-**heap.ml**
+#### heap.ml
+
 ```ocaml
 module type OrderedType = sig
   type t
@@ -297,7 +298,7 @@ Advanced Module Systems, ICFP 2000
 
 ## Injecting Dependencies Using Functors
 
-**Dependencies Between Modules**
+### Dependencies Between Modules
 
 Here is a new version of the `funkt` program:
 
@@ -321,12 +322,12 @@ let _ =
 ```
 
 It embeds an additional `IterPrint` module that exposes a single function `f` of type `string list -> unit` and has two dependencies:
-  - Module `List` through `List.iter` and `f`'s type
-  - Module `Out_channel` through `Out_channel.output_string`
+* Module `List` through `List.iter` and `f`'s type
+* Module `Out_channel` through `Out_channel.output_string`
 
 Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
-**Dependency Injection**
+### Dependency Injection
 
 [Dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) is a way to parametrise over a dependency.
 
@@ -369,7 +370,7 @@ let _ =
 
 The dependency `List` is _injected_ when compiling the module `Funkt`. Observe that the code using `IterPrint` is unchanged. Check the program's behaviour using `opam exec -- dune exec funkt < dune`.
 
-**Replacing a Dependency**
+### Replacing a Dependency
 
 Now, replacing the implementation of `iter` inside `IterListPrint` is no longer a refactoring; it is another functor application with another dependency. Here, [`Array`](/manual/api/Array.html) replaces `List`:
 
@@ -433,7 +434,7 @@ module Make(Dep: Iterable) : S with type 'a t := 'a Dep.t = struct
 end
 ```
 
-In the example above, `t` from `with type` takes precedence over the local `t`, which only has a local scope. 
+In the example above, `t` from `with type` takes precedence over the local `t`, which only has a local scope.
 
 **Warning**: Don't shadow names too often because it makes the code harder to understand.
 

--- a/data/tutorials/language/1ms_03_dune.md
+++ b/data/tutorials/language/1ms_03_dune.md
@@ -26,7 +26,7 @@ We use unique terms for different elements of our project to avoid ambiguity. Fo
 This section details the structure of an almost-minimum Dune project setup. Check [Your First OCaml Program](/docs/your-first-program) for automatic setup using the `dune init proj` command.
 
 ```shell
-$ mkdir mixtli; cd mixtli
+mkdir mixtli; cd mixtli
 ```
 
 In this directory, create four more files: `dune-project`, `dune`, `cloud.ml`, and `wmo.ml`:
@@ -76,7 +76,6 @@ Nimbostratus (Ns)
 Cumulonimbus (Cb)
 ```
 
-
 Here is the directory contents:
 
 ```shell
@@ -91,7 +90,7 @@ $ tree
 Dune stores the files it creates, and a copy of the sources, in a directory named `_build`. You don't need to edit anything there. In a project managed using Git, the `_build` directory should be ignored
 
 ```shell
-$ echo _build >> .gitignore
+echo _build >> .gitignore
 ```
 
 You can also configure your editor or IDE to ignore it too.
@@ -99,12 +98,12 @@ You can also configure your editor or IDE to ignore it too.
 In OCaml, each `.ml` file defines a module. In the `mixtli` project, the file `cloud.ml` defines the `Cloud` module, the file `wmo.ml` defines the `Wmo` module that contains two submodules: `Stratus` and `Cumulus`.
 
 Here are the different names:
-* `mixtli` is the project's name (it means *cloud* in [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl)
-* `cloud.ml` is the OCaml source file's name, referred as `cloud` in the `dune` file.
-* `nube` is the executable command's name (it means *cloud* in Spanish).
-* `Cloud` is the name of the module associated with the file `cloud.ml`.
-* `Wmo` is the name of the module associated with the file `wmo.ml`.
-* `wmo-clouds` is the name of the package built by this project.
+- `mixtli` is the project's name (it means *cloud* in [Nahuatl](https://en.wikipedia.org/wiki/Nahuatl)
+- `cloud.ml` is the OCaml source file's name, referred as `cloud` in the `dune` file.
+- `nube` is the executable command's name (it means *cloud* in Spanish).
+- `Cloud` is the name of the module associated with the file `cloud.ml`.
+- `Wmo` is the name of the module associated with the file `wmo.ml`.
+- `wmo-clouds` is the name of the package built by this project.
 
 The `dune describe` command allows having a look at the project's module structure. Here is its output:
 
@@ -132,12 +131,12 @@ The `dune describe` command allows having a look at the project's module structu
 ## Libraries
 
 <!--This contrasts with the `struct ... end` syntax where modules are aggregated top-down by nesting submodules into container modules. -->
-In OCaml, a library is a collection of modules. By default, when Dune builds a library, it wraps the bundled modules into a module. This allows having several modules with the same name, inside different libraries, in the same project. That feature is known as [_namespaces_](https://en.wikipedia.org/wiki/Namespace) for module names. This is similar to what modules do for definitions; they avoid name clashes.
+In OCaml, a library is a collection of modules. By default, when Dune builds a library, it wraps the bundled modules into a module. This allows having several modules with the same name, inside different libraries, in the same project. That feature is known as [*namespaces*](https://en.wikipedia.org/wiki/Namespace) for module names. This is similar to what modules do for definitions; they avoid name clashes.
 
 Dune creates libraries from directories. Let's look at an example. Here the `lib` directory contains its sources. This is different from the Unix standard, where `lib` stores compiled library binaries.
 
 ```shell
-$ mkdir lib
+mkdir lib
 ```
 
 The `lib` directory is populated with the following source files:
@@ -171,7 +170,7 @@ let nimbus = "Nimbostratus (Ns)"
 All the modules found in the `lib` directory are bundled into the `Wmo` module. This module is the same as what we had in the `wmo.ml` file. To avoid redundancy, we delete it:
 
 ```shell
-$ rm wmo.ml
+rm wmo.ml
 ```
 
 We update the `dune` file building the executable to use the library as a dependency.
@@ -185,9 +184,9 @@ We update the `dune` file building the executable to use the library as a depend
 ```
 
 **Observations**:
-* Dune creates a module `Wmo` from the contents of directory `lib`.
-* The directory's name (here `lib`) is irrelevant.
-* The library name appears uncapitalised (`wmo`) in `dune` files:
+- Dune creates a module `Wmo` from the contents of directory `lib`.
+- The directory's name (here `lib`) is irrelevant.
+- The library name appears uncapitalised (`wmo`) in `dune` files:
   - In its definition, in `lib/dune`
   - When used as a dependency in `dune`
 
@@ -214,7 +213,7 @@ When a library directory contains a wrapper module (here `wmo.ml`), it is the on
 
 Using a wrapper file makes several things possible:
 - Have different public and internal names, `module CumulusCloud = Cumulus`
-- Define values in the wrapper module, `let ... = `
+- Define values in the wrapper module, `let ... =`
 - Expose module resulting from functor application, `module StringSet = Set.Make(String)`
 - Apply the same interface type to several modules without duplicating files
 - Hide modules by not listing them
@@ -226,11 +225,11 @@ By default, Dune builds a library from the modules found in the same directory a
 In this example, we create subdirectories and move files there.
 
 ```shell
-$ mkdir lib/cumulus lib/stratus
-$ mv lib/cumulus.ml lib/cumulus/m.ml
-$ mv lib/cumulus.mli lib/cumulus/m.mli
-$ mv lib/stratus.ml lib/stratus/m.ml
-$ mv lib/stratus.mli lib/stratus/m.mli
+mkdir lib/cumulus lib/stratus
+mv lib/cumulus.ml lib/cumulus/m.ml
+mv lib/cumulus.mli lib/cumulus/m.mli
+mv lib/stratus.ml lib/stratus/m.ml
+mv lib/stratus.mli lib/stratus/m.mli
 ```
 
 Change from the default behaviour with the `include_subdirs` stanza.
@@ -251,7 +250,7 @@ module Stratus = Stratus.M
 
 Run `dune exec nube` to see that the behaviour of the program is the same as in the two previous sections.
 
-The `include_subdirs qualified` stanza works recursively, except on subdirectories containing a `dune` file. See the [Dune](https://dune.readthedocs.io/en/stable/dune-files.html#include-subdirs) [documentation](https://github.com/ocaml/dune/issues/1084) for [more](https://discuss.ocaml.org/t/upcoming-dune-feature-include-subdirs-qualified) on this [topic](https://github.com/ocaml/dune/tree/main/test/blackbox-tests/test-cases/include-qualified).
+The `include_subdirs qualified` stanza works recursively, except on subdirectories containing a `dune` file. See the [Dune documentation](https://dune.readthedocs.io/en/stable/dune-files.html#include-subdirs), this [GitHub issue](https://github.com/ocaml/dune/issues/1084), the [Discuss announcement](https://discuss.ocaml.org/t/upcoming-dune-feature-include-subdirs-qualified), and the [test cases](https://github.com/ocaml/dune/tree/main/test/blackbox-tests/test-cases/include-qualified) for more on this topic.
 
 <!--
 ## Starting a Project from a Single File
@@ -404,12 +403,11 @@ module Stratus : sig val nimbus : string end
 ```
 
 **Remarks**:
-* When the file `lib/wmo.ml` exists, the `modules` stanza that doesn't list it
+- When the file `lib/wmo.ml` exists, the `modules` stanza that doesn't list it
   prevents it from being bundled in the library
-* When the file `lib/wmo.ml` doesn't exist, the `wrapped false` stanza prevents
+- When the file `lib/wmo.ml` doesn't exist, the `wrapped false` stanza prevents
    the creation of the `Wmo` wrapper
 
 ## Conclusion
 
 The OCaml module system allows organising a project in many ways. Dune provides several means to arrange modules into libraries.
-

--- a/data/tutorials/language/3ds_02_maps.md
+++ b/data/tutorials/language/3ds_02_maps.md
@@ -9,8 +9,8 @@ category: "Data Structures"
 ## Introduction
 
 In the most general sense, the [`Map`](/manual/api/Map.html) module lets you create _immutable_ key-value
-[associative array](https://en.wikipedia.org/wiki/Associative_array) for your types. More concretely, 
-OCaml's `Map` module is implemented using a binary search tree algorithm to support fast lookups (of O(Log n)). 
+[associative array](https://en.wikipedia.org/wiki/Associative_array) for your types. More concretely,
+OCaml's `Map` module is implemented using a binary search tree algorithm to support fast lookups (of O(Log n)).
 
 **Note**: The concept of a `Map` in this tutorial refers to a data structure that stores a
 set of key-value pairs. It is sometimes called a dictionary or an association table. This
@@ -101,12 +101,12 @@ To find entries in a map, use the `find_opt` or `find` functions:
 ```
 
 When the searched key is present in the map:
-- `find_opt` returns the associated value, wrapped in an option
-- `find` returns the associated value
+* `find_opt` returns the associated value, wrapped in an option
+* `find` returns the associated value
 
 When the searched key is absent from the map:
-- `find_opt` returns `None`
-- `find` throws the `Not_found` exception
+* `find_opt` returns `None`
+* `find` throws the `Not_found` exception
 
 We can also use `find_first_opt` and `find_last_opt` if we want to use a
 predicate function:
@@ -222,9 +222,9 @@ val pick_snd : 'a -> 'b -> 'c -> 'c option = <fun>
 val drop : 'a -> 'b -> 'c -> 'd option = <fun>
 ```
 
-- `pick_fst` picks the result's value from the first map
-- `pick_snd` picks the result's value from the second map
-- `drop` drops both entries in the result map
+* `pick_fst` picks the result's value from the first map
+* `pick_snd` picks the result's value from the second map
+* `drop` drops both entries in the result map
 
 ```ocaml
 # StringMap.(

--- a/data/tutorials/language/3ds_03_sets.md
+++ b/data/tutorials/language/3ds_03_sets.md
@@ -10,7 +10,7 @@ category: "Data Structures"
 
 `Set` provides the functor `Set.Make`. You must start by passing `Set.Make` a module. It specifies the element type for your set. In return, you get another module with those elements' set operations.
 
-**Disclaimer:** The examples in this tutorial require OCaml 5.1. If you're running a previous version of OCaml, you can either use `elements` instead of `to_list`, which is a new function in OCaml 5.1, or upgrade OCaml by running `opam update`, then `opam upgrade ocaml`. Check your current version with `ocaml --version`. 
+**Disclaimer:** The examples in this tutorial require OCaml 5.1. If you're running a previous version of OCaml, you can either use `elements` instead of `to_list`, which is a new function in OCaml 5.1, or upgrade OCaml by running `opam update`, then `opam upgrade ocaml`. Check your current version with `ocaml --version`.
 
 If you need to work with string sets, you must invoke `Set.Make(String)`. That returns a new module.
 
@@ -52,7 +52,7 @@ For `StringSet.empty`, you can see that the OCaml toplevel displays the placehol
 
 (Remember, for OCaml versions before 5.1, it will be `StringSet.empty |> StringSet.elements;;`)
 
-2. A set with a single element is created using `StringSet.singleton`:
+1. A set with a single element is created using `StringSet.singleton`:
 
 ```ocaml
 # StringSet.singleton "hello";;
@@ -62,7 +62,7 @@ For `StringSet.empty`, you can see that the OCaml toplevel displays the placehol
 - : string list = ["hello"]
 ```
 
-3. Converting a list into a set using `StringSet.of_list`:
+1. Converting a list into a set using `StringSet.of_list`:
 
 ```ocaml
 # StringSet.of_list ["hello"; "hi"];;
@@ -223,4 +223,3 @@ end);;
 ## Conclusion
 
 We gave an overview of OCaml's `Set` module by creating a `StringSet` module using the `Set.Make` functor. Further, we looked at how to create sets based on a custom comparison function. For more information, refer to [Set](/manual/api/Set.Make.html) in the Standard Library documentation.
-

--- a/data/tutorials/language/3ds_04_hashtbl.md
+++ b/data/tutorials/language/3ds_04_hashtbl.md
@@ -103,7 +103,7 @@ value of `"h"`.
 
 However, the previous values associated with the key `"h"` were not replaced.
 What we may want instead is all the elements that start with `"h"`. To do this we
-want to *find all* of them. What better name for this than `find_all`?
+want to _find all_ of them. What better name for this than `find_all`?
 
 ```ocaml
 # Hashtbl.find_all my_hash "h";;
@@ -131,7 +131,7 @@ variable of the same name.
 
 ### Replacing Data in Hash Tables
 
-In other contexts, one may prefer new values *replace* the previous ones.  In
+In other contexts, one may prefer new values _replace_ the previous ones.  In
 this case, one uses `Hashtbl.replace`:
 
 ```ocaml

--- a/data/tutorials/language/3ds_05_seq.md
+++ b/data/tutorials/language/3ds_05_seq.md
@@ -261,7 +261,7 @@ sequences. The result returned by `Seq.unfold f x` is the sequence built by
 accumulating the results of successive calls to `f` until it returns `None`.
 This is:
 
-```
+```text
 (fst p₀, fst p₁, fst p₂, fst p₃, fst p₄, ...)
 ```
 
@@ -578,10 +578,6 @@ OCaml 4.14. Beware books and documentation written before may still mention it.
   * Xavier Van de Woestyne [@xvw](https://github.com/xvw)
   * Simon Cruanes [@c-cube](https://github.com/c-cube)
   * Glen Mével [gmevel](https://github.com/gmevel) -->
-
-
-
-
 
 <!--
 Suggestion: perhaps it would be enlightening to illustrate the use of Seq.unfold by re-implementing the already seen function primes? Perhaps in an exercise rather than in the main text of the tutorial.

--- a/data/tutorials/language/3ds_06_memoization.md
+++ b/data/tutorials/language/3ds_06_memoization.md
@@ -146,8 +146,8 @@ Each employee has an associated “fun value” and we want the set of invited
 employees to have a maximum total fun value. However, no employee is fun if his
 superior is invited, so we never invite two employees who are connected in the
 org chart. (The less fun name for this problem is the maximum weight independent
-set in a tree.) For an org chart with `n` employees, there are 2&#8319; possible 
-invitation lists, so the naive algorithm that compares the fun of every valid 
+set in a tree.) For an org chart with `n` employees, there are 2&#8319; possible
+invitation lists, so the naive algorithm that compares the fun of every valid
 invitation list takes exponential time.
 
 We can use memoization to turn this into a linear-time algorithm. We start by

--- a/data/tutorials/language/4ad_00_metaprogramming.md
+++ b/data/tutorials/language/4ad_00_metaprogramming.md
@@ -21,8 +21,8 @@ preprocessor](https://github.com/ocaml-ppx/ppxlib/tree/main/examples/simple-exte
 Printf.printf "This program has been compiled by user: %s" [%get_env "USER"]
 ```
 
-The preprocessor will replace [%get_env "USER"] with the content of the USER 
-environment variable at compile time. This environment variable has no effect at 
+The preprocessor will replace [%get_env "USER"] with the content of the USER
+environment variable at compile time. This environment variable has no effect at
 runtime. For example, if USER is set to "JohnDoe", the line would become:
 
 <!-- $MDX skip -->
@@ -77,7 +77,6 @@ However, some preprocessors such as
 [`cppo`](https://github.com/ocaml-community/cppo) have been made especially to
 integrate well with OCaml.
 
-
 In OCaml, preprocessing text files do not have specific support from the language. Instead
 it is the build system's role to drive the preprocessing. So, applying
 preprocessors will boil down to telling Dune about it. Only for educational
@@ -115,8 +114,8 @@ Hello, Universe!
 ### Preprocessing With Dune
 
 Dune's build system has a specific stanza to apply preprocessing to files.
-The full documentation can be found
-[here](https://dune.readthedocs.io/en/stable/explanation/preprocessing.html),
+The full documentation can be found in the
+[Dune preprocessing guide](https://dune.readthedocs.io/en/stable/explanation/preprocessing.html),
 and should serve as a reference. In this section, we only give a few examples.
 
 The stanza to apply preprocessing on the source file is `(preprocess (action
@@ -147,7 +146,7 @@ comments could get in the way...
 Consider another example. Suppose you have defined a type, and you want to
 generate a serializer at compile time from this specific type to an encoding of
 it in a `json` format, such as `Yojson` (see
-[here](#why-ppxs-are-especially-useful-in-ocaml) for the reasons it has to be
+[Why PPXs Are Especially Useful in OCaml](#why-ppxs-are-especially-useful-in-ocaml) for the reasons it has to be
 generated at compile-time). This serialization code could be written by a
 preprocessor, which would look for the type in the file and serialize it
 differently depending on the type structure; that is, whether it is a variants

--- a/data/tutorials/language/4ad_01_operators.md
+++ b/data/tutorials/language/4ad_01_operators.md
@@ -95,35 +95,35 @@ This allows users to write more compact code. However, be careful not to write e
 
 OCaml has a subtle syntax; not everything is allowed as an operator symbol. An operator symbol is an identifier with a special syntax, so it must have the following structure:
 
-**Prefix Operator**
+### Prefix Operator
 
 1. First character, either:
-    * `?` `~`
-    * `!`
+    - `?` `~`
+    - `!`
 1. Following characters, at least one if the first character is `?` or `~`, optional otherwise:
-    * `$` `&` `*` `+` `-` `/` `=` `>` `@` `^` `|`
-    * `%` `<`
+    - `$` `&` `*` `+` `-` `/` `=` `>` `@` `^` `|`
+    - `%` `<`
 
-**Binary Operator**
+### Binary Operator
 
 1. First character, either:
-    * `$` `&` `*` `+` `-` `/` `=` `>` `@` `^` `|`
-    * `%` `<`
-    * `#`
+    - `$` `&` `*` `+` `-` `/` `=` `>` `@` `^` `|`
+    - `%` `<`
+    - `#`
 1. Following characters, at least one if the first character is `#`, optional otherwise:
-    * `$` `&` `*` `+` `-` `/` `=` `>` `@` `^` `|`
-    * `%` `<`
-    * `!` `.` `:` `?` `~`
+    - `$` `&` `*` `+` `-` `/` `=` `>` `@` `^` `|`
+    - `%` `<`
+    - `!` `.` `:` `?` `~`
 
 This is defined in the [Prefix and Infix symbols](/manual/lex.html#sss:lex-ops-symbols) section of The OCaml Manual.
 
 Tips:
-  * Don't define wide scope operators. Restrict their scope to module or function.
-  * Don't use many of them.
-  * Before defining a custom binary operator, check that the symbol is not already used. This can be done in two ways:
-    - By surrounding the candidate symbol with parentheses in UTop and see if it responds with a type or with an `Unbound value` error
-    - Use [Sherlocode](https://sherlocode.com/) to check if it is already used in some OCaml project
-  * Avoid shadowing existing operators.
+- Don't define wide scope operators. Restrict their scope to module or function.
+- Don't use many of them.
+- Before defining a custom binary operator, check that the symbol is not already used. This can be done in two ways:
+  - By surrounding the candidate symbol with parentheses in UTop and see if it responds with a type or with an `Unbound value` error
+  - Use [Sherlocode](https://sherlocode.com/) to check if it is already used in some OCaml project
+- Avoid shadowing existing operators.
 
 ## Operator Associativity and Precedence
 

--- a/data/tutorials/language/4ad_02_objects.md
+++ b/data/tutorials/language/4ad_02_objects.md
@@ -7,7 +7,8 @@ category: "Advanced Topics"
 ---
 
 ## Objects and Classes
-OCaml is an [object-oriented, imperative, functional programming language](https://ocaml.org/about). 
+
+OCaml is an [object-oriented, imperative, functional programming language](https://ocaml.org/about).
 It mixes all these paradigms and lets you use the most appropriate
 (or most familiar) programming paradigm for the task at hand. In this
 chapter, we're going to look at object-oriented programming in OCaml, but
@@ -74,7 +75,7 @@ Error: This expression has type int but an expression was expected of type
 
 Type safety is preserved. Back to the example ...
 
-This class has four simple methods: 
+This class has four simple methods:
 - `push` pushes an integer onto the
 stack.
 - `pop` pops the top integer off the stack and returns it. Notice
@@ -135,6 +136,7 @@ val s : stack_of_ints = <obj>
 from callers.
 
 ### Polymorphic Classes
+
 A stack of integers is good, but what about a stack that can store any
 type? (Not a single stack that can store a mixture of types, but
 multiple stacks each storing objects of any single type). As with
@@ -227,6 +229,7 @@ val drain_stack : 'a stack -> unit = <fun>
 ```
 
 ### Inheritance, Virtual Classes, Initialisers
+
 I've noticed programmers in Java tend to overuse inheritance, possibly
 because it's the only reasonable way of extending code in that language.
 A much better and more general way to extend code is usually to use
@@ -238,7 +241,7 @@ Let's consider an imaginary OCaml widget library similar to Java's
 Swing. We will define buttons and labels with the following class
 hierarchy:
 
-```
+```text
 widget  (superclass for all widgets)
   |
   +----> container  (any widget that can contain other widgets)
@@ -378,7 +381,7 @@ Notes:
 ```
 
 Would this modify the private internal representation of my `container`
-class, by prepending `x` to the list of widgets? No it wouldn't. If you run 
+class, by prepending `x` to the list of widgets? No it wouldn't. If you run
 the above code, you'll see it throws an error:
 
 ```ocaml
@@ -512,6 +515,7 @@ Button being repainted, state is Released
 ```
 
 ### A Note About `self`
+
 In all the examples above, we defined classes using the general pattern:
 
 <!-- $MDX skip -->
@@ -593,6 +597,7 @@ this direction is *unsafe*. You might try to coerce a `widget` which is
 in fact a `label`, not a `button`.
 
 ### The `Oo` Module and Comparing Objects
+
 The `Oo` module contains a few useful functions for OO programming.
 
 `Oo.copy` makes a shallow copy of an object. `Oo.id object` returns a
@@ -605,10 +610,12 @@ etc., which provides an ordering of objects based apparently on their
 IDs.
 
 ## Objects Without Class
+
 Here we examine how to use objects pretty much like records, without
 necessarily using classes.
 
 ### Immediate Objects and Object Types
+
 Objects can be used instead of records. Plus, they have some nice properties
 that can make them preferable to records in some cases. We saw that the
 canonical way of creating objects is to first define a class, then use
@@ -662,19 +669,20 @@ val r : counter_r = {get = <fun>; incr = <fun>}
 In terms of functionality, both the object and the record are similar,
 but each solution has its own advantages:
 
-* **speed**: slightly faster field access in records
-* **field names**: it is inconvenient to manipulate records of
+- **speed**: slightly faster field access in records
+- **field names**: it is inconvenient to manipulate records of
  different types when some fields are named identically but it's not
  a problem with objects.
-* **subtyping**: it is impossible to coerce the record type to a
+- **subtyping**: it is impossible to coerce the record type to a
  type with fewer fields. However, that is possible with objects, so
  objects of different kinds that share some methods can be mixed in a
  data structure where only their common methods are visible (see next
  section).
-* **type definitions**: there is no need to define an object type in
+- **type definitions**: there is no need to define an object type in
  advance, so it lightens the dependency constraints between modules.
 
 ### Class Types vs. Just Types
+
 Beware of the confusion between *class types* and object *types*. A
 *class type* is not a data *type*, normally referred to as *type* in the
 OCaml jargon. An object *type* is a kind of data *type*, just like a

--- a/data/tutorials/language/5rt_00_memory_representation.md
+++ b/data/tutorials/language/5rt_00_memory_representation.md
@@ -160,7 +160,6 @@ of modern processor instructions to hide the extra shifts where possible.
 Addition is a single `LEA` x86 instruction, subtraction can be two
 instructions, and multiplication is only a few more.
 
-
 ## Blocks and Values
 
 An OCaml *block* is the basic unit of allocation on the heap. A block
@@ -196,36 +195,36 @@ type, which we describe in more detail later in this chapter.
 The exact representation of values inside a block depends on their static
 OCaml type. All OCaml types are distilled down into `values`, and summarized below.
 
-- `int` or `char` are stored directly as a value, shifted left by 1
+* `int` or `char` are stored directly as a value, shifted left by 1
   bit, with the least significant bit set to 1.
 
-- `unit`, `[]`, `false` are all stored as OCaml `int` 0.
+* `unit`, `[]`, `false` are all stored as OCaml `int` 0.
 
-- `true` is stored as OCaml `int` 1.
+* `true` is stored as OCaml `int` 1.
 
-- `Foo | Bar` variants are stored as ascending OCaml `int`s, starting
+* `Foo | Bar` variants are stored as ascending OCaml `int`s, starting
   from 0.
 
-- `Foo | Bar of int` variants with parameters are boxed, while
+* `Foo | Bar of int` variants with parameters are boxed, while
   variants with no parameters are unboxed.
 
-- Polymorphic variants with parameters are boxed with an extra
+* Polymorphic variants with parameters are boxed with an extra
   header word to store the value, as compared to normal variants.
   Polymorphic variants with no parameters are unboxed.
 
-- Floating-point numbers are stored as a block with a single field
+* Floating-point numbers are stored as a block with a single field
   containing the double-precision float.
 
-- Strings are word-aligned byte arrays with an explicit length.
+* Strings are word-aligned byte arrays with an explicit length.
 
-- `[1; 2; 3]` lists are stored as `1::2::3::[]` where `[]` is an int,
+* `[1; 2; 3]` lists are stored as `1::2::3::[]` where `[]` is an int,
   and `h::t` a block with tag 0 and two parameters.
 
-- Tuples, records, and arrays are stored as a C array of
+* Tuples, records, and arrays are stored as a C array of
   values. Arrays can be variable size, but tuples and records are
   fixed-size.
 
-- Records or arrays that are all float use a special tag for unboxed
+* Records or arrays that are all float use a special tag for unboxed
   arrays of floats, or records that only have `float` fields.
 
 ### Integers, Characters, and Other Basic Types
@@ -243,11 +242,9 @@ parameters to your functions. Modern architectures such as `x86_64` have a
 lot of spare registers to further improve the efficiency of using unboxed
 integers.
 
-
 ## Tuples, Records, and Arrays
 
-![](/media/tutorials/language/runtime-memory-layout/tuple_layout.png "Tuple Layout")
-
+![Tuple Layout](/media/tutorials/language/runtime-memory-layout/tuple_layout.png "Tuple Layout")
 
 Tuples, records, and arrays are all represented identically at runtime as a
 block with tag `0`. Tuples and records have constant sizes determined at
@@ -292,8 +289,7 @@ contains the floats packed directly in the data section, with
 `Double_array_tag` set to signal to the collector that the contents
 are not OCaml values.
 
-
-![](/media/tutorials/language/runtime-memory-layout/float_array_layout.png "Float array layout")
+![Float array layout](/media/tutorials/language/runtime-memory-layout/float_array_layout.png "Float array layout")
 
 First, let's check that float arrays do in fact have a different tag number
 from normal floating-point values:
@@ -328,7 +324,6 @@ have the normal tuple tag value (0).
 
 Only records and arrays can have the float array optimization, and for
 records, every single field must be a float.
-
 
 ## Variants and Lists
 
@@ -464,24 +459,24 @@ machine words. The `String_tag` (252) is higher than the
 the collector. The block contents are the contents of the string, with
 padding bytes to align the block on a word boundary.
 
-![](/media/tutorials/language/runtime-memory-layout/string_block.png "String block layout")
+![String block layout](/media/tutorials/language/runtime-memory-layout/string_block.png "String block layout")
 
 On a 32-bit machine, the padding is calculated based on the modulo of the
 string length and word size to ensure the result is word-aligned. A 64-bit
 machine extends the potential padding up to 7 bytes instead of 3.
 Given a string length modulo 4:
 
-- `0` has padding `00 00 00 03`
-- `1` has padding `00 00 02`
-- `2` has padding `00 01`
-- `3` has padding `00`
+* `0` has padding `00 00 00 03`
+* `1` has padding `00 00 02`
+* `2` has padding `00 01`
+* `3` has padding `00`
 
 This string representation is a clever way to ensure that the contents
 are always zero-terminated by the padding word and to still compute
 its length efficiently without scanning the whole string. The
 following formula is used:
 
-```
+```text
 number_of_words_in_block * sizeof(word) - last_byte_of_block - 1
 ```
 
@@ -508,7 +503,7 @@ The first word of the data within the custom block is a C pointer to a
 `struct` of custom operations. The custom block cannot have pointers to OCaml
 blocks and is opaque to the GC:
 
-```
+```c
 struct custom_operations {
   char *identifier;
   void (*finalize)(value v);

--- a/data/tutorials/language/5rt_01_garbage-collector.md
+++ b/data/tutorials/language/5rt_01_garbage-collector.md
@@ -79,7 +79,7 @@ explain how they differ in more detail next.
 
 <div class="note">
 
-#### The Gc Module and OCAMLRUNPARAM
+### The Gc Module and OCAMLRUNPARAM
 
 OCaml provides several mechanisms to query and alter the behavior of
 the runtime system. The `Gc` module provides this functionality from
@@ -117,7 +117,7 @@ interruption.
 The minor heap is a contiguous chunk of virtual memory that is usually a few
 megabytes in size so that it can be scanned quickly.
 
-![](/media/tutorials/language/garbage-collector/minor_heap.png "Minor GC heap")
+![Minor GC heap layout](/media/tutorials/language/garbage-collector/minor_heap.png "Minor GC heap")
 
 The runtime stores the boundaries of the minor heap in two pointers that
 delimit the start and end of the heap region (`caml_young_start` and
@@ -295,7 +295,7 @@ allocations. Allocations for these sizes can be serviced from their segregated
 free lists or, if they are empty, from the next size with a space.
 
 The second strategy, for larger allocations, is the use of a specialized data
-structure known as a _splay tree_ for the free list. This is a type of search
+structure known as a *splay tree* for the free list. This is a type of search
 tree that adapts to recent access patterns. For our use this means that the
 most commonly requested allocation sizes are the quickest to access.
 
@@ -377,7 +377,7 @@ available memory.
 The marking process starts with a set of *root* values that are always live
 (such as the application stack and globals). These root values have their
 color set to black and are pushed on to a specialized data structure known as
-the _mark_ stack. Marking proceeds by popping a value from the stack and
+the *mark* stack. Marking proceeds by popping a value from the stack and
 examining its fields. Any fields containing white-colored blocks are changed
 to black and pushed onto the mark stack.
 
@@ -386,7 +386,7 @@ values to mark. There's one important edge case in this process, though. The
 mark stack can only grow to a certain size, after which the GC can no longer
 recurse into intermediate values since it has nowhere to store them while it
 follows their fields. This is known as mark stack *overflow* and a process
-called _pruning_ begins. Pruning empties the mark stack entirely, summarizing
+called *pruning* begins. Pruning empties the mark stack entirely, summarizing
 the addresses of each block as start and end ranges in each heap chunk header.
 
 Later in the marking process when the mark stack is empty it is replenished by
@@ -563,13 +563,13 @@ Benchmark for mutable, immutable
   barrier_bench.exe [COLUMN ...]
 
 Columns that can be specified are:
-	time       - Number of nano secs taken.
-	cycles     - Number of CPU cycles (RDTSC) taken.
-	alloc      - Allocation of major, minor and promoted words.
-	gc         - Show major and minor collections per 1000 runs.
-	percentage - Relative execution time as a percentage.
-	speedup    - Relative execution cost as a speedup.
-	samples    - Number of samples collected for profiling.
+ time       - Number of nano secs taken.
+ cycles     - Number of CPU cycles (RDTSC) taken.
+ alloc      - Allocation of major, minor and promoted words.
+ gc         - Show major and minor collections per 1000 runs.
+ percentage - Relative execution time as a percentage.
+ speedup    - Relative execution cost as a speedup.
+ samples    - Number of samples collected for profiling.
 ...
 ```
 
@@ -583,7 +583,7 @@ been closed, or that a log message is recorded.
 
 <div class="note">
 
-#### What Values Can Be Finalized?
+### What Values Can Be Finalized?
 
 Various values cannot have finalizers attached since they aren't
 heap-allocated. Some examples of values that are not heap-allocated are

--- a/data/tutorials/language/5rt_02_compiler_frontend.md
+++ b/data/tutorials/language/5rt_02_compiler_frontend.md
@@ -62,7 +62,7 @@ archive that can be reused by other applications.
 
 The overall compilation pipeline looks like this:
 
-![](/media/tutorials/language/compiler-frontend/pipeline.png "Compilation pipeline")
+![Compilation pipeline](/media/tutorials/language/compiler-frontend/pipeline.png "Compilation pipeline")
 
 Notice that the pipeline branches toward the end. OCaml has multiple compiler
 backends that reuse the early stages of compilation but produce very
@@ -238,11 +238,11 @@ outside the compiler but is intended to be the long-term replacement.
 Try compiling the HTML documentation and UNIX man pages by running `ocamldoc`
 over the source file:
 
-```
-$ mkdir -p html man/man3
-$ ocamldoc -html -d html doc.ml
-$ ocamldoc -man -d man/man3 doc.ml
-$ man -M man Doc
+```shell
+mkdir -p html man/man3
+ocamldoc -html -d html doc.ml
+ocamldoc -man -d man/man3 doc.ml
+man -M man Doc
 ```
 
 You should now have HTML files inside the `html/`
@@ -258,7 +258,7 @@ integration with dune, as described in ["Generating Documentation"](/docs/genera
 ## Preprocessing with ppx
 
 One powerful feature in OCaml is a facility to extend the standard language via
-_extension points_.  These represent placeholders in the OCaml syntax tree and are
+*extension points*.  These represent placeholders in the OCaml syntax tree and are
 ignored by the standard compiler tooling, beyond being delimited and stored in
 the abstract syntax tree alongside the normal parsed source code. They are
 intended to be expanded by external tools that select extension nodes that can
@@ -266,8 +266,8 @@ interpret them.  The external tools can choose to generate further OCaml code
 by transforming the input syntax tree, thus forming the basis of an extensible
 preprocessor for the language.
 
-There are two primary forms of extension points in OCaml: _attributes_ and
-_extension nodes_.  Let's first run through some examples of what they look
+There are two primary forms of extension points in OCaml: *attributes* and
+*extension nodes*.  Let's first run through some examples of what they look
 like, and then see how to use them in your own code.
 
 ### Extension Attributes
@@ -369,7 +369,7 @@ to generate boilerplate code for handling s-expressions.  These are
 introduced by a third-party library using the `(preprocess)` directive
 in a dune file, for example:
 
-```
+```dune
 (library
  (name hello_world)
  (libraries core)
@@ -380,7 +380,6 @@ This allows you to take advantage of a community of syntax augmentation.
 There are also a number of builtin attributes
 in the core OCaml compiler.  Some are performance oriented and give directives to the compiler,
 whereas others will activate usage warnings. The full list is available in the [attributes section](https://ocaml.org/manual/attributes.html) of the OCaml manual.
-
 
 ### Extension Nodes
 
@@ -401,7 +400,6 @@ handling (`let%bind`), for command-line parsing (`let%map`) or
 inline testing (`let%expect_test`).  Extension nodes are introduced
 via dune rules in the same fashion as extension attributes, via the
 `(preprocess)` attribute.
-
 
 ## Static Type Checking
 
@@ -535,7 +533,6 @@ signature files also speeds up incremental compilation in larger code bases,
 since recompiling a `mli` signature is much faster than a full compilation of
 the implementation to native code.
 </div>
-
 
 ### Type Inference <a name="type-inference-1"></a>
 
@@ -824,7 +821,6 @@ up won't let you violate type safety, but it can result in the type checker
 failing unexpectedly very occasionally. In this case, just recompile with a
 clean source tree.
 
-
 ### Modules and Separate Compilation
 
 The OCaml module system enables smaller components to be reused effectively
@@ -942,7 +938,7 @@ hashes means that a compilation unit with the same module name may have
 conflicting type signatures in different modules. The compiler will reject
 such programs with an error similar to this:
 
-```
+```shell
 $ ocamlc -c foo.ml
 File "foo.ml", line 1, characters 0-1:
 Error: The files /home/build/bar.cmi
@@ -957,7 +953,6 @@ run into it, just clean out your intermediate files and recompile from
 scratch.
 </div>
 
-
 ### Wrapping Libraries with Module Aliases
 
 The module-to-file mapping described so far rigidly enforces a 1:1 mapping
@@ -966,9 +961,9 @@ modules into separate files to make editing easier, but still compile them
 all into a single OCaml module.
 
 Dune provides a very convenient way of doing this for libraries via
-automatically generating a toplevel _module alias_ file that places all the
+automatically generating a toplevel *module alias* file that places all the
 files in a given library as submodules within the toplevel module for
-that library. This is known as _wrapping_ the library, and works as follows.
+that library. This is known as *wrapping* the library, and works as follows.
 
 Let's define a simple library with two files `a.ml` and `b.ml` that each define
 a single value.
@@ -1076,7 +1071,7 @@ import the replacement modules and functions.
 There's one downside to this approach: type errors suddenly get much more
 verbose. We can see this if you run the vanilla OCaml toplevel (not `utop`).
 
-```
+```shell
 $ ocaml
 # List.map print_endline "";;
 Error: This expression has type string but an expression was expected of type
@@ -1086,7 +1081,7 @@ Error: This expression has type string but an expression was expected of type
 This type error without `Core` has a straightforward type error. When we
 switch to Core, though, it gets more verbose:
 
-```
+```shell
 $ ocaml
 # open Core;;
 # List.map ~f:print_endline "";;
@@ -1103,7 +1098,7 @@ causes the compiler to search all the type aliases for the shortest module
 path and use that as the preferred output type. The option is activated by
 passing `-short-paths` to the compiler, and works on the toplevel, too.
 
-```
+```shell
 $ ocaml -short-paths
 # open Core;;
 # List.map ~f:print_endline "foo";;
@@ -1120,7 +1115,6 @@ would be lost in the error if the shortest module path is always picked.
 You'll need to choose for yourself if you prefer short paths or the default
 behavior in your own projects, and pass the `-short-paths` flag to the
 compiler if you need
-
 
 ## The Typed Syntax Tree
 

--- a/data/tutorials/language/5rt_03_compiler_backend.md
+++ b/data/tutorials/language/5rt_03_compiler_backend.md
@@ -180,7 +180,6 @@ It's not essential that you understand all of this just to use pattern
 matching, of course, but it'll give you insight as to why pattern
 matching is such an efficient language construct in OCaml.
 
-
 ### Benchmarking Pattern Matching
 
 Let's benchmark these three pattern-matching techniques to quantify their
@@ -288,7 +287,6 @@ format that we'll cover next. It's often easier to look at the textual output
 from this stage than to wade through the native assembly code from compiled
 executables.
 
-
 ## Generating Portable Bytecode
 
 After the lambda form has been generated, we are very close to having
@@ -331,19 +329,19 @@ examples:
 
 ```sh dir=examples/back-end
 $ ocamlc -dinstr pattern_monomorphic_small.ml 2>&1
-	branch L2
-L1:	acc 0
-	branchifnot L3
-	const 101
-	return 1
-L3:	const 100
-	return 1
-L2:	closure L1, 0
-	push
-	acc 0
-	makeblock 1, 0
-	pop 1
-	setglobal Pattern_monomorphic_small!
+ branch L2
+L1: acc 0
+ branchifnot L3
+ const 101
+ return 1
+L3: const 100
+ return 1
+L2: closure L1, 0
+ push
+ acc 0
+ makeblock 1, 0
+ pop 1
+ setglobal Pattern_monomorphic_small!
 ```
 
 The preceding bytecode has been simplified from the lambda form into a set of
@@ -356,7 +354,7 @@ arity). You can find full details
 
 <div class="note">
 
-#### Where Did the Bytecode Instruction Set Come From?
+### Where Did the Bytecode Instruction Set Come From?
 
 The bytecode interpreter is much slower than compiled native code, but is
 still remarkably performant for an interpreter without a JIT compiler. Its
@@ -374,7 +372,6 @@ Understanding the reasoning behind the different implementations of the
 bytecode interpreter and the native compiler is a very useful exercise for
 any budding language hacker.
 </div>
-
 
 ### Compiling and Linking Bytecode
 
@@ -415,8 +412,8 @@ other libraries that aren't loaded by default.
 Information about these extra libraries can be specified while linking a
 bytecode archive:
 
-```
-$ ocamlc -a -o mylib.cma a.cmo b.cmo -dllib -lmylib
+```shell
+ocamlc -a -o mylib.cma a.cmo b.cmo -dllib -lmylib
 ```
 
 The `dllib` flag embeds the arguments in the archive file. Any subsequent
@@ -428,8 +425,8 @@ You can also generate a complete standalone executable that bundles the
 `ocamlrun` interpreter with the bytecode in a single binary. This is known as
 a *custom runtime* mode and is built as follows:
 
-```
-$ ocamlc -a -o mylib.cma -custom a.cmo b.cmo -cclib -lmylib
+```shell
+ocamlc -a -o mylib.cma -custom a.cmo b.cmo -cclib -lmylib
 ```
 
 The custom mode is the most similar mode to native code compilation, as both
@@ -473,15 +470,13 @@ Create two OCaml source files that contain a single print line:
 let () = print_endline "hello embedded world 1"
 ```
 
-
-
 ```ocaml file=examples/back-end-embed/embed_me2.ml
 let () = print_endline "hello embedded world 2"
 ```
 
 Next, create a C file to be your main entry point:
 
-```
+```c
 #include <stdio.h>
 #include <caml/alloc.h>
 #include <caml/mlvalues.h>
@@ -502,15 +497,15 @@ main (int argc, char **argv)
 Now compile the OCaml files into a standalone object file:
 
 ```sh dir=examples/back-end-embed
-$ rm -f embed_out.c
-$ ocamlc -output-obj -o embed_out.o embed_me1.ml embed_me2.ml
+rm -f embed_out.c
+ocamlc -output-obj -o embed_out.o embed_me1.ml embed_me2.ml
 ```
 
 After this point, you no longer need the OCaml compiler, as `embed_out.o` has
 all of the OCaml code compiled and linked into a single object file. Compile
 an output binary using `gcc` to test this out:
 
-```
+```shell
 $ gcc -fPIC -Wall -I`ocamlc -where` -L`ocamlc -where` -ltermcap -lm -ldl \
   -o finalbc.native main.c embed_out.o -lcamlrun
 $ ./finalbc.native
@@ -526,7 +521,7 @@ You can even obtain the C source code to the `-output-obj` result by
 specifying a `.c` output file extension instead of the `.o` we used earlier:
 
 ```sh dir=examples/back-end-embed
-$ ocamlc -output-obj -o embed_out.c embed_me1.ml embed_me2.ml
+ocamlc -output-obj -o embed_out.c embed_me1.ml embed_me2.ml
 ```
 
 Embedding OCaml code like this lets you write OCaml that interfaces with any
@@ -604,7 +599,7 @@ let cmp (a:int) (b:int) =
 Now compile this into assembly and read the resulting `compare_mono.S` file.
 
 ```sh dir=examples/back-end,skip
-$ ocamlopt -S compare_mono.ml
+ocamlopt -S compare_mono.ml
 ```
 
 This file extension may be lowercase on some platforms such as Linux.
@@ -614,7 +609,7 @@ we'll try to give you some basic instructions to spot patterns in this
 section. The excerpt of the implementation of the `cmp` function can be found
 below:
 
-```
+```asm
 _camlCompare_mono__cmp_1008:
         .cfi_startproc
 .L101:
@@ -647,7 +642,7 @@ let cmp a b =
 Compiling this code with `-S` results in a significantly more complex
 assembly output for the same function:
 
-```
+```asm
 _camlCompare_poly__cmp_1008:
         .cfi_startproc
         subq    $24, %rsp
@@ -761,7 +756,6 @@ accessing them through the `Stdlib` module, as we did in our
 benchmark.
 </div>
 
-
 ### Debugging Native Code Binaries
 
 The native code compiler builds executables that can be debugged using
@@ -850,7 +844,7 @@ $ ./_build/default/alternate_list.exe -ascii -quota 1
 
 Now we can run this interactively within `gdb`:
 
-```
+```text
 $ gdb ./alternate_list.native
 GNU gdb (GDB) 7.4.1-debian
 Copyright (C) 2012 Free Software Foundation, Inc.
@@ -868,7 +862,7 @@ Reading symbols from /home/avsm/alternate_list.native...done.
 The `gdb` prompt lets you enter debug directives. Let's set the program to
 break just before the first call to `take`:
 
-```
+```text
 (gdb) break camlAlternate_list__take_69242
 Breakpoint 1 at 0x5658d0: file alternate_list.ml, line 5.
 ```
@@ -880,7 +874,7 @@ possible completions.
 
 Once you've set the breakpoint, start the program executing:
 
-```
+```text
 (gdb) run
 Starting program: /home/avsm/alternate_list.native
 [Thread debugging using libthread_db enabled]
@@ -895,7 +889,7 @@ waiting for further instructions. GDB has lots of features, so let's
 continue the program and check the backtrace after a couple of
 recursions:
 
-```
+```text
 (gdb) cont
 Continuing.
 
@@ -935,7 +929,6 @@ same stack. This means that GDB backtraces can give you a combined view of
 what's going on in your program *and* runtime library. This includes any
 calls to C libraries or even callbacks into OCaml from the C layer if you're
 in an environment which embeds the OCaml runtime as a library.
-
 
 ### Profiling Native Code
 
@@ -978,7 +971,7 @@ Run Perf on a compiled binary to record information first. We'll use our
 write barrier benchmark from earlier, which measures memory allocation versus
 in-place modification:
 
-```
+```shell
 $ perf record -g ./barrier_bench.native
 Estimated testing time 20s (change using -quota SECS).
 
@@ -1003,7 +996,7 @@ Estimated testing time 20s (change using -quota SECS).
 
 When this completes, you can interactively explore the results:
 
-```
+```shell
 $ perf report -g
 +  48.86%  barrier.native  barrier.native  [.] camlBarrier__test_immutable_69282
 +  30.22%  barrier.native  barrier.native  [.] camlBarrier__test_mutable_69279
@@ -1042,13 +1035,12 @@ opam provides a compiler switch that compiles OCaml with the frame pointer
 activated:
 
 ```sh skip
-$ opam switch create 4.13+fp ocaml-variants.4.13.1+options ocaml-option-fp
+opam switch create 4.13+fp ocaml-variants.4.13.1+options ocaml-option-fp
 ```
 
 Using the frame pointer changes the OCaml calling convention, but opam takes
 care of recompiling all your libraries with the new interface.
 </div>
-
 
 ### Embedding Native Code in C
 
@@ -1063,7 +1055,7 @@ installed as `libasmrun.a` in the OCaml standard library directory.
 Try this custom linking by using the same source files from the bytecode
 embedding example earlier in this chapter:
 
-```
+```shell
 $ ocamlopt -output-obj -o embed_native.o embed_me1.ml embed_me2.ml
 $ gcc -Wall -I `ocamlc -where` -o final.native embed_native.o main.c \
    -L `ocamlc -where` -lasmrun -ltermcap -lm -ldl

--- a/data/tutorials/platform/0_01_managing_deps.md
+++ b/data/tutorials/platform/0_01_managing_deps.md
@@ -12,7 +12,7 @@ We recommend installing a project's dependencies in a local opam switch to sandb
 
 If you're using opam `2.0.X`, you can do this with:
 
-```
+```shell
 # if you need external system dependencies
 opam pin add -n .
 opam depext -i <packages>
@@ -21,32 +21,32 @@ opam install . --deps-only --with-test --with-doc
 
 If you use opam `2.1.X`, it will install the system dependencies automatically, so you can run:
 
-```
+```shell
 opam install . --deps-only --with-test --with-doc
 ```
 
 Now, if for some reason you prefer to install your dependencies in a global switch, you can run:
 
-```
+```shell
 opam switch set <switch_name>
 opam install . --deps-only --with-test --with-doc
 ```
 
 Once the dependencies have been installed successfully, and assuming the project uses Dune as the build system, you can compile it with:
 
-```
+```shell
 opam exec -- dune build
 ```
 
 Or if you set your environment with `eval $(opam env)`:
 
-```
+```shell
 dune build
 ```
 
 ## Adding Dependencies From the opam Repository
 
-To avoid duplicating the project configuration into multiple files, Dune allows you to generate the project's `*.opam` file from the 
+To avoid duplicating the project configuration into multiple files, Dune allows you to generate the project's `*.opam` file from the
 package definitions in `dune-project` when adding the `(generate_opam_files true)` stanza.
 
 However, opam remains a central piece of the ecosystem, and it's very likely that you will have to work with `*.opam` files at some point,
@@ -74,7 +74,6 @@ Once you have added your dependency, you can build your project with `dune build
 ### Adding a Dependency to Your .opam File
 
 If the `*.opam` files are not generated, you can add the dependencies in them directly in the `depends` field. It should look like this:
-
 
 ```opam
 opam-version: "2.0"
@@ -107,14 +106,14 @@ Either way, once you have added your dependency in the appropriate file, you can
 ### Installing a Dependency in Your Switch
 
 Installing a package from the opam repository to your active switch, you can run
-```
+```shell
 opam install <package-name>
 ```
 
 to get the latest version of the package.
 
 If you want to install a specific version of the package, use
-```
+```shell
 opam install <package-name>.<package-version>
 ```
 
@@ -134,19 +133,19 @@ If your project does not have a file matching the name of your project's `.opam`
 
 For example, if your project's opam file is `my_project.opam`, create `my_project.opam.template` and use `pin-depends` to tell `opam` to install a package from a Git repository.
 
-```
+```opam
 pin-depends: [
   ["<package-name>.dev" "git+https://<repository-url>#<branch-or-commit>"]
 ]
 ```
 
 Next, regenerate the `.opam` file of your project by running
-```
+```shell
 opam exec -- dune build
 ```
 
 Then, run
-```
+```shell
 opam install . --deps-only
 ```
 
@@ -158,7 +157,7 @@ To open your opam file, locate the `opam` file for your OCaml project. This file
 
 Add the `pin-depends` field in the `opam` file if it doesn't exist. Inside this field, you specify the package and the URL from which it should be fetched. For example:
 
-```
+```opam
 pin-depends: [
   ["<package-name>.dev" "git+https://<repository-url>#<branch-or-commit>"]
 ]
@@ -166,7 +165,7 @@ pin-depends: [
 
 Finally, use opam install to install the dependencies, including the one specified in the `pin-depends` field.
 
-```
+```shell
 opam install . --deps-only
 ```
 
@@ -174,7 +173,7 @@ opam install . --deps-only
 
 You can install a package in your active switch directly from a Git URL:
 
-```
+```shell
 opam pin add <package-name> <git-url>#<branch-or-commit>
 ```
 

--- a/data/tutorials/platform/0_02_install_compiler.md
+++ b/data/tutorials/platform/0_02_install_compiler.md
@@ -8,14 +8,14 @@ category: "Projects"
 ---
 
 > **TL;DR**
-> 
+>
 > Use `opam switch set` to manually select the switch to use and use `dune-workspace` to automatically run commands in different environments.
 
 Compilation environments are managed with opam switches. The typical workflow is to have a local opam switch for the project, but you may need to select a different compilation environment (i.e. a different compiler version) sometimes. For instance, to run unit tests on an older/newer version of OCaml.
 
 To do this, you'll need to create global opam switches. To create an opam switch with a given version of the compiler, you can use:
 
-```
+```shell
 opam switch create 4.14.0 ocaml-base-compiler.4.14.0
 ```
 
@@ -23,7 +23,7 @@ This will create a new switch called `4.14.0` with the compiler version `4.14.0`
 
 The list of available compiler versions can be retrieved with:
 
-```
+```shell
 opam switch list-available
 ```
 
@@ -31,7 +31,7 @@ This will list the available compiler versions for all of the configured Opam re
 
 Once you've created a switch (or you already have a switch you'd like to use), you can run:
 
-```
+```shell
 opam switch set <switch_name>
 eval $(opam env)
 ```
@@ -42,8 +42,7 @@ If it is a new switch, you will need to reinstall your dependencies (see "Instal
 
 Alternatively, you may want to automatically run commands in a given set of compilation environments. To do this, you can create a file `dune-workspace` at the root of your project and list the opam switches you'd like to use there:
 
-
-```
+```dune
 (lang dune 2.0)
 (context (opam (switch 4.11.0)))
 (context (opam (switch 4.12.0)))
@@ -52,7 +51,7 @@ Alternatively, you may want to automatically run commands in a given set of comp
 
 All the Dune commands you run will be run on all of the switches listed. For instance with the definition above:
 
-```
+```shell
 dune runtest --workspace dune-workspace
 ```
 

--- a/data/tutorials/platform/0_03_run_executables_and_tests.md
+++ b/data/tutorials/platform/0_03_run_executables_and_tests.md
@@ -10,7 +10,7 @@ category: "Projects"
 ## Running Executables
 
 > **TL;DR**
-> 
+>
 > Add an `executable` stanza in your `dune` file and run the executable with `dune exec <executable_path>.exe` or `dune exec <public_name>`.
 
 To tell Dune to produce an executable, you can use the executable stanza:
@@ -48,10 +48,11 @@ Keep in mind:
 * `dune build --watch` monitors files and triggers necessary recompilation.
 * Dune locks the build directory, so you can't run two Dune commands simultaneously.
 * To run the application, stop the watch process (Ctrl-C) or execute the app directly with `_build\default\<executable_path>.exe`.
+
 ## Running Tests
 
 > **TL;DR**
-> 
+>
 > Add a `test` stanza in your `dune` file and run the tests with `dune test`.
 
 Tests are created using Dune's `test` stanza. The `test` stanza is a simple convenience wrapper that will create an executable and add it to the list of tests of the `@runtest` target.
@@ -72,7 +73,7 @@ let () = exit 1
 
 Running `dune test` will fail with the following output:
 
-```
+```text
   dummy_test alias src/ocamlorg_web/test/runtest (exit 1)
 ```
 
@@ -110,8 +111,7 @@ let () =
 
 If we run `dune test` again, the test should be successful and output the following:
 
-
-```
+```text
 Testing `Dummy'.
 This run has ID `B5926D16-0DD4-4C97-8C7A-5AFE1F5DF31B'.
 

--- a/data/tutorials/platform/0_09_opam_path.md
+++ b/data/tutorials/platform/0_09_opam_path.md
@@ -14,23 +14,24 @@ The `opam env` command is used to set environment variables for a specific opam 
 
 Usage:
 ```bash
-$ eval "$(opam env)"
+eval "$(opam env)"
 ```
 
 This command evaluates the output of opam env and sets the necessary environment variables for the currently active switch. After running this command, you'll have access to the packages installed in the opam switch.
 
 ## Using `opam exec`
+
 The opam exec command allows you to run a command in the context of a specific opam switch without modifying your shell environment.
 
 Usage:
 ```bash
-$ opam exec -- <command>
+opam exec -- <command>
 ```
 Replace `<command>` with the actual command you want to run. This ensures that the command is executed within the opam switch's environment.
 
 Example:
 ```bash
-$ opam exec -- ocaml
+opam exec -- ocaml
 ```
 
 This will launch the version of the OCaml REPL within the context of the current opam switch.
@@ -43,35 +44,35 @@ This will launch the version of the OCaml REPL within the context of the current
 
 Ensure `direnv` is installed on your system. You can install it using a package manager or follow the instructions on the official website.
 
-2. Setup `direnv` integration
+1. Setup `direnv` integration
 
 Add the following line to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`):
 ```bash
-$ eval "$(direnv hook <shell>)"
+eval "$(direnv hook <shell>)"
 ```
 Replace `<shell>` with your actual shell type (`bash`, `zsh`, `fish`, etc.).
 
-3. Configure opam with `direnv`
+1. Configure opam with `direnv`
 
 In your OCaml project directory, create a file named `.envrc` and add the following line to automatically load the opam environment:
 ```bash
 eval $(opam env)
 ```
 
-4. Allow `direnv`
+1. Allow `direnv`
 
 Navigate to your project directory and run the following command to allow `direnv` to load the environment:
 ```bash
-$ direnv allow
+direnv allow
 ```
 
 This command activates `direnv` for the current directory, ensuring that the opam switch environment is loaded whenever you enter the directory.
 
-5. Usage
+1. Usage
 
 Now, whenever you navigate to your OCaml project directory, `direnv` will automatically activate the opam switch environment specified in your `.envrc` file. This eliminates the need to manually run `opam env` each time you work on your project.
 
-6. Example
+1. Example
 
 Suppose you have an OCaml project in directory `disco` and a local opam switch is associated with it, and a `.envrc` file in that directory containing the following:
 ```bash
@@ -79,18 +80,18 @@ eval $(opam env)
 ```
 After running `direnv allow`, `direnv` will handle the opam switch activation for you.
 
-7. Messages from `direnv`
+1. Messages from `direnv`
 
 Whenever entering or leaving a `direnv` managed directory, you will be informed of the actions performed.
 
 On entrance:
-```
+```text
 direnv: loading ~/caml/ocaml.org/.envrc
 direnv: export ~CAML_LD_LIBRARY_PATH ~MANPATH ~OCAML_TOPLEVEL_PATH ~OPAM_SWITCH_PREFIX ~PATH
 ```
 
 On exit:
-```
+```text
 direnv: loading ~/.envrc
 direnv: export ~PATH
 ```

--- a/data/tutorials/platform/1_07_ocamlformat.md
+++ b/data/tutorials/platform/1_07_ocamlformat.md
@@ -13,7 +13,7 @@ An empty file is accepted, but since different versions of OCamlFormat will vary
 is good practice to specify the version you're using. Running
 
 ```shell
-$ echo "version = `ocamlformat --version`" > .ocamlformat
+echo "version = `ocamlformat --version`" > .ocamlformat
 ```
 
 creates a configuration file for the currently installed version of OCamlFormat.
@@ -21,5 +21,5 @@ creates a configuration file for the currently installed version of OCamlFormat.
 In addition to editor plugins that use OCamlFormat for automatic code formatting, Dune also offers a command to run OCamlFormat to automatically format all files from your codebase:
 
 ```shell
-$ opam exec -- dune fmt
+opam exec -- dune fmt
 ```

--- a/data/tutorials/platform/2_08_odoc.md
+++ b/data/tutorials/platform/2_08_odoc.md
@@ -26,7 +26,7 @@ $ explorer _build\default\_doc\_html\index.html
 Alternatively, you can use the `dune ocaml doc` command, which builds the documentation and automatically opens it in your web browser:
 
 ```shell
-$ dune ocaml doc
+dune ocaml doc
 ```
 
 This is a convenient shortcut that combines the build and open steps into a single command.
@@ -43,7 +43,7 @@ To make Dune find your `.mld` pages and process them with `odoc`,
 the `dune` file in the same directory as your `.mld` files needs to
 include this stanza:
 
-```
+```dune
 (documentation
  (package name-of-your-package))
 ```

--- a/data/tutorials/platform/3_04_create_libraries.md
+++ b/data/tutorials/platform/3_04_create_libraries.md
@@ -8,7 +8,7 @@ category: "Libraries & Packages"
 ---
 
 > **TL;DR**
-> 
+>
 > Add a `library` stanza in your `dune` file.
 
 Creating a library with dune is as simple as adding a `library` stanza in your dune file:

--- a/data/tutorials/platform/3_05_publish_packages.md
+++ b/data/tutorials/platform/3_05_publish_packages.md
@@ -8,7 +8,7 @@ category: "Libraries & Packages"
 ---
 
 > **TL;DR**
-> 
+>
 > Create a `CHANGES.md` file and run `dune-release bistro`.
 
 The opam package manager may differ from the package manager you're used to. In order to ensure the highest stability of the ecosystem, each package publication goes through two processes:
@@ -26,7 +26,7 @@ This is a heavy process, but hopefully, all of it is completely automated on the
 
 Once you're ready to publish your package on opam, simply create a `CHANGES.md` file with the following format:
 
-```
+```text
 # <version>
 
 <release note>


### PR DESCRIPTION
Follow-up to #3491 - this fixes all the markdownlint violations across the tutorial files (469 issues, now down to 0).

The bulk of the changes:

- **Code block languages** (~86 blocks): added `ocaml`, `shell`, `text`, `dune`, `opam`, `c`, `asm` tags as appropriate
- **Consistent formatting**: unified list markers, emphasis style, removed trailing whitespace and extra blank lines
- **Heading fixes**: fixed levels that skip (e.g. h2 -> h4), converted bold text used as pseudo-headings to proper headings
- **Links**: fixed broken internal anchors, replaced non-descriptive link text like "[here]" and "[more]" with meaningful text
- **Images**: added missing alt text
- **Other**: fixed ordered list numbering, indentation, code span spacing, line length in one heading