### PR TITLE
(docs) Hash Tables: O(1) is constant time, not linear

### DIFF
--- a/data/tutorials/language/3ds_04_hashtbl.md
+++ b/data/tutorials/language/3ds_04_hashtbl.md
@@ -17,7 +17,7 @@ differences that can be weighed when choosing between the two.
 One of the benefits of a hash table over a map is that instead of having a
 logarithmic time complexity (O(log n)), a [`hash
 table`](https://en.wikipedia.org/wiki/Hash_table) is able to retrieve
-information at a nearly instantaneous linear time complexity (O(1)).
+information at a nearly instantaneous constant time complexity (O(1)).
 
 A hash table data structure achieves efficient reads and writes by employing a
 hashing function that converts the key of a key/value pair into an


### PR DESCRIPTION
Hi, just noticed what looks like a small error to me in the Hash Tables tutorial.
From what I can read at this time on main ([link](https://github.com/ocaml/ocaml.org/blob/main/data/tutorials/language/3ds_04_hashtbl.md?plain=1#L20)):
> One of the benefits of a hash table over a map is that instead of having a
> logarithmic time complexity (O(log n)), a [`hash
> table`](https://en.wikipedia.org/wiki/Hash_table) is able to retrieve
> information at a nearly instantaneous **linear** time complexity (O(1)).

Except that O(1) is constant, not linear. Linear would be O(n). (Related [wikipedia page](https://en.wikipedia.org/wiki/Big_O_notation#Orders_of_common_functions).)