### PR TITLE
Workshop 2026: white text on orange Important Dates pills

### DIFF
--- a/src/ocamlorg_frontend/pages/ocaml_workshop_2026.eml
+++ b/src/ocamlorg_frontend/pages/ocaml_workshop_2026.eml
@@ -63,7 +63,7 @@ Workshop_layout.single_column_layout
         <div class="flex items-center">
           <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">1 Jul</div>
           <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
-          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-white px-4 py-2">
             <div class="text-xs font-semibold">UPCOMING</div>
             <div>Submission deadline (AoE)</div>
           </div>
@@ -71,7 +71,7 @@ Workshop_layout.single_column_layout
         <div class="flex items-center">
           <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">27 Jul</div>
           <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
-          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-white px-4 py-2">
             <div class="text-xs font-semibold">UPCOMING</div>
             <div>Speaker notification</div>
           </div>
@@ -79,7 +79,7 @@ Workshop_layout.single_column_layout
         <div class="flex items-center">
           <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">24 Aug</div>
           <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
-          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-white px-4 py-2">
             <div class="text-xs font-semibold">UPCOMING</div>
             <div>Workshop</div>
           </div>

--- a/src/ocamlorg_frontend/pages/ocaml_workshop_2026_cfp.eml
+++ b/src/ocamlorg_frontend/pages/ocaml_workshop_2026_cfp.eml
@@ -63,14 +63,14 @@ Workshop_layout.single_column_layout
         <div class="flex items-center">
           <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">1 Jul</div>
           <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
-          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-white px-4 py-2">
             <div class="text-xs font-semibold">SUBMISSION DEADLINE (AoE)</div>
           </div>
         </div>
         <div class="flex items-center">
           <div class="text-primary dark:text-dark-primary font-semibold w-20 text-right">27 Jul</div>
           <div class="bg-primary dark:bg-dark-primary h-5 w-5 rounded-full mx-2"></div>
-          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-title dark:text-dark-title px-4 py-2">
+          <div class="bg-primary dark:bg-dark-primary flex-1 rounded-xl text-white px-4 py-2">
             <div class="text-xs font-semibold">SPEAKER NOTIFICATION</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- The Important Dates pills on `/ocaml-workshop-2026` and `/ocaml-workshop-2026/cfp` used `text-title` (near-black in the light theme) on a `bg-primary` (orange) background, giving poor contrast — feedback raised by Sudha.
- Switch to `text-white` so the `UPCOMING` label and the date description stay legible in both light and dark themes, matching the `.btn` treatment already used for the "Call for Talks" CTA Sudha pointed at.

## Test plan
- [ ] `dune build src/ocamlorg_frontend` succeeds (verified locally).
- [ ] Visit `/ocaml-workshop-2026` in the light theme and confirm the three Important Dates pills (1 Jul / 27 Jul / 24 Aug) render white text on orange.
- [ ] Visit `/ocaml-workshop-2026/cfp` and confirm the two pills (1 Jul / 27 Jul) render white text on orange.
- [ ] Toggle to dark theme — still legible (the orange background is theme-invariant, white text remains correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)