### PR TITLE
Changelog(fix): Include tool name in release announcement titles

### DIFF
--- a/data/platform_releases/merlin/2025-12-20-merlin-v5.6.1-504.md
+++ b/data/platform_releases/merlin/2025-12-20-merlin-v5.6.1-504.md
@@ -1,5 +1,5 @@
 ---
-title: 5.6.1-504
+title: Merlin 5.6.1-504
 tags:
 - merlin
 - platform

--- a/data/platform_releases/opam-publish/2025-11-18-opam-publish-2.7.1.md
+++ b/data/platform_releases/opam-publish/2025-11-18-opam-publish-2.7.1.md
@@ -1,5 +1,5 @@
 ---
-title: 2.7.1
+title: opam-publish 2.7.1
 tags:
 - opam-publish
 - platform

--- a/data/platform_releases/opam/2025-11-20-opam-2.5.0-rc1.md
+++ b/data/platform_releases/opam/2025-11-20-opam-2.5.0-rc1.md
@@ -1,5 +1,5 @@
 ---
-title: 2.5.0~rc1
+title: opam 2.5.0~rc1
 tags:
 - opam
 - platform

--- a/data/platform_releases/opam/2025-11-27-opam-2.5.0.md
+++ b/data/platform_releases/opam/2025-11-27-opam-2.5.0.md
@@ -1,5 +1,5 @@
 ---
-title: 2.5.0
+title: opam 2.5.0
 tags:
 - opam
 - platform


### PR DESCRIPTION
The titles for opam-publish 2.7.1, opam 2.5.0, opam 2.5.0~rc1, and Merlin 5.6.1-504 were bare version numbers. Add the tool name so they display correctly on the changelog and backstage pages.