### PR TITLE
values-and-functions: add missing space before `->` in type definition

### DIFF
--- a/data/tutorials/language/0it_00_values_functions.md
+++ b/data/tutorials/language/0it_00_values_functions.md
@@ -494,7 +494,7 @@ Functions don't have to be bound to a name unless they are [recursive](#recursiv
 - : int -> int = <fun>
 
 # fun s t -> s ^ " " ^ t ;;
-- : string -> string-> string = <fun>
+- : string -> string -> string = <fun>
 
 # function [] -> None | x :: _ -> Some x;;
 - : 'a list -> 'a option = <fun>


### PR DESCRIPTION
While reading the documentation I noticed the error is not aligned properly in type definition