### PR TITLE
Mention OCaml devcontainer in tutorials

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -11,6 +11,8 @@ This guide will walk you through a minimum installation of OCaml. That includes 
 
 On this page, you'll find installation instructions for Linux, macOS, Windows, and &ast;BSD for recent OCaml versions. For Docker, Linux instructions apply, except when setting up opam.
 
+**Want to skip installation?** The [OCaml devcontainer](https://github.com/tarides/ocaml-devcontainer) provides a pre-configured OCaml environment that works with VS Code, GitHub Codespaces, or the DevContainer CLI. It is designed for use when quick onboarding matters, such as tutorials and workshops.
+
 **Note**: You'll be installing OCaml and its tools through a [command line interface (CLI), or shell](https://www.youtube.com/watch?v=0PxTAn4g20U)
 
 ## Install opam

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -9,6 +9,8 @@ While the toplevel is great for interactively trying out the language, we will s
 
 OCaml has plugins for many editors, but the most actively maintained are for Visual Studio Code, Emacs, and Vim.
 
+**Note**: The [OCaml devcontainer](https://github.com/tarides/ocaml-devcontainer) ships with OCaml LSP, OCamlFormat, and editor support pre-configured for VS Code, Vim, and Emacs.
+
 ## Visual Studio Code
 
 > TL;DR

--- a/data/tutorials/platform/2_11_docker.md
+++ b/data/tutorials/platform/2_11_docker.md
@@ -103,6 +103,10 @@ opam install <package>
 - **`archive`** - Contains a snapshot of all source archives for opam-repository (useful for setting up a local cache)
 - **SHA256 hashes** - Used by OCaml-CI for reproducible builds
 
+## Dev Containers
+
+For a development-oriented Docker setup with OCaml LSP, editors, and debugging tools pre-installed, see the [OCaml devcontainer](https://github.com/tarides/ocaml-devcontainer). It works with VS Code, GitHub Codespaces, and the DevContainer CLI.
+
 ## Example: Basic Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a note in the [Installing OCaml](/docs/installing-ocaml) tutorial pointing to the devcontainer as a way to skip installation
- Add a note in the [Configuring Your Editor](/docs/set-up-editor) tutorial mentioning the devcontainer ships with editor support pre-configured
- Add a "Dev Containers" section in the [Docker Images](/docs/ocaml-docker) tutorial to distinguish the dev-oriented setup from CI images

## Test plan
- [ ] Verify the three pages render correctly (`make watch`)
- [ ] Check the links to https://github.com/tarides/ocaml-devcontainer resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)