### PR TITLE
OCaml 4.14.4 release

### DIFF
--- a/data/platform_releases/ocaml/2026-06-15-ocaml-4.14.4.md
+++ b/data/platform_releases/ocaml/2026-06-15-ocaml-4.14.4.md
@@ -1,7 +1,7 @@
 ---
 title: Release of OCaml 4.14.4
 tags: [ocaml]
-experimental: true
+experimental: false
 changelog: |
   ## Changes in OCaml 4.14.4 (15 June 2026)
   ### Build system:

--- a/data/platform_releases/ocaml/2026-06-15-ocaml-4.14.4.md
+++ b/data/platform_releases/ocaml/2026-06-15-ocaml-4.14.4.md
@@ -1,0 +1,68 @@
+---
+title: Release of OCaml 4.14.4
+tags: [ocaml]
+experimental: true
+changelog: |
+  ## Changes in OCaml 4.14.4 (15 June 2026)
+  ### Build system:
+  
+  - [#12372](https://github.com/ocaml/ocaml/issues/12372), [#14572](https://github.com/ocaml/ocaml/issues/14572): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+    so that code sections remain readable, as needed for closure marshaling.
+    Originally backported in 4.14.2, but the flag was accidentally not passed when
+    linking the .so versions of the OCaml runtime libraries or when linking .cmxs
+    files.
+    (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+    Sébastien Hinderer)
+  
+  ### Bug fixes:
+  
+  - [#14599](https://github.com/ocaml/ocaml/issues/14599), [#14606](https://github.com/ocaml/ocaml/issues/14606): on ARM64 platforms, ocamlopt was under-estimating
+    the sizes of some instructions.  This could lead to overflows in
+    relative branch offsets, reported as errors by the assembler.
+    (Xavier Leroy, review by Vincent Laviron, report by Raphaël Proust)
+  
+  - [#14607](https://github.com/ocaml/ocaml/issues/14607): Fix linking with libasmrun_shared.so on Risc-V (undefined symbol
+    declared riscv.o)
+    (David Allsopp, review by Nicolás Ojeda Bär)
+  
+  - [#14661](https://github.com/ocaml/ocaml/issues/14661): Build dllthreads.so with pthreads flags (removed in [#13018](https://github.com/ocaml/ocaml/issues/13018)). For
+    normal programs there's no semantic difference, because ocamlrun and
+    ocamlc.opt are always linked with pthreads, but it was a regression to require
+    programs wishing to dlopen dllthreads.so to have already linked with pthreads
+    themselves.
+    (David Allsopp, review by Gabriel Scherer)
+  
+  - [#14655](https://github.com/ocaml/ocaml/issues/14655), [#14691](https://github.com/ocaml/ocaml/issues/14691), CVE-2026-34353, OSEC-2026-04: check for size overflow in
+    caml_ba_reshape
+    (Stephen Dolan, review by Xavier Leroy)
+  
+  - [#14853](https://github.com/ocaml/ocaml/issues/14853), CVE-2026-41083, OSEC-2026-05: fix quoting of filenames passed to
+    Filename.quote_command on Windows.
+    (David Allsopp, report by Andrew Nesbitt, review by Florian Angeletti)
+---
+
+We have the pleasure of celebrating the anniversary of the first flight of Ariane 4 by announcing the release of OCaml version 4.14.4.
+
+This release is a collection of safe bug fixes, cherry-picked from the OCaml 5 branch.
+The 4.14 branch is expected to receive updates until at least the end of 2026.
+However, the end of its extended maintenance period is on the horizon.
+Consequently, please mention to us any obstacle remaining to your migration to OCaml 5.
+
+In the meanwhile, do not hesitate to report any bugs on the [OCaml issue tracker](https://github.com/ocaml/ocaml/issues).
+
+See the list of changes below for more details.
+
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+
+```bash
+opam update
+opam switch create 4.14.4
+```
+The source code for the release candidate is also directly available on:
+
+* [GitHub](https://github.com/ocaml/ocaml/archive/4.14.4.tar.gz)
+* [Inria archive](https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.4.tar.gz)

--- a/data/releases/4.14.3.md
+++ b/data/releases/4.14.3.md
@@ -2,7 +2,7 @@
 kind: compiler
 version: 4.14.3
 date: 2026-02-17
-is_lts: true
+is_lts: false
 intro: |
   This page describes OCaml version **4.14.3**, released on
   Feb 17, 2026. Go [here](/releases) for a list of all releases.

--- a/data/releases/4.14.4.md
+++ b/data/releases/4.14.4.md
@@ -1,0 +1,113 @@
+---
+kind: compiler
+version: 4.14.4
+date: 2026-06-15
+is_lts: true
+intro: |
+  This page describes OCaml version **4.14.4**, released on
+  Jun 15, 2026. Go [here](/releases) for a list of all releases.
+
+  This is a bug-fix release of [OCaml 4.14.3](/releases/4.14.3).
+
+  As the last version of OCaml 4, the 4.14 branch of OCaml will be maintained during the transition period for OCaml 5.
+  During this period, OCaml 4.14 will receive episodic bugfix updates as a long term support branch until at least 2027.
+highlights: |
+  - Security fix for check for size overflow in caml_ba_reshape (CVE-2026-34353, OSEC-2026-04)
+  - Security fix for quoting of filenames passed to Filename.quote_command on Windows
+  - Bug fixes for 4.14.3
+---
+
+## Installation Instructions
+
+The base compiler can be installed as an opam switch with the following commands:
+```bash
+opam update
+opam switch create 4.14.4
+```
+
+### Configuration Options
+
+The configuration of the installed [opam](https://opam.ocaml.org/) switch can be tuned with the
+following options:
+
+- `ocaml-option-afl`: sets OCaml to be compiled with `afl-fuzz` instrumentation
+- `ocaml-option-bytecode-only`: compiles OCaml without the native-code compiler
+- `ocaml-option-flambda`: sets OCaml to be compiled with `flambda` activated
+- `ocaml-option-musl`: sets OCaml to be compiled with `musl-gcc`
+- `ocaml-option-no-flat-float-array`: sets OCaml to be compiled with `--disable-flat-float-array`
+- `ocaml-option-static`: sets OCaml to be compiled with `musl-gcc -static`
+- `ocaml-option-32bit`: sets OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts
+- `ocaml-option-nnp`: sets OCaml to be compiled with `--disable-naked-pointers`
+- `ocaml-option-nnpchecker`: set OCaml to be compiled with `--enable-naked-pointers-checker`
+- `ocaml-option-fp`: sets OCaml to be compiled with frame-pointers enabled
+
+For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with:
+
+```bash
+opam switch create 4.14.4+flambda+nnpchecker ocaml-variants.4.14.4+options ocaml-option-flambda ocaml-option-nnpchecker
+```
+
+---
+
+## Source Distribution
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.14.4.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.14.4.zip)
+  format.
+- [opam](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](https://ocaml.org/releases/4.14/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions. See also the [Windows release
+notes](https://ocaml.org/releases/4.14/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+---
+
+## Changes for OCaml 4.14.4 (15 June 2026)
+
+### Build system
+
+- [#12372](https://github.com/ocaml/ocaml/issues/12372), [#14572](https://github.com/ocaml/ocaml/issues/14572): Pass option -no-execute-only to the linker for OpenBSD >= 7.3
+  so that code sections remain readable, as needed for closure marshaling.
+  Originally backported in 4.14.2, but the flag was accidentally not passed when
+  linking the .so versions of the OCaml runtime libraries or when linking .cmxs
+  files.
+  (Xavier Leroy and Anil Madhavapeddy, review by Anil Madhavapeddy and
+  Sébastien Hinderer)
+
+### Bug fixes
+
+- [#14599](https://github.com/ocaml/ocaml/issues/14599), [#14606](https://github.com/ocaml/ocaml/issues/14606): on ARM64 platforms, ocamlopt was under-estimating
+  the sizes of some instructions.  This could lead to overflows in
+  relative branch offsets, reported as errors by the assembler.
+  (Xavier Leroy, review by Vincent Laviron, report by Raphaël Proust)
+
+- [#14607](https://github.com/ocaml/ocaml/issues/14607): Fix linking with libasmrun_shared.so on Risc-V (undefined symbol
+  declared riscv.o)
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
+- [#14661](https://github.com/ocaml/ocaml/issues/14661): Build dllthreads.so with pthreads flags (removed in [#13018](https://github.com/ocaml/ocaml/issues/13018)). For
+  normal programs there's no semantic difference, because ocamlrun and
+  ocamlc.opt are always linked with pthreads, but it was a regression to require
+  programs wishing to dlopen dllthreads.so to have already linked with pthreads
+  themselves.
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#14655](https://github.com/ocaml/ocaml/issues/14655), [#14691](https://github.com/ocaml/ocaml/issues/14691), CVE-2026-34353, OSEC-2026-04: check for size overflow in
+  caml_ba_reshape
+  (Stephen Dolan, review by Xavier Leroy)
+
+- [#14853](https://github.com/ocaml/ocaml/issues/14853), CVE-2026-41083, OSEC-2026-05: fix quoting of filenames passed to
+  Filename.quote_command on Windows.
+  (David Allsopp, report by Andrew Nesbitt, review by Florian Angeletti)
+  


### PR DESCRIPTION
This PR adds the release page and the changelog entry for the upcoming 4.14.4 release of OCaml (see https://github.com/ocaml/opam-repository/pull/30054 for the corresponding opam PR).