### PR TITLE
(data) fix: repair broken links on Academic Institutions page (#3531)

### DIFF
--- a/data/academic_institutions/Ashoka.md
+++ b/data/academic_institutions/Ashoka.md
@@ -8,7 +8,7 @@ continent: Asia
 courses:
     - name: Introduction to Computer Science
       acronym: ICS
-      url: "https://aalok-thakkar.github.io/teaching/ics2025/ics2025.html"
+      url: "https://aalok-thakkar.github.io/teaching/spring2025/ics/index.html"
       year: 2025
       lecture_notes: true
       exercises: true

--- a/data/academic_institutions/Beira.md
+++ b/data/academic_institutions/Beira.md
@@ -7,29 +7,29 @@ logo: academic_institution/beira.jpg
 continent: Europe
 courses:
     - name: Certified Programming
-      url: "https://www.di.ubi.pt/~desousa/PC/pc.html"
+      url: "https://web.archive.org/web/20241214062007/https://www.di.ubi.pt/~desousa/PC/pc.html"
       year: 2016
     - name: Computation Theory
-      url: "https://www.di.ubi.pt/~desousa/TC/tcomp.html"
+      url: "https://web.archive.org/web/20241004214951/https://www.di.ubi.pt/~desousa/TC/tcomp.html"
       year: 2023
       lecture_notes: true
     - name: Computational Logic
-      url: "https://www.di.ubi.pt/~desousa/LC/lc.html"
+      url: "https://web.archive.org/web/20241004220002/https://www.di.ubi.pt/~desousa/LC/lc.html"
       year: 2017
       lecture_notes: true
       exercises: true
     - name: Functional Programming, Algorithms, and Data Structures
-      url: "https://www.di.ubi.pt/~desousa/PF/pf.html"
+      url: "https://web.archive.org/web/20241214065703/https://www.di.ubi.pt/~desousa/PF/pf.html"
       year: 2023
       lecture_notes: true
       exercises: true
     - name: Programming Languages and Compilers Design
-      url: "https://www.di.ubi.pt/~desousa/DLPC/dlpc.html"
+      url: "https://web.archive.org/web/20241214072504/https://www.di.ubi.pt/~desousa/DLPC/dlpc.html"
       year: 2023
       lecture_notes: true
       exercises: true
     - name: Proof and Programming Theory
-      url: "https://www.di.ubi.pt/~desousa/TPP/tpp.html"
+      url: "https://web.archive.org/web/20241214061911/https://www.di.ubi.pt/~desousa/TPP/tpp.html"
       year: 2016
 location:
      lat: 40.2779

--- a/data/academic_institutions/bitspilani.md
+++ b/data/academic_institutions/bitspilani.md
@@ -8,7 +8,7 @@ continent: Asia
 courses:
     - name: Principles of Programming Languages
       acronym: CS F301
-      url: NA
+      url:
       year: 2024
       teacher: Dhruv Kumar
       lecture_notes: false

--- a/data/academic_institutions/caltech.md
+++ b/data/academic_institutions/caltech.md
@@ -8,8 +8,8 @@ continent: North America
 courses:
     - name: "Compilers"
       acronym: CS 164
-      url: "https://mvanier.github.io/cs164/Fall2024/book/"
-      year: 2024
+      url: "https://mvanier.github.io/cs164/Fall2025/book/"
+      year: 2025
       teacher: Mike Vanier
 location:
      lat: 34.1377


### PR DESCRIPTION
- Ashoka University: update course URL to new site structure
- Caltech: update CS 164 Compilers URL and year to Fall 2025
- BITS Pilani: fix invalid `url: NA` to proper null value
- Beira Interior: replace 6 dead URLs with Wayback Machine archives

Fixes #3531