### PR TITLE
(data) add talk detail page links for FUN OCaml 2024 and 2025

### DIFF
--- a/data/conferences/2024-fun-ocaml.md
+++ b/data/conferences/2024-fun-ocaml.md
@@ -9,71 +9,85 @@ presentations:
   - title: "Maybe OCaml Was the Friends We Made Along the Way"
     authors:
       - Dillon Mulroy
+    link: "https://fun-ocaml.com/2024/journey-of-growth/"
     youtube_video: https://www.youtube.com/watch?v=1HlIHPa38gY
     watch_ocamlorg_video: https://watch.ocaml.org/w/rwDYUk9N3X9cMRyhCav35X
   - title: "Easy GADTs by Repeating Yourself"
     authors:
       - Eduardo Rafael
+    link: "https://fun-ocaml.com/2024/easy-gadts/"
     youtube_video: https://www.youtube.com/watch?v=-XYO_ILJG2M
     watch_ocamlorg_video: https://watch.ocaml.org/w/3i71o7rfq7UzzpTRyCSx2w
   - title: "The Story Behind the Fastest Image Comparison Library"
     authors:
       - Dmitriy Kovalenko
+    link: "https://fun-ocaml.com/2024/image-comparison/"
     youtube_video: https://www.youtube.com/watch?v=hTAvAKolWd8
     watch_ocamlorg_video: https://watch.ocaml.org/w/hSHDx6iT8z9PBgoaXNnFmW
   - title: "Universal React in OCaml"
     authors:
       - David Sancho Moreno
+    link: "https://fun-ocaml.com/2024/universal-react/"
     youtube_video: https://www.youtube.com/watch?v=Oy3lZl2kE-0
     watch_ocamlorg_video: https://watch.ocaml.org/w/wwYKmvEH8CqKZ7TzRAEZXq
   - title: "The Future of Dune"
     authors:
       - Leandro Ostera
+    link: "https://fun-ocaml.com/2024/future-of-dune/"
     youtube_video: https://www.youtube.com/watch?v=7_bv3EvQANY
     watch_ocamlorg_video: https://watch.ocaml.org/w/2A6bTKjqQ1StL6yfQehnvp
   - title: "MirageOS - Developing Operating Systems in OCaml"
     authors:
       - Hannes Mehnert
+    link: "https://fun-ocaml.com/2024/mirage-os/"
     youtube_video: https://www.youtube.com/watch?v=g7Kl5mRDCDo
     watch_ocamlorg_video: https://watch.ocaml.org/w/8guYKggC1zYWk8MjcHLtG9
   - title: "Learning OCaml with Tiny Code Xmas"
     authors:
       - Michael Dales
+    link: "https://fun-ocaml.com/2024/tiny-code-xmas/"
     youtube_video: https://www.youtube.com/watch?v=2ZswyN4aP2o
     watch_ocamlorg_video: https://watch.ocaml.org/w/bBWrw9qh6AaEFVRmFCFMKT
   - title: "Let Signals in OCaml"
     authors:
       - Rizo Isrof
+    link: "https://fun-ocaml.com/2024/let-signals/"
     youtube_video: https://www.youtube.com/watch?v=34bceAuSRXE
     watch_ocamlorg_video: https://watch.ocaml.org/w/78sg2vm4WzbKvcbSmtCpwd
   - title: "A 'Melange' of Tooling Coming Together"
     authors:
       - Antonio Monteiro
+    link: "https://fun-ocaml.com/2024/melange/"
     youtube_video: https://www.youtube.com/watch?v=3oCXT-ycHHs
     watch_ocamlorg_video: https://watch.ocaml.org/w/vCzFWXa4RfN6y7BTSenBY5
   - title: "How the Multicore Garbage Collector works"
     authors:
       - Sudha Parimala
+    link: "https://fun-ocaml.com/2024/multicore-gc/"
     youtube_video: https://www.youtube.com/watch?v=fgdB_9DcJj4
     watch_ocamlorg_video: https://watch.ocaml.org/w/772GsUvu7eRobHgLDUeE2M
   - title: "Building Incremental and Reproducible Data Pipelines"
     authors:
       - Patrick Ferris
+    link: "https://fun-ocaml.com/2024/incremental-data-pipelines/"
     youtube_video: https://www.youtube.com/watch?v=6mxx2j1jmhE
     watch_ocamlorg_video: https://watch.ocaml.org/w/21fL5BUJxWdLigoALGMpLb
   - title: "Type engineering in OCaml, Illustrated on the OCaml Compiler"
     authors:
       - Florian Angeletti
+    link: "https://fun-ocaml.com/2024/type-engineering/"
     youtube_video: https://www.youtube.com/watch?v=FHWH6ayUV8c
     watch_ocamlorg_video: https://watch.ocaml.org/w/g8xFJmbxhyXDnpwaT6pBJm
   - title: "Using odoc to Write Documentation"
     authors:
       - Paul-Elliot Anglès d'Auriac
+    link: "https://fun-ocaml.com/2024/odoc/"
     youtube_video: https://www.youtube.com/watch?v=Qzf_ZB1TKLQ
     watch_ocamlorg_video: https://watch.ocaml.org/w/uFvC5GQU8jChh5PmGNrmTo
   - title: "OCANNL, the `neural_nets_lib`"
     authors:
       - Lukasz Stafiniak
+    link: "https://fun-ocaml.com/2024/ocannl/"
     youtube_video: https://www.youtube.com/watch?v=1J2XyHLb2J0
     watch_ocamlorg_video: https://watch.ocaml.org/w/vQYhM1uQ3d3ZACKfRPCtrq
 organising_committee: 

