### PR TITLE
fix: tools mobile dropdown now includes Infrastructure link

### DIFF
--- a/src/ocamlorg_frontend/layouts/tools_layout.eml
+++ b/src/ocamlorg_frontend/layouts/tools_layout.eml
@@ -1,18 +1,26 @@
 type section =
   | Overview
   | Releases
+  | Infrastructure
 
 let tabs
 ~current =
   let url_of_section = function
     | Overview -> Url.tools
     | Releases -> Url.releases
+    | Infrastructure -> Url.tool_page "ocaml-infrastructure"
   in
   let title_of_section = function
     | Overview -> "Overview"
     | Releases -> "Compiler Releases"
+    | Infrastructure -> "Infrastructure"
   in
-  Layout.subnav_tabs ~title:"Tools" ~current ~sections:[Overview; Releases] ~url_of_section ~title_of_section
+  Layout.subnav_tabs
+    ~title:"Tools"
+    ~current
+    ~sections:[Overview; Releases; Infrastructure]
+    ~url_of_section
+    ~title_of_section
 
 let single_column_layout
 ?use_swiper

--- a/src/ocamlorg_frontend/pages/tool_page.eml
+++ b/src/ocamlorg_frontend/pages/tool_page.eml
@@ -28,13 +28,18 @@ let href, description =
     ("https://github.com/ocaml/ocaml.org/blob/"^ commit_hash ^"/data/"^ page.fpath,
     "All OCaml docs are open source. See something that's wrong or unclear? Submit a pull request.")
 in
+let current_section =
+  if page.category = "OCaml Infrastructure"
+  then Tools_layout.Infrastructure
+  else Tools_layout.Overview
+in
 Tools_layout.three_column_layout
 ~title:(Printf.sprintf "%s · OCaml Documentation" page.short_title)
 ~description:page.description
 ~canonical
 ~left_sidebar_html:(Some(left_sidebar ~current_page:(page.slug) ~pages))
 ~right_sidebar_html:(Some(right_sidebar page))
-~current:Overview @@
+~current:current_section @@
   <div class="prose prose-orange dark:prose-invert max-w-full">
     <%s! render_title page %>
     <%s! page.body_html %>


### PR DESCRIPTION
## Summary
- add an `Infrastructure` entry to the Tools subnav sections so it appears in the mobile dropdown
- route the new entry to `/tools/ocaml-infrastructure`
- mark OCaml Infrastructure tool pages as the `Infrastructure` section in the top nav

Fixes #3162