### PR TITLE
chore: Disable MD060 (table-column-style) in markdownlint config

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -22,6 +22,8 @@
         // Allow inline HTML
         "MD033": false,
         // First line in a file doesn't need to be a top-level header
-        "MD041": false
+        "MD041": false,
+        // Allow any table column style (compact, padded, etc.)
+        "MD060": false
     }
 }


### PR DESCRIPTION
The MD060 rule (added in markdownlint v0.37+) enforces a single table column style, but existing content uses a mix of compact and padded table formatting. Disable it to avoid false positives.