--- a/data/conferences/2025-fun-ocaml.md
+++ b/data/conferences/2025-fun-ocaml.md
@@ -11,57 +11,68 @@ presentations:
   - title: "A Vision for OCaml in the AI Era"
     authors:
       - Thibaut Mattio
+    link: "https://fun-ocaml.com/2025/a-vision-for-ocaml-in-the-ai-era/"
     youtube_video: https://www.youtube.com/watch?v=BAvXqd0QeVM
     watch_ocamlorg_video: https://watch.ocaml.org/w/oTv8j7T7eGrtHxpzaRe1LZ
   - title: "OCaml at LexiFi"
     authors:
       - Nicolás Ojeda Bär
+    link: "https://fun-ocaml.com/2025/ocaml-at-lexifi/"
     youtube_video: https://www.youtube.com/watch?v=_uwvra1NFJg
     watch_ocamlorg_video: https://watch.ocaml.org/w/62JkXM1mcVRAjX6k4xwfVk
   - title: "I Can See The Pixels: Designing Cross-Stitch Patterns in OCaml"
     authors:
       - Mindy Preston
+    link: "https://fun-ocaml.com/2025/i-can-see-the-pixels/"
     youtube_video: https://www.youtube.com/watch?v=Q2-qIrYzSXw
     watch_ocamlorg_video: https://watch.ocaml.org/w/ewpvKhPvKhrKmvQ35N42kx
   - title: "Frameworks: No, Libraries: Yes. Developing a product in OCaml from Scratch"
     authors:
       - Malcolm Matalka
+    link: "https://fun-ocaml.com/2025/terrateam/"
     youtube_video: https://www.youtube.com/watch?v=0Hwd7NxQ8_c
     watch_ocamlorg_video: https://watch.ocaml.org/w/arLEkYE7NC4fdCcWz2LBLt
   - title: "Purely functional gRPC and HTTP/2 with OCaml"
     authors:
       - Adam Cholewiński
+    link: "https://fun-ocaml.com/2025/production-grade-network-protocols/"
     youtube_video: https://www.youtube.com/watch?v=exR5eWSQ_8o
     watch_ocamlorg_video: https://watch.ocaml.org/w/1crzn8PE9UGcyPErYE6QYd
   - title: "Analyzing Programs with SMT Solvers"
     authors:
       - Tikhon Jelvis
+    link: "https://fun-ocaml.com/2025/analyzing-programs-with-smt-solvers/"
     youtube_video: https://www.youtube.com/watch?v=BL8bmtBfd7E
     watch_ocamlorg_video: https://watch.ocaml.org/w/aTPecM67BvKkb3fmdct4WB
   - title: "Slipshow: A Full-Featured Presentation Tool in OCaml"
     authors:
       - Paul-Elliot Anglès d'Auriac
+    link: "https://fun-ocaml.com/2025/slipshow/"
     youtube_video: https://www.youtube.com/watch?v=5HMpiGKHu9A
     watch_ocamlorg_video: https://watch.ocaml.org/w/2oY2gmi7Dtfgb58iv4Ww7J
   - title: "0xCaml From a System Engineer's Point of View"
     authors:
       - Dmitriy Kovalenko
+    link: "https://fun-ocaml.com/2025/oxcaml-system-engineers-pov/"
     youtube_video: https://www.youtube.com/watch?v=iQc5fHW5SZA
     watch_ocamlorg_video: https://watch.ocaml.org/w/a1aMiaWYLXVxU2Yf3iGFFE
   - title: "Performance Pitfalls: Tales From a Python/OCaml Codebase"
     authors:
       - Emma Jin
+    link: "https://fun-ocaml.com/2025/performance-pitfalls-tales-from-a-python-ocaml-codebase/"
     youtube_video: https://www.youtube.com/watch?v=UfrryqltZUQ
     watch_ocamlorg_video: https://watch.ocaml.org/w/4FDjm7yK4KsiXxN8fjV7ZW
   - title: "Generating Static Websites the Functional Programming Way"
     authors:
       - Xavier Van de Woestyne
+    link: "https://fun-ocaml.com/2025/static-websites-functional-programming/"
     youtube_video: https://www.youtube.com/watch?v=rHGMD49eb_k
     watch_ocamlorg_video: https://watch.ocaml.org/w/uSaQB8ejXBUdJGgUBfHCW8
   - title: "From OCaml 4 to 5 and from Parmap to Effects: A legacy code transition story"
     authors:
       - Nathan Taylor
       - Nat Mote
+    link: "https://fun-ocaml.com/2025/from-ocaml-4-to-5/"
     youtube_video: https://www.youtube.com/watch?v=zfGlQZ2pkss
     watch_ocamlorg_video: https://watch.ocaml.org/w/x5XKaNB7Z2zyaFQWPBU2ZL
 organising_committee: 


### PR DESCRIPTION
## Summary
- Add `link` fields pointing to individual talk session pages on fun-ocaml.com for all presentations in FUN OCaml 2024 (14 talks) and FUN OCaml 2025 (11 talks)
- This matches the pattern already used by OCaml Workshop conference data, where each presentation has a `link` to its detail page

## Test plan
- [x] Verify the conference pages at `/conferences/fun-ocaml-2024` and `/conferences/fun-ocaml-2025` render talk links correctly
- [x] Spot-check a few URLs to confirm they resolve to the correct session pages on fun-ocaml.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)