### PR TITLE
Add OCaml 5.4.1 release data

### DIFF
--- a/data/releases/5.4.0.md
+++ b/data/releases/5.4.0.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 5.4.0
 date: 2025-10-09
-is_latest: true
+is_latest: false
 intro: |
   This page describes OCaml version **5.4.0**, released on
   2025-10-09. Go [here](/releases) for a list of all releases.

--- a/data/releases/5.4.1.md
+++ b/data/releases/5.4.1.md
@@ -1,0 +1,98 @@
+---
+kind: compiler
+version: 5.4.1
+date: 2026-02-17
+is_latest: true
+intro: |
+  This page describes OCaml version **5.4.1**, released on
+  Feb 17, 2026. Go [here](/releases) for a list of all releases.
+
+  This is a bug-fix release of [OCaml 5.4.0](/releases/5.4.0).
+highlights: |
+  - Security hardening of the Marshal module ([OSEC-2026-01](https://osv.dev/vulnerability/OSEC-2026-01))
+  - Fix for `-pack` mode on macOS
+  - Fix for miscompilation of string operations
+  - Several ThreadSanitizer (TSan) fixes
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 5.4.1
+```
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: Set OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: Compile OCaml without the native-code compiler
+- `ocaml-option-flambda`: Set OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: Set OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: Set OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: Set OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-address-sanitizer`: Set OCaml to be compiled with address sanitiser
+- `ocaml-option-leak-sanitizer`: Set OCaml to be compiled with leak sanitiser
+- `ocaml-option-fp`: Set OCaml to be compiled with frame pointers
+
+For instance, one can install a switch with both `flambda` and the `--disable-flat-float-array` option with
+
+```
+opam switch create 5.4.1+flambda+nffa ocaml-variants.5.4.1+options ocaml-option-flambda ocaml-option-no-flat-float-array
+```
+
+
+Source Distribution
+-------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/5.4.1.tar.gz)
+  (`.tar.gz`) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [`.zip`](https://github.com/ocaml/ocaml/archive/5.4.1.zip)
+  format.
+- [Opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://ocaml.org/releases/5.4/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions. See also the [Windows release
+notes](https://ocaml.org/releases/5.4/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+## Changes
+
+### Bug fixes:
+
+- [#14010](https://github.com/ocaml/ocaml/issues/14010): Fix miscompilation / liveness errors for string operations
+  (Mark Shinwell, Xavier Clerc, review by Xavier Leroy and Gabriel Scherer)
+
+- [#14065](https://github.com/ocaml/ocaml/issues/14065): Fix function signature mismatch of `__tsan_func_exit` with GCC 15.
+  Check in the configure step if the TSan provided internal builtins are the
+  same as what we expect, introduce `caml_tsan_*` wrappers for the `__tsan_*`
+  functions we use.
+  (Hari Hara Naveen S, report by Hari Hara Naveen S,
+  review by Gabriel Scherer, Antonin Decimo, Olivier Nicole)
+
+- [#14417](https://github.com/ocaml/ocaml/issues/14417): Fix issue with nested packs on macOS.
+  (Vincent Laviron, report by Kate Deplaix, review by Gabriel Scherer)
+
+- [#14213](https://github.com/ocaml/ocaml/issues/14213): Fix shadow-stack-related crashes with TSan
+  (Olivier Nicole, report by Nathan Taylor, review by Gabriel Scherer and
+  Stefan Muenzel)
+
+- [#14255](https://github.com/ocaml/ocaml/issues/14255): Fix TSan bug with C calls that take many arguments
+  (Olivier Nicole and Miod Vallat, report by Nathan Taylor, review by Gabriel
+  Scherer)
+
+- [OSEC-2026-01](https://osv.dev/vulnerability/OSEC-2026-01): robustify intern.c
+  (Xavier Leroy and Nicolas Ojeda Bar, review by Olivier Nicole, Mindy Preston,
+  Edwin Torok, and Gabriel Scherer)

--- a/data/releases/5.4.1.md
+++ b/data/releases/5.4.1.md
@@ -40,13 +40,11 @@ following options:
 
 For instance, one can install a switch with both `flambda` and the `--disable-flat-float-array` option with
 
-```
+```bash
 opam switch create 5.4.1+flambda+nffa ocaml-variants.5.4.1+options ocaml-option-flambda ocaml-option-no-flat-float-array
 ```
 
-
-Source Distribution
--------------------
+## Source Distribution
 
 - [Source
   tarball](https://github.com/ocaml/ocaml/archive/5.4.1.tar.gz)
@@ -70,7 +68,7 @@ instructions on how to build under Windows.
 
 ## Changes
 
-### Bug fixes:
+### Bug fixes
 
 - [#14010](https://github.com/ocaml/ocaml/issues/14010): Fix miscompilation / liveness errors for string operations
   (Mark Shinwell, Xavier Clerc, review by Xavier Leroy and Gabriel Scherer)


### PR DESCRIPTION
## Summary

- Add `data/releases/5.4.1.md` with release notes from the existing platform release announcement
- Set `is_latest: false` on `data/releases/5.4.0.md`

This makes OCaml 5.4.1 appear on the front page alongside 4.14.3 (LTS). The release data was already present in `data/platform_releases/ocaml/2026-02-17-ocaml-5.4.1-and-4.14.3.md` but the per-version release file was missing.

## Test plan

- [ ] `make build` succeeds
- [ ] Front page shows 5.4.1 as the latest OCaml version
- [ ] `/releases/5.4.1` page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)