### PR TITLE
Update planet sources: disable dead feeds, add Rocq Prover

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -29,6 +29,7 @@
 - id: ujamjar
   name: Andy Ray
   url: http://www.ujamjar.com/ocaml.xml
+  disabled: true
 - id: ashishagarwal
   name: Ashish Agarwal
   url: http://ashishagarwal.org/tag/ocaml/feed/
@@ -45,6 +46,11 @@
 - id: coq
   name: Coq
   url: https://coq.inria.fr/rss.xml
+  publish_all: false
+  disabled: true
+- id: rocq
+  name: Rocq Prover
+  url: https://rocq-prover.org/news.xml
   publish_all: false
 - id: cburnout
   name: Cranial Burnout


### PR DESCRIPTION
## Summary

- Disable `ujamjar` feed (domain taken over by a casino spam site)
- Disable `coq` feed (`coq.inria.fr` now 301-redirects to `rocq-prover.org`, old `/rss.xml` returns 404)
- Add `rocq` as a new source (`https://rocq-prover.org/news.xml`)

Both disabled sources keep their entries so existing blog posts under `data/planet/ujamjar/` and `data/planet/coq/` still resolve.

## Context

- #3512 tracks the YouTube RSS feed platform-wide outage
- #3513 tracks river library improvements (timeout increase, User-Agent header)

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)