### PR TITLE
fix: remove debug output from data-packer to fix broken RSS feeds

### DIFF
--- a/tool/data-packer/lib/packer.ml
+++ b/tool/data-packer/lib/packer.ml
@@ -16,140 +16,51 @@ let pack_to_file ~output data =
     output_char oc (Bigstringaf.get buf i)
   done;
   close_out oc;
-  Printf.printf "Packed %d bytes to %s\n" (Bigstringaf.length buf) output
+  Printf.eprintf "Packed %d bytes to %s\n" (Bigstringaf.length buf) output
 
 let load_all () =
-  Printf.printf "Loading data from %s\n" (Fpath.to_string Utils.root_dir);
-
-  (* Simple YAML data *)
   let testimonials = Testimonial_parser.all () in
-  Printf.printf "  Loaded %d testimonials\n" (List.length testimonials);
-
   let academic_testimonials = Academic_testimonial_parser.all () in
-  Printf.printf "  Loaded %d academic_testimonials\n"
-    (List.length academic_testimonials);
-
   let jobs = Job_parser.all () in
-  Printf.printf "  Loaded %d jobs\n" (List.length jobs);
-
   let opam_users = Opam_user_parser.all () in
-  Printf.printf "  Loaded %d opam_users\n" (List.length opam_users);
-
   let resources = Resource_parser.all () in
-  Printf.printf "  Loaded %d resources\n" (List.length resources);
-
   let featured_resources = Resource_parser.featured () in
-  Printf.printf "  Loaded %d featured_resources\n"
-    (List.length featured_resources);
-
   let videos = Video_parser.all () in
-  Printf.printf "  Loaded %d videos\n" (List.length videos);
-
-  (* Markdown-based content *)
   let academic_institutions = Academic_institution_parser.all () in
-  Printf.printf "  Loaded %d academic_institutions\n"
-    (List.length academic_institutions);
-
   let books = Book_parser.all () in
-  Printf.printf "  Loaded %d books\n" (List.length books);
-
   let code_examples = Code_example_parser.all () in
-  Printf.printf "  Loaded %d code_examples\n" (List.length code_examples);
-
   let papers = Paper_parser.all () in
-  Printf.printf "  Loaded %d papers\n" (List.length papers);
-
   let tools = Tool_parser.all () in
-  Printf.printf "  Loaded %d tools\n" (List.length tools);
-
   let releases = Release_parser.all () in
-  Printf.printf "  Loaded %d releases\n" (List.length releases);
-
   let release_latest =
     try Some (Release_parser.latest ()) with Invalid_argument _ -> None
   in
-  Printf.printf "  Loaded release_latest: %s\n"
-    (match release_latest with Some r -> r.version | None -> "none");
-
   let release_lts =
     try Some (Release_parser.lts ()) with Invalid_argument _ -> None
   in
-  Printf.printf "  Loaded release_lts: %s\n"
-    (match release_lts with Some r -> r.version | None -> "none");
-
   let success_stories = Success_story_parser.all () in
-  Printf.printf "  Loaded %d success_stories\n" (List.length success_stories);
-
   let industrial_users = Industrial_user_parser.all () in
-  Printf.printf "  Loaded %d industrial_users\n" (List.length industrial_users);
-
   let news = News_parser.all () in
-  Printf.printf "  Loaded %d news\n" (List.length news);
-
   let events = Event_parser.all () in
-  Printf.printf "  Loaded %d events\n" (List.length events);
-
   let recurring_events = Event_parser.recurring_event_all () in
-  Printf.printf "  Loaded %d recurring_events\n" (List.length recurring_events);
-
   let exercises = Exercise_parser.all () in
-  Printf.printf "  Loaded %d exercises\n" (List.length exercises);
-
   let pages = Page_parser.all () in
-  Printf.printf "  Loaded %d pages\n" (List.length pages);
-
   let conferences = Conference_parser.all () in
-  Printf.printf "  Loaded %d conferences\n" (List.length conferences);
-
   let tutorials = Tutorial_parser.all () in
-  Printf.printf "  Loaded %d tutorials\n" (List.length tutorials);
-
   let tutorial_search_documents = Tutorial_parser.all_search_documents () in
-  Printf.printf "  Loaded %d tutorial_search_documents\n"
-    (List.length tutorial_search_documents);
-
-  (* Complex data structures *)
   let changelog = Changelog_parser.all () in
-  Printf.printf "  Loaded %d changelog entries\n" (List.length changelog);
-
   let backstage = Backstage_parser.all () in
