### PR TITLE
Add OCaml Workshop 2026 pre-event mini-site

### DIFF
--- a/src/global/url.ml
+++ b/src/global/url.ml
@@ -102,3 +102,6 @@ let github_opam_file package_name package_version =
     package_name package_name package_version
 
 let is_ocaml_yet id = Printf.sprintf "/docs/is-ocaml-%s-yet" id
+let ocaml_workshop_2026 = "/ocaml-workshop-2026"
+let ocaml_workshop_2026_cfp = "/ocaml-workshop-2026/cfp"
+let ocaml_workshop_2026_committee = "/ocaml-workshop-2026/committee"

--- a/src/ocamlorg_frontend/layouts/layout.eml
+++ b/src/ocamlorg_frontend/layouts/layout.eml
@@ -53,6 +53,7 @@ let base
 ?canonical
 ?alternate
 ?(active_top_nav_item: Header.nav_item option)
+?(show_header = true)
 ?(footer_html = "")
 inner =
   let social_media_image_url =
@@ -139,7 +140,9 @@ inner =
       </div>
       <% ); %>
 
+      <% if show_header then ( %>
       <%s! Header.render ~show_get_started ?active_top_nav_item () %>
+      <% ); %>
       <main class="bg-background dark:bg-dark-background"><%s! inner %></main>
 
       <button class="fixed bottom-8 right-10 md:bottom-[5rem] lg:bottom-[8.37rem] lg:right-[6.5rem] border-0 hidden focus:outline-none z-50 rounded-full shadow-custom p-4 bg-primary dark:bg-dark-primary" onclick="scrollToTop()" id="scrollToTop" title="Scroll to top"><%s! Icons.arrow_up "h-6 w-6"%></button>

--- a/src/ocamlorg_frontend/layouts/workshop_layout.eml
+++ b/src/ocamlorg_frontend/layouts/workshop_layout.eml
@@ -1,0 +1,84 @@
+type section =
+  | Home
+  | Cfp
+  | Committee
+
+let url_of_section = function
+  | Home -> Url.ocaml_workshop_2026
+  | Cfp -> Url.ocaml_workshop_2026_cfp
+  | Committee -> Url.ocaml_workshop_2026_committee
+
+let title_of_section = function
+  | Home -> "Home"
+  | Cfp -> "Call for Talks"
+  | Committee -> "Program Committee"
+
+let sections = [Home; Cfp; Committee]
+
+let workshop_header ~current =
+  <header class="h-20 flex items-center bg-sand dark:bg-dark-background_navigation">
+    <nav class="container-fluid wide header flex justify-between items-center gap-5 xl:gap-8">
+      <ul class="order-0 items-center flex text-content font-medium dark:text-title dark:text-opacity-60 dark:font-semibold">
+        <li style="width:132px">
+          <a href="<%s Url.index %>" class="block pb-2" aria-label="ocaml.org">
+            <img src="<%s Ocamlorg_static.Asset.url "logo-with-name.svg" %>" width="132" alt="OCaml logo" class="dark:hidden">
+            <img src="<%s Ocamlorg_static.Asset.url "logo-with-name-white.svg" %>" width="132" alt="OCaml logo" class="hidden dark:inline">
+          </a>
+        </li>
+      </ul>
+      <ul class="order-1 mr-auto ml-2 lg:ml-6 items-center flex flex-wrap font-medium dark:text-white dark:text-opacity-60 dark:font-semibold">
+        <% sections |> List.iter (fun s -> %>
+        <li><%s! Header.menu_link ~active:(s = current) ~href:(url_of_section s) ~title:(title_of_section s) () %></li>
+        <% ); %>
+      </ul>
+      <ul class="order-3 hidden lg:flex items-center">
+        <li>
+          <a href="https://types-hotcrp.paris.inria.fr/ocaml26/" class="border border-primary dark:border-dark-primary text-primary dark:text-dark-primary font-bold py-2.5 px-7 whitespace-nowrap rounded">
+            Submit a Talk
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </header>
+
+let footer () =
+  <footer class="bg-[#EAE6DC] dark:bg-dark-card border-t border-separator_30 dark:border-dark-separator_30">
+    <div class="container-fluid wide pt-16 pb-8 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+      <div class="flex flex-col gap-2 text-sm text-content dark:text-dark-content">
+        <div>
+          Hosted on <a href="<%s Url.index %>" class="text-primary dark:text-dark-primary hover:underline">ocaml.org</a>.
+        </div>
+        <div>
+          Part of <a href="https://www.irif.fr/~scherer/events/fpw-2026/announce.html" class="text-primary dark:text-dark-primary hover:underline">FPW'26</a> · Paris, 24 August 2026
+        </div>
+      </div>
+      <div x-data class="flex w-full md:w-auto">
+        <%s! Footer.LightDarkModeSwitch.render %>
+      </div>
+    </div>
+    <%s! Footer.LightDarkModeSwitch.script %>
+  </footer>
+
+let single_column_layout
+?use_swiper
+?styles
+~title
+~description
+~canonical
+~current
+inner_html
+=
+  Layout.base
+  ?use_swiper
+  ?styles
+  ~title
+  ~description
+  ~canonical
+  ~show_header:false
+  ~footer_html:(footer ()) @@
+  <%s! workshop_header ~current %>
+  <div class="bg-background dark:bg-dark-background">
+    <div class="flex-1 z-0 min-w-0">
+      <%s! inner_html %>
+    </div>
+  </div>

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -55,3 +55,6 @@ let logos = Logos.render
 let cookbook = Cookbook.render
 let cookbook_task = Cookbook_task.render
 let cookbook_recipe = Cookbook_recipe.render
