### PR TITLE
style: run ocamlformat on code example parser

### DIFF
--- a/tool/data-packer/lib/code_example_parser.ml
+++ b/tool/data-packer/lib/code_example_parser.ml
@@ -8,8 +8,12 @@ let all () : t list =
          let title = Filename.basename path in
          { title; body })
   |> fun examples ->
-  if List.exists (fun (example : t) -> String.equal example.title "default.ml") examples
+  if
+    List.exists
+      (fun (example : t) -> String.equal example.title "default.ml")
+      examples
   then examples
   else
     failwith
-      "Missing required code example: data/code_examples/default.ml. This file is used by /play."
+      "Missing required code example: data/code_examples/default.ml. This file \
+       is used by /play."


### PR DESCRIPTION
## Summary
- Rebased `fix_fmt` on `upstream/main`.
- Ran `make fmt` and committed the resulting formatting update.
- Applies ocamlformat changes in `tool/data-packer/lib/code_example_parser.ml`.