### PR TITLE
Revert Posthog analytics in favour of Plausible

### DIFF
--- a/data/pages/privacy_policy.md
+++ b/data/pages/privacy_policy.md
@@ -20,7 +20,7 @@ As a visitor to the OCaml.org website:
 - No information is mined or harvested for personal and behavioral trends
 - No information is monetized
 
-We collect some anonymous usage data for statistical purposes. The goal is to track overall trends in our website traffic, it is not to track individual visitors. All the data is in aggregate only. No personal data is collected. You can view the data we collect on [our analytics dashboard](https://posthog.ci.dev/shared/seqtamWuMXLwxJEAX1XNjwhzciAajw).
+We collect some anonymous usage data for statistical purposes. The goal is to track overall trends in our website traffic, it is not to track individual visitors. All the data is in aggregate only. No personal data is collected. You can view the data we collect on [our analytics dashboard](https://plausible.ci.dev/ocaml.org).
 
 Data collected includes referral sources, top pages, visit duration, information from the devices (device type, operating system, country and browser) used during the visit and more.
 

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -101,16 +101,7 @@ inner =
       <script defer src="<%s Ocamlorg_static.Asset.url "vendors/alpine-clipboard.js" %>"></script>
       <script defer src="<%s Ocamlorg_static.Asset.url "vendors/alpine.min.js" %>"></script>
       <script defer src="<%s Ocamlorg_static.Asset.url "vendors/htmx.min.js" %>"></script>
-      <!-- FIXME: remove plausible script when Plausible is retired -->
       <script defer data-domain="ocaml.org" src="https://plausible.ci.dev/js/script.js"></script>
-      <script>
-          !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init me ws ys ps bs capture je Di ks register register_once register_for_session unregister unregister_for_session Ps getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Es $s createPersonProfile Is opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Ss debug xs getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-          posthog.init('phc_OCqqItGZelQ6GJ5spVGiClX6FMqxWoDGBloGJVVSY5n', {
-              api_host: 'https://posthog.ci.dev',
-              person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
-              enable_heatmaps: true,
-          })
-      </script>
       <% if use_swiper then ( %>
       <link rel="stylesheet" href="<%s Ocamlorg_static.Asset.url "vendors/swiper-bundle.min.css" %>">
       <link rel="alternate" type="application/rss+xml" title="OCaml Planet Feed" href="/planet.xml">


### PR DESCRIPTION
## Summary
- Reverts #3101
- Removes the Posthog tracking script from the site layout
- Restores the Plausible analytics link in the privacy policy