### PR TITLE
Clarify Core usage in garbage collector tutorial

### DIFF
--- a/data/tutorials/language/5rt_01_garbage-collector.md
+++ b/data/tutorials/language/5rt_01_garbage-collector.md
@@ -167,6 +167,13 @@ profile). This setting can be overridden via the `s=<words>` argument to
 `OCAMLRUNPARAM`. You can change it after the program has started by calling
 the `Gc.set` function:
 
+> **Note**
+>
+> The examples below use Jane Street's Core library, which provides
+> convenience functions such as `Gc.tune`. If you are using only the
+> OCaml standard library, similar functionality can be achieved using
+> `Gc.get` and `Gc.set`.
+
 ```ocaml env=tune
 # open Core;;
 # let c = Gc.get ();;


### PR DESCRIPTION
Fixes #3664

Add a note clarifying that examples using `Gc.tune` rely on Jane Street's Core library.

This helps readers who are using only the OCaml standard library understand that `Gc.tune` is not part of Stdlib and that similar functionality can be achieved using `Gc.get` and `Gc.set`.