### PR TITLE
Add OCaml 4.14.3 release data

### DIFF
--- a/data/releases/4.14.1.md
+++ b/data/releases/4.14.1.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 4.14.1
 date: 2022-12-20
-is_lts: true
+is_lts: false
 intro: |
   This page describes OCaml version **4.14.1**, released on
   Dec 20, 2022. Go [here](/releases) for a list of all releases.

--- a/data/releases/4.14.2.md
+++ b/data/releases/4.14.2.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 4.14.2
 date: 2024-03-15
-is_lts: true
+is_lts: false
 intro: |
   This page describes OCaml version **4.14.2**, released on
   Mar 14, 2024. Go [here](/releases) for a list of all releases.

--- a/data/releases/4.14.3.md
+++ b/data/releases/4.14.3.md
@@ -42,15 +42,13 @@ following options:
 
 For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with:
 
-
-```
+```bash
 opam switch create 4.14.3+flambda+nnpchecker ocaml-variants.4.14.3+options ocaml-option-flambda ocaml-option-nnpchecker
 ```
 
 ---
 
-Source Distribution
--------------------
+## Source Distribution
 
 - [Source
   tarball](https://github.com/ocaml/ocaml/archive/4.14.3.tar.gz)
@@ -79,8 +77,7 @@ instructions on how to build under Windows.
 This is the
 [changelog](https://ocaml.org/releases/4.14/notes/Changes).
 
-
-### Bug fixes:
+### Bug fixes
 
 - [#12070](https://github.com/ocaml/ocaml/issues/12070), [#12075](https://github.com/ocaml/ocaml/issues/12075), [#13209](https://github.com/ocaml/ocaml/issues/13209): auto-detect whether `ar` support @FILE arguments at
   configure-time to avoid using this feature with toolchains that do not support

--- a/data/releases/4.14.3.md
+++ b/data/releases/4.14.3.md
@@ -1,0 +1,119 @@
+---
+kind: compiler
+version: 4.14.3
+date: 2026-02-17
+is_lts: true
+intro: |
+  This page describes OCaml version **4.14.3**, released on
+  Feb 17, 2026. Go [here](/releases) for a list of all releases.
+
+  This is a bug-fix release of [OCaml 4.14.2](/releases/4.14.2).
+
+  As the last version of OCaml 4, the 4.14 branch of OCaml will be maintained during the transition period for OCaml 5.
+  During this period, OCaml 4.14 will receive episodic bugfix updates as a long term support branch until at least 2024.
+highlights: |
+  - Security fix for Marshal deserialization ([CVE-2026-28364](https://www.cve.org/CVERecord?id=CVE-2026-28364))
+  - Bug fixes for 4.14.2
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 4.14.3
+```
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: sets OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: compiles OCaml without the native-code compiler
+- `ocaml-option-flambda`: sets OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: sets OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: sets OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: sets OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-32bit`: sets OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts
+- `ocaml-option-nnp`: sets OCaml to be compiled with `--disable-naked-pointers`
+- `ocaml-option-nnpchecker`: set OCaml to be compiled with `--enable-naked-pointers-checker`
+- `ocaml-option-fp`: sets OCaml to be compiled with frame-pointers enabled
+
+For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with:
+
+
+```
+opam switch create 4.14.3+flambda+nnpchecker ocaml-variants.4.14.3+options ocaml-option-flambda ocaml-option-nnpchecker
+```
+
+---
+
+Source Distribution
+-------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.14.3.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.14.3.zip)
+  format.
+- [opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://ocaml.org/releases/4.14/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions. See also the [Windows release
+notes](https://ocaml.org/releases/4.14/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+---
+
+## Changes in OCaml 4.14.3 (17 February 2026)
+
+This is the
+[changelog](https://ocaml.org/releases/4.14/notes/Changes).
+
+
+### Bug fixes:
+
+- [#12070](https://github.com/ocaml/ocaml/issues/12070), [#12075](https://github.com/ocaml/ocaml/issues/12075), [#13209](https://github.com/ocaml/ocaml/issues/13209): auto-detect whether `ar` support @FILE arguments at
+  configure-time to avoid using this feature with toolchains that do not support
+  it (eg FreeBSD/Darwin); backport from 5.3.
+  (backport by Boris Dobroslavov, original fix by Nicolás Ojeda Bär, review by
+  Xavier Leroy, David Allsopp, Javier Chávarri, Anil Madhavapeddy)
+
+- [#12207](https://github.com/ocaml/ocaml/issues/12207), [#12222](https://github.com/ocaml/ocaml/issues/12222): Make closure computation linear in the number of recursive
+  functions instead of quadratic
+  (Vincent Laviron, report by François Pottier, review by Nathanaëlle Courant
+  and Gabriel Scherer)
+
+- [#13430](https://github.com/ocaml/ocaml/issues/13430), [#13434](https://github.com/ocaml/ocaml/issues/13434): protect memory-safety on Lazy.force races
+  (Gabriel Scherer and Vincent Laviron, report by Edwin Török,
+   review by Vincent Laviron)
+
+- [#13448](https://github.com/ocaml/ocaml/issues/13448), [#13449](https://github.com/ocaml/ocaml/issues/13449): fix a code-generation bug on unsafe array accesses
+  at type int32, int64, nativeint, which has been introduced in OCaml 4.04.
+  (Gabriel Scherer, review by Nicolás Ojeda Bär and Vincent Laviron,
+   report by Simon Cruanes)
+
+- [#13516](https://github.com/ocaml/ocaml/issues/13516): Fix regression where error conditions during bytecode initialisation
+  caused a segmentation fault rather than being properly reported (regression of
+  #5115 in #11788)
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
+- [#13847](https://github.com/ocaml/ocaml/issues/13847): On Windows, maintain a number of threads waiting on the master lock to
+  avoid unnecessary context switches
+  (Dmitry Bely, review by Antonin Décimo)
+
+- [#14007](https://github.com/ocaml/ocaml/issues/14007), [#14015](https://github.com/ocaml/ocaml/issues/14015): Fix memory corruption when an exception is raised during
+  demarshaling.
+  (Benoît Vaugon, review by David Allsopp and Gabriel Scherer)
+
+- Robustify intern.c
+  (Xavier Leroy, review by Damien Doligez and Olivier Nicole)


### PR DESCRIPTION
## Summary
- Add `data/releases/4.14.3.md` with the changelog from the [4.14 Changes file](https://github.com/ocaml/ocaml/blob/4.14/Changes)
- Move `is_lts: true` from 4.14.2 and 4.14.1 to 4.14.3
- Highlights the security fix for [CVE-2026-28364](https://www.cve.org/CVERecord?id=CVE-2026-28364) (Marshal deserialization buffer over-read, [OSEC-2026-01](https://github.com/ocaml/security-advisories/blob/main/advisories/2026/OSEC-2026-01.md))

The landing page now correctly shows 4.14.3 as the Long Term Support release.

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (16/16 tests)
- [x] Server starts and landing page shows "Long Term Support release: 4.14.3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)