### PR TITLE
fix: fail fast when playground default example is missing

### DIFF
--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -696,8 +696,16 @@ let code_of_conduct = page Url.code_of_conduct
 let security = page Url.security
 
 let playground _req =
-  let default = Data.Code_example.get "default.ml" in
-  let default_code = default.body in
+  let default_code =
+    Data.Code_example.all
+    |> List.find_opt (fun (example : Data.Code_example.t) ->
+           let title = String.lowercase_ascii example.title in
+           String.equal title "default.ml" || String.equal title "default")
+    |> Option.map (fun (example : Data.Code_example.t) -> example.body)
+    |> Option.value
+         ~default:
+           "(* Unable to load the default code example for the playground. *)"
+  in
   Dream.html (Ocamlorg_frontend.playground ~default_code)
 
 let governance _req =

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -696,16 +696,8 @@ let code_of_conduct = page Url.code_of_conduct
 let security = page Url.security
 
 let playground _req =
-  let default_code =
-    Data.Code_example.all
-    |> List.find_opt (fun (example : Data.Code_example.t) ->
-           let title = String.lowercase_ascii example.title in
-           String.equal title "default.ml" || String.equal title "default")
-    |> Option.map (fun (example : Data.Code_example.t) -> example.body)
-    |> Option.value
-         ~default:
-           "(* Unable to load the default code example for the playground. *)"
-  in
+  let default = Data.Code_example.get "default.ml" in
+  let default_code = default.body in
   Dream.html (Ocamlorg_frontend.playground ~default_code)
 
 let governance _req =

--- a/tool/data-packer/lib/code_example_parser.ml
+++ b/tool/data-packer/lib/code_example_parser.ml
@@ -5,8 +5,11 @@ type t = Data_intf.Code_examples.t = { title : string; body : string }
 let all () : t list =
   Utils.read_from_dir "code_examples/*.ml"
   |> List.map (fun (path, body) ->
-         let title =
-           Filename.basename path |> Filename.remove_extension
-           |> String.capitalize_ascii
-         in
+         let title = Filename.basename path in
          { title; body })
+  |> fun examples ->
+  if List.exists (fun (example : t) -> String.equal example.title "default.ml") examples
+  then examples
+  else
+    failwith
+      "Missing required code example: data/code_examples/default.ml. This file is used by /play."


### PR DESCRIPTION
## Summary
- restore code example titles to filename form (e.g. `default.ml`) to match `/play` lookup
- add a data-packer guard that fails early if `data/code_examples/default.ml` is missing
- fixes #3528
