### PR TITLE
chore: Use Hilite's new ocaml-mdx support

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,7 @@
   yojson
   lwt
   (hilite
-   (>= 0.4.0))
+   (>= 0.6.0))
   river
   syndic
   ounit

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -37,7 +37,7 @@ depends: [
   "timedesc" {>= "2.0.0"}
   "yojson"
   "lwt"
-  "hilite" {>= "0.4.0"}
+  "hilite" {>= "0.6.0"}
   "river"
   "syndic"
   "ounit"
@@ -74,4 +74,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
-
+pin-depends: [
+  [ "hilite.0.6.0" "git+https://github.com/patricoferris/hilite#f5368558f765ff6c884fda68acf4d4e9256970b4" ]
+]

--- a/ocamlorg.opam.template
+++ b/ocamlorg.opam.template
@@ -1,1 +1,3 @@
-
+pin-depends: [
+  [ "hilite.0.6.0" "git+https://github.com/patricoferris/hilite#f5368558f765ff6c884fda68acf4d4e9256970b4" ]
+]

--- a/tool/data-packer/lib/backstage_parser.ml
+++ b/tool/data-packer/lib/backstage_parser.ml
@@ -26,9 +26,8 @@ module Posts = struct
       post_metadata_of_yaml head |> Result.map_error (Utils.where fname)
     in
     let body_html =
-      Cmarkit_html.of_doc ~safe:false
-        (Hilite.Md.transform
-           (Cmarkit.Doc.of_string ~strict:true (String.trim body)))
+      Markdown.Content.render ~syntax_highlighting:true
+        (Cmarkit.Doc.of_string ~strict:true (String.trim body))
     in
 
     Result.map

--- a/tool/data-packer/lib/changelog_parser.ml
+++ b/tool/data-packer/lib/changelog_parser.ml
@@ -26,9 +26,8 @@ module Posts = struct
       post_metadata_of_yaml head |> Result.map_error (Utils.where fname)
     in
     let body_html =
-      Cmarkit_html.of_doc ~safe:false
-        (Hilite.Md.transform
-           (Cmarkit.Doc.of_string ~strict:true (String.trim body)))
+      Markdown.Content.render ~syntax_highlighting:true
+        (Cmarkit.Doc.of_string ~strict:true (String.trim body))
     in
 
     Result.map

--- a/tool/data-packer/lib/cookbook_parser.ml
+++ b/tool/data-packer/lib/cookbook_parser.ml
@@ -38,8 +38,7 @@ type metadata = { packages : package list; discussion : string option }
 let render_markdown str =
   str |> String.trim
   |> Cmarkit.Doc.of_string ~strict:true
-  |> Hilite_markdown.transform
-  |> Cmarkit_html.of_doc ~safe:false
+  |> Markdown.Content.render ~syntax_highlighting:true
 
 let decode (tasks : task list) (fpath, (head, body)) =
   let ( let* ) = Result.bind in

--- a/tool/data-packer/lib/cookbook_parser.ml
+++ b/tool/data-packer/lib/cookbook_parser.ml
@@ -38,7 +38,7 @@ type metadata = { packages : package list; discussion : string option }
 let render_markdown str =
   str |> String.trim
   |> Cmarkit.Doc.of_string ~strict:true
-  |> Hilite.Md.transform
+  |> Hilite_markdown.transform
   |> Cmarkit_html.of_doc ~safe:false
 
 let decode (tasks : task list) (fpath, (head, body)) =

--- a/tool/data-packer/lib/dune
+++ b/tool/data-packer/lib/dune
@@ -14,7 +14,7 @@
   bos
   fpath
   cmarkit
-  hilite
+  hilite.markdown
   str
   re
   syndic

--- a/tool/data-packer/lib/exercise_parser.ml
+++ b/tool/data-packer/lib/exercise_parser.ml
@@ -56,7 +56,7 @@ let split_body body =
 
 let render_with_highlight md =
   let doc = Cmarkit.Doc.of_string ~strict:true ~heading_auto_ids:true md in
-  Hilite.Md.transform doc |> Cmarkit_html.of_doc ~safe:false
+  Markdown.Content.render ~syntax_highlighting:true doc
 
 let decode (fpath, (head, body)) =
   let ( let* ) = Result.bind in

--- a/tool/data-packer/lib/is_ocaml_yet_parser.ml
+++ b/tool/data-packer/lib/is_ocaml_yet_parser.ml
@@ -43,8 +43,7 @@ let decode (fpath, (head, body_md)) =
   let modify_categories u =
     let modify_description description =
       Cmarkit.Doc.of_string ~strict:true (String.trim description)
-      |> Hilite.Md.transform
-      |> Cmarkit_html.of_doc ~safe:false
+      |> Markdown.Content.render ~syntax_highlighting:true
     in
     List.map
       (fun cat ->

--- a/tool/data-packer/lib/markdown.ml
+++ b/tool/data-packer/lib/markdown.ml
@@ -69,8 +69,10 @@ module Content = struct
   let of_string content =
     Cmarkit.Doc.of_string ~strict:true ~heading_auto_ids:true content
 
-  let render ?(syntax_highlighting = false) doc =
+  let options = Hilite_markdown.Options.(set_ocaml_mdx_syntax true default)
+
+  let render ?(syntax_highlighting = false) ?(options = options) doc =
     if syntax_highlighting then
-      Hilite.Md.transform doc |> Cmarkit_html.of_doc ~safe:false
+      Hilite_markdown.transform ~options doc |> Cmarkit_html.of_doc ~safe:false
     else doc |> Cmarkit_html.of_doc ~safe:false
 end

--- a/tool/data-packer/lib/platform_release_parser.ml
+++ b/tool/data-packer/lib/platform_release_parser.ml
@@ -43,9 +43,8 @@ let decode (fname, (head, body)) =
     metadata_of_yaml head |> Result.map_error (Utils.where fname)
   in
   let body_html =
-    Cmarkit_html.of_doc ~safe:false
-      (Hilite.Md.transform
-         (Cmarkit.Doc.of_string ~strict:true (String.trim body)))
+    Markdown.Content.render ~syntax_highlighting:true
+      (Cmarkit.Doc.of_string ~strict:true (String.trim body))
   in
 
   Result.map
@@ -56,8 +55,7 @@ let decode (fname, (head, body)) =
         | Some changelog ->
             Some
               (Cmarkit.Doc.of_string ~strict:true (String.trim changelog)
-              |> Hilite.Md.transform
-              |> Cmarkit_html.of_doc ~safe:false)
+              |> Markdown.Content.render ~syntax_highlighting:true)
       in
       let date, slug_version =
         match Slug.parse_slug slug with


### PR DESCRIPTION
Fixes #3037 

Wherever possible, enable the support in hilite for correctly syntax highlighting OCaml codeblocks that use the MDX `#` syntax. I took the liberty of reusing the `Markdown.Content.render` function in all these places, I think that was the right choice.

The most problematic cases were confusing line directives with integers or floats, a before and after below to show what I mean.

### Before 

<img width="1038" height="390" alt="before" src="https://github.com/user-attachments/assets/d5cf483b-6d7c-4a6d-a523-4457a4e21842" />

---
### After

<img width="1017" height="373" alt="after" src="https://github.com/user-attachments/assets/6c716b73-d612-42e7-a3af-e5c3d1c72122" />

Note: this support is not yet released to opam (ocaml.org is the biggest user of hilite so I want to use this to test it).
