### PR TITLE
Add note about setting up combobulate for ocaml in emacs

### DIFF
--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -122,6 +122,10 @@ Opening an OCaml file should launch an `ocaml-lsp` server, and you can convince 
 
 OCaml-eglot [README](https://github.com/tarides/ocaml-eglot/blob/main/README.md) provides a comprehensive overview of all the functions available in this mode!
 
+#### Structured Navigation and Editing
+
+> **Note:** For advanced structured navigation and editing, OCaml is supported by [Combobulate](https://github.com/mickeynp/combobulate). It leverages `tree-sitter` to provide syntax-aware movement and structural editing for your OCaml code. You can learn more about setting up Combobulate with OCaml in the [Combobulate documentation](https://github.com/mickeynp/combobulate/blob/master/README.rst).
+
 ## Vim
 
 For Vim, we won't use the LSP server but rather directly talk to Merlin.

--- a/data/tutorials/getting-started/2_00_editor_setup.md
+++ b/data/tutorials/getting-started/2_00_editor_setup.md
@@ -124,7 +124,7 @@ OCaml-eglot [README](https://github.com/tarides/ocaml-eglot/blob/main/README.md)
 
 #### Structured Navigation and Editing
 
-> **Note:** For advanced structured navigation and editing, OCaml is supported by [Combobulate](https://github.com/mickeynp/combobulate). It leverages `tree-sitter` to provide syntax-aware movement and structural editing for your OCaml code. You can learn more about setting up Combobulate with OCaml in the [Combobulate documentation](https://github.com/mickeynp/combobulate/blob/master/README.rst).
+**Note:** For advanced structured navigation and editing, OCaml is supported by [Combobulate](https://github.com/mickeynp/combobulate). It leverages `tree-sitter` to provide syntax-aware movement and structural editing for your OCaml code. You can learn more about setting up Combobulate with OCaml in the [Combobulate documentation](https://github.com/mickeynp/combobulate/blob/master/README.rst).
 
 ## Vim
 


### PR DESCRIPTION
When the [Pr](https://github.com/mickeynp/combobulate/pull/157) adding support for ocaml in combobulate is merged, this will be a helpful note to add in the emacs section.

cc @pitag-ha 