### PR TITLE
Remove dead code: unused function and stale build dep

### DIFF
--- a/dune
+++ b/dune
@@ -17,7 +17,6 @@
   (target planet.xml)
   (deps
    (source_tree %{project_root}/data/planet)
-   (source_tree %{project_root}/data/planet-local-blogs)
    (:gen_feed %{project_root}/tool/ood-gen/bin/feed.exe))
   (action
    (chdir

--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -65,7 +65,6 @@ let conferences = "/conferences"
 let conference v = "/conferences/" ^ v
 let ocaml_planet = "/ocaml-planet"
 let local_blog source = "/blog/" ^ source
-let blog_post source v = "/blog/" ^ source ^ "/" ^ v
 let news = "/news"
 let news_post v = "/news/" ^ v
 let jobs = "/jobs"


### PR DESCRIPTION
I noticed a couple of small bits of dead code while poking around the codebase:

- **`Url.blog_post`** in `src/global/url.ml` — this function isn't called anywhere. `local_blog` is used, but `blog_post` appears to be a leftover.
- **`planet-local-blogs` source_tree dep** in the root `dune` file — references `data/planet-local-blogs/`, which doesn't exist. Likely from an earlier iteration of the planet feed setup.

Neither removal affects any functionality. Just tidying things up.