### PR TITLE
fix: expose Governance in Community tabs

### DIFF
--- a/src/ocamlorg_frontend/layouts/community_layout.eml
+++ b/src/ocamlorg_frontend/layouts/community_layout.eml
@@ -5,6 +5,7 @@ type section =
   | Resources
   | Outreachy
   | Conferences
+  | Governance
 
 let tabs
 ~current =
@@ -15,6 +16,7 @@ let tabs
     | Resources -> Url.resources
     | Outreachy -> Url.outreachy
     | Conferences -> Url.conferences
+    | Governance -> Url.governance
   in
   let title_of_section = function
     | Overview -> "Overview"
@@ -23,8 +25,9 @@ let tabs
     | Resources -> "Resources"
     | Outreachy -> "Outreachy Internships"
     | Conferences -> "Conferences"
+    | Governance -> "Governance"
   in
-  Layout.subnav_tabs ~title:"Community" ~current ~sections:[Overview; Jobs; Events; Resources; Outreachy; Conferences] ~url_of_section ~title_of_section
+  Layout.subnav_tabs ~title:"Community" ~current ~sections:[Overview; Jobs; Events; Resources; Outreachy; Conferences; Governance] ~url_of_section ~title_of_section
 
 let single_column_layout
 ?use_swiper

--- a/src/ocamlorg_frontend/pages/governance.eml
+++ b/src/ocamlorg_frontend/pages/governance.eml
@@ -31,10 +31,12 @@ let render_team_card (team: Data.Governance.team) member_label =
   </div>
 
 let render ~teams ~working_groups =
-Layout.render
+Community_layout.single_column_layout
 ~title:"Governance"
 ~description:"OCaml is a mature, statically-typed, functional programming language. Learn more about its rich history
-and what makes it unique." @@
+and what makes it unique."
+~canonical:Url.governance
+~current:Governance @@
 <div class="w-full border-b intro-section-simple dark:dark-intro-section-simple md:bg-transparent dark:border-none md:bg-[length:cover] py-16 md:bg-[url('/img/governance/hero-background.png')] dark:md:bg-[url('/img/governance/dark-hero-background.png')]">
   <div class="container-fluid">
       <div class="flex md:flex-row flex-col">


### PR DESCRIPTION
## Summary
- add a `Governance` tab to the Community sub-navigation so the page is discoverable from Community pages
- render the Governance page with `Community_layout.single_column_layout` and mark `Governance` as the active Community tab
- keep canonical URL set to `/governance` while making governance reachable from the Community tab flow

Fixes #3466

<img width="1819" height="766" alt="Screenshot 2026-02-27 at 12-59-27 Governance" src="https://github.com/user-attachments/assets/d0ef0d7b-4c54-44b9-954f-e0d9b6e290e2" />
