### PR TITLE
Skip scheduled scraping workflows on forks

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   scrape:
     name: Run Scrapers
+    if: github.event_name != 'schedule' || github.repository == 'ocaml/ocaml.org'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/scrape_platform_releases.yml
+++ b/.github/workflows/scrape_platform_releases.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   scrape:
     name: Run Scrapers
+    if: github.event_name != 'schedule' || github.repository == 'ocaml/ocaml.org'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
- Forks inherit the daily cron schedule from `scrape.yml` and `scrape_platform_releases.yml`, causing unnecessary CI failures and email notifications
- Add an `if` condition so scheduled runs only execute in `ocaml/ocaml.org`
- Manual dispatch (`workflow_dispatch`) remains available in all forks

## Test plan
- [ ] Verify scheduled scrape workflows no longer trigger on forks
- [ ] Verify manual dispatch still works on forks
- [ ] Verify scheduled runs continue working on `ocaml/ocaml.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)