### PR TITLE
Add AWS to industrial users

### DIFF
--- a/data/industrial_users/aws.md
+++ b/data/industrial_users/aws.md
@@ -1,0 +1,12 @@
+---
+name: Amazon Web Services (AWS)
+description: >
+  Amazon Web Services (AWS) is a cloud computing platform providing a wide range of infrastructure and application services.
+url: "https://aws.amazon.com"
+locations:
+  - United States
+consortium: false
+featured: false
+---
+
+AWS uses OCaml-based formal verification tools in the development of cryptographic software. The s2n-bignum project, used by AWS-LC, is verified using HOL Light, a theorem prover implemented in OCaml. These proofs help ensure the correctness of cryptographic routines used in AWS security infrastructure.


### PR DESCRIPTION
Fixes #3652

Add Amazon Web Services (AWS) to the industrial users page.

AWS uses HOL Light, an OCaml-based theorem prover, for formal verification of the s2n-bignum project used in AWS-LC.
