### PR TITLE
Remove pin on aantron/river fork, use stock river 0.4

### DIFF
--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -70,6 +70,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
-pin-depends: [
-  ["river.dev" "git+https://github.com/aantron/river#476dc945a908a69548bddd267f143a3e5d9c8a1a"]
-]
+

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,3 +1,1 @@
-pin-depends: [
-  ["river.dev" "git+https://github.com/aantron/river#476dc945a908a69548bddd267f143a3e5d9c8a1a"]
-]
+


### PR DESCRIPTION
## Summary

- Remove the `pin-depends` on `aantron/river` fork from `ocamlorg.opam.template`
- Stock `river.0.4` from opam-repository works correctly

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes (16/16)
- [x] `make scrape_ocaml_planet` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)