### PR TITLE
fix: add missing dune to install commands on install page

### DIFF
--- a/data/tutorials/getting-started/1_00_install_OCaml.md
+++ b/data/tutorials/getting-started/1_00_install_OCaml.md
@@ -134,7 +134,7 @@ Now that we've successfully installed the OCaml compiler and the opam package ma
 All these tools can be installed using a single command:
 
 ```shell
-opam install ocaml-lsp-server odoc ocamlformat utop
+opam install dune ocaml-lsp-server odoc ocamlformat utop
 ```
 
 You're now all set and ready to start hacking.

--- a/src/ocamlorg_frontend/pages/install.eml
+++ b/src/ocamlorg_frontend/pages/install.eml
@@ -109,7 +109,7 @@ Layout.render
             complete your OCaml development environment. To install them in your current opam switch, run this command:
           </p>
 
-          <%s! Copy_to_clipboard.small_code_snippet ~id:"install-platform-tools" "opam install ocaml-lsp-server odoc ocamlformat utop" %>
+          <%s! Copy_to_clipboard.small_code_snippet ~id:"install-platform-tools" "opam install dune ocaml-lsp-server odoc ocamlformat utop" %>
 
           <p>Now you are ready to write some OCaml code!</p>
         </div>
@@ -193,7 +193,7 @@ Layout.render
             complete your OCaml development environment. To install them in your current opam switch, run this command:
           </p>
 
-          <%s! Copy_to_clipboard.small_code_snippet ~id:"install-platform-tools" "opam install ocaml-lsp-server odoc ocamlformat utop" %>
+          <%s! Copy_to_clipboard.small_code_snippet ~id:"install-platform-tools" "opam install dune ocaml-lsp-server odoc ocamlformat utop" %>
 
           <p>Now you are ready to write some OCaml code!</p>
         </div>


### PR DESCRIPTION
The install page and tutorial listed Dune in the descriptive text but omitted it from the actual opam install command.