### PR TITLE
(data) Add changelogs to ignore for dune 3.22 and 3.23 alpha releases

### DIFF
--- a/data/platform_releases/dune/2026-03-03-dune-3.22.0_alpha0-draft.md
+++ b/data/platform_releases/dune/2026-03-03-dune-3.22.0_alpha0-draft.md
@@ -1,0 +1,278 @@
+---
+title: Dune 3.22.0~alpha0
+tags:
+- dune
+- platform
+contributors:
+changelog:
+versions:
+authors: []
+experimental: true
+ignore: true
+released_on_github_by: shonfeder
+github_release_tags:
+- 3.22.0_alpha0
+---
+
+<p>CHANGES:</p>
+<h3>Fixed</h3>
+<ul>
+<li>
+<p><code>Dyn.to_string</code> now uses a smarter way to convert floats. This ensures that<br>
+floats are printed with enough precision to round-trip and are valid OCaml<br>
+lexemes. (<a href="https://github.com/ocaml/dune/pull/12982" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3735560714" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12982" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12982/hovercard">#12982</a>, fixes <a href="https://github.com/ocaml/dune/issues/12980" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3735323107" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12980" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12980/hovercard">#12980</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune install --prefix</code> failing with relative paths outside the workspace<br>
+like <code>../foo</code> (<a href="https://github.com/ocaml/dune/pull/12993" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3741028006" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12993" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12993/hovercard">#12993</a>, fixes <a href="https://github.com/ocaml/dune/issues/12241" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3341071125" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12241" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12241/hovercard">#12241</a>, <a href="https://github.com/benodiwal" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/benodiwal/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@benodiwal</a>)</p>
+</li>
+<li>
+<p>Delete sandboxes with broken permissions (<a href="https://github.com/ocaml/dune/pull/13511" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3881696180" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13511" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13511/hovercard">#13511</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix compiling Menhir parsers that refer to sibling modules within a<br>
+subdirectory of <code>(include_subdirs qualified)</code>. (<a href="https://github.com/ocaml/dune/pull/13118" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3768896609" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13118" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13118/hovercard">#13118</a>, fixes <a href="https://github.com/ocaml/dune/issues/11119" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2654196727" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11119" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11119/hovercard">#11119</a>,<br>
+<a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fixed the dependency specification of C stubs, which could result in C<br>
+stubs not getting rebuilt when needed (which could in turn lead to<br>
+segmentation faults and other hard-to-track bugs).<br>
+(<a href="https://github.com/ocaml/dune/pull/13652" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3970278708" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13652" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13652/hovercard">#13652</a>, fixes <a href="https://github.com/ocaml/dune/issues/13651" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3970143988" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13651" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13651/hovercard">#13651</a>, <a href="https://github.com/nojb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/nojb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@nojb</a>)</p>
+</li>
+<li>
+<p>Fix rpc not transferring promotion warnings to the client<br>
+(<a href="https://github.com/ocaml/dune/pull/12604" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3533499392" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12604" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12604/hovercard">#12604</a>, fixes <a href="https://github.com/ocaml/dune/issues/12578" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3517292941" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12578" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12578/hovercard">#12578</a>, <a href="https://github.com/ElectreAAS" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/ElectreAAS/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@ElectreAAS</a>)</p>
+</li>
+<li>
+<p>Fix issue where <code>dune exec -w</code> was unable to kill running programs on<br>
+rebuild. (<a href="https://github.com/ocaml/dune/pull/12360" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3369437282" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12360" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12360/hovercard">#12360</a>, fixes <a href="https://github.com/ocaml/dune/issues/12323" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3360045149" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12323" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12323/hovercard">#12323</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Resolve context and workspace binaries introduced by the respective <code>(env (binaries ..))</code> stanzas. (<a href="https://github.com/ocaml/dune/pull/12952" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3727063772" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12952" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12952/hovercard">#12952</a>, fixes <a href="https://github.com/ocaml/dune/issues/6220" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1406253137" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6220" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6220/hovercard">#6220</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix <code>diff</code> promotions originating from sandboxed rules. Previously, they<br>
+would be completely ignored as the sandbox with the promoted file would be<br>
+destroyed if the promotion fired (<a href="https://github.com/ocaml/dune/pull/13520" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3883144672" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13520" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13520/hovercard">#13520</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix failure to digest installed directory targets, allowing them to be used<br>
+as dependencies to other rules. (<a href="https://github.com/ocaml/dune/pull/13045" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3760995777" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13045" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13045/hovercard">#13045</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix handling of <code>(select ..)</code> field when used with <code>(include_subdirs ..)</code>.<br>
+<code>(select &lt;path&gt; from ..)</code> modules now parse <code>path</code> as a relative path<br>
+starting from the module group root (<a href="https://github.com/ocaml/dune/pull/13175" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3776051068" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13175" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13175/hovercard">#13175</a>, fixes <a href="https://github.com/ocaml/dune/issues/4383" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="837752295" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4383" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4383/hovercard">#4383</a>, <a href="https://github.com/ocaml/dune/issues/12450" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3410109716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12450" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12450/hovercard">#12450</a>,<br>
+<a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix dune trying to kill processes that were already reaped due to race<br>
+conditions (<a href="https://github.com/ocaml/dune/pull/13245" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3797179627" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13245" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13245/hovercard">#13245</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>O_CLOEXEC</code> to all files used for stdin/stdout/stderr (<a href="https://github.com/ocaml/dune/pull/13385" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3831363644" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13385" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13385/hovercard">#13385</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>$ dune promote dir/foo</code> when <code>dir</code> does not exist (<a href="https://github.com/ocaml/dune/pull/13493" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3872969699" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13493" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13493/hovercard">#13493</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>(select ..)</code> field evaluation when a transitive library has optional<br>
+dependencies (fixes <a href="https://github.com/ocaml/dune/issues/13299" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3805627091" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13299" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13299/hovercard">#13299</a>, <a href="https://github.com/ocaml/dune/pull/13389" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3831717202" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13389" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13389/hovercard">#13389</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix sandboxed builds of <code>library</code> stanzas that set<br>
+<code>(stdlib (modules_before_stdlib ..))</code> (<a href="https://github.com/ocaml/dune/pull/13624" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3935624771" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13624" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13624/hovercard">#13624</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fixed non-build caches not following <code>$DUNE_CACHE_ROOT</code> and instead only<br>
+relying on <code>$XDG_CACHE_HOME</code>.<br>
+This means the normal build cache moves:<br>
+<code>$DUNE_CACHE_ROOT -&gt; $DUNE_CACHE_ROOT/db</code> (no changes if that variable was<br>
+unset). Affected users can prevent a full cache invalidation by moving<br>
+previous contents:<br>
+<code>cd $DUNE_CACHE_ROOT; mkdir db; mv &lt;contents of directory&gt; db</code>.<br>
+(<a href="https://github.com/ocaml/dune/pull/11612" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2976721313" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11612" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/11612/hovercard">#11612</a>, fixes <a href="https://github.com/ocaml/dune/issues/11584" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2959960787" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11584" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11584/hovercard">#11584</a>, <a href="https://github.com/ElectreAAS" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/ElectreAAS/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@ElectreAAS</a>)</p>
+</li>
+<li>
+<p><code>$ dune promotion list</code> writes output to stdout rather than stderr (<a href="https://github.com/ocaml/dune/pull/13462" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3858100731" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13462" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13462/hovercard">#13462</a>)</p>
+</li>
+<li>
+<p>Improve handling of empty files in the <code>diff</code> action. These are now correctly<br>
+distinguished from <em>empty</em> files. (<a href="https://github.com/ocaml/dune/pull/13696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4004483629" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13696/hovercard">#13696</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Pass <code>/dev/null</code> to <code>--diff-command</code> instead of non-existent files (<a href="https://github.com/ocaml/dune/pull/13696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4004483629" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13696/hovercard">#13696</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix failure when multiple <code>rocq.extraction</code> stanzas existing in a directory<br>
+(<a href="https://github.com/ocaml/dune/pull/13531" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3888262788" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13531" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13531/hovercard">#13531</a>, fixes <a href="https://github.com/ocaml/dune/issues/8042" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1772883745" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/8042" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/8042/hovercard">#8042</a>, <a href="https://github.com/rlepigre-skylabs-ai" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rlepigre-skylabs-ai/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rlepigre-skylabs-ai</a>)</p>
+</li>
+<li>
+<p>Print <code>$ dune promotion show</code> output to stdout rather than stderr (<a href="https://github.com/ocaml/dune/pull/13481" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3864767296" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13481" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13481/hovercard">#13481</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix deadlock in the <code>memo</code> library in the presence of dependency cycles<br>
+(<a href="https://github.com/ocaml/dune/pull/13625" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3935834171" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13625" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13625/hovercard">#13625</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix promotions that modify a directory into a file (<a href="https://github.com/ocaml/dune/pull/13516" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3882586407" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13516" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13516/hovercard">#13516</a>, fixes <a href="https://github.com/ocaml/dune/issues/4067" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="774992697" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4067" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4067/hovercard">#4067</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix installation of implementations of virtual libraries. This failed when<br>
+the implementation had no private modules, but the virtual library did<br>
+(<a href="https://github.com/ocaml/dune/issues/10635" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2344749343" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10635" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10635/hovercard">#10635</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Respect the <code>(dir ..)</code> field on packages when setting up cram tests (<a href="https://github.com/ocaml/dune/pull/13581" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3910747944" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13581" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13581/hovercard">#13581</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>
+<p>Add support for generating <code>.cms</code> files using oxcaml and adding <code>.cms</code> or<br>
+<code>.cmt</code> files as compilation dependencies (<a href="https://github.com/ocaml/dune/pull/13397" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833275686" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13397" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13397/hovercard">#13397</a>, <a href="https://github.com/spiessimon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/spiessimon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@spiessimon</a>)</p>
+</li>
+<li>
+<p>Add trace events for custom actions (<a href="https://github.com/ocaml/dune/pull/13265" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3800380631" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13265" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13265/hovercard">#13265</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow enabling extensions with <code>(using ..)</code> in <code>dune-workspace</code> files<br>
+(<a href="https://github.com/ocaml/dune/pull/13395" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833202404" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13395" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13395/hovercard">#13395</a>, <a href="https://github.com/spiessimon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/spiessimon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@spiessimon</a>)</p>
+</li>
+<li>
+<p>Add sandbox extraction trace event (<a href="https://github.com/ocaml/dune/pull/13544" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3898256868" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13544" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13544/hovercard">#13544</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add the initial cwd to the first config event (<a href="https://github.com/ocaml/dune/pull/13026" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3751510385" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13026" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13026/hovercard">#13026</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Dune produces trace events in <code>DUNE_ACTION_TRACE_DIR</code> if this variable<br>
+is set. (<a href="https://github.com/ocaml/dune/pull/13302" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3806227611" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13302" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13302/hovercard">#13302</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add file watching events to the trace file (<a href="https://github.com/ocaml/dune/pull/13038" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3755134419" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13038" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13038/hovercard">#13038</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Introduce the <code>$ dune trace cat</code> subcommand to view the trace file. (<a href="https://github.com/ocaml/dune/pull/13055" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764032511" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13055" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13055/hovercard">#13055</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add diagnostic events to the trace. (<a href="https://github.com/ocaml/dune/pull/13041" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3758381346" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13041" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13041/hovercard">#13041</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>DUNE_JOBS</code> environment variable for controlling concurrency of Dune from<br>
+environment. The <code>INSIDE_DUNE</code> variable also now no longer controls<br>
+concurrency (<a href="https://github.com/ocaml/dune/pull/12800" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3670969816" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12800" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12800/hovercard">#12800</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Support for Rocq expected output tests (<a href="https://github.com/ocaml/dune/pull/13632" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3943611177" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13632" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13632/hovercard">#13632</a>, <a href="https://github.com/rlepigre-skylabs-ai" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rlepigre-skylabs-ai/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rlepigre-skylabs-ai</a>)</p>
+</li>
+<li>
+<p>Add <code>rusage</code> information to completed processes in the trace (<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>,<br>
+<a href="https://github.com/ocaml/dune/pull/13241" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3794757038" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13241" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13241/hovercard">#13241</a>)</p>
+</li>
+<li>
+<p>Add process start events to the trace (<a href="https://github.com/ocaml/dune/pull/13261" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3800114266" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13261" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13261/hovercard">#13261</a>, rgrinberg)</p>
+</li>
+<li>
+<p>Generate odoc documentation in markdown using the <code>@doc-markdown</code> alias<br>
+(<a href="https://github.com/ocaml/dune/pull/12581" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3519116591" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12581" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12581/hovercard">#12581</a>, <a href="https://github.com/davesnx" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/davesnx/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@davesnx</a>)</p>
+</li>
+<li>
+<p>Add timing information for every command executed by cram (<a href="https://github.com/ocaml/dune/pull/13092" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766088066" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13092" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13092/hovercard">#13092</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add the workspace root to the config trace event (<a href="https://github.com/ocaml/dune/pull/12922" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3718678842" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12922" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12922/hovercard">#12922</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Introduce the <code>dune-action-trace</code> library. This public library is to be used<br>
+by custom actions to emit trace events while executed as part of a dune<br>
+build. The trace events emitted through this library will be incorporated<br>
+into dune's own trace (<a href="https://github.com/ocaml/dune/pull/13348" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3825976320" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13348" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13348/hovercard">#13348</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>dune-find-dominating</code> to <code>dune.el</code>, a command to find the<br>
+dominating dune file. (<a href="https://github.com/ocaml/dune/pull/12696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3599579081" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12696/hovercard">#12696</a>, <a href="https://github.com/arvidj" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/arvidj/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@arvidj</a>)</p>
+</li>
+<li>
+<p>Add a <code>--no-recursive</code> flag to <code>$ dune describe workspace</code> (<a href="https://github.com/ocaml/dune/pull/13590" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3913860581" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13590" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13590/hovercard">#13590</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Trace events for files written directly by dune (<a href="https://github.com/ocaml/dune/pull/13618" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3929244990" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13618" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13618/hovercard">#13618</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow expansion of special forms like <code>(:include ..)</code> and <code>%{read-lines:..}</code><br>
+in the <code>modules</code> specification for the <code>ocamllex</code>, <code>ocamlyacc</code> and <code>menhir</code><br>
+stanzas. (<a href="https://github.com/ocaml/dune/pull/13105" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766996679" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13105" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13105/hovercard">#13105</a>, <a href="https://github.com/ocaml/dune/pull/13135" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3771460013" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13135" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13135/hovercard">#13135</a>, <a href="https://github.com/ocaml/dune/pull/13157" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3774256677" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13157" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13157/hovercard">#13157</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Add a trace event for snapshotting the sandbox (<a href="https://github.com/ocaml/dune/pull/13541" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3898125996" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13541" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13541/hovercard">#13541</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add signal send and receive events to the trace (<a href="https://github.com/ocaml/dune/pull/13193" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3778408898" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13193" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13193/hovercard">#13193</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Emit final trace event before exiting. (<a href="https://github.com/ocaml/dune/pull/13018" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3750981598" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13018" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13018/hovercard">#13018</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>dune runtest</code> can now run individual test executables from <code>(tests)</code> stanzas<br>
+and inline tests from <code>(library (inline_tests))</code> stanzas by providing their<br>
+source files as arguments. (<a href="https://github.com/ocaml/dune/pull/13064" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764872270" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13064" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13064/hovercard">#13064</a>, fixes <a href="https://github.com/ocaml/dune/issues/870" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="330879527" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/870" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/870/hovercard">#870</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Add a <code>shell</code> field to the cram stanza. This field allows customizing the<br>
+shell to be <code>bash</code> rather than <code>sh</code> (<a href="https://github.com/ocaml/dune/pull/13083" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3765870121" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13083" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13083/hovercard">#13083</a>, <a href="https://github.com/haochenx" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/haochenx/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@haochenx</a>)</p>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>
+<p>Start sandboxing the execution of tests defined with the <code>test</code> and <code>tests</code><br>
+stanzas (<a href="https://github.com/ocaml/dune/pull/13510" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3880290724" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13510" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13510/hovercard">#13510</a>, <a href="https://github.com/ocaml/dune/pull/13617" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3929243234" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13617" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13617/hovercard">#13617</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Disabled cram tests can now be run explicitly with <code>dune runtest disabled.t</code>.<br>
+The <code>enabled_if</code> field now only controls whether a test is included in<br>
+the <code>@runtest</code> alias. (<a href="https://github.com/ocaml/dune/pull/13081" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3765722827" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13081" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13081/hovercard">#13081</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Process categories in trace events are moved to their own field in <code>args</code><br>
+(<a href="https://github.com/ocaml/dune/pull/13024" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3751122219" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13024" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13024/hovercard">#13024</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Sandbox running <code>ocamllex</code> and <code>ocamlyacc</code> actions. (<a href="https://github.com/ocaml/dune/pull/13098" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766201590" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13098" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13098/hovercard">#13098</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Sandboxing mdx test actions is now the default starting from <code>0.5</code> (<a href="https://github.com/ocaml/dune/pull/13504" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3878986649" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13504" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13504/hovercard">#13504</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Start sandboxing Melange rules by default in the <code>(library ..)</code> and<br>
+<code>(melange.emit ..)</code> stanzas (<a href="https://github.com/ocaml/dune/pull/13619" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3930304738" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13619" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13619/hovercard">#13619</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Introduce a promotion trace event and remove the corresponding verbose log<br>
+message. (<a href="https://github.com/ocaml/dune/pull/12949" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3726978397" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12949" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12949/hovercard">#12949</a>, <a href="https://github.com/ocaml/dune/pull/13444" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3849393797" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13444" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13444/hovercard">#13444</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Change dune's trace format to emit canonical s-expressions. This improves<br>
+performance and is better aligned with dune's usage of the format<br>
+elsewhere. <code>$ dune trace cat</code> can also emit the trace in <code>--chrome-trace</code><br>
+for perfetto, or <code>--sexp</code> for regular s-expressions for interactive usage.<br>
+(<a href="https://github.com/ocaml/dune/pull/13059" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764147538" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13059" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13059/hovercard">#13059</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Move all logging statements to the trace file. All log statements now contain<br>
+structured payloads (<a href="https://github.com/ocaml/dune/pull/13015" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3749972872" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13015" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13015/hovercard">#13015</a>, fixes <a href="https://github.com/ocaml/dune/issues/12904" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3712595073" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12904" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12904/hovercard">#12904</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add a target resolution event to replace the equivalent log message (<a href="https://github.com/ocaml/dune/pull/12955" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3728098444" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12955" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12955/hovercard">#12955</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>

--- a/data/platform_releases/dune/2026-03-11-dune-3.22.0_alpha1-draft.md
+++ b/data/platform_releases/dune/2026-03-11-dune-3.22.0_alpha1-draft.md
@@ -1,0 +1,303 @@
+---
+title: Dune 3.22.0~alpha1
+tags:
+- dune
+- platform
+contributors:
+changelog:
+versions:
+authors: []
+experimental: true
+ignore: true
+released_on_github_by: shonfeder
+github_release_tags:
+- 3.22.0_alpha1
+---
+
+<p>CHANGES:</p>
+<h3>Fixed</h3>
+<ul>
+<li>
+<p><code>Dyn.to_string</code> now uses a smarter way to convert floats. This ensures that<br>
+floats are printed with enough precision to round-trip and are valid OCaml<br>
+lexemes. (<a href="https://github.com/ocaml/dune/pull/12982" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3735560714" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12982" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12982/hovercard">#12982</a>, fixes <a href="https://github.com/ocaml/dune/issues/12980" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3735323107" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12980" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12980/hovercard">#12980</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune install --prefix</code> failing with relative paths outside the workspace<br>
+like <code>../foo</code> (<a href="https://github.com/ocaml/dune/pull/12993" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3741028006" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12993" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12993/hovercard">#12993</a>, fixes <a href="https://github.com/ocaml/dune/issues/12241" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3341071125" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12241" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12241/hovercard">#12241</a>, <a href="https://github.com/benodiwal" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/benodiwal/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@benodiwal</a>)</p>
+</li>
+<li>
+<p>Place the default trace file inside the build directory at the<br>
+workspace root, rather than relative to the current directory.<br>
+(<a href="https://github.com/ocaml/dune/pull/13735" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4028367595" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13735" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13735/hovercard">#13735</a>, <a href="https://github.com/vouillon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/vouillon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@vouillon</a>)</p>
+</li>
+<li>
+<p>Fixed interpreting relative paths in <code>%{bin:..}</code> and <code>%{bin-available:..}</code>.<br>
+These are now interpreted correctly, relative to the dune file they're in.<br>
+(<a href="https://github.com/ocaml/dune/pull/13712" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4009454408" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13712" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13712/hovercard">#13712</a>, fixes <a href="https://github.com/ocaml/dune/issues/9564" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2054423578" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/9564" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/9564/hovercard">#9564</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Delete sandboxes with broken permissions (<a href="https://github.com/ocaml/dune/pull/13511" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3881696180" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13511" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13511/hovercard">#13511</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix compiling Menhir parsers that refer to sibling modules within a<br>
+subdirectory of <code>(include_subdirs qualified)</code>. (<a href="https://github.com/ocaml/dune/pull/13118" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3768896609" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13118" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13118/hovercard">#13118</a>, fixes <a href="https://github.com/ocaml/dune/issues/11119" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2654196727" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11119" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11119/hovercard">#11119</a>,<br>
+<a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fixed the dependency specification of C stubs, which could result in C<br>
+stubs not getting rebuilt when needed (which could in turn lead to<br>
+segmentation faults and other hard-to-track bugs).<br>
+(<a href="https://github.com/ocaml/dune/pull/13652" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3970278708" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13652" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13652/hovercard">#13652</a>, fixes <a href="https://github.com/ocaml/dune/issues/13651" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3970143988" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13651" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13651/hovercard">#13651</a>, <a href="https://github.com/nojb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/nojb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@nojb</a>)</p>
+</li>
+<li>
+<p>Fix the Dune cache on Windows by correctly handling renames onto read-only<br>
+files. Before this change, the Dune cache would be filled but the stored<br>
+artifacts would not generally be usable by Dune. (<a href="https://github.com/ocaml/dune/pull/13713" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4011439895" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13713" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13713/hovercard">#13713</a>, <a href="https://github.com/Nevor" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Nevor/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Nevor</a>)</p>
+</li>
+<li>
+<p>Fix rpc not transferring promotion warnings to the client<br>
+(<a href="https://github.com/ocaml/dune/pull/12604" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3533499392" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12604" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12604/hovercard">#12604</a>, fixes <a href="https://github.com/ocaml/dune/issues/12578" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3517292941" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12578" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12578/hovercard">#12578</a>, <a href="https://github.com/ElectreAAS" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/ElectreAAS/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@ElectreAAS</a>)</p>
+</li>
+<li>
+<p>Fix issue where <code>dune exec -w</code> was unable to kill running programs on<br>
+rebuild. (<a href="https://github.com/ocaml/dune/pull/12360" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3369437282" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12360" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12360/hovercard">#12360</a>, fixes <a href="https://github.com/ocaml/dune/issues/12323" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3360045149" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12323" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12323/hovercard">#12323</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix package extraction on systems with tar implementations that don't<br>
+auto-detect compression (e.g., OpenBSD). Dune now passes explicit<br>
+decompression flags (-z for gzip, -j for bzip2) when needed, and provides<br>
+clear error messages for unsupported formats like XZ and LZMA. (<a href="https://github.com/ocaml/dune/pull/13688" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4001698860" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13688" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13688/hovercard">#13688</a>,<br>
+fixes <a href="https://github.com/ocaml/dune/issues/10123" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2150372814" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10123" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10123/hovercard">#10123</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Resolve context and workspace binaries introduced by the respective <code>(env (binaries ..))</code> stanzas. (<a href="https://github.com/ocaml/dune/pull/12952" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3727063772" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12952" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12952/hovercard">#12952</a>, fixes <a href="https://github.com/ocaml/dune/issues/6220" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1406253137" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6220" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6220/hovercard">#6220</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix <code>diff</code> promotions originating from sandboxed rules. Previously, they<br>
+would be completely ignored as the sandbox with the promoted file would be<br>
+destroyed if the promotion fired (<a href="https://github.com/ocaml/dune/pull/13520" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3883144672" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13520" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13520/hovercard">#13520</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix failure to digest installed directory targets, allowing them to be used<br>
+as dependencies to other rules. (<a href="https://github.com/ocaml/dune/pull/13045" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3760995777" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13045" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13045/hovercard">#13045</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix handling of <code>(select ..)</code> field when used with <code>(include_subdirs ..)</code>.<br>
+<code>(select &lt;path&gt; from ..)</code> modules now parse <code>path</code> as a relative path<br>
+starting from the module group root (<a href="https://github.com/ocaml/dune/pull/13175" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3776051068" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13175" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13175/hovercard">#13175</a>, fixes <a href="https://github.com/ocaml/dune/issues/4383" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="837752295" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4383" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4383/hovercard">#4383</a>, <a href="https://github.com/ocaml/dune/issues/12450" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3410109716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12450" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12450/hovercard">#12450</a>,<br>
+<a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix dune trying to kill processes that were already reaped due to race<br>
+conditions (<a href="https://github.com/ocaml/dune/pull/13245" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3797179627" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13245" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13245/hovercard">#13245</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>O_CLOEXEC</code> to all files used for stdin/stdout/stderr (<a href="https://github.com/ocaml/dune/pull/13385" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3831363644" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13385" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13385/hovercard">#13385</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>$ dune promote dir/foo</code> when <code>dir</code> does not exist (<a href="https://github.com/ocaml/dune/pull/13493" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3872969699" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13493" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13493/hovercard">#13493</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>(select ..)</code> field evaluation when a transitive library has optional<br>
+dependencies (fixes <a href="https://github.com/ocaml/dune/issues/13299" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3805627091" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13299" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13299/hovercard">#13299</a>, <a href="https://github.com/ocaml/dune/pull/13389" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3831717202" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13389" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13389/hovercard">#13389</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix sandboxed builds of <code>library</code> stanzas that set<br>
+<code>(stdlib (modules_before_stdlib ..))</code> (<a href="https://github.com/ocaml/dune/pull/13624" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3935624771" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13624" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13624/hovercard">#13624</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Dune cache: use of hard links under Windows. (<a href="https://github.com/ocaml/dune/pull/13714" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4011446684" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13714" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13714/hovercard">#13714</a>, <a href="https://github.com/Nevor" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Nevor/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Nevor</a>)</p>
+</li>
+<li>
+<p>Fixed non-build caches not following <code>$DUNE_CACHE_ROOT</code> and instead only<br>
+relying on <code>$XDG_CACHE_HOME</code>.<br>
+This means the normal build cache moves:<br>
+<code>$DUNE_CACHE_ROOT -&gt; $DUNE_CACHE_ROOT/db</code> (no changes if that variable was<br>
+unset). Affected users can prevent a full cache invalidation by moving<br>
+previous contents:<br>
+<code>cd $DUNE_CACHE_ROOT; mkdir db; mv &lt;contents of directory&gt; db</code>.<br>
+(<a href="https://github.com/ocaml/dune/pull/11612" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2976721313" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11612" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/11612/hovercard">#11612</a>, fixes <a href="https://github.com/ocaml/dune/issues/11584" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2959960787" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11584" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11584/hovercard">#11584</a>, <a href="https://github.com/ElectreAAS" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/ElectreAAS/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@ElectreAAS</a>)</p>
+</li>
+<li>
+<p><code>$ dune promotion list</code> writes output to stdout rather than stderr (<a href="https://github.com/ocaml/dune/pull/13462" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3858100731" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13462" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13462/hovercard">#13462</a>)</p>
+</li>
+<li>
+<p>Improve handling of empty files in the <code>diff</code> action. These are now correctly<br>
+distinguished from <em>empty</em> files. (<a href="https://github.com/ocaml/dune/pull/13696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4004483629" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13696/hovercard">#13696</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Pass <code>/dev/null</code> to <code>--diff-command</code> instead of non-existent files (<a href="https://github.com/ocaml/dune/pull/13696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4004483629" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13696/hovercard">#13696</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix failure when multiple <code>rocq.extraction</code> stanzas existing in a directory<br>
+(<a href="https://github.com/ocaml/dune/pull/13531" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3888262788" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13531" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13531/hovercard">#13531</a>, fixes <a href="https://github.com/ocaml/dune/issues/8042" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1772883745" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/8042" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/8042/hovercard">#8042</a>, <a href="https://github.com/rlepigre-skylabs-ai" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rlepigre-skylabs-ai/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rlepigre-skylabs-ai</a>)</p>
+</li>
+<li>
+<p>Print <code>$ dune promotion show</code> output to stdout rather than stderr (<a href="https://github.com/ocaml/dune/pull/13481" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3864767296" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13481" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13481/hovercard">#13481</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix deadlock in the <code>memo</code> library in the presence of dependency cycles<br>
+(<a href="https://github.com/ocaml/dune/pull/13625" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3935834171" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13625" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13625/hovercard">#13625</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix promotions that modify a directory into a file (<a href="https://github.com/ocaml/dune/pull/13516" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3882586407" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13516" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13516/hovercard">#13516</a>, fixes <a href="https://github.com/ocaml/dune/issues/4067" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="774992697" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4067" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4067/hovercard">#4067</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix installation of implementations of virtual libraries. This failed when<br>
+the implementation had no private modules, but the virtual library did<br>
+(<a href="https://github.com/ocaml/dune/issues/10635" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2344749343" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10635" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10635/hovercard">#10635</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Respect the <code>(dir ..)</code> field on packages when setting up cram tests (<a href="https://github.com/ocaml/dune/pull/13581" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3910747944" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13581" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13581/hovercard">#13581</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>
+<p>Add support for generating <code>.cms</code> files using oxcaml and adding <code>.cms</code> or<br>
+<code>.cmt</code> files as compilation dependencies (<a href="https://github.com/ocaml/dune/pull/13397" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833275686" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13397" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13397/hovercard">#13397</a>, <a href="https://github.com/spiessimon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/spiessimon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@spiessimon</a>)</p>
+</li>
+<li>
+<p>Add trace events for custom actions (<a href="https://github.com/ocaml/dune/pull/13265" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3800380631" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13265" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13265/hovercard">#13265</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow enabling extensions with <code>(using ..)</code> in <code>dune-workspace</code> files<br>
+(<a href="https://github.com/ocaml/dune/pull/13395" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833202404" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13395" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13395/hovercard">#13395</a>, <a href="https://github.com/spiessimon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/spiessimon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@spiessimon</a>)</p>
+</li>
+<li>
+<p>Add sandbox extraction trace event (<a href="https://github.com/ocaml/dune/pull/13544" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3898256868" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13544" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13544/hovercard">#13544</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add the initial cwd to the first config event (<a href="https://github.com/ocaml/dune/pull/13026" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3751510385" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13026" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13026/hovercard">#13026</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Dune dune produces trace events in <code>DUNE_ACTION_TRACE_DIR</code> if this variable<br>
+is set. (<a href="https://github.com/ocaml/dune/pull/13302" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3806227611" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13302" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13302/hovercard">#13302</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add file watching events to the trace file (<a href="https://github.com/ocaml/dune/pull/13038" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3755134419" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13038" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13038/hovercard">#13038</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Introduce the <code>$ dune trace cat</code> subcommand to view the trace file. (<a href="https://github.com/ocaml/dune/pull/13055" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764032511" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13055" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13055/hovercard">#13055</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add diagnostic events to the trace. (<a href="https://github.com/ocaml/dune/pull/13041" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3758381346" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13041" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13041/hovercard">#13041</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>DUNE_JOBS</code> environment variable for controlling concurrency of Dune from<br>
+environment. The <code>INSIDE_DUNE</code> variable also now no longer controls<br>
+concurrency (<a href="https://github.com/ocaml/dune/pull/12800" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3670969816" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12800" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12800/hovercard">#12800</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Support for Rocq expected output tests (<a href="https://github.com/ocaml/dune/pull/13632" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3943611177" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13632" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13632/hovercard">#13632</a>, <a href="https://github.com/rlepigre-skylabs-ai" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rlepigre-skylabs-ai/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rlepigre-skylabs-ai</a>)</p>
+</li>
+<li>
+<p>Add <code>rusage</code> information to completed processes in the trace (<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>,<br>
+<a href="https://github.com/ocaml/dune/pull/13241" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3794757038" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13241" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13241/hovercard">#13241</a>)</p>
+</li>
+<li>
+<p>Add process start events to the trace (<a href="https://github.com/ocaml/dune/pull/13261" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3800114266" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13261" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13261/hovercard">#13261</a>, rgrinberg)</p>
+</li>
+<li>
+<p>Generate odoc documentation in markdown using the <code>@doc-markdown</code> alias<br>
+(<a href="https://github.com/ocaml/dune/pull/12581" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3519116591" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12581" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12581/hovercard">#12581</a>, <a href="https://github.com/davesnx" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/davesnx/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@davesnx</a>)</p>
+</li>
+<li>
+<p>Add timing information for every command executed by cram (<a href="https://github.com/ocaml/dune/pull/13092" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766088066" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13092" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13092/hovercard">#13092</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add the workspace root to the config trace event (<a href="https://github.com/ocaml/dune/pull/12922" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3718678842" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12922" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12922/hovercard">#12922</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Introduce the <code>dune-action-trace</code> library. This public library is to be used<br>
+by custom actions to emit trace events while executed as part of a dune<br>
+build. The trace events emitted through this library will be incorporated<br>
+into dune's own trace (<a href="https://github.com/ocaml/dune/pull/13348" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3825976320" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13348" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13348/hovercard">#13348</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>dune-find-dominating</code> to <code>dune.el</code>, a command to find the<br>
+dominating dune file. (<a href="https://github.com/ocaml/dune/pull/12696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3599579081" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12696/hovercard">#12696</a>, <a href="https://github.com/arvidj" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/arvidj/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@arvidj</a>)</p>
+</li>
+<li>
+<p>Add a <code>--no-recursive</code> flag to <code>$ dune describe workspace</code> (<a href="https://github.com/ocaml/dune/pull/13590" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3913860581" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13590" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13590/hovercard">#13590</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Trace events for files written directly by dune (<a href="https://github.com/ocaml/dune/pull/13618" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3929244990" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13618" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13618/hovercard">#13618</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow expansion of special forms like <code>(:include ..)</code> and <code>%{read-lines:..}</code><br>
+in the <code>modules</code> specification for the <code>ocamllex</code>, <code>ocamlyacc</code> and <code>menhir</code><br>
+stanzas. (<a href="https://github.com/ocaml/dune/pull/13105" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766996679" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13105" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13105/hovercard">#13105</a>, <a href="https://github.com/ocaml/dune/pull/13135" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3771460013" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13135" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13135/hovercard">#13135</a>, <a href="https://github.com/ocaml/dune/pull/13157" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3774256677" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13157" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13157/hovercard">#13157</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Add a trace event for snapshotting the asndbox (<a href="https://github.com/ocaml/dune/pull/13541" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3898125996" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13541" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13541/hovercard">#13541</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add signal send and receive events to the trace (<a href="https://github.com/ocaml/dune/pull/13193" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3778408898" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13193" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13193/hovercard">#13193</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Emit final trace event before exiting. (<a href="https://github.com/ocaml/dune/pull/13018" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3750981598" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13018" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13018/hovercard">#13018</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>dune runtest</code> can now run individual test executables from <code>(tests)</code> stanzas<br>
+and inline tests from <code>(library (inline_tests))</code> stanzas by providing their<br>
+source files as arguments. (<a href="https://github.com/ocaml/dune/pull/13064" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764872270" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13064" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13064/hovercard">#13064</a>, fixes <a href="https://github.com/ocaml/dune/issues/870" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="330879527" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/870" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/870/hovercard">#870</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Add a <code>shell</code> field to the cram stanza. This field allows customizing the<br>
+shell to be <code>bash</code> rather than <code>sh</code> (<a href="https://github.com/ocaml/dune/pull/13083" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3765870121" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13083" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13083/hovercard">#13083</a>, <a href="https://github.com/haochenx" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/haochenx/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@haochenx</a>)</p>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>
+<p>Start sandboxing the execution of tests defined with the <code>test</code> and <code>tests</code><br>
+stanzas (<a href="https://github.com/ocaml/dune/pull/13510" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3880290724" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13510" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13510/hovercard">#13510</a>, <a href="https://github.com/ocaml/dune/pull/13617" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3929243234" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13617" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13617/hovercard">#13617</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Disabled cram tests can now be run explicitly with <code>dune runtest disabled.t</code>.<br>
+The <code>enabled_if</code> field now only controls whether a test is included in<br>
+the <code>@runtest</code> alias. (<a href="https://github.com/ocaml/dune/pull/13081" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3765722827" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13081" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13081/hovercard">#13081</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Process categories in trace events are moved to their own field in <code>args</code><br>
+(<a href="https://github.com/ocaml/dune/pull/13024" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3751122219" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13024" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13024/hovercard">#13024</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Sandbox running <code>ocamllex</code> and <code>ocamlyacc</code> actions. (<a href="https://github.com/ocaml/dune/pull/13098" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766201590" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13098" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13098/hovercard">#13098</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Sandboxing mdx test actions is now the default starting from <code>0.5</code> (<a href="https://github.com/ocaml/dune/pull/13504" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3878986649" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13504" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13504/hovercard">#13504</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Start sandboxing Melange rules by default in the <code>(library ..)</code> and<br>
+<code>(melange.emit ..)</code> stanzas (<a href="https://github.com/ocaml/dune/pull/13619" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3930304738" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13619" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13619/hovercard">#13619</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Introduce a promotion trace event and remove the corresponding verbose log<br>
+message. (<a href="https://github.com/ocaml/dune/pull/12949" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3726978397" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12949" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12949/hovercard">#12949</a>, <a href="https://github.com/ocaml/dune/pull/13444" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3849393797" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13444" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13444/hovercard">#13444</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Change dune's trace format to emit canonical s-expressions. This improves<br>
+performance and is better aligned with dune's usage of the format<br>
+elsewhere. <code>$ dune trace cat</code> can also emit the trace in <code>--chrome-trace</code><br>
+for perfetto, or <code>--sexp</code> for regular s-expressions for interactive usage.<br>
+(<a href="https://github.com/ocaml/dune/pull/13059" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764147538" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13059" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13059/hovercard">#13059</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Move all logging statements to the trace file. All log statements now contain<br>
+structured payloads (<a href="https://github.com/ocaml/dune/pull/13015" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3749972872" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13015" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13015/hovercard">#13015</a>, fixes <a href="https://github.com/ocaml/dune/issues/12904" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3712595073" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12904" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12904/hovercard">#12904</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add a target resolution event to replace the equivalent log message (<a href="https://github.com/ocaml/dune/pull/12955" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3728098444" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12955" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12955/hovercard">#12955</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>

--- a/data/platform_releases/dune/2026-03-16-dune-3.22.0_alpha2-draft.md
+++ b/data/platform_releases/dune/2026-03-16-dune-3.22.0_alpha2-draft.md
@@ -1,0 +1,303 @@
+---
+title: Dune 3.22.0~alpha2
+tags:
+- dune
+- platform
+contributors:
+changelog:
+versions:
+authors: []
+experimental: true
+ignore: true
+released_on_github_by: shonfeder
+github_release_tags:
+- 3.22.0_alpha2
+---
+
+<p>CHANGES:</p>
+<h3>Fixed</h3>
+<ul>
+<li>
+<p><code>Dyn.to_string</code> now uses a smarter way to convert floats. This ensures that<br>
+floats are printed with enough precision to round-trip and are valid OCaml<br>
+lexemes. (<a href="https://github.com/ocaml/dune/pull/12982" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3735560714" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12982" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12982/hovercard">#12982</a>, fixes <a href="https://github.com/ocaml/dune/issues/12980" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3735323107" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12980" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12980/hovercard">#12980</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune install --prefix</code> failing with relative paths outside the workspace<br>
+like <code>../foo</code> (<a href="https://github.com/ocaml/dune/pull/12993" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3741028006" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12993" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12993/hovercard">#12993</a>, fixes <a href="https://github.com/ocaml/dune/issues/12241" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3341071125" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12241" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12241/hovercard">#12241</a>, <a href="https://github.com/benodiwal" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/benodiwal/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@benodiwal</a>)</p>
+</li>
+<li>
+<p>Place the default trace file inside the build directory at the<br>
+workspace root, rather than relative to the current directory.<br>
+(<a href="https://github.com/ocaml/dune/pull/13735" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4028367595" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13735" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13735/hovercard">#13735</a>, <a href="https://github.com/vouillon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/vouillon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@vouillon</a>)</p>
+</li>
+<li>
+<p>Fixed interpreting relative paths in <code>%{bin:..}</code> and <code>%{bin-available:..}</code>.<br>
+These are now interpreted correctly, relative to the dune file they're in.<br>
+(<a href="https://github.com/ocaml/dune/pull/13712" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4009454408" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13712" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13712/hovercard">#13712</a>, fixes <a href="https://github.com/ocaml/dune/issues/9564" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2054423578" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/9564" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/9564/hovercard">#9564</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Delete sandboxes with broken permissions (<a href="https://github.com/ocaml/dune/pull/13511" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3881696180" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13511" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13511/hovercard">#13511</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix compiling Menhir parsers that refer to sibling modules within a<br>
+subdirectory of <code>(include_subdirs qualified)</code>. (<a href="https://github.com/ocaml/dune/pull/13118" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3768896609" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13118" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13118/hovercard">#13118</a>, fixes <a href="https://github.com/ocaml/dune/issues/11119" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2654196727" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11119" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11119/hovercard">#11119</a>,<br>
+<a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fixed the dependency specification of C stubs, which could result in C<br>
+stubs not getting rebuilt when needed (which could in turn lead to<br>
+segmentation faults and other hard-to-track bugs).<br>
+(<a href="https://github.com/ocaml/dune/pull/13652" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3970278708" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13652" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13652/hovercard">#13652</a>, fixes <a href="https://github.com/ocaml/dune/issues/13651" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3970143988" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13651" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13651/hovercard">#13651</a>, <a href="https://github.com/nojb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/nojb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@nojb</a>)</p>
+</li>
+<li>
+<p>Fix the Dune cache on Windows by correctly handling renames onto read-only<br>
+files. Before this change, the Dune cache would be filled but the stored<br>
+artifacts would not generally be usable by Dune. (<a href="https://github.com/ocaml/dune/pull/13713" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4011439895" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13713" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13713/hovercard">#13713</a>, <a href="https://github.com/Nevor" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Nevor/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Nevor</a>)</p>
+</li>
+<li>
+<p>Fix rpc not transferring promotion warnings to the client<br>
+(<a href="https://github.com/ocaml/dune/pull/12604" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3533499392" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12604" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12604/hovercard">#12604</a>, fixes <a href="https://github.com/ocaml/dune/issues/12578" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3517292941" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12578" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12578/hovercard">#12578</a>, <a href="https://github.com/ElectreAAS" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/ElectreAAS/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@ElectreAAS</a>)</p>
+</li>
+<li>
+<p>Fix issue where <code>dune exec -w</code> was unable to kill running programs on<br>
+rebuild. (<a href="https://github.com/ocaml/dune/pull/12360" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3369437282" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12360" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12360/hovercard">#12360</a>, fixes <a href="https://github.com/ocaml/dune/issues/12323" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3360045149" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12323" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12323/hovercard">#12323</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix package extraction on systems with tar implementations that don't<br>
+auto-detect compression (e.g., OpenBSD). Dune now passes explicit<br>
+decompression flags (-z for gzip, -j for bzip2) when needed, and provides<br>
+clear error messages for unsupported formats like XZ and LZMA. (<a href="https://github.com/ocaml/dune/pull/13688" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4001698860" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13688" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13688/hovercard">#13688</a>,<br>
+fixes <a href="https://github.com/ocaml/dune/issues/10123" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2150372814" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10123" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10123/hovercard">#10123</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Resolve context and workspace binaries introduced by the respective <code>(env (binaries ..))</code> stanzas. (<a href="https://github.com/ocaml/dune/pull/12952" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3727063772" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12952" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12952/hovercard">#12952</a>, fixes <a href="https://github.com/ocaml/dune/issues/6220" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1406253137" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6220" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6220/hovercard">#6220</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix <code>diff</code> promotions originating from sandboxed rules. Previously, they<br>
+would be completely ignored as the sandbox with the promoted file would be<br>
+destroyed if the promotion fired (<a href="https://github.com/ocaml/dune/pull/13520" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3883144672" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13520" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13520/hovercard">#13520</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix failure to digest installed directory targets, allowing them to be used<br>
+as dependencies to other rules. (<a href="https://github.com/ocaml/dune/pull/13045" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3760995777" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13045" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13045/hovercard">#13045</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix handling of <code>(select ..)</code> field when used with <code>(include_subdirs ..)</code>.<br>
+<code>(select &lt;path&gt; from ..)</code> modules now parse <code>path</code> as a relative path<br>
+starting from the module group root (<a href="https://github.com/ocaml/dune/pull/13175" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3776051068" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13175" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13175/hovercard">#13175</a>, fixes <a href="https://github.com/ocaml/dune/issues/4383" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="837752295" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4383" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4383/hovercard">#4383</a>, <a href="https://github.com/ocaml/dune/issues/12450" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3410109716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12450" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12450/hovercard">#12450</a>,<br>
+<a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix dune trying to kill processes that were already reaped due to race<br>
+conditions (<a href="https://github.com/ocaml/dune/pull/13245" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3797179627" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13245" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13245/hovercard">#13245</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>O_CLOEXEC</code> to all files used for stdin/stdout/stderr (<a href="https://github.com/ocaml/dune/pull/13385" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3831363644" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13385" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13385/hovercard">#13385</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>$ dune promote dir/foo</code> when <code>dir</code> does not exist (<a href="https://github.com/ocaml/dune/pull/13493" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3872969699" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13493" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13493/hovercard">#13493</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>(select ..)</code> field evaluation when a transitive library has optional<br>
+dependencies (fixes <a href="https://github.com/ocaml/dune/issues/13299" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3805627091" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13299" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13299/hovercard">#13299</a>, <a href="https://github.com/ocaml/dune/pull/13389" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3831717202" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13389" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13389/hovercard">#13389</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix sandboxed builds of <code>library</code> stanzas that set<br>
+<code>(stdlib (modules_before_stdlib ..))</code> (<a href="https://github.com/ocaml/dune/pull/13624" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3935624771" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13624" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13624/hovercard">#13624</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Dune cache: use of hard links under Windows. (<a href="https://github.com/ocaml/dune/pull/13714" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4011446684" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13714" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13714/hovercard">#13714</a>, <a href="https://github.com/Nevor" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Nevor/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Nevor</a>)</p>
+</li>
+<li>
+<p>Fixed non-build caches not following <code>$DUNE_CACHE_ROOT</code> and instead only<br>
+relying on <code>$XDG_CACHE_HOME</code>.<br>
+This means the normal build cache moves:<br>
+<code>$DUNE_CACHE_ROOT -&gt; $DUNE_CACHE_ROOT/db</code> (no changes if that variable was<br>
+unset). Affected users can prevent a full cache invalidation by moving<br>
+previous contents:<br>
+<code>cd $DUNE_CACHE_ROOT; mkdir db; mv &lt;contents of directory&gt; db</code>.<br>
+(<a href="https://github.com/ocaml/dune/pull/11612" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2976721313" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11612" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/11612/hovercard">#11612</a>, fixes <a href="https://github.com/ocaml/dune/issues/11584" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2959960787" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11584" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11584/hovercard">#11584</a>, <a href="https://github.com/ElectreAAS" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/ElectreAAS/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@ElectreAAS</a>)</p>
+</li>
+<li>
+<p><code>$ dune promotion list</code> writes output to stdout rather than stderr (<a href="https://github.com/ocaml/dune/pull/13462" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3858100731" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13462" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13462/hovercard">#13462</a>)</p>
+</li>
+<li>
+<p>Improve handling of empty files in the <code>diff</code> action. These are now correctly<br>
+distinguished from <em>empty</em> files. (<a href="https://github.com/ocaml/dune/pull/13696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4004483629" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13696/hovercard">#13696</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Pass <code>/dev/null</code> to <code>--diff-command</code> instead of non-existent files (<a href="https://github.com/ocaml/dune/pull/13696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4004483629" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13696/hovercard">#13696</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix failure when multiple <code>rocq.extraction</code> stanzas existing in a directory<br>
+(<a href="https://github.com/ocaml/dune/pull/13531" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3888262788" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13531" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13531/hovercard">#13531</a>, fixes <a href="https://github.com/ocaml/dune/issues/8042" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1772883745" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/8042" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/8042/hovercard">#8042</a>, <a href="https://github.com/rlepigre-skylabs-ai" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rlepigre-skylabs-ai/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rlepigre-skylabs-ai</a>)</p>
+</li>
+<li>
+<p>Print <code>$ dune promotion show</code> output to stdout rather than stderr (<a href="https://github.com/ocaml/dune/pull/13481" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3864767296" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13481" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13481/hovercard">#13481</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix deadlock in the <code>memo</code> library in the presence of dependency cycles<br>
+(<a href="https://github.com/ocaml/dune/pull/13625" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3935834171" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13625" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13625/hovercard">#13625</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Fix promotions that modify a directory into a file (<a href="https://github.com/ocaml/dune/pull/13516" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3882586407" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13516" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13516/hovercard">#13516</a>, fixes <a href="https://github.com/ocaml/dune/issues/4067" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="774992697" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4067" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4067/hovercard">#4067</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix installation of implementations of virtual libraries. This failed when<br>
+the implementation had no private modules, but the virtual library did<br>
+(<a href="https://github.com/ocaml/dune/issues/10635" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2344749343" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10635" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10635/hovercard">#10635</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Respect the <code>(dir ..)</code> field on packages when setting up cram tests (<a href="https://github.com/ocaml/dune/pull/13581" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3910747944" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13581" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13581/hovercard">#13581</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>
+<p>Add support for generating <code>.cms</code> files using oxcaml and adding <code>.cms</code> or<br>
+<code>.cmt</code> files as compilation dependencies (<a href="https://github.com/ocaml/dune/pull/13397" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833275686" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13397" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13397/hovercard">#13397</a>, <a href="https://github.com/spiessimon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/spiessimon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@spiessimon</a>)</p>
+</li>
+<li>
+<p>Add trace events for custom actions (<a href="https://github.com/ocaml/dune/pull/13265" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3800380631" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13265" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13265/hovercard">#13265</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow enabling extensions with <code>(using ..)</code> in <code>dune-workspace</code> files<br>
+(<a href="https://github.com/ocaml/dune/pull/13395" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833202404" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13395" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13395/hovercard">#13395</a>, <a href="https://github.com/spiessimon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/spiessimon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@spiessimon</a>)</p>
+</li>
+<li>
+<p>Add sandbox extraction trace event (<a href="https://github.com/ocaml/dune/pull/13544" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3898256868" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13544" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13544/hovercard">#13544</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add the initial cwd to the first config event (<a href="https://github.com/ocaml/dune/pull/13026" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3751510385" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13026" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13026/hovercard">#13026</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Dune dune produces trace events in <code>DUNE_ACTION_TRACE_DIR</code> if this variable<br>
+is set. (<a href="https://github.com/ocaml/dune/pull/13302" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3806227611" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13302" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13302/hovercard">#13302</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add file watching events to the trace file (<a href="https://github.com/ocaml/dune/pull/13038" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3755134419" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13038" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13038/hovercard">#13038</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Introduce the <code>$ dune trace cat</code> subcommand to view the trace file. (<a href="https://github.com/ocaml/dune/pull/13055" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764032511" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13055" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13055/hovercard">#13055</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add diagnostic events to the trace. (<a href="https://github.com/ocaml/dune/pull/13041" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3758381346" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13041" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13041/hovercard">#13041</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>DUNE_JOBS</code> environment variable for controlling concurrency of Dune from<br>
+environment. The <code>INSIDE_DUNE</code> variable also now no longer controls<br>
+concurrency (<a href="https://github.com/ocaml/dune/pull/12800" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3670969816" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12800" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12800/hovercard">#12800</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Support for Rocq expected output tests (<a href="https://github.com/ocaml/dune/pull/13632" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3943611177" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13632" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13632/hovercard">#13632</a>, <a href="https://github.com/rlepigre-skylabs-ai" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rlepigre-skylabs-ai/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rlepigre-skylabs-ai</a>)</p>
+</li>
+<li>
+<p>Add <code>rusage</code> information to completed processes in the trace (<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>,<br>
+<a href="https://github.com/ocaml/dune/pull/13241" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3794757038" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13241" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13241/hovercard">#13241</a>)</p>
+</li>
+<li>
+<p>Add process start events to the trace (<a href="https://github.com/ocaml/dune/pull/13261" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3800114266" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13261" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13261/hovercard">#13261</a>, rgrinberg)</p>
+</li>
+<li>
+<p>Generate odoc documentation in markdown using the <code>@doc-markdown</code> alias<br>
+(<a href="https://github.com/ocaml/dune/pull/12581" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3519116591" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12581" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12581/hovercard">#12581</a>, <a href="https://github.com/davesnx" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/davesnx/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@davesnx</a>)</p>
+</li>
+<li>
+<p>Add timing information for every command executed by cram (<a href="https://github.com/ocaml/dune/pull/13092" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766088066" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13092" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13092/hovercard">#13092</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add the workspace root to the config trace event (<a href="https://github.com/ocaml/dune/pull/12922" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3718678842" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12922" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12922/hovercard">#12922</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Introduce the <code>dune-action-trace</code> library. This public library is to be used<br>
+by custom actions to emit trace events while executed as part of a dune<br>
+build. The trace events emitted through this library will be incorporated<br>
+into dune's own trace (<a href="https://github.com/ocaml/dune/pull/13348" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3825976320" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13348" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13348/hovercard">#13348</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add <code>dune-find-dominating</code> to <code>dune.el</code>, a command to find the<br>
+dominating dune file. (<a href="https://github.com/ocaml/dune/pull/12696" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3599579081" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12696" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12696/hovercard">#12696</a>, <a href="https://github.com/arvidj" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/arvidj/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@arvidj</a>)</p>
+</li>
+<li>
+<p>Add a <code>--no-recursive</code> flag to <code>$ dune describe workspace</code> (<a href="https://github.com/ocaml/dune/pull/13590" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3913860581" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13590" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13590/hovercard">#13590</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Trace events for files written directly by dune (<a href="https://github.com/ocaml/dune/pull/13618" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3929244990" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13618" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13618/hovercard">#13618</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow expansion of special forms like <code>(:include ..)</code> and <code>%{read-lines:..}</code><br>
+in the <code>modules</code> specification for the <code>ocamllex</code>, <code>ocamlyacc</code> and <code>menhir</code><br>
+stanzas. (<a href="https://github.com/ocaml/dune/pull/13105" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766996679" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13105" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13105/hovercard">#13105</a>, <a href="https://github.com/ocaml/dune/pull/13135" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3771460013" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13135" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13135/hovercard">#13135</a>, <a href="https://github.com/ocaml/dune/pull/13157" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3774256677" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13157" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13157/hovercard">#13157</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Add a trace event for snapshotting the asndbox (<a href="https://github.com/ocaml/dune/pull/13541" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3898125996" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13541" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13541/hovercard">#13541</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add signal send and receive events to the trace (<a href="https://github.com/ocaml/dune/pull/13193" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3778408898" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13193" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13193/hovercard">#13193</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Emit final trace event before exiting. (<a href="https://github.com/ocaml/dune/pull/13018" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3750981598" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13018" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13018/hovercard">#13018</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>dune runtest</code> can now run individual test executables from <code>(tests)</code> stanzas<br>
+and inline tests from <code>(library (inline_tests))</code> stanzas by providing their<br>
+source files as arguments. (<a href="https://github.com/ocaml/dune/pull/13064" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764872270" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13064" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13064/hovercard">#13064</a>, fixes <a href="https://github.com/ocaml/dune/issues/870" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="330879527" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/870" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/870/hovercard">#870</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Add a <code>shell</code> field to the cram stanza. This field allows customizing the<br>
+shell to be <code>bash</code> rather than <code>sh</code> (<a href="https://github.com/ocaml/dune/pull/13083" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3765870121" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13083" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13083/hovercard">#13083</a>, <a href="https://github.com/haochenx" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/haochenx/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@haochenx</a>)</p>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>
+<p>Start sandboxing the execution of tests defined with the <code>test</code> and <code>tests</code><br>
+stanzas (<a href="https://github.com/ocaml/dune/pull/13510" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3880290724" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13510" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13510/hovercard">#13510</a>, <a href="https://github.com/ocaml/dune/pull/13617" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3929243234" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13617" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13617/hovercard">#13617</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Disabled cram tests can now be run explicitly with <code>dune runtest disabled.t</code>.<br>
+The <code>enabled_if</code> field now only controls whether a test is included in<br>
+the <code>@runtest</code> alias. (<a href="https://github.com/ocaml/dune/pull/13081" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3765722827" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13081" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13081/hovercard">#13081</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Process categories in trace events are moved to their own field in <code>args</code><br>
+(<a href="https://github.com/ocaml/dune/pull/13024" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3751122219" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13024" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13024/hovercard">#13024</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Sandbox running <code>ocamllex</code> and <code>ocamlyacc</code> actions. (<a href="https://github.com/ocaml/dune/pull/13098" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3766201590" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13098" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13098/hovercard">#13098</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Sandboxing mdx test actions is now the default starting from <code>0.5</code> (<a href="https://github.com/ocaml/dune/pull/13504" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3878986649" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13504" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13504/hovercard">#13504</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Start sandboxing Melange rules by default in the <code>(library ..)</code> and<br>
+<code>(melange.emit ..)</code> stanzas (<a href="https://github.com/ocaml/dune/pull/13619" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3930304738" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13619" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13619/hovercard">#13619</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Introduce a promotion trace event and remove the corresponding verbose log<br>
+message. (<a href="https://github.com/ocaml/dune/pull/12949" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3726978397" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12949" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12949/hovercard">#12949</a>, <a href="https://github.com/ocaml/dune/pull/13444" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3849393797" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13444" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13444/hovercard">#13444</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Change dune's trace format to emit canonical s-expressions. This improves<br>
+performance and is better aligned with dune's usage of the format<br>
+elsewhere. <code>$ dune trace cat</code> can also emit the trace in <code>--chrome-trace</code><br>
+for perfetto, or <code>--sexp</code> for regular s-expressions for interactive usage.<br>
+(<a href="https://github.com/ocaml/dune/pull/13059" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3764147538" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13059" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13059/hovercard">#13059</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Move all logging statements to the trace file. All log statements now contain<br>
+structured payloads (<a href="https://github.com/ocaml/dune/pull/13015" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3749972872" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13015" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13015/hovercard">#13015</a>, fixes <a href="https://github.com/ocaml/dune/issues/12904" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3712595073" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12904" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12904/hovercard">#12904</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Add a target resolution event to replace the equivalent log message (<a href="https://github.com/ocaml/dune/pull/12955" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3728098444" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12955" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12955/hovercard">#12955</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>

--- a/data/platform_releases/dune/2026-04-30-dune-3.23.0_alpha0-draft.md
+++ b/data/platform_releases/dune/2026-04-30-dune-3.23.0_alpha0-draft.md
@@ -1,0 +1,261 @@
+---
+title: Dune 3.23.0~alpha0
+tags:
+- dune
+- platform
+contributors:
+changelog:
+versions:
+authors: []
+experimental: true
+ignore: true
+released_on_github_by: shonfeder
+github_release_tags:
+- 3.23.0_alpha0
+---
+
+<p>CHANGES:</p>
+<h3>Fixed</h3>
+<ul>
+<li>
+<p>Auto-inject <code>"menhir" {&gt;= "20180523"}</code> into generated opam files when the<br>
+menhir extension is used. Dune's menhir rules rely on <code>--infer-write-query</code><br>
+and <code>--infer-read-reply</code>, which require at least this version; without the<br>
+lower bound, builds fail with older menhir installations.<br>
+(<a href="https://github.com/ocaml/dune/issues/10707" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2398162104" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10707" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10707/hovercard">#10707</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix <code>--display=quiet</code> not suppressing "Entering directory" and "Leaving<br>
+directory" messages when using <code>--root</code>. These messages are now deferred<br>
+until there is actual output, so silent builds produce no noise.<br>
+(<a href="https://github.com/ocaml/dune/pull/12974" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3731408966" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12974" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12974/hovercard">#12974</a>, fixes <a href="https://github.com/ocaml/dune/issues/12854" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3690110770" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12854" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12854/hovercard">#12854</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix an internal error when a module is shared between a <code>rocq.theory</code> and<br>
+<code>rocq.extraction</code> stanza. The error now includes a hint pointing to the<br>
+conflicting stanza. (<a href="https://github.com/ocaml/dune/pull/13733" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4025781774" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13733" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13733/hovercard">#13733</a>, <a href="https://github.com/Durbatuluk1701" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Durbatuluk1701/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Durbatuluk1701</a>)</p>
+</li>
+<li>
+<p>Fix cookies defined on <code>ppx_rewriter</code> being lost when that rewriter was used<br>
+as a dependency of another <code>ppx_rewriter</code>. (<a href="https://github.com/ocaml/dune/pull/13737" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4033908249" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13737" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13737/hovercard">#13737</a>, fixes <a href="https://github.com/ocaml/dune/issues/3426" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="606799105" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3426" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3426/hovercard">#3426</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Improve opam file generation for packages that set <code>(dir ..)</code>. Such packages<br>
+will now have a test target that is limited to this directory. (<a href="https://github.com/ocaml/dune/pull/13778" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4060790412" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13778" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13778/hovercard">#13778</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Stop duplicating dune diagnostics to subscribers over RPC (<a href="https://github.com/ocaml/dune/pull/13816" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4085256125" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13816" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13816/hovercard">#13816</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix dependency cycle when using the <code>package</code> with a library<br>
+conditionally enabled via <code>enabled_if</code>. (<a href="https://github.com/ocaml/dune/pull/13833" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4095590645" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13833" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13833/hovercard">#13833</a>, <a href="https://github.com/toots" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/toots/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@toots</a>)</p>
+</li>
+<li>
+<p>Fix underspecification of dependencies in the sandbox for modules with<br>
+interfaces. (<a href="https://github.com/ocaml/dune/pull/13842" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4100008918" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13842" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13842/hovercard">#13842</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Honor sandbox settings specified inside <code>(:include ..)</code> expressions in the <code>deps</code> field<br>
+(<a href="https://github.com/ocaml/dune/pull/13898" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4123872252" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13898" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13898/hovercard">#13898</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune pkg lock</code> failing when a <code>pin</code> stanza contains a <code>file://</code> URL with<br>
+a relative path outside the workspace (<a href="https://github.com/ocaml/dune/pull/13915" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4135742453" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13915" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13915/hovercard">#13915</a>, fixes <a href="https://github.com/ocaml/dune/issues/10254" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2180882093" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10254" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10254/hovercard">#10254</a>, <a href="https://github.com/shunueda" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/shunueda/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@shunueda</a>)</p>
+</li>
+<li>
+<p>Use all stat attributes to detect patch back source tree changes (<a href="https://github.com/ocaml/dune/pull/13986" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4173717364" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13986" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13986/hovercard">#13986</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Use device and inode number for invalidating cached digests (<a href="https://github.com/ocaml/dune/pull/13991" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4174047968" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13991" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13991/hovercard">#13991</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Stop trying to set SO_REUSEADDR on unix sockets when setting up dune rpc<br>
+(<a href="https://github.com/ocaml/dune/pull/14056" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4208679877" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14056" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14056/hovercard">#14056</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix autolocking to correctly detect changes to <code>(depends)</code> in watch mode<br>
+(<a href="https://github.com/ocaml/dune/pull/14066" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4213061006" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14066" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14066/hovercard">#14066</a>, fixes <a href="https://github.com/ocaml/dune/issues/13234" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3791560995" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13234" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13234/hovercard">#13234</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix incremental builds for libraries using <code>(wrapped (transition ...))</code>.<br>
+The compat shim modules were never recompiled when the inner module's<br>
+interface changed, causing "inconsistent assumptions" errors.<br>
+(<a href="https://github.com/ocaml/dune/pull/14090" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4224124682" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14090" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14090/hovercard">#14090</a>, fixes <a href="https://github.com/ocaml/dune/issues/14089" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4224116872" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14089" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/14089/hovercard">#14089</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix Rocq configuration detection to use <code>rocq c --config</code> subcommand<br>
+instead of <code>rocq --config</code> (<a href="https://github.com/ocaml/dune/pull/14093" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4226950382" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14093" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14093/hovercard">#14093</a>, fixes <a href="https://github.com/ocaml/dune/issues/13774" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4057592137" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13774" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13774/hovercard">#13774</a>, <a href="https://github.com/Durbatuluk1701" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Durbatuluk1701/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Durbatuluk1701</a>)</p>
+</li>
+<li>
+<p>Bump dune rpc's request pending request limit 10 to 100 (<a href="https://github.com/ocaml/dune/pull/14094" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4227059822" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14094" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14094/hovercard">#14094</a>, @rginberg)</p>
+</li>
+<li>
+<p>Invalidate stale cached digests in all build commands (<a href="https://github.com/ocaml/dune/pull/14126" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4239718171" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14126" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14126/hovercard">#14126</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>root_module</code> generating duplicate module definitions when a<br>
+findlib sub-package shares a directory with its parent (e.g.,<br>
+<code>logs.lwt</code> alongside <code>logs</code>). (<a href="https://github.com/ocaml/dune/pull/14135" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4242560190" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14135" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14135/hovercard">#14135</a>, fixes <a href="https://github.com/ocaml/dune/issues/6148" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1371119435" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6148" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6148/hovercard">#6148</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune subst</code> prepending a duplicate <code>version:</code> field to opam<br>
+files that already contain one, instead of replacing it in place.<br>
+(<a href="https://github.com/ocaml/dune/pull/14136" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4242741081" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14136" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14136/hovercard">#14136</a>, fixes <a href="https://github.com/ocaml/dune/issues/878" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="331888993" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/878" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/878/hovercard">#878</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix <code>@ocaml-index</code> alias being generated for all contexts, causing build<br>
+errors in multi-context workspaces where some libraries are disabled in<br>
+non-default contexts. The alias is now only generated for the merlin context.<br>
+(<a href="https://github.com/ocaml/dune/pull/14137" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4242878552" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14137" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14137/hovercard">#14137</a>, fixes <a href="https://github.com/ocaml/dune/issues/12007" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3220918716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12007" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12007/hovercard">#12007</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Remove the warning about the deprecation of the coq stanza for<br>
+dune lang before 3.21 since it has been introduced in this<br>
+version (<a href="https://github.com/ocaml/dune/pull/14187" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4270169917" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14187" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14187/hovercard">#14187</a>, <a href="https://github.com/bobot" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/bobot/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@bobot</a>)</p>
+</li>
+<li>
+<p><code>$ dune init</code> now generates projects with correct .opam files (<a href="https://github.com/ocaml/dune/pull/14192" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4271950944" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14192" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14192/hovercard">#14192</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Send SIGTERM before SIGKILL when cancelling child processes in watch<br>
+mode, giving cleanup handlers a chance to run before escalating.<br>
+(<a href="https://github.com/ocaml/dune/pull/14224" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4285103716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14224" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14224/hovercard">#14224</a>, <a href="https://github.com/ocaml/dune/pull/14170" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4251020561" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14170" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14170/hovercard">#14170</a>, fixes <a href="https://github.com/ocaml/dune/issues/2445" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="472516334" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/2445" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/2445/hovercard">#2445</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Correctly specify dependencies for <code>generate_runner</code> in inline tests (<a href="https://github.com/ocaml/dune/pull/14276" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4298967658" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14276" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14276/hovercard">#14276</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix duplicate dune version bounds in generated opam files. When users<br>
+declare <code>(dune (&gt;= X.Y))</code> matching or exceeding the <code>(lang dune X.Y)</code><br>
+version, the generated opam <code>depends</code> no longer contains redundant<br>
+constraints like <code>{&gt;= "2.7" &amp; &gt;= "2.7"}</code>. (<a href="https://github.com/ocaml/dune/issues/3916" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="735931834" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3916" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3916/hovercard">#3916</a>, <a href="https://github.com/ocaml/dune/issues/11106" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2644426694" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11106" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11106/hovercard">#11106</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix inline tests not being executed for byte-only libraries. When a library<br>
+has <code>(modes byte)</code>, the inline test runner is now linked in byte mode so the<br>
+library's test code is included. (<a href="https://github.com/ocaml/dune/issues/9757" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2084170534" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/9757" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/9757/hovercard">#9757</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>
+<p>Add support for <code>c_library_flags</code> in foreign_stubs (<a href="https://github.com/ocaml/dune/pull/13484" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3865267069" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13484" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13484/hovercard">#13484</a>, <a href="https://github.com/madroach" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/madroach/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@madroach</a>)</p>
+</li>
+<li>
+<p>Move the management of Jsoo config details out of dune (<a href="https://github.com/ocaml/dune/pull/13613" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3927776387" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13613" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13613/hovercard">#13613</a>, <a href="https://github.com/vouillon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/vouillon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@vouillon</a>)</p>
+</li>
+<li>
+<p>Js_of_ocaml: share standalone runtimes (<a href="https://github.com/ocaml/dune/pull/13621" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3931028992" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13621" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13621/hovercard">#13621</a>, <a href="https://github.com/vouillon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/vouillon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@vouillon</a>)</p>
+</li>
+<li>
+<p>Allow multiple <code>(dirs ..)</code> stanzas in the same Dune file. Starting with<br>
+<code>(lang dune 3.23)</code>, Dune takes the union of the specified directories<br>
+(<a href="https://github.com/ocaml/dune/pull/13734" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4026530444" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13734" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13734/hovercard">#13734</a>, fixes <a href="https://github.com/ocaml/dune/issues/6249" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1412280172" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6249" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6249/hovercard">#6249</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Sandboxed rules are now allowed to produce diff promotions when <code>(corrections produce)</code> is set on the rules. Whenever such an action produces <code>foo.corrected</code>, it will<br>
+be automatically registered as a promotion for <code>foo</code> (<a href="https://github.com/ocaml/dune/pull/13813" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4079307575" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13813" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13813/hovercard">#13813</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>$ dune clean</code> now accepts arguments to only remove certain targets from the<br>
+_build directory (<a href="https://github.com/ocaml/dune/pull/13875" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4113706744" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13875" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13875/hovercard">#13875</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>$ dune promote</code> now promotes all paths that are a prefix of the path provided.<br>
+For example, <code>$ dune promote foo</code> will promote <code>foo</code>, <code>foo/bar</code>, <code>foo/bar/baz</code><br>
+(but not <code>foobar</code>). (<a href="https://github.com/ocaml/dune/pull/13876" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4113777232" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13876" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13876/hovercard">#13876</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow for the <code>diff</code> action to diff entire directories (<a href="https://github.com/ocaml/dune/pull/13880" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4115710378" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13880" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13880/hovercard">#13880</a>, fixes <a href="https://github.com/ocaml/dune/issues/3567" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="641641205" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3567" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3567/hovercard">#3567</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>A hint is now emitted when trying to build a target inside a directory that<br>
+was excluded by a <code>(dirs ...)</code> stanza (<a href="https://github.com/ocaml/dune/pull/13919" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4142816464" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13919" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13919/hovercard">#13919</a>, <a href="https://github.com/mefyl" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/mefyl/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@mefyl</a>).</p>
+</li>
+<li>
+<p>Add --debug-backtraces to <code>$ dune {promote,trace,cache}</code> (<a href="https://github.com/ocaml/dune/pull/13933" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4147695123" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13933" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13933/hovercard">#13933</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Actions are now able to observe their project directory via<br>
+<code>DUNE_PROJECT_ROOT</code> (<a href="https://github.com/ocaml/dune/pull/13934" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4151811764" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13934" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13934/hovercard">#13934</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Support hardlink sandboxing on Windows. (<a href="https://github.com/ocaml/dune/pull/13987" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4173827054" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13987" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13987/hovercard">#13987</a>, addresses part of <a href="https://github.com/ocaml/dune/issues/4362" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="833739033" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4362" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4362/hovercard">#4362</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p><code>rocq.extraction</code>: Add <code>extracted_files</code> field in <code>(rocq 0.13)</code>, replacing<br>
+<code>extracted_modules</code>, supporting extraction to languages other than OCaml<br>
+(<a href="https://github.com/ocaml/dune/pull/13997" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4183729383" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13997" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13997/hovercard">#13997</a>, <a href="https://github.com/Durbatuluk1701" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Durbatuluk1701/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Durbatuluk1701</a>).</p>
+</li>
+<li>
+<p>Infer source directories as dependencies when they're as reference<br>
+directories in <code>diff</code> actions.</p>
+</li>
+<li>
+<p>Add trace events for build start/stop/restarts (<a href="https://github.com/ocaml/dune/pull/14163" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4248836741" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14163" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14163/hovercard">#14163</a>, <a href="https://github.com/ocaml/dune/pull/14166" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4250120070" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14166" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14166/hovercard">#14166</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Generate <code>compile_commands.json</code> for C/C++ foreign stubs when building<br>
+<code>@check</code> with <code>(lang dune 3.23)</code>. This enables <code>clangd</code>, <code>ccls</code>, and other<br>
+tools that consume compilation databases. (<a href="https://github.com/ocaml/dune/pull/14185" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4265770798" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14185" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14185/hovercard">#14185</a>, fixes <a href="https://github.com/ocaml/dune/issues/3531" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="631673004" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3531" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3531/hovercard">#3531</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Add <code>%{pkg:&lt;package&gt;:&lt;section&gt;:&lt;path&gt;}</code> pform for resolving package install<br>
+files. Works with workspace packages, lock-file packages, and installed<br>
+packages. (<a href="https://github.com/ocaml/dune/pull/14200" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4279022953" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14200" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14200/hovercard">#14200</a>, fixes <a href="https://github.com/ocaml/dune/issues/14193" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4272034736" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14193" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/14193/hovercard">#14193</a>, fixes <a href="https://github.com/ocaml/dune/issues/3378" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="600813770" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3378" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3378/hovercard">#3378</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Add trace events for accepting clients and shutting down RPC (<a href="https://github.com/ocaml/dune/pull/14232" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4287600250" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14232" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14232/hovercard">#14232</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Back up the default trace file as <code>trace.csexp.old</code> before each build,<br>
+preserving the previous trace for comparison. This does not apply when<br>
+<code>--trace-file</code> is used. (<a href="https://github.com/ocaml/dune/pull/14269" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4296615933" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14269" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14269/hovercard">#14269</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>
+<p>Dune digests target files and directories in background threads (<a href="https://github.com/ocaml/dune/pull/13341" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3824840017" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13341" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13341/hovercard">#13341</a>,<br>
+@rgrinbreg)</p>
+</li>
+<li>
+<p><code>Dyn.pp</code> now prints valid OCaml literals for more constructors:</p>
+<ul>
+<li><code>Char</code> is quoted (e.g., <code>'a'</code>)</li>
+<li><code>Int32</code>/<code>Int64</code>/<code>Nativeint</code> include literal suffixes (<code>l</code>/<code>L</code>/<code>n</code>)</li>
+<li><code>Float</code> handles <code>infinity</code>, <code>neg_infinity</code>, and <code>nan</code><br>
+(<a href="https://github.com/ocaml/dune/pull/13394" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833196924" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13394" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13394/hovercard">#13394</a>, grants <a href="https://github.com/ocaml/dune/issues/13378" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3829258454" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13378" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13378/hovercard">#13378</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</li>
+</ul>
+</li>
+<li>
+<p>Bump the minimal OCaml version required to build Dune from 4.08 to 4.14.<br>
+(<a href="https://github.com/ocaml/dune/pull/13533" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3888374274" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13533" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13533/hovercard">#13533</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Starting from 3.23, user rules are sandboxed by default (<a href="https://github.com/ocaml/dune/pull/13805" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4078152919" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13805" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13805/hovercard">#13805</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Dune will no longer stat paths in the _build directory. This was done as protection<br>
+from user rules accidentally touching things in the _build directory. This is forbidden,<br>
+and dune offers rule sandboxing to prevent this (<a href="https://github.com/ocaml/dune/pull/13875" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4113706744" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13875" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13875/hovercard">#13875</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Improve mtime precision by no longer approximating them with floats (<a href="https://github.com/ocaml/dune/pull/13962" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4161960319" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13962" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13962/hovercard">#13962</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>).</p>
+</li>
+<li>
+<p>Remove <code>--makefile</code> (or <code>-m</code>) in <code>$ dune rules</code>. The sexp output is the only<br>
+supported way of reflecting dune rules (<a href="https://github.com/ocaml/dune/pull/14069" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4213855914" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14069" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14069/hovercard">#14069</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Do not automatically promote files. Now, opam files must be manually<br>
+promoted with <code>$ dune promote</code>. Their generation is triggered by <code>@install</code>,<br>
+<code>@runtest</code>, and <code>@opam</code>. In release mode, .opam files aren't generated at all<br>
+and whatever is in the source is used (<a href="https://github.com/ocaml/dune/pull/14108" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4234407054" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14108" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14108/hovercard">#14108</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Inline test runner generation is now sandboxed (<a href="https://github.com/ocaml/dune/pull/14257" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4292144194" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14257" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14257/hovercard">#14257</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>

--- a/data/platform_releases/dune/2026-04-30-dune-3.23.0_alpha1-draft.md
+++ b/data/platform_releases/dune/2026-04-30-dune-3.23.0_alpha1-draft.md
@@ -1,0 +1,23 @@
+---
+title: Dune 3.23.0~alpha1
+tags:
+- dune
+- platform
+contributors:
+changelog:
+versions:
+authors: []
+experimental: true
+ignore: true
+released_on_github_by: shonfeder
+github_release_tags:
+- 3.23.0_alpha1
+---
+
+<p>CHANGES:</p>
+<h3>Fixed</h3>
+<ul>
+<li>Revert the change in behavior of <code>--diff-command</code> back to 3.21. Non-existent<br>
+files are now passed to this command instead of being replaced with /dev/null<br>
+(<a href="https://github.com/ocaml/dune/pull/14098" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4228012721" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14098" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14098/hovercard">#14098</a>, fixes 13891, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</li>
+</ul>

--- a/data/platform_releases/dune/2026-04-30-dune-3.23.0_alpha2-draft.md
+++ b/data/platform_releases/dune/2026-04-30-dune-3.23.0_alpha2-draft.md
@@ -1,0 +1,256 @@
+---
+title: Dune 3.23.0~alpha2
+tags:
+- dune
+- platform
+contributors:
+changelog:
+versions:
+authors: []
+experimental: true
+ignore: true
+released_on_github_by: shonfeder
+github_release_tags:
+- 3.23.0_alpha2
+---
+
+<p>CHANGES:</p>
+<h3>Fixed</h3>
+<ul>
+<li>
+<p>Auto-inject <code>"menhir" {&gt;= "20180523"}</code> into generated opam files when the<br>
+menhir extension is used. Dune's menhir rules rely on <code>--infer-write-query</code><br>
+and <code>--infer-read-reply</code>, which require at least this version; without the<br>
+lower bound, builds fail with older menhir installations.<br>
+(<a href="https://github.com/ocaml/dune/issues/10707" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2398162104" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10707" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10707/hovercard">#10707</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix <code>--display=quiet</code> not suppressing "Entering directory" and "Leaving<br>
+directory" messages when using <code>--root</code>. These messages are now deferred<br>
+until there is actual output, so silent builds produce no noise.<br>
+(<a href="https://github.com/ocaml/dune/pull/12974" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3731408966" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12974" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/12974/hovercard">#12974</a>, fixes <a href="https://github.com/ocaml/dune/issues/12854" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3690110770" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12854" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12854/hovercard">#12854</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix an internal error when a module is shared between a <code>rocq.theory</code> and<br>
+<code>rocq.extraction</code> stanza. The error now includes a hint pointing to the<br>
+conflicting stanza. (<a href="https://github.com/ocaml/dune/pull/13733" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4025781774" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13733" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13733/hovercard">#13733</a>, <a href="https://github.com/Durbatuluk1701" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Durbatuluk1701/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Durbatuluk1701</a>)</p>
+</li>
+<li>
+<p>Fix cookies defined on <code>ppx_rewriter</code> being lost when that rewriter was used<br>
+as a dependency of another <code>ppx_rewriter</code>. (<a href="https://github.com/ocaml/dune/pull/13737" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4033908249" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13737" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13737/hovercard">#13737</a>, fixes <a href="https://github.com/ocaml/dune/issues/3426" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="606799105" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3426" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3426/hovercard">#3426</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Improve opam file generation for packages that set <code>(dir ..)</code>. Such packages<br>
+will now have a test target that is limited to this directory. (<a href="https://github.com/ocaml/dune/pull/13778" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4060790412" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13778" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13778/hovercard">#13778</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Stop duplicating dune diagnostics to subscribers over RPC (<a href="https://github.com/ocaml/dune/pull/13816" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4085256125" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13816" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13816/hovercard">#13816</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix dependency cycle when using the <code>package</code> with a library<br>
+conditionally enabled via <code>enabled_if</code>. (<a href="https://github.com/ocaml/dune/pull/13833" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4095590645" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13833" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13833/hovercard">#13833</a>, <a href="https://github.com/toots" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/toots/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@toots</a>)</p>
+</li>
+<li>
+<p>Fix underspecification of dependencies in the sandbox for modules with<br>
+interfaces. (<a href="https://github.com/ocaml/dune/pull/13842" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4100008918" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13842" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13842/hovercard">#13842</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Honor sandbox settings specified inside <code>(:include ..)</code> expressions in the <code>deps</code> field<br>
+(<a href="https://github.com/ocaml/dune/pull/13898" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4123872252" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13898" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13898/hovercard">#13898</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune pkg lock</code> failing when a <code>pin</code> stanza contains a <code>file://</code> URL with<br>
+a relative path outside the workspace (<a href="https://github.com/ocaml/dune/pull/13915" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4135742453" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13915" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13915/hovercard">#13915</a>, fixes <a href="https://github.com/ocaml/dune/issues/10254" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2180882093" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/10254" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/10254/hovercard">#10254</a>, <a href="https://github.com/shunueda" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/shunueda/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@shunueda</a>)</p>
+</li>
+<li>
+<p>Use all stat attributes to detect patch back source tree changes (<a href="https://github.com/ocaml/dune/pull/13986" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4173717364" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13986" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13986/hovercard">#13986</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Use device and inode number for invalidating cached digests (<a href="https://github.com/ocaml/dune/pull/13991" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4174047968" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13991" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13991/hovercard">#13991</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Stop trying to set SO_REUSEADDR on unix sockets when setting up dune rpc<br>
+(<a href="https://github.com/ocaml/dune/pull/14056" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4208679877" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14056" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14056/hovercard">#14056</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix autolocking to correctly detect changes to <code>(depends)</code> in watch mode<br>
+(<a href="https://github.com/ocaml/dune/pull/14066" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4213061006" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14066" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14066/hovercard">#14066</a>, fixes <a href="https://github.com/ocaml/dune/issues/13234" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3791560995" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13234" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13234/hovercard">#13234</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix incremental builds for libraries using <code>(wrapped (transition ...))</code>.<br>
+The compat shim modules were never recompiled when the inner module's<br>
+interface changed, causing "inconsistent assumptions" errors.<br>
+(<a href="https://github.com/ocaml/dune/pull/14090" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4224124682" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14090" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14090/hovercard">#14090</a>, fixes <a href="https://github.com/ocaml/dune/issues/14089" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4224116872" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14089" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/14089/hovercard">#14089</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Fix Rocq configuration detection to use <code>rocq c --config</code> subcommand<br>
+instead of <code>rocq --config</code> (<a href="https://github.com/ocaml/dune/pull/14093" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4226950382" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14093" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14093/hovercard">#14093</a>, fixes <a href="https://github.com/ocaml/dune/issues/13774" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4057592137" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13774" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13774/hovercard">#13774</a>, <a href="https://github.com/Durbatuluk1701" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Durbatuluk1701/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Durbatuluk1701</a>)</p>
+</li>
+<li>
+<p>Bump dune rpc's request pending request limit 10 to 100 (<a href="https://github.com/ocaml/dune/pull/14094" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4227059822" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14094" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14094/hovercard">#14094</a>, @rginberg)</p>
+</li>
+<li>
+<p>Invalidate stale cached digests in all build commands (<a href="https://github.com/ocaml/dune/pull/14126" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4239718171" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14126" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14126/hovercard">#14126</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix <code>root_module</code> generating duplicate module definitions when a<br>
+findlib sub-package shares a directory with its parent (e.g.,<br>
+<code>logs.lwt</code> alongside <code>logs</code>). (<a href="https://github.com/ocaml/dune/pull/14135" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4242560190" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14135" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14135/hovercard">#14135</a>, fixes <a href="https://github.com/ocaml/dune/issues/6148" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1371119435" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6148" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6148/hovercard">#6148</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix <code>dune subst</code> prepending a duplicate <code>version:</code> field to opam<br>
+files that already contain one, instead of replacing it in place.<br>
+(<a href="https://github.com/ocaml/dune/pull/14136" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4242741081" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14136" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14136/hovercard">#14136</a>, fixes <a href="https://github.com/ocaml/dune/issues/878" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="331888993" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/878" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/878/hovercard">#878</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix <code>@ocaml-index</code> alias being generated for all contexts, causing build<br>
+errors in multi-context workspaces where some libraries are disabled in<br>
+non-default contexts. The alias is now only generated for the merlin context.<br>
+(<a href="https://github.com/ocaml/dune/pull/14137" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4242878552" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14137" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14137/hovercard">#14137</a>, fixes <a href="https://github.com/ocaml/dune/issues/12007" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3220918716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/12007" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/12007/hovercard">#12007</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Remove the warning about the deprecation of the coq stanza for<br>
+dune lang before 3.21 since it has been introduced in this<br>
+version (<a href="https://github.com/ocaml/dune/pull/14187" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4270169917" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14187" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14187/hovercard">#14187</a>, <a href="https://github.com/bobot" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/bobot/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@bobot</a>)</p>
+</li>
+<li>
+<p><code>$ dune init</code> now generates projects with correct .opam files (<a href="https://github.com/ocaml/dune/pull/14192" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4271950944" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14192" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14192/hovercard">#14192</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Send SIGTERM before SIGKILL when cancelling child processes in watch<br>
+mode, giving cleanup handlers a chance to run before escalating.<br>
+(<a href="https://github.com/ocaml/dune/pull/14224" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4285103716" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14224" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14224/hovercard">#14224</a>, <a href="https://github.com/ocaml/dune/pull/14170" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4251020561" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14170" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14170/hovercard">#14170</a>, fixes <a href="https://github.com/ocaml/dune/issues/2445" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="472516334" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/2445" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/2445/hovercard">#2445</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Correctly specify dependencies for <code>generate_runner</code> in inline tests (<a href="https://github.com/ocaml/dune/pull/14276" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4298967658" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14276" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14276/hovercard">#14276</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Fix duplicate dune version bounds in generated opam files. When users<br>
+declare <code>(dune (&gt;= X.Y))</code> matching or exceeding the <code>(lang dune X.Y)</code><br>
+version, the generated opam <code>depends</code> no longer contains redundant<br>
+constraints like <code>{&gt;= "2.7" &amp; &gt;= "2.7"}</code>. (<a href="https://github.com/ocaml/dune/issues/3916" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="735931834" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3916" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3916/hovercard">#3916</a>, <a href="https://github.com/ocaml/dune/issues/11106" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2644426694" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/11106" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/11106/hovercard">#11106</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+<li>
+<p>Fix inline tests not being executed for byte-only libraries. When a library<br>
+has <code>(modes byte)</code>, the inline test runner is now linked in byte mode so the<br>
+library's test code is included. (<a href="https://github.com/ocaml/dune/issues/9757" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2084170534" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/9757" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/9757/hovercard">#9757</a>, <a href="https://github.com/robinbb" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/robinbb/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@robinbb</a>)</p>
+</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li>
+<p>Add support for <code>c_library_flags</code> in foreign_stubs (<a href="https://github.com/ocaml/dune/pull/13484" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3865267069" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13484" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13484/hovercard">#13484</a>, <a href="https://github.com/madroach" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/madroach/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@madroach</a>)</p>
+</li>
+<li>
+<p>Move the management of Jsoo config details out of dune (<a href="https://github.com/ocaml/dune/pull/13613" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3927776387" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13613" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13613/hovercard">#13613</a>, <a href="https://github.com/vouillon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/vouillon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@vouillon</a>)</p>
+</li>
+<li>
+<p>Js_of_ocaml: share standalone runtimes (<a href="https://github.com/ocaml/dune/pull/13621" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3931028992" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13621" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13621/hovercard">#13621</a>, <a href="https://github.com/vouillon" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/vouillon/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@vouillon</a>)</p>
+</li>
+<li>
+<p>Allow multiple <code>(dirs ..)</code> stanzas in the same Dune file. Starting with<br>
+<code>(lang dune 3.23)</code>, Dune takes the union of the specified directories<br>
+(<a href="https://github.com/ocaml/dune/pull/13734" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4026530444" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13734" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13734/hovercard">#13734</a>, fixes <a href="https://github.com/ocaml/dune/issues/6249" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1412280172" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/6249" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/6249/hovercard">#6249</a>, <a href="https://github.com/anmonteiro" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anmonteiro/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@anmonteiro</a>)</p>
+</li>
+<li>
+<p>Sandboxed rules are now allowed to produce diff promotions when <code>(corrections produce)</code> is set on the rules. Whenever such an action produces <code>foo.corrected</code>, it will<br>
+be automatically registered as a promotion for <code>foo</code> (<a href="https://github.com/ocaml/dune/pull/13813" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4079307575" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13813" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13813/hovercard">#13813</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>$ dune clean</code> now accepts arguments to only remove certain targets from the<br>
+_build directory (<a href="https://github.com/ocaml/dune/pull/13875" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4113706744" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13875" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13875/hovercard">#13875</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p><code>$ dune promote</code> now promotes all paths that are a prefix of the path provided.<br>
+For example, <code>$ dune promote foo</code> will promote <code>foo</code>, <code>foo/bar</code>, <code>foo/bar/baz</code><br>
+(but not <code>foobar</code>). (<a href="https://github.com/ocaml/dune/pull/13876" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4113777232" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13876" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13876/hovercard">#13876</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Allow for the <code>diff</code> action to diff entire directories (<a href="https://github.com/ocaml/dune/pull/13880" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4115710378" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13880" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13880/hovercard">#13880</a>, fixes <a href="https://github.com/ocaml/dune/issues/3567" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="641641205" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3567" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3567/hovercard">#3567</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>A hint is now emitted when trying to build a target inside a directory that<br>
+was excluded by a <code>(dirs ...)</code> stanza (<a href="https://github.com/ocaml/dune/pull/13919" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4142816464" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13919" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13919/hovercard">#13919</a>, <a href="https://github.com/mefyl" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/mefyl/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@mefyl</a>).</p>
+</li>
+<li>
+<p>Add --debug-backtraces to <code>$ dune {promote,trace,cache}</code> (<a href="https://github.com/ocaml/dune/pull/13933" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4147695123" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13933" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13933/hovercard">#13933</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Actions are now able to observe their project directory via<br>
+<code>DUNE_PROJECT_ROOT</code> (<a href="https://github.com/ocaml/dune/pull/13934" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4151811764" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13934" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13934/hovercard">#13934</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Support hardlink sandboxing on Windows. (<a href="https://github.com/ocaml/dune/pull/13987" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4173827054" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13987" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13987/hovercard">#13987</a>, addresses part of <a href="https://github.com/ocaml/dune/issues/4362" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="833739033" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/4362" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/4362/hovercard">#4362</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p><code>rocq.extraction</code>: Add <code>extracted_files</code> field in <code>(rocq 0.13)</code>, replacing<br>
+<code>extracted_modules</code>, supporting extraction to languages other than OCaml<br>
+(<a href="https://github.com/ocaml/dune/pull/13997" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4183729383" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13997" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13997/hovercard">#13997</a>, <a href="https://github.com/Durbatuluk1701" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Durbatuluk1701/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Durbatuluk1701</a>).</p>
+</li>
+<li>
+<p>Infer source directories as dependencies when they're as reference<br>
+directories in <code>diff</code> actions.</p>
+</li>
+<li>
+<p>Add trace events for build start/stop/restarts (<a href="https://github.com/ocaml/dune/pull/14163" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4248836741" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14163" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14163/hovercard">#14163</a>, <a href="https://github.com/ocaml/dune/pull/14166" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4250120070" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14166" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14166/hovercard">#14166</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Generate <code>compile_commands.json</code> for C/C++ foreign stubs when building<br>
+<code>@check</code> with <code>(lang dune 3.23)</code>. This enables <code>clangd</code>, <code>ccls</code>, and other<br>
+tools that consume compilation databases. (<a href="https://github.com/ocaml/dune/pull/14185" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4265770798" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14185" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14185/hovercard">#14185</a>, fixes <a href="https://github.com/ocaml/dune/issues/3531" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="631673004" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/3531" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/3531/hovercard">#3531</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Add trace events for accepting clients and shutting down RPC (<a href="https://github.com/ocaml/dune/pull/14232" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4287600250" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14232" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14232/hovercard">#14232</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Back up the default trace file as <code>trace.csexp.old</code> before each build,<br>
+preserving the previous trace for comparison. This does not apply when<br>
+<code>--trace-file</code> is used. (<a href="https://github.com/ocaml/dune/pull/14269" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4296615933" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14269" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14269/hovercard">#14269</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>
+<p>Dune digests target files and directories in background threads (<a href="https://github.com/ocaml/dune/pull/13341" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3824840017" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13341" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13341/hovercard">#13341</a>,<br>
+@rgrinbreg)</p>
+</li>
+<li>
+<p><code>Dyn.pp</code> now prints valid OCaml literals for more constructors:</p>
+<ul>
+<li><code>Char</code> is quoted (e.g., <code>'a'</code>)</li>
+<li><code>Int32</code>/<code>Int64</code>/<code>Nativeint</code> include literal suffixes (<code>l</code>/<code>L</code>/<code>n</code>)</li>
+<li><code>Float</code> handles <code>infinity</code>, <code>neg_infinity</code>, and <code>nan</code><br>
+(<a href="https://github.com/ocaml/dune/pull/13394" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3833196924" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13394" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13394/hovercard">#13394</a>, grants <a href="https://github.com/ocaml/dune/issues/13378" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3829258454" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13378" data-hovercard-type="issue" data-hovercard-url="/ocaml/dune/issues/13378/hovercard">#13378</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</li>
+</ul>
+</li>
+<li>
+<p>Bump the minimal OCaml version required to build Dune from 4.08 to 4.14.<br>
+(<a href="https://github.com/ocaml/dune/pull/13533" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="3888374274" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13533" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13533/hovercard">#13533</a>, <a href="https://github.com/Alizter" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Alizter/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@Alizter</a>)</p>
+</li>
+<li>
+<p>Starting from 3.23, user rules are sandboxed by default (<a href="https://github.com/ocaml/dune/pull/13805" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4078152919" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13805" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13805/hovercard">#13805</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Dune will no longer stat paths in the _build directory. This was done as protection<br>
+from user rules accidentally touching things in the _build directory. This is forbidden,<br>
+and dune offers rule sandboxing to prevent this (<a href="https://github.com/ocaml/dune/pull/13875" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4113706744" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13875" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13875/hovercard">#13875</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Improve mtime precision by no longer approximating them with floats (<a href="https://github.com/ocaml/dune/pull/13962" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4161960319" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/13962" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/13962/hovercard">#13962</a>,<br>
+<a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>).</p>
+</li>
+<li>
+<p>Remove <code>--makefile</code> (or <code>-m</code>) in <code>$ dune rules</code>. The sexp output is the only<br>
+supported way of reflecting dune rules (<a href="https://github.com/ocaml/dune/pull/14069" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4213855914" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14069" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14069/hovercard">#14069</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Do not automatically promote files. Now, opam files must be manually<br>
+promoted with <code>$ dune promote</code>. Their generation is triggered by <code>@install</code>,<br>
+<code>@runtest</code>, and <code>@opam</code>. In release mode, .opam files aren't generated at all<br>
+and whatever is in the source is used (<a href="https://github.com/ocaml/dune/pull/14108" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4234407054" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14108" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14108/hovercard">#14108</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+<li>
+<p>Inline test runner generation is now sandboxed (<a href="https://github.com/ocaml/dune/pull/14257" class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4292144194" data-permission-text="Title is private" data-url="https://github.com/ocaml/dune/issues/14257" data-hovercard-type="pull_request" data-hovercard-url="/ocaml/dune/pull/14257/hovercard">#14257</a>, <a href="https://github.com/rgrinberg" class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/rgrinberg/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">@rgrinberg</a>)</p>
+</li>
+</ul>


### PR DESCRIPTION
Auto-generated from GitHub release notes via the platform_releases scraper. Marked ignore: true since the alpha releases are not announced individually on discuss.ocaml.org. This will shut up the scraper and keep a complete list to create the newsletter from. 