### PR TITLE
Add docs about getting the latest version of OCaml

### DIFF
--- a/data/tutorials/getting-started/2_02_opam_switch.md
+++ b/data/tutorials/getting-started/2_02_opam_switch.md
@@ -31,7 +31,9 @@ Before creating a switch, you'll need to pick a compiler version:
 opam switch list-available ocaml-base-compiler
 ```
 
-This lists all available compiler versions. Pick the latest stable version unless you have a reason not to.
+This lists all available compiler versions. Pick the latest stable version unless you have a reason not to: as of the time of writing, this is 5.4.1, but you can check this against the [OCaml Releases](https://ocaml.org/releases) website.
+
+If the list doesn't include the newest version, it may be that you installed opam a while ago and haven't updated its list of packages. You can run `opam update` and check again.
 
 Omitting `ocaml-base-compiler` shows the full list, including compiler variants with additional options enabled (such as flambda optimisations or frame pointers). These are useful for advanced use cases but not needed to get started.
 
@@ -40,7 +42,7 @@ Omitting `ocaml-base-compiler` shows the full list, including compiler variants 
 To create a named global switch:
 
 ```shell
-opam switch create my_switch 5.4.0
+opam switch create my_switch 5.4.1
 ```
 
 Then update your shell environment:
@@ -56,7 +58,7 @@ This switch is now available from any directory. It lives at `~/.opam/my_switch/
 To create a switch tied to your project, run this from inside the project directory:
 
 ```shell
-opam switch create . 5.4.0
+opam switch create . 5.4.1
 ```
 
 Then update your shell environment:
@@ -67,7 +69,7 @@ eval $(opam env)
 
 This creates an `_opam/` directory in your project. Whenever you `cd` into this directory, opam will automatically select this switch.
 
-If the directory contains `.opam` files, opam will automatically install their dependencies into the new switch. You can prevent this with `opam switch create . 5.4.0 --no-install`.
+If the directory contains `.opam` files, opam will automatically install their dependencies into the new switch. You can prevent this with `opam switch create . 5.4.1 --no-install`.
 
 ## Listing Your Switches
 
@@ -79,8 +81,8 @@ The arrow `->` marks the currently active switch:
 
 ```shell
 #   switch                      compiler      description
-->  /home/user/my_project       ocaml.5.4.0   /home/user/my_project
-    default                     ocaml.5.4.0   default
+->  /home/user/my_project       ocaml.5.4.1   /home/user/my_project
+    default                     ocaml.5.4.1   default
 ```
 
 ## Switching Between Switches

--- a/data/tutorials/platform/0_09_opam_path.md
+++ b/data/tutorials/platform/0_09_opam_path.md
@@ -42,58 +42,58 @@ This will launch the version of the OCaml REPL within the context of the current
 
 1. Install `direnv`
 
-Ensure `direnv` is installed on your system. You can install it using a package manager or follow the instructions on the official website.
+   Ensure `direnv` is installed on your system. You can install it using a package manager or follow the instructions on the official website.
 
 1. Setup `direnv` integration
 
-Add the following line to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`):
-```bash
-eval "$(direnv hook <shell>)"
-```
-Replace `<shell>` with your actual shell type (`bash`, `zsh`, `fish`, etc.).
+   Add the following line to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`):
+   ```bash
+   eval "$(direnv hook <shell>)"
+   ```
+   Replace `<shell>` with your actual shell type (`bash`, `zsh`, `fish`, etc.).
 
 1. Configure opam with `direnv`
 
-In your OCaml project directory, create a file named `.envrc` and add the following line to automatically load the opam environment:
-```bash
-eval $(opam env)
-```
+   In your OCaml project directory, create a file named `.envrc` and add the following line to automatically load the opam environment:
+   ```bash
+   eval $(opam env)
+   ```
 
 1. Allow `direnv`
 
-Navigate to your project directory and run the following command to allow `direnv` to load the environment:
-```bash
-direnv allow
-```
+   Navigate to your project directory and run the following command to allow `direnv` to load the environment:
+   ```bash
+   direnv allow
+   ```
 
-This command activates `direnv` for the current directory, ensuring that the opam switch environment is loaded whenever you enter the directory.
+   This command activates `direnv` for the current directory, ensuring that the opam switch environment is loaded whenever you enter the directory.
 
 1. Usage
 
-Now, whenever you navigate to your OCaml project directory, `direnv` will automatically activate the opam switch environment specified in your `.envrc` file. This eliminates the need to manually run `opam env` each time you work on your project.
+   Now, whenever you navigate to your OCaml project directory, `direnv` will automatically activate the opam switch environment specified in your `.envrc` file. This eliminates the need to manually run `opam env` each time you work on your project.
 
 1. Example
 
-Suppose you have an OCaml project in directory `disco` and a local opam switch is associated with it, and a `.envrc` file in that directory containing the following:
-```bash
-eval $(opam env)
-```
-After running `direnv allow`, `direnv` will handle the opam switch activation for you.
+   Suppose you have an OCaml project in directory `disco` and a local opam switch is associated with it, and a `.envrc` file in that directory containing the following:
+   ```bash
+   eval $(opam env)
+   ```
+   After running `direnv allow`, `direnv` will handle the opam switch activation for you.
 
 1. Messages from `direnv`
 
-Whenever entering or leaving a `direnv` managed directory, you will be informed of the actions performed.
+   Whenever entering or leaving a `direnv` managed directory, you will be informed of the actions performed.
 
-On entrance:
-```text
-direnv: loading ~/caml/ocaml.org/.envrc
-direnv: export ~CAML_LD_LIBRARY_PATH ~MANPATH ~OCAML_TOPLEVEL_PATH ~OPAM_SWITCH_PREFIX ~PATH
-```
+   On entrance:
+   ```text
+   direnv: loading ~/caml/ocaml.org/.envrc
+   direnv: export ~CAML_LD_LIBRARY_PATH ~MANPATH ~OCAML_TOPLEVEL_PATH ~OPAM_SWITCH_PREFIX ~PATH
+   ```
 
-On exit:
-```text
-direnv: loading ~/.envrc
-direnv: export ~PATH
-```
+   On exit:
+   ```text
+   direnv: loading ~/.envrc
+   direnv: export ~PATH
+   ```
 
-By using `direnv` in conjunction with opam, you can streamline your development workflow, ensuring that the correct opam switch is automatically set up whenever you work on a specific project.
+   By using `direnv` in conjunction with opam, you can streamline your development workflow, ensuring that the correct opam switch is automatically set up whenever you work on a specific project.


### PR DESCRIPTION
Hello! I'm revisiting OCaml after a long time away and I noticed the docs were given a makeover (which I really appreciate). Thanks @sabine!

As it happens, I couldn't figure out why I didn't have 5.4.0 and it turns out I needed `opam update`. I added a sentence for this which might help others in the same boat as me.

While writing this I also discovered that `opam switch list-available` now has 5.4.1, but the [Releases page](https://ocaml.org/releases) doesn't have a corresponding entry, so the suggestion to check that page for the newest version is actually invalid right now. I assume that's because a `data/releases/5.4.1.md` file wasn't created.

If you trust me to do it, I'm actually quite happy to put one together following the existing format, but I thought maybe it might be better left to an actual maintainer :)

-----

Edit: Also fixed the formatting issues in https://ocaml.org/docs/opam-path#using-direnv