### PR TITLE
Make watch.ocaml.org video scraper resilient to source failure

### DIFF
--- a/tool/data-scrape/lib/watch_scraper.ml
+++ b/tool/data-scrape/lib/watch_scraper.ml
@@ -91,22 +91,34 @@ let get_all_videos () =
   in
   aux data
 
+let source_id = "watch.ocaml.org"
+
 let scrape yaml_file =
   let old_count = List.length (all ()) in
-  let watch =
-    get_all_videos ()
-    |> List.stable_sort (fun w1 w2 ->
-           String.compare w1.Data_packer.Vid.title w2.Data_packer.Vid.title)
-  in
-  let yaml = to_yaml watch in
-  let output =
-    Yaml.pp Format.str_formatter yaml;
-    Format.flush_str_formatter ()
-  in
-  let oc = open_out yaml_file in
-  Printf.fprintf oc "%s" output;
-  close_out oc;
-  let new_count = List.length watch - old_count in
-  if new_count > 0 then
-    [ Scrape_report.Video_update { file = yaml_file; new_count } ]
-  else []
+  (* A failure of the watch.ocaml.org source (e.g. network outage or expired TLS
+     certificate) must not abort the whole scrape: report it as an error and
+     leave the existing yaml file untouched so we don't lose data. *)
+  match get_all_videos () with
+  | exception e ->
+      let message = Printexc.to_string e in
+      Printf.eprintf " [WARN] Could not fetch %s videos: %s\n%!" source_id
+        message;
+      [ Scrape_report.Error { source_id; message } ]
+  | videos ->
+      let watch =
+        videos
+        |> List.stable_sort (fun w1 w2 ->
+               String.compare w1.Data_packer.Vid.title w2.Data_packer.Vid.title)
+      in
+      let yaml = to_yaml watch in
+      let output =
+        Yaml.pp Format.str_formatter yaml;
+        Format.flush_str_formatter ()
+      in
+      let oc = open_out yaml_file in
+      Printf.fprintf oc "%s" output;
+      close_out oc;
+      let new_count = List.length watch - old_count in
+      if new_count > 0 then
+        [ Scrape_report.Video_update { file = yaml_file; new_count } ]
+      else []


### PR DESCRIPTION
## Problem

A single failing source can abort the entire OCaml Planet scrape job. In run [`28080838425`](https://github.com/ocaml/ocaml.org/actions/runs/28080838425/job/83135162326) the `watch.ocaml.org` TLS certificate had expired, the video scraper raised an uncaught `certificate verify failed`, and the whole scheduled job failed — so **no PR was created at all**, even though the blog/planet and YouTube phases had already scraped successfully.

The blog scraper (`blog_scraper.ml`) and the YouTube scraper (`youtube_scraper.ml`) already isolate each source with a `try/with`, so one dead source just yields a `Scrape_report.Error` and the rest continue. The `watch.ocaml.org` scraper was the only one missing this guard: it called `get_all_videos ()` directly, so any failure propagated uncaught through `video_cmd` and crashed the process.

## Fix

Wrap the fetch in `Watch_scraper.scrape` in the same per-source error pattern used elsewhere:

- on failure (network outage, expired TLS cert, malformed response): log a `[WARN]`, emit a `Scrape_report.Error` entry, and **leave the existing `data/video-watch.yml` untouched** so no data is lost;
- on success: behaviour unchanged.

With this in place, the run that failed would instead have scraped the blog posts and YouTube videos, recorded `watch.ocaml.org: certificate verify failed` as a non-fatal error in the report, exited `0`, and created the PR with everything that succeeded.

## Scope

This closes the actual asymmetry — the watch scraper was the only video source without per-source isolation. I deliberately did not add a broader catch-all around `video_cmd`: the remaining raise paths in the YouTube scraper are config-decode / YAML-serialization errors that should fail loudly rather than be swallowed.

Refs #3694

🤖 Generated with [Claude Code](https://claude.com/claude-code)
