### PR TITLE
Auto-ignore and auto-detect pre-releases in platform release scraper

### DIFF
--- a/tool/data-packer/lib/platform_release_parser.ml
+++ b/tool/data-packer/lib/platform_release_parser.ml
@@ -8,6 +8,7 @@ type t = {
   date : string;
   tags : string list;
   experimental : bool;
+  ignore : bool;
   changelog_html : string option;
   body_html : string;
   body : string;
@@ -77,6 +78,7 @@ let decode (fname, (head, body)) =
         date;
         tags = metadata.tags;
         experimental = Option.value ~default:false metadata.experimental;
+        ignore = Option.value ~default:false metadata.ignore;
         changelog_html;
         body_html;
         body;
@@ -90,6 +92,10 @@ let decode (fname, (head, body)) =
       })
     metadata
 
-let all () =
+let all_including_ignored () =
   Utils.map_md_files decode "platform_releases/*/*.md"
   |> List.sort (fun (a : t) b -> String.compare b.slug a.slug)
+
+let all () =
+  all_including_ignored ()
+  |> List.filter (fun (t : t) -> not t.ignore)

--- a/tool/data-packer/lib/platform_release_parser.ml
+++ b/tool/data-packer/lib/platform_release_parser.ml
@@ -97,5 +97,4 @@ let all_including_ignored () =
   |> List.sort (fun (a : t) b -> String.compare b.slug a.slug)
 
 let all () =
-  all_including_ignored ()
-  |> List.filter (fun (t : t) -> not t.ignore)
+  all_including_ignored () |> List.filter (fun (t : t) -> not t.ignore)

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -204,7 +204,7 @@ let write_release_announcement_file project github_tag tags ~ignore
       changelog = None;
       versions = None;
       authors = Some [];
-      experimental = Some ignore;
+      experimental = Some false;
       ignore = Some ignore;
       released_on_github_by;
       github_release_tags =

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -171,6 +171,16 @@ let group_releases_by_project all =
       SMap.add t.project_name updated acc)
     SMap.empty all
 
+let is_prerelease github_tag =
+  let tag = String.lowercase_ascii github_tag in
+  let has pattern =
+    try
+      let _ = Str.search_forward (Str.regexp pattern) tag 0 in
+      true
+    with Not_found -> false
+  in
+  has "alpha" || has "beta" || has "rc[0-9]"
+
 let tag_matches_ignore_patterns ignore_patterns github_tag =
   List.exists
     (fun pattern ->
@@ -180,7 +190,7 @@ let tag_matches_ignore_patterns ignore_patterns github_tag =
       with Not_found -> false)
     ignore_patterns
 
-let write_release_announcement_file project github_tag tags ~ignore
+let write_release_announcement_file project github_tag tags ~ignore ~experimental
     (post : River.post) =
   let yyyy_mm_dd =
     River.date post |> Option.get |> Ptime.to_rfc3339
@@ -204,7 +214,7 @@ let write_release_announcement_file project github_tag tags ~ignore
       changelog = None;
       versions = None;
       authors = Some [];
-      experimental = Some false;
+      experimental = Some experimental;
       ignore = Some ignore;
       released_on_github_by;
       github_release_tags =
@@ -230,9 +240,11 @@ let check_if_uptodate project known_tags =
           let ignore =
             tag_matches_ignore_patterns ignore_patterns github_tag
           in
+          let experimental = is_prerelease github_tag in
           warn "We don't have the release notes for %S github tag %S\n%!"
             project github_tag;
-          write_release_announcement_file project github_tag tags ~ignore post))
+          write_release_announcement_file project github_tag tags ~ignore
+            ~experimental post))
       scraped_versions
   in
   match List.assoc_opt project github_project_release_feeds with

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -179,13 +179,18 @@ let is_prerelease github_tag =
       true
     with Not_found -> false
   in
-  has "alpha" || has "beta" || has "rc[0-9]"
+  has "alpha" || has "beta" || has "rc[0-9]" || has "preview"
 
 let tag_matches_ignore_patterns ignore_patterns github_tag =
