### PR TITLE
(docs) Rewrite opam switches tutorial and managing dependencies tutorials for newcomers

### DIFF
--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -28,10 +28,10 @@ There are two kinds of switches:
 Before creating a switch, you'll need to pick a compiler version:
 
 ```shell
-opam switch list-available
+opam switch list-available ocaml-base-compiler
 ```
 
-This shows all OCaml compiler versions you can install. Pick the latest stable version unless you have a reason not to.
+This lists all available compiler versions. Pick the latest stable version unless you have a reason not to.
 
 ## Creating a Global Switch
 
@@ -64,6 +64,8 @@ eval $(opam env)
 ```
 
 This creates an `_opam/` directory in your project. Whenever you `cd` into this directory, opam will automatically select this switch.
+
+If the directory contains `.opam` files, opam will automatically install their dependencies into the new switch. You can prevent this with `opam switch create . 5.4.0 --no-install`.
 
 ## Listing Your Switches
 

--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -77,7 +77,7 @@ opam switch list
 
 The arrow `->` marks the currently active switch:
 
-```
+```shell
 #   switch                      compiler      description
 ->  /home/user/my_project       ocaml.5.4.0   /home/user/my_project
     default                     ocaml.5.4.0   default

--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -4,6 +4,8 @@ title: Introduction to opam Switches
 description: |
   This page will give you a brief introduction to opam switches, what they're used for, and how to create them.
 category: "Tooling"
+recommended_next_tutorials:
+  - "managing-dependencies"
 ---
 
 ## What Is an opam Switch?

--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -33,6 +33,8 @@ opam switch list-available ocaml-base-compiler
 
 This lists all available compiler versions. Pick the latest stable version unless you have a reason not to.
 
+Omitting `ocaml-base-compiler` shows the full list, including compiler variants with additional options enabled (such as flambda optimisations or frame pointers). These are useful for advanced use cases but not needed to get started.
+
 ## Creating a Global Switch
 
 To create a named global switch:

--- a/data/tutorials/platform/0_01_managing_deps.md
+++ b/data/tutorials/platform/0_01_managing_deps.md
@@ -103,21 +103,21 @@ build: [
 
 Either way, once you have added your dependency in the appropriate file, you can run `opam install . --deps-only` to update your current switch dependencies.
 
-### Installing a Dependency in Your Switch
+## Installing a Package Directly
 
-Installing a package from the opam repository to your active switch, you can run
+To quickly install a package into your active switch without declaring it in your project files:
+
 ```shell
 opam install <package-name>
 ```
 
-to get the latest version of the package.
+Or a specific version:
 
-If you want to install a specific version of the package, use
 ```shell
 opam install <package-name>.<package-version>
 ```
 
-instead.
+This is handy for trying out a library, but for project work you should declare the dependency in your `dune-project` or `*.opam` file (as described above) so that collaborators and CI can reproduce your setup with `opam install . --deps-only`.
 
 ## Adding Dependencies From a Git Repository
 

--- a/data/tutorials/platform/0_01_managing_deps.md
+++ b/data/tutorials/platform/0_01_managing_deps.md
@@ -4,31 +4,31 @@ title: "Managing Dependencies With opam"
 description: |
   How to manage dependencies with opam
 category: "Projects"
+prerequisite_tutorials:
+  - "opam-switch-introduction"
 ---
 
 ## Installing Existing Dependencies
 
-We recommend installing a project's dependencies in a local opam switch to sandbox your development environment.
+We recommend installing a project's dependencies in a [local opam switch](/docs/opam-switch-introduction) to sandbox your development environment. If you haven't created one yet, run `opam switch create .` from your project directory first.
 
-If you're using opam `2.0.X`, you can do this with:
+Before installing, make sure your package index is up to date:
 
 ```shell
-# if you need external system dependencies
-opam pin add -n .
-opam depext -i <packages>
-opam install . --deps-only --with-test --with-doc
+opam update
 ```
 
-If you use opam `2.1.X`, it will install the system dependencies automatically, so you can run:
+Then install the project's dependencies:
 
 ```shell
 opam install . --deps-only --with-test --with-doc
 ```
 
-Now, if for some reason you prefer to install your dependencies in a global switch, you can run:
+If you prefer to install your dependencies in a global switch instead, select it first:
 
 ```shell
 opam switch set <switch_name>
+eval $(opam env)
 opam install . --deps-only --with-test --with-doc
 ```
 
@@ -78,7 +78,7 @@ If the `*.opam` files are not generated, you can add the dependencies in them di
 ```opam
 opam-version: "2.0"
 synopsis: "A short, but powerful statement about your project"
-description: "An complete and exhaustive description everything your project does."
+description: "A complete and exhaustive description of everything your project does."
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune"
@@ -177,34 +177,25 @@ You can install a package in your active switch directly from a Git URL:
 opam pin add <package-name> <git-url>#<branch-or-commit>
 ```
 
-## Dealing With Development-Only Dependencies
+## Dependency Categories
 
-Opam does not have a notion of development dependencies. Instead, each dependency can be either:
+Each dependency in opam can be tagged with a flag to indicate when it is needed:
 
-- A normal dependency (used at runtime)
-- A build dependency (used to build the project)
-- A test dependency (used to test the project)
-- A documentation dependency (used to generate the documentation)
+- **Normal** (no flag): used at runtime
+- **Build** (`build`): used only to build the project
+- **Test** (`with-test`): used only to run tests
+- **Documentation** (`with-doc`): used only to generate documentation
 
-When adding a new dependency, as seen in the "Update Dependencies" workflow, you can add a flag to your dependency.
-
-For `dune-project`, it looks like this:
+In `dune-project`, flags look like this:
 
 ```dune
 (alcotest :with-test)
 ```
 
-And for the `*.opam` file, it looks like:
+In `*.opam` files:
 
 ```opam
 "alcotest" {with-test}
 ```
-
-The available flags for each dependency are:
-
-- Normal: no flag
-- Build: `build`
-- Test: `with-test`
-- Documentation: `with-doc`
 
 See [opam documentation](https://opam.ocaml.org/doc/Manual.html#Package-variables) for more details on the opam syntax.


### PR DESCRIPTION
Restructure the introduction to opam switches into a step-by-step walkthrough: concept, global vs local, creating, listing, switching, and removing. Add eval $(opam env) prominently, show local switch creation, add switch removal, and update examples to OCaml 5.4.0.