-  Printf.printf "  Loaded %d backstage entries\n" (List.length backstage);
-
   let planet = Planet_parser.all () in
-  Printf.printf "  Loaded %d planet entries\n" (List.length planet);
-
   let blog_sources = Blog_parser.all_sources () in
-  Printf.printf "  Loaded %d blog_sources\n" (List.length blog_sources);
-
   let blog_posts = Blog_parser.all_posts () in
-  Printf.printf "  Loaded %d blog_posts\n" (List.length blog_posts);
-
   let cookbook_recipes = Cookbook_parser.all () in
-  Printf.printf "  Loaded %d cookbook_recipes\n" (List.length cookbook_recipes);
-
   let cookbook_tasks = Cookbook_parser.tasks in
-  Printf.printf "  Loaded %d cookbook_tasks\n" (List.length cookbook_tasks);
-
   let cookbook_top_categories = Cookbook_parser.top_categories in
-  Printf.printf "  Loaded %d cookbook_top_categories\n"
-    (List.length cookbook_top_categories);
-
   let is_ocaml_yet = Is_ocaml_yet_parser.all () in
-  Printf.printf "  Loaded %d is_ocaml_yet pages\n" (List.length is_ocaml_yet);
-
   let outreachy = Outreachy_parser.all () in
-  Printf.printf "  Loaded %d outreachy rounds\n" (List.length outreachy);
-
   let governance_teams = Governance_parser.teams () in
-  Printf.printf "  Loaded %d governance_teams\n" (List.length governance_teams);
-
   let governance_working_groups = Governance_parser.working_groups () in
-  Printf.printf "  Loaded %d governance_working_groups\n"
-    (List.length governance_working_groups);
-
   let tool_pages = Tool_page_parser.all () in
-  Printf.printf "  Loaded %d tool_pages\n" (List.length tool_pages);
-
   {
     All_data.testimonials;
     academic_testimonials;


### PR DESCRIPTION
Packer.load_all() was printing debug messages to stdout via Printf.printf. Since dune uses `with-stdout-to` to capture feed generator output into XML files, these debug messages were being prepended to all RSS/Atom feeds (planet.xml, news.xml, changelog.xml, backstage.xml, events.xml, jobs.xml), making them invalid XML.

e.g. response to https://ocaml.org/planet.xml was 

```
Loading data from /home/opam/_build/default/data
  Loaded 7 testimonials
  Loaded 2 academic_testimonials
  Loaded 21 jobs
  Loaded 12 opam_users
  Loaded 11 resources
  Loaded 6 featured_resources
  Loaded 417 videos
  Loaded 38 academic_institutions
  Loaded 20 books
  Loaded 1 code_examples
  Loaded 74 papers
  Loaded 17 tools
  Loaded 35 releases
  Loaded release_latest: 5.4.0
  Loaded release_lts: 4.14.2
  Loaded 11 success_stories
  Loaded 50 industrial_users
  Loaded 83 news
  Loaded 20 events
  Loaded 12 recurring_events
  Loaded 87 exercises
  Loaded 6 pages
  Loaded 20 conferences
  Loaded 60 tutorials
  Loaded 802 tutorial_search_documents
  Loaded 572 changelog entries
  Loaded 107 backstage entries
  Loaded 2520 planet entries
  Loaded 78 blog_sources
  Loaded 2103 blog_posts
  Loaded 59 cookbook_recipes
  Loaded 86 cookbook_tasks
  Loaded 19 cookbook_top_categories
  Loaded 2 is_ocaml_yet pages
  Loaded 14 outreachy rounds
  Loaded 9 governance_teams
  Loaded 1 governance_working_groups
  Loaded 11 tool_pages
<feed xmlns="http://www.w3.org/2005/Atom"><id>https://ocaml.org/planet.xml</id><title type="text">OCaml Planet</title><updated>2026-02-24T12:00:00-00:00</updated><entry><link href="[https://alan.petitepomme.net/cwn/2026.02.24.html](view-source:https://alan.petitepomme.net/cwn/2026.02.24.html)" rel="alternate"/><content type="text"></content><id>https://alan.petitepomme.net/cwn/2026.02.24.html</id><title type="text">OCaml Weekly News, 24 Feb 2026</title><updated>2026-02-24T12:00:00-00:00</updated><author><name>Caml Weekly[...]
```

Remove the debug prints from load_all() entirely — it's a library function that should just load data and return it without side effects.