### PR TITLE
Add workflow to build and release scraper binary

### DIFF
--- a/.github/workflows/release-scrapers.yml
+++ b/.github/workflows/release-scrapers.yml
@@ -1,0 +1,57 @@
+name: Release Scrapers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'tool/**'
+      - 'src/**'
+      - 'dune-project'
+      - '*.opam'
+      - '.github/workflows/release-scrapers.yml'
+
+jobs:
+  release:
+    name: Build and Release Scraper Binary
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Use OCaml 5.2.0
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.2.0"
+          dune-cache: true
+          opam-repositories: |
+            pin: git+https://github.com/ocaml/opam-repository#584630e7a7e27e3cf56158696a3fe94623a0cf4f
+          opam-disable-sandboxing: true
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libev-dev libonig-dev libcurl4-openssl-dev
+
+      - name: Install opam dependencies
+        run: opam install --deps-only --with-test .
+
+      - name: Build scraper
+        run: opam exec -- dune build tool/data-scrape/bin/scrape.exe
+
+      - name: Delete previous release
+        run: gh release delete scraper-latest --cleanup-tag --yes || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        run: |
+          gh release create scraper-latest \
+            _build/default/tool/data-scrape/bin/scrape.exe \
+            --title "Scraper (latest)" \
+            --notes "Built from ${{ github.sha }}" \
+            --latest=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- New `release-scrapers.yml` workflow that builds the scraper binary and publishes it as a `scraper-latest` GitHub release
- Triggers on pushes to `main` that touch `tool/**`, `src/**`, `dune-project`, or `*.opam`
- Also supports `workflow_dispatch` for manual bootstrapping
- This is PR 1 of 2: a follow-up PR will update the scrape workflows to use the released binary instead of rebuilding from source each time

## Test plan
- [X] Merge this PR
- [X] Trigger `release-scrapers.yml` manually via workflow_dispatch
- [X] Verify the `scraper-latest` release is created with `scrape.exe` asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)