+let ocaml_workshop_2026 = Ocaml_workshop_2026.render
+let ocaml_workshop_2026_cfp = Ocaml_workshop_2026_cfp.render
+let ocaml_workshop_2026_committee = Ocaml_workshop_2026_committee.render

--- a/src/ocamlorg_frontend/pages/ocaml_workshop_2026.eml
+++ b/src/ocamlorg_frontend/pages/ocaml_workshop_2026.eml
@@ -1,0 +1,101 @@
+let render () =
+Workshop_layout.single_column_layout
+~title:"OCaml Workshop 2026"
+~description:"OCaml Workshop 2026, part of FPW'26 in Paris on 24 August 2026."
+~canonical:Url.ocaml_workshop_2026
+~current:Home @@
+<div class="intro-section-simple dark:dark-intro-section-simple">
+  <div class="container-fluid">
+    <div class="flex flex-col lg:flex-row justify-between items-center">
+      <div>
+        <h1 class="font-bold mb-3 text-title dark:text-dark-title">OCaml Workshop 2026</h1>
+        <div class="flex flex-col md:flex-row">
+          <div class="flex items-center">
+            <%s! Icons.map_pin "h-5 w-5 text-primary dark:text-dark-primary" %>
+            <p class="text-content dark:text-dark-content text-xl ml-2">Paris, France</p>
+          </div>
+          <div class="flex items-center md:ml-6">
+            <%s! Icons.calendar "h-5 w-5 text-primary dark:text-dark-primary" %>
+            <p class="text-content dark:text-dark-content text-xl ml-2">24 August 2026 (morning + afternoon)</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="bg-background dark:bg-dark-background">
+  <div class="container-fluid">
+    <div class="flex flex-col lg:flex-row justify-between mt-10 gap-10">
+      <div class="prose dark:prose-invert prose-orange max-w-2xl">
+        <p>The OCaml Workshop welcomes a broad audience of OCaml users ranging from enthusiasts who are discovering the magic of OCaml to wizards well-proficient in the cast of unsafe spells. Their common denominator is their passion for OCaml and the desire to learn more, connect with fellow OCamlers, and collectively find ways to improve the language.</p>
+        <p>This edition is part of <a href="https://www.irif.fr/~scherer/events/fpw-2026/announce.html">Functional Programming Workshops (FPW) 2026</a> in Paris, alongside other workshops and events. This is a departure from the usual habit of having the OCaml Workshop co-located with ICFP. Because some FPW'26 events are bi-located with ICFP, the events will take place at roughly the same dates.</p>
+
+        <h2>Venue</h2>
+        <p>Amphithéâtre Buffon, 15 rue Hélène Brion, Université Paris Cité, 75013 Paris.</p>
+        <p>The OCaml Workshop takes place at a separate venue from the rest of FPW'26, approximately 30 minutes away from INRIA Paris where the other workshops are held.</p>
+
+        <h2>Registration</h2>
+        <p>Coming soon.</p>
+
+        <h2>Other FPW'26 events</h2>
+        <p>The OCaml Workshop is one of several events gathered under <a href="https://www.irif.fr/~scherer/events/fpw-2026/announce.html">FPW'26</a>:</p>
+        <ul>
+          <li><a href="https://icfp26.sigplan.org/home/hope-2026">HOPE</a> — Higher-Order Programming with Effects (Mon 24 Aug, bi-located with ICFP'26)</li>
+          <li><a href="https://conf.researchr.org/series/fproper">FProPer</a> — Functional Programming for Productivity and Performance (Mon 24 Aug)</li>
+          <li><a href="https://tydeworkshop.org/2026">TyDe</a> — Type-Driven Development (Wed 26 – Thu 27 Aug)</li>
+          <li><a href="https://icfp26.sigplan.org/home/mlfamilyworkshop-2026#About">ML Family Workshop</a> (Fri 28 Aug, bi-located with ICFP'26)</li>
+        </ul>
+        <p>The <a href="https://www.haskell.org/haskell-symposium/">Haskell Symposium</a> remains at ICFP this year with no physical presence in Paris.</p>
+        <p>The ML Family Workshop in particular may be of interest to OCaml attendees: it is language-agnostic and more research-oriented than the OCaml Workshop, which focuses on the OCaml ecosystem. Authors whose submissions fit both venues are welcome to indicate this at submission time or reach out to the program chairs.</p>
+
+        <h2>Past editions</h2>
+        <ul>
+          <li><a href="<%s Url.conference "ocaml-workshop-2025" %>">OCaml Workshop 2025</a></li>
+          <li><a href="<%s Url.conference "ocaml-workshop-2024" %>">OCaml Workshop 2024</a></li>
+          <li><a href="<%s Url.conference "ocaml-workshop-2023" %>">OCaml Workshop 2023</a></li>
+          <li><a href="<%s Url.conferences %>">All past workshops</a></li>
+        </ul>
+      </div>
+
+      <div class="flex flex-col space-y-6 relative mt-4 lg:mt-0 lg:w-96 flex-shrink-0">
+        <h3 class="font-bold text-title dark:text-dark-title">Important Dates</h3>
+        <div class="flex items-center">
+          <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">1 Jul</div>
+          <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+            <div class="text-xs font-semibold">UPCOMING</div>
+            <div>Submission deadline (AoE)</div>
+          </div>
+        </div>
+        <div class="flex items-center">
+          <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">27 Jul</div>
+          <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+            <div class="text-xs font-semibold">UPCOMING</div>
+            <div>Speaker notification</div>
+          </div>
+        </div>
+        <div class="flex items-center">
+          <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">24 Aug</div>
+          <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+            <div class="text-xs font-semibold">UPCOMING</div>
+            <div>Workshop</div>
+          </div>
+        </div>
+
+        <div class="mt-6 flex flex-col gap-3">
+          <a href="<%s Url.ocaml_workshop_2026_cfp %>" class="btn">
+            Call for Talks
+            <%s! Icons.chevron_right "h-5 w-5 inline-block" %>
+          </a>
+          <a href="https://types-hotcrp.paris.inria.fr/ocaml26/" class="btn btn-ghost">
+            Submit a Talk
+            <%s! Icons.arrow_top_right_on_square "h-5 w-5 inline-block" %>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/ocamlorg_frontend/pages/ocaml_workshop_2026_cfp.eml
+++ b/src/ocamlorg_frontend/pages/ocaml_workshop_2026_cfp.eml
@@ -1,0 +1,85 @@
+let render () =
+Workshop_layout.single_column_layout
+~title:"OCaml Workshop 2026 — Call for Talks"
+~description:"Submit a talk proposal to the OCaml Workshop 2026, part of FPW'26 in Paris."
+~canonical:Url.ocaml_workshop_2026_cfp
+~current:Cfp @@
+<div class="intro-section-simple dark:dark-intro-section-simple">
+  <div class="container-fluid">
+    <a href="<%s Url.ocaml_workshop_2026 %>" class="text-primary dark:text-dark-primary hover:text-primary pr-2 mb-3 flex mt-4 items-center dark:hover:text-dark-primary hover:underline group">
+      <%s! Icons.chevron_left "h-5 w-5 text-primary dark:text-dark-primary group-hover:text-primary group-hover:underline dark:group-hover:text-dark-primary" %>
+      Back to OCaml Workshop 2026
+    </a>
+    <h1 class="font-bold mb-3 text-title dark:text-dark-title">Call for Talks</h1>
+  </div>
+</div>
+
+<div class="bg-background dark:bg-dark-background">
+  <div class="container-fluid">
+    <div class="flex flex-col lg:flex-row justify-between mt-10 gap-10">
+      <div class="prose dark:prose-invert prose-orange max-w-2xl">
+        <h2>Scope</h2>
+        <p>The OCaml Workshop welcomes a broad audience of OCaml users ranging from enthusiasts who are discovering the magic of OCaml to wizards well-proficient in the cast of unsafe spells. Their common denominator is their passion for OCaml and the desire to learn more, connect with fellow OCamlers, and collectively find ways to improve the language.</p>
+        <p>We invite talk proposals just as broad: <strong>anything OCaml related</strong> is welcome!</p>
+        <p>The topics are not limited to the following, but, to give an idea, examples from previous years include: OCaml editing tools, verified OCaml artefacts, interoperability between OCaml and other languages, the OCaml code of conduct, compiler optimisations, OS portability, OCaml testing frameworks, packages for concurrency in OCaml, etc.</p>
+        <p>The full catalogue from previous editions can be accessed through the links below:</p>
+        <ul>
+          <li><a href="<%s Url.conference "ocaml-workshop-2025" %>">2025</a></li>
+          <li><a href="<%s Url.conference "ocaml-workshop-2024" %>">2024</a></li>
+          <li><a href="<%s Url.conference "ocaml-workshop-2023" %>">2023</a></li>
+          <li><a href="<%s Url.conference "ocaml-workshop-2022" %>">2022</a></li>
+          <li><a href="<%s Url.conference "ocaml-workshop-2021" %>">2021</a></li>
+        </ul>
+
+        <h2>Format</h2>
+        <p>In addition to the <strong>Standard Talk</strong> format of 20 minutes, we allow the following formats:</p>
+        <ul>
+          <li><strong>Demo.</strong> 30 minutes tutorial-style demonstration of a tool.</li>
+          <li><strong>Informed Position.</strong> 20 minutes presentation on topics in the design space of OCaml (such as, but not limited to, the inclusion or removal of a feature).</li>
+          <li><strong>Experience Report.</strong> 20 minutes report on the use of OCaml or a tool.</li>
+        </ul>
+
+        <h2>Submission</h2>
+        <p>Please submit a description of the talk (typically two to three pages long; it could also be less or more): the problems that are addressed and the solutions or methods that are proposed. If you believe the delivery itself is a unique feature of the talk, please feel free to also include a description of how you plan to deliver the talk.</p>
+        <p>LaTeX-produced PDFs are common but not required.</p>
+        <p>Last year's accepted presentations are available <a href="https://icfp25.sigplan.org/home/ocaml-2025#event-overview">online</a>.</p>
+
+        <h2>Evaluation Criteria</h2>
+        <p>We will evaluate submissions according to:</p>
+        <ul>
+          <li>Relevance for the OCaml community</li>
+          <li>Rigor and soundness</li>
+          <li>Novelty</li>
+          <li>Clarity</li>
+          <li>Potential to deliver an engaging and informative presentation</li>
+        </ul>
+
+        <h2>Recommendations on LLM Usage</h2>
+        <p>Proposals largely written by LLMs are not acceptable and will be desk-rejected. The use of LLMs to correct grammar and enhance style is perfectly fine (especially if English is not your first language), but their use to produce material directly is dangerous and unprofessional, and undermines both authorship and reviewer effort.</p>
+      </div>
+
+      <div class="flex flex-col space-y-6 relative mt-4 lg:mt-0 lg:w-96 flex-shrink-0">
+        <h3 class="font-bold text-title dark:text-dark-title">Important Dates</h3>
+        <div class="flex items-center">
+          <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">1 Jul</div>
+          <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+            <div class="text-xs font-semibold">SUBMISSION DEADLINE (AoE)</div>
+          </div>
+        </div>
+        <div class="flex items-center">
+          <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">27 Jul</div>
+          <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+            <div class="text-xs font-semibold">SPEAKER NOTIFICATION</div>
+          </div>
+        </div>
+
+        <a href="https://types-hotcrp.paris.inria.fr/ocaml26/" class="btn">
+          Submit a Talk
+          <%s! Icons.arrow_top_right_on_square "h-5 w-5 inline-block" %>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/ocamlorg_frontend/pages/ocaml_workshop_2026_committee.eml
+++ b/src/ocamlorg_frontend/pages/ocaml_workshop_2026_committee.eml
@@ -1,0 +1,58 @@
+let chairs = [
+  "Paulo de Vilhena";
+  "Sudha Parimala";
+]
+
+let members = [
+  "Clément Allain";
+  "Pedro Carrott";
+  "Simon Cruanes";
+  "Marko Doko";
+  "Patrick Ferris";
+  "Jean-Christophe Filliâtre";
+  "Sadiq Jaffer";
+  "Robbert Krebbers";
+  "Vincent Laviron";
+  "Tim McGilchrist";
+  "António Monteiro";
+  "Carine Morel";
+  "Andreas Rossberg";
+  "Vimala Soundarapandian";
+  "Jérôme Vouillon";
+  "John Whitington";
+]
+
+let render () =
+Workshop_layout.single_column_layout
+~title:"OCaml Workshop 2026 — Program Committee"
+~description:"Program committee of the OCaml Workshop 2026."
+~canonical:Url.ocaml_workshop_2026_committee
+~current:Committee @@
+<div class="intro-section-simple dark:dark-intro-section-simple">
+  <div class="container-fluid">
+    <a href="<%s Url.ocaml_workshop_2026 %>" class="text-primary dark:text-dark-primary hover:text-primary pr-2 mb-3 flex mt-4 items-center dark:hover:text-dark-primary hover:underline group">
+      <%s! Icons.chevron_left "h-5 w-5 text-primary dark:text-dark-primary group-hover:text-primary group-hover:underline dark:group-hover:text-dark-primary" %>
+      Back to OCaml Workshop 2026
+    </a>
+    <h1 class="font-bold mb-3 text-title dark:text-dark-title">Program Committee</h1>
+  </div>
+</div>
+
+<div class="w-full deep-blue-gradient dark:section-blue-gradient">
+  <div class="container-fluid pt-6 pb-12">
+    <p class="uppercase text-sm text-dark-content dark:text-dark-content tracking-widest font-medium my-4">OCaml Workshop 2026</p>
+    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2">Co-Chairs</h2>
+    <ul class="grid grid-cols-1 md:grid-cols-2 mt-4">
+      <% chairs |> List.iter (fun name -> %>
+        <li class="mb-4"><p class="text-dark-content"><span class="mr-2">•</span><span class="font-bold mr-2"><%s name %></span></p></li>
+      <% ); %>
+    </ul>
+
+    <h2 class="font-bold text-2xl text-white dark:text-dark-title mb-2 mt-8">Program Committee</h2>
+    <ul class="grid grid-cols-1 md:grid-cols-2 mt-4">
+      <% members |> List.iter (fun name -> %>
+        <li class="mb-4"><p class="text-dark-content"><span class="mr-2">•</span><span class="font-bold mr-2"><%s name %></span></p></li>
+      <% ); %>
+    </ul>
+  </div>
+</div>

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -510,6 +510,15 @@ let academic_institutions req =
 
 let about _req = Dream.html (Ocamlorg_frontend.about ())
 
+let ocaml_workshop_2026 _req =
+  Dream.html (Ocamlorg_frontend.ocaml_workshop_2026 ())
+
+let ocaml_workshop_2026_cfp _req =
+  Dream.html (Ocamlorg_frontend.ocaml_workshop_2026_cfp ())
+
+let ocaml_workshop_2026_committee _req =
+  Dream.html (Ocamlorg_frontend.ocaml_workshop_2026_committee ())
+
 let books req =
   let language = Dream.query req "language" in
   let pricing = Dream.query req "pricing" in

--- a/src/ocamlorg_web/lib/router.ml
+++ b/src/ocamlorg_web/lib/router.ml
@@ -77,6 +77,10 @@ let page_routes t =
       Dream.get (Url.tutorial ":id") (Handler.tutorial Commit.hash);
       Dream.get Url.playground Handler.playground;
       Dream.get Url.logos Handler.logos;
+      Dream.get Url.ocaml_workshop_2026 Handler.ocaml_workshop_2026;
+      Dream.get Url.ocaml_workshop_2026_cfp Handler.ocaml_workshop_2026_cfp;
+      Dream.get Url.ocaml_workshop_2026_committee
+        Handler.ocaml_workshop_2026_committee;
     ]
 
 let package_route t =


### PR DESCRIPTION
## Summary

- Adds a small pre-event mini-site for OCaml Workshop 2026 (part of FPW'26 in Paris, 24 Aug 2026). Routes: `/ocaml-workshop-2026`, `/ocaml-workshop-2026/cfp`, `/ocaml-workshop-2026/committee`. Content provided by the co-chairs Sudha Parimala and Paulo de Vilhena.
- Built as a bespoke layout (workshop chrome with workshop tabs + Submit-a-Talk CTA, plus a small footer carrying the standard light/dark/system theme toggle). The standard top-nav header is suppressed on these pages via a new `?show_header` opt-out on `Layout.base`; all other pages are unchanged.
- The archival `data/conferences/` system is deliberately untouched. That system records *past* workshops (PC + accepted talks + video links); the lifecycle is different from an open-CFP pre-event site, so `Conference.t` is not extended. An archival 2026 entry will be added later, after the workshop runs.

### Why

Since OCaml Workshop 2026 is at FPW'26 rather than ICFP this year, `conf.researchr.org` is no longer providing the usual pre-event micro-site (CFP, dates, submission portal, committee). The co-chairs asked ocaml.org to host the equivalent.

### Notable choices

- **No main-nav linkage yet.** The mini-site is reachable by URL but not advertised from ocaml.org's header/footer. Soft launch; we can wire it in later when the co-chairs say go.
- **Theme toggle in the workshop footer.** Since the global header (which normally carries the toggle) is suppressed on workshop pages, the footer reuses `Footer.LightDarkModeSwitch` so users can still switch theme.
- **Footer background uses an arbitrary value (`bg-[#EAE6DC]`).** The natural choice `bg-dark-sand` doesn't generate a CSS rule — there is no `dark.sand` token in `tailwind.config.js`, so the class is silently dropped and the footer reads as white. This affects the standard `Footer.primary_footer` too; I'd rather fix it upstream (add `sand` under `dark:` in the tailwind config) in a separate PR than tangle scopes here.

## Test plan

- [ ] Visit `/ocaml-workshop-2026` — workshop header (logo + Home / Call for Talks / Program Committee + Submit a Talk), important dates panel, venue, FPW + ML cross-references, footer with theme toggle.
- [ ] Visit `/ocaml-workshop-2026/cfp` — scope, formats, submission instructions, LLM policy, evaluation criteria; Submit-a-Talk button points to the HotCRP portal.
- [ ] Visit `/ocaml-workshop-2026/committee` — co-chairs and PC.
- [ ] Active-state on the header nav highlights the current page.
- [ ] Footer theme toggle switches between Light / Dark / System and persists to localStorage.
- [ ] Confirm `/` and other top-level pages still render the standard ocaml.org header (no regression).
- [ ] Confirm `/conferences` and `/conferences/ocaml-workshop-2025` (archival) still render unchanged.
- [ ] Mobile rendering (375×812, iPhone-class viewport):
  - [ ] Header doesn't overflow horizontally; nav items wrap (or collapse) cleanly, no horizontal scrollbar.
  - [ ] Submit-a-Talk CTA is hidden below the `lg` breakpoint (visible on desktop only).
  - [ ] Active workshop tab remains underlined and legible after wrap.
  - [ ] Hero section ("OCaml Workshop 2026" title + location + date) renders without truncation.
  - [ ] Right-side panels (Important Dates, Submit CTA) stack below the main content rather than sitting alongside.
  - [ ] Footer stacks vertically (text + theme toggle) per the `md:flex-row` breakpoint; theme toggle is full-width.
- [ ] Narrower breakpoint (~360px, common Android): same checks pass; nav still navigable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