+  let tag = String.lowercase_ascii github_tag in
   List.exists
     (fun pattern ->
       try
-        let _ = Str.search_forward (Str.regexp_string pattern) github_tag 0 in
+        let _ =
+          Str.search_forward
+            (Str.regexp_string (String.lowercase_ascii pattern))
+            tag 0
+        in
         true
       with Not_found -> false)
     ignore_patterns

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -10,7 +10,11 @@
      dune exec -- tool/data-scrape/bin/scrape.exe platform_releases
     v} *)
 
-type release_feed_entry = { github_feed_url : string; tags : string list }
+type release_feed_entry = {
+  github_feed_url : string;
+  tags : string list;
+  ignore_patterns : string list;
+}
 
 let github_project_release_feeds =
   [
@@ -18,69 +22,85 @@ let github_project_release_feeds =
       {
         github_feed_url = "https://github.com/ocaml-ppx/ocamlformat";
         tags = [ "ocamlformat"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "dune",
       {
         github_feed_url = "https://github.com/ocaml/dune";
         tags = [ "dune"; "platform" ];
+        ignore_patterns = [ "alpha" ];
       } );
     ( "dune-release",
       {
         github_feed_url = "https://github.com/tarides/dune-release";
         tags = [ "dune-release"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "mdx",
       {
         github_feed_url = "https://github.com/realworldocaml/mdx";
         tags = [ "mdx"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "merlin",
       {
         github_feed_url = "https://github.com/ocaml/merlin";
         tags = [ "merlin"; "platform"; "editors" ];
+        ignore_patterns = [];
       } );
     ( "ocaml",
-      { github_feed_url = "https://github.com/ocaml/ocaml"; tags = [ "ocaml" ] }
-    );
+      {
+        github_feed_url = "https://github.com/ocaml/ocaml";
+        tags = [ "ocaml" ];
+        ignore_patterns = [];
+      } );
     ( "ocaml-lsp",
       {
         github_feed_url = "https://github.com/ocaml/ocaml-lsp";
         tags = [ "ocaml-lsp"; "platform"; "editors" ];
+        ignore_patterns = [];
       } );
     ( "ocp-indent",
       {
         github_feed_url = "https://github.com/OCamlPro/ocp-indent";
         tags = [ "ocp-indent"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "odoc",
       {
         github_feed_url = "https://github.com/ocaml/odoc";
         tags = [ "odoc"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "opam",
       {
         github_feed_url = "https://github.com/ocaml/opam/";
         tags = [ "opam"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "opam-publish",
       {
         github_feed_url = "https://github.com/ocaml-opam/opam-publish";
         tags = [ "opam-publish"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "ppxlib",
       {
         github_feed_url = "https://github.com/ocaml-ppx/ppxlib";
         tags = [ "ppxlib"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "utop",
       {
         github_feed_url = "https://github.com/ocaml-community/utop";
         tags = [ "utop"; "platform" ];
+        ignore_patterns = [];
       } );
     ( "omp",
       {
         github_feed_url = "https://github.com/ocaml-ppx/ocaml-migrate-parsetree";
         tags = [ "ocaml-migrate-parsetree"; "platform" ];
+        ignore_patterns = [];
       } );
   ]
 
@@ -151,8 +171,17 @@ let group_releases_by_project all =
       SMap.add t.project_name updated acc)
     SMap.empty all
 
-let write_release_announcement_file project github_tag tags (post : River.post)
-    =
+let tag_matches_ignore_patterns ignore_patterns github_tag =
+  List.exists
+    (fun pattern ->
+      try
+        let _ = Str.search_forward (Str.regexp_string pattern) github_tag 0 in
+        true
+      with Not_found -> false)
+    ignore_patterns
+
+let write_release_announcement_file project github_tag tags ~ignore
+    (post : River.post) =
   let yyyy_mm_dd =
     River.date post |> Option.get |> Ptime.to_rfc3339
     |> String.split_on_char 'T' |> List.hd
@@ -175,8 +204,8 @@ let write_release_announcement_file project github_tag tags (post : River.post)
       changelog = None;
       versions = None;
       authors = Some [];
-      experimental = Some false;
-      ignore = Some false;
+      experimental = Some ignore;
+      ignore = Some ignore;
       released_on_github_by;
       github_release_tags =
         (match
@@ -193,18 +222,22 @@ let write_release_announcement_file project github_tag tags (post : River.post)
 
 let check_if_uptodate project known_tags =
   let known_github_tags = SSet.of_list known_tags in
-  let check repo tags =
+  let check repo tags ignore_patterns =
     let scraped_versions = fetch_github repo in
     List.iter
       (fun { github_tag; post } ->
         if not (SSet.mem github_tag known_github_tags) then (
+          let ignore =
+            tag_matches_ignore_patterns ignore_patterns github_tag
+          in
           warn "We don't have the release notes for %S github tag %S\n%!"
             project github_tag;
-          write_release_announcement_file project github_tag tags post))
+          write_release_announcement_file project github_tag tags ~ignore post))
       scraped_versions
   in
   match List.assoc_opt project github_project_release_feeds with
-  | Some { github_feed_url; tags } -> check github_feed_url tags
+  | Some { github_feed_url; tags; ignore_patterns } ->
+      check github_feed_url tags ignore_patterns
   | None ->
       warn
         "Don't know how to lookup project %S. Please update \
@@ -213,6 +246,6 @@ let check_if_uptodate project known_tags =
         project
 
 let scrape () =
-  Data_packer.Platform_release_parser.all ()
+  Data_packer.Platform_release_parser.all_including_ignored ()
   |> group_releases_by_project
   |> SMap.iter check_if_uptodate

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -195,8 +195,8 @@ let tag_matches_ignore_patterns ignore_patterns github_tag =
       with Not_found -> false)
     ignore_patterns
 
-let write_release_announcement_file project github_tag tags ~ignore ~experimental
-    (post : River.post) =
+let write_release_announcement_file project github_tag tags ~ignore
+    ~experimental (post : River.post) =
   let yyyy_mm_dd =
     River.date post |> Option.get |> Ptime.to_rfc3339
     |> String.split_on_char 'T' |> List.hd

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -242,9 +242,7 @@ let check_if_uptodate project known_tags =
     List.iter
       (fun { github_tag; post } ->
         if not (SSet.mem github_tag known_github_tags) then (
-          let ignore =
-            tag_matches_ignore_patterns ignore_patterns github_tag
-          in
+          let ignore = tag_matches_ignore_patterns ignore_patterns github_tag in
           let experimental = is_prerelease github_tag in
           warn "We don't have the release notes for %S github tag %S\n%!"
             project github_tag;


### PR DESCRIPTION
## Summary

Addresses the feedback from @shonfeder in #3551: dune alpha releases are QA artifacts and should not appear on the site at all.

**Per-project ignore_patterns:**
- Adds ignore_patterns to the platform release scraper config. When a GitHub release tag contains any of a project's ignore patterns (case-insensitive substring match), the scraped draft file is written with ignore: true.
- Makes the existing ignore metadata field actually work: Platform_release_parser.all() now filters out ignore: true entries. A new all_including_ignored() function is used by the scraper so it does not re-create files it already knows about.
- Currently only dune has an ignore pattern configured (alpha).

**Auto-detect pre-releases as experimental:**
- Tags containing alpha, beta, rc followed by a digit, or preview are automatically marked experimental: true, placing them on the backstage page instead of the changelog.
- This is a global heuristic applied to all projects.
- Note: existing data files already on main are unaffected - only newly scraped releases get the auto-detection.

## Test plan

- [x] dune build passes (full site build including data packing)
- [x] Ran scraper - new dune alpha files get ignore: true
- [x] Verified with headless Chrome: no dune 3.21/3.22 alphas on changelog or backstage pages
- [x] Verify that newly scraped OCaml alpha/beta/rc releases get experimental: true