### PR TITLE
Clarify opam package version status and dates

### DIFF
--- a/src/ocamlorg_frontend/components/package_breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/package_breadcrumbs.eml
@@ -41,7 +41,7 @@ let render_package_and_version
     | Overview _ -> Url.Package.overview package.name ?version
     | Documentation _ -> Url.Package.documentation package.name ?version ?hash ?page
   in
-  let version_options (v: Package.version_with_publication_date) =
+  let version_options (v: Package.version_summary) =
     <% if v.version = package.latest_version then ( %>
     <option value="<%s url None %>" <%s if package.version = Latest then "selected" else "" %>>
       <%s "latest (" ^ package.latest_version ^ ")" %>

--- a/src/ocamlorg_frontend/package.ml
+++ b/src/ocamlorg_frontend/package.ml
@@ -1,6 +1,12 @@
 type version = Latest | Specific of string
 type documentation_status = Success | Failure | Unknown
-type version_with_publication_date = { version : string; publication : float }
+type version_status = Avoided | Deprecated
+
+type version_summary = {
+  version : string;
+  opam_repository_date : float;
+  statuses : version_status list;
+}
 
 type package = {
   name : string;
@@ -8,13 +14,13 @@ type package = {
   description : string;
   license : string;
   version : version;
-  versions : version_with_publication_date list;
+  versions : version_summary list;
   latest_version : string;
   tags : string list;
   rev_deps : string list;
   authors : Data.Opam_user.t list;
   maintainers : Data.Opam_user.t list;
-  publication : float;
+  opam_repository_date : float;
   homepages : string list;
   source : (string * string list) option;
       (* TODO: these should be part of package.json coming from voodoo, but they

--- a/src/ocamlorg_frontend/pages/package_overview.eml
+++ b/src/ocamlorg_frontend/pages/package_overview.eml
@@ -220,8 +220,8 @@ let render
             <% ); %>
           <% ); %>
           <div class="flex-grow"></div>
-          <h2 class="font-semibold text-base text-content dark:text-dark-content">Published:
-            <span class="font-normal"><%s Utils.human_date_of_timestamp package.publication %></span>
+          <h2 class="font-semibold text-base text-content dark:text-dark-content">Added to opam-repository:
+            <time datetime="<%s Utils.iso_date_of_timestamp package.opam_repository_date %>" class="font-normal"><%s Utils.human_date_of_timestamp package.opam_repository_date %></time>
           </h2>
         </div>
 

--- a/src/ocamlorg_frontend/pages/package_versions.eml
+++ b/src/ocamlorg_frontend/pages/package_versions.eml
@@ -20,6 +20,16 @@ let documentation_href (package : Package.package) version =
     Printf.sprintf "/manual/%s/index.html" (ocaml_manual_version version)
   else Printf.sprintf "/p/%s/%s/doc/index.html" package.name version
 
+let is_ocaml_compiler_package name =
+  List.mem name
+    [
+      "ocaml";
+      "ocaml-compiler";
+      "ocaml-base-compiler";
+      "ocaml-system";
+      "ocaml-variants";
+    ]
+
 let render_statuses ~is_latest ~is_selected item =
   let previous = not is_latest && not (is_discouraged item) in
   let badges =
@@ -28,7 +38,7 @@ let render_statuses ~is_latest ~is_selected item =
          Some
            (status_badge
               "border-primary bg-primary_25 text-title dark:border-dark-primary dark:bg-dark-primary_10 dark:text-dark-title"
-              "Latest")
+              "Latest URL target")
        else None);
       (if previous then
          Some
@@ -127,8 +137,24 @@ Layout.render
     <h1 class="text-2xl font-medium text-title dark:text-dark-title"><%s package.name %> opam package versions (<%i List.length package.versions %>)</h1>
   </div>
   <div class="container-fluid">
+    <% if is_ocaml_compiler_package package.name then ( %>
+      <aside aria-labelledby="official-ocaml-releases-title"
+        class="mb-6 max-w-3xl rounded border-l-4 border-primary bg-primary_25 p-5 text-content dark:border-dark-primary dark:bg-dark-primary_10 dark:text-dark-content">
+        <h2 id="official-ocaml-releases-title" class="text-lg font-semibold text-title dark:text-dark-title">Official OCaml releases</h2>
+        <p class="mt-2">
+          This page is an opam package listing, not the list of official OCaml releases.
+          It may include compiler versions that have not been officially released.
+        </p>
+        <a href="<%s Url.releases %>"
+          class="mt-2 inline-flex min-h-[44px] items-center font-medium text-primary underline underline-offset-4 focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:text-dark-primary dark:focus-visible:outline-dark-primary">
+          View official OCaml releases
+        </a>
+      </aside>
+    <% ); %>
     <p class="max-w-3xl text-content dark:text-dark-content">
-      On ocaml.org, the <code>latest</code> URL points to version <strong><%s package.latest_version %></strong>.
+      This page lists package versions found in opam-repository.
+      On ocaml.org, the <code>latest</code> URL currently points to version <strong><%s package.latest_version %></strong>;
+      this does not indicate an upstream release status.
       Versions marked Avoided or Deprecated are not normally selected by opam.
     </p>
     <div class="mt-4 overflow-x-auto">
@@ -142,7 +168,7 @@ Layout.render
             <th scope="col" class="border-b-2 border-gray-200 px-4 py-4 font-normal text-title dark:border-gray-400 dark:text-dark-title">Links</th>
           </tr>
         </thead>
-        <%s! render_group "Latest version" latest_versions %>
+        <%s! render_group "Version selected by the latest URL" latest_versions %>
         <%s! render_group "Previous versions" previous_versions %>
         <%s! render_group "Versions not normally selected by opam" discouraged_versions %>
       </table>

--- a/src/ocamlorg_frontend/pages/package_versions.eml
+++ b/src/ocamlorg_frontend/pages/package_versions.eml
@@ -7,6 +7,19 @@ let is_discouraged item =
 let status_badge class_ label =
   <span class="inline-flex items-center whitespace-nowrap rounded border px-2 py-1 text-xs font-medium <%s class_ %>"><%s label %></span>
 
+let ocaml_manual_version version =
+  match String.split_on_char '.' version with
+  | major :: minor :: _ ->
+      let minor = List.hd (String.split_on_char '~' minor) in
+      let minor = List.hd (String.split_on_char '+' minor) in
+      Printf.sprintf "%s.%s" major minor
+  | _ -> version
+
+let documentation_href (package : Package.package) version =
+  if package.name = "ocaml" then
+    Printf.sprintf "/manual/%s/index.html" (ocaml_manual_version version)
+  else Printf.sprintf "/p/%s/%s/doc/index.html" package.name version
+
 let render_statuses ~is_latest ~is_selected item =
   let previous = not is_latest && not (is_discouraged item) in
   let badges =
@@ -83,7 +96,7 @@ let render_row (item : Package.version_summary) =
       </time>
     </td>
     <td class="rounded-r text-left text-sm <%s cell_background %>">
-      <a href="/p/<%s package.name %>/<%s item.version %>/doc/index.html"
+      <a href="<%s documentation_href package item.version %>"
         class="inline-flex min-h-[44px] items-center gap-2 p-4 font-medium text-primary hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-primary dark:text-dark-primary dark:focus-visible:outline-dark-primary">
         <span aria-hidden="true"><%s! Icons.document "h-5 w-5"; %></span>
         Documentation

--- a/src/ocamlorg_frontend/pages/package_versions.eml
+++ b/src/ocamlorg_frontend/pages/package_versions.eml
@@ -1,50 +1,138 @@
+let has_status status (item : Package.version_summary) =
+  List.mem status item.statuses
+
+let is_discouraged item =
+  has_status Package.Avoided item || has_status Package.Deprecated item
+
+let status_badge class_ label =
+  <span class="inline-flex items-center whitespace-nowrap rounded border px-2 py-1 text-xs font-medium <%s class_ %>"><%s label %></span>
+
+let render_statuses ~is_latest ~is_selected item =
+  let previous = not is_latest && not (is_discouraged item) in
+  let badges =
+    [
+      (if is_latest then
+         Some
+           (status_badge
+              "border-primary bg-primary_25 text-title dark:border-dark-primary dark:bg-dark-primary_10 dark:text-dark-title"
+              "Latest")
+       else None);
+      (if previous then
+         Some
+           (status_badge
+              "border-gray-300 bg-gray-100 text-title dark:border-gray-500 dark:bg-gray-700 dark:text-dark-title"
+              "Previous")
+       else None);
+      (if has_status Package.Avoided item then
+         Some
+           (status_badge
+              "border-yellow-600 bg-yellow-100 text-yellow-900 dark:border-yellow-500 dark:bg-yellow-900 dark:text-yellow-100"
+              "Avoided by opam")
+       else None);
+      (if has_status Package.Deprecated item then
+         Some
+           (status_badge
+              "border-red-600 bg-red-100 text-red-900 dark:border-red-500 dark:bg-red-900 dark:text-red-100"
+              "Deprecated by opam")
+       else None);
+      (if is_selected then
+         Some
+           (status_badge
+              "border-title bg-white text-title dark:border-dark-title dark:bg-dark-card dark:text-dark-title"
+              "Selected")
+       else None);
+    ]
+    |> List.filter_map Fun.id
+  in
+  <span class="flex flex-wrap gap-2"><%s! String.concat "" badges %></span>
+
 let render
 (package : Package.package)
 =
+let selected_version = Package.specific_version package in
+let latest_versions, remaining_versions =
+  List.partition
+    (fun (item : Package.version_summary) ->
+      item.version = package.latest_version)
+    package.versions
+in
+let discouraged_versions, previous_versions =
+  List.partition is_discouraged remaining_versions
+in
+let render_row (item : Package.version_summary) =
+  let is_latest = item.version = package.latest_version in
+  let is_selected = selected_version = item.version in
+  let cell_background =
+    if is_selected then
+      "bg-primary_25 dark:bg-dark-primary_10"
+    else "bg-white dark:bg-dark-card"
+  in
+  <tr>
+    <th scope="row" class="rounded-l text-left text-title dark:text-dark-title <%s cell_background %>">
+      <a href="/p/<%s package.name %>/<%s item.version %>" aria-current="<%s if is_selected then "page" else "false" %>"
+        class="inline-flex min-h-[44px] items-center p-4 text-base hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-primary dark:focus-visible:outline-dark-primary">
+        <%s item.version %>
+      </a>
+    </th>
+    <td class="p-4 text-left text-title dark:text-dark-title <%s cell_background %>">
+      <%s! render_statuses ~is_latest ~is_selected item %>
+    </td>
+    <td class="p-4 text-left text-sm text-title dark:text-dark-title <%s cell_background %>">
+      <time datetime="<%s Utils.iso_date_of_timestamp item.opam_repository_date %>">
+        <%s Utils.human_date_of_timestamp item.opam_repository_date %>
+      </time>
+    </td>
+    <td class="rounded-r text-left text-sm <%s cell_background %>">
+      <a href="/p/<%s package.name %>/<%s item.version %>/doc/index.html"
+        class="inline-flex min-h-[44px] items-center gap-2 p-4 font-medium text-primary hover:underline focus-visible:rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-4px] focus-visible:outline-primary dark:text-dark-primary dark:focus-visible:outline-dark-primary">
+        <span aria-hidden="true"><%s! Icons.document "h-5 w-5"; %></span>
+        Documentation
+      </a>
+    </td>
+  </tr>
+in
+let render_group title versions =
+  match versions with
+  | [] -> ""
+  | versions ->
+      <tbody>
+        <tr>
+          <th colspan="4" scope="rowgroup" class="pb-1 pt-6 text-left text-lg font-semibold text-title dark:text-dark-title"><%s title %></th>
+        </tr>
+        <%s! versions |> List.map render_row |> String.concat "" %>
+      </tbody>
+in
 Layout.render
-~title:(Printf.sprintf "%s Versions" package.name)
-~description:"Package Versions" @@
-let version = Package.specific_version package in
-<div class="bg-default dark:bg-dark-default py-8">
+~title:(Printf.sprintf "%s opam package versions" package.name)
+~description:(Printf.sprintf "Versions and opam status for the %s package" package.name) @@
+<div class="py-8">
   <div class="container-fluid flex items-center gap-2">
-    <a href="/p/<%s package.name %>" class="h-11 w-11 m-5 border-primary border-2 rounded-full flex items-center justify-center"><%s! Icons.arrow_left "h-6 w-6 text-primary"; %></a>
-    <h1 class="text-2xl text-title dark:text-dark-title font-medium"><%s package.name %> Versions (<%i List.length package.versions %>) </h1>
+    <a href="/p/<%s package.name %>" aria-label="Back to <%s package.name %> package"
+      class="m-5 flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 border-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-dark-primary dark:focus-visible:outline-dark-primary">
+      <span aria-hidden="true"><%s! Icons.arrow_left "h-6 w-6 text-primary dark:text-dark-primary"; %></span>
+    </a>
+    <h1 class="text-2xl font-medium text-title dark:text-dark-title"><%s package.name %> opam package versions (<%i List.length package.versions %>)</h1>
   </div>
-  <div class="container-fluid flex justify-center">
-    <table class="table-auto border-separate border-spacing-y-6">
-        <thead class="container-fluid text-md text-lighter text-left">
-            <tr class="py-4">
-                <th class="hidden sm:table-cell text-left text-title dark:text-dark-title font-normal border-b-2 border-gray-200 dark:border-gray-400 py-4 pl-3 md:pr-14"><%s! Icons.bars_3 "h-5 w-5"; %></th>
-                <th class="text-left text-title dark:text-dark-title font-normal border-b-2 border-gray-200 dark:border-gray-400 px-5 md:pr-12">Version</th>
-                <th class="text-left text-title dark:text-dark-title font-normal border-b-2 border-gray-200 dark:border-gray-400 md:pr-14">Release Date</th>
-                <th class="text-left text-title dark:text-dark-title font-normal border-b-2 border-gray-200 dark:border-gray-400 px-5 md:pr-14">Links</th>
-            </tr>
-        </thead>
-        <tbody>
-          <% package.versions |> List.iter (fun (item: Package.version_with_publication_date) -> %>
-          <tr class="tr-selected">
-            <td class="hidden sm:table-cell text-left font-normal py-5 px-4 <%s if version = item.version then "bg-primary-200 rounded-l" else "" %>">
-              <% if version = item.version then ( %><div class="bg-primary dark:bg-dark-primary h-3 w-3 rounded-full"></div><% ) else ( %><div class="bg-gray-200 dark:bg-gray-400 h-2 w-2 rounded-full ml-0.5"></div><% ); %>
-              <div class="absolute h-[4.5rem] pl-1">
-                <% if List.nth package.versions (List.length package.versions -1) <> item then ( %>
-                <div class="-ml-px w-1 border-solid border-r-2 border-gray-200 dark:border-gray-400 h-full"></div>
-                <% ); %>
-              </div>
-            </td>
-            <td class="text-left text-title dark:text-dark-title bg-primary-200">
-              <a href="/p/<%s package.name %>/<%s item.version %>" class="p-5 hover:no-underline hover:text-primary focus:text-primary focus:no-underline <%s if version = item.version then "font-bold focus:font-bold" else "" %> text-base md:mr-10">
-                <%s item.version %>
-              </a>
-            </td>
-            <td class="pr-4 text-left text-title dark:text-dark-title text-sm bg-primary-200">
-              <%s Utils.human_date_of_timestamp item.publication %>
-            </td>
-            <td class="text-left text-sm bg-primary-200 rounded-r">
-              <a href="/p/<%s package.name %>/<%s item.version %>/doc/index.html" class="text-primary dark:text-dark-primary flex items-center p-2 font-medium sm:p-4"><%s! Icons.document "h-5 w-5"; %> Documentation</a>
-            </td>
+  <div class="container-fluid">
+    <p class="max-w-3xl text-content dark:text-dark-content">
+      On ocaml.org, the <code>latest</code> URL points to version <strong><%s package.latest_version %></strong>.
+      Versions marked Avoided or Deprecated are not normally selected by opam.
+    </p>
+    <div class="mt-4 overflow-x-auto">
+      <table class="w-full min-w-[48rem] table-auto border-separate border-spacing-y-3">
+        <caption class="sr-only">Versions and opam status for the <%s package.name %> package</caption>
+        <thead class="text-left">
+          <tr>
+            <th scope="col" class="border-b-2 border-gray-200 px-4 py-4 font-normal text-title dark:border-gray-400 dark:text-dark-title">Version</th>
+            <th scope="col" class="border-b-2 border-gray-200 px-4 py-4 font-normal text-title dark:border-gray-400 dark:text-dark-title">Status</th>
+            <th scope="col" class="border-b-2 border-gray-200 px-4 py-4 font-normal text-title dark:border-gray-400 dark:text-dark-title">Added to opam-repository</th>
+            <th scope="col" class="border-b-2 border-gray-200 px-4 py-4 font-normal text-title dark:border-gray-400 dark:text-dark-title">Links</th>
           </tr>
-          <% ); %>
-        </tbody>
-    </table>
+        </thead>
+        <%s! render_group "Latest version" latest_versions %>
+        <%s! render_group "Previous versions" previous_versions %>
+        <%s! render_group "Versions not normally selected by opam" discouraged_versions %>
+      </table>
+    </div>
   </div>
 </div>

--- a/src/ocamlorg_frontend/pages/packages_search.eml
+++ b/src/ocamlorg_frontend/pages/packages_search.eml
@@ -114,8 +114,8 @@ let render ~total ~search ~(pagination_info : Pagination.t) (packages : Package.
                 <span>Used by <%d List.length package.rev_deps %> other packages</span>
               </div>
               <div class="flex items-center gap-1">
-                <%s! Icons.calendar "h-5 w-5"; %>
-                <span><%s Utils.human_date_of_timestamp package.publication %></span>
+                <span aria-hidden="true"><%s! Icons.calendar "h-5 w-5"; %></span>
+                <span>Added to opam-repository <time datetime="<%s Utils.iso_date_of_timestamp package.opam_repository_date %>"><%s Utils.human_date_of_timestamp package.opam_repository_date %></time></span>
               </div>
             </div>
           </li>

--- a/src/ocamlorg_frontend/utils.ml
+++ b/src/ocamlorg_frontend/utils.ml
@@ -29,6 +29,11 @@ let human_date_of_timestamp t =
   let ts = Timestamp.of_float_s t in
   Format.asprintf "%a" (Timestamp.pp ~format:"{day:0X} {mon:Xxx} {year}" ()) ts
 
+let iso_date_of_timestamp t =
+  let date = Unix.gmtime t in
+  Printf.sprintf "%04d-%02d-%02d" (date.tm_year + 1900) (date.tm_mon + 1)
+    date.tm_mday
+
 let host_of_uri uri =
   let uri = Uri.of_string uri in
   Uri.host_with_default uri

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -113,19 +113,22 @@ let save_state t =
     (fun () -> Marshal.to_channel channel t [])
     ~finally:(fun () -> close_out channel)
 
+let has_flag flag (info : Info.t) = List.exists (( = ) flag) info.flags
+
+let is_discouraged info =
+  has_flag OpamTypes.Pkgflag_AvoidVersion info
+  || has_flag OpamTypes.Pkgflag_Deprecated info
+
+let select_latest versions =
+  let _, preferred = Version.Map.partition (fun _ -> is_discouraged) versions in
+  match Version.Map.max_binding_opt preferred with
+  | Some package -> Some package
+  | None -> Version.Map.max_binding_opt versions
+
 let get_latest' packages name =
-  Name.Map.find_opt name packages
-  |> Option.map (fun versions ->
-         let avoid_version _ (info : Info.t) =
-           List.exists (( = ) OpamTypes.Pkgflag_AvoidVersion) info.flags
-         in
-         let avoided, packages = Version.Map.partition avoid_version versions in
-         let version, info =
-           match Version.Map.max_binding_opt packages with
-           | None -> Version.Map.max_binding avoided
-           | Some (version, info) -> (version, info)
-         in
-         { version; info; name })
+  Option.bind (Name.Map.find_opt name packages) (fun versions ->
+      select_latest versions
+      |> Option.map (fun (version, info) -> { version; info; name }))
 
 let time_it_lwt name f =
   let open Lwt.Syntax in
@@ -188,10 +191,10 @@ let init ?(disable_polling = false) () =
   state
 
 let all_latest t =
-  t.packages
-  |> Name.Map.map Version.Map.max_binding
-  |> Name.Map.bindings
-  |> List.map (fun (name, (version, info)) -> { name; version; info })
+  t.packages |> Name.Map.bindings
+  |> List.filter_map (fun (name, versions) ->
+         select_latest versions
+         |> Option.map (fun (version, info) -> { name; version; info }))
 
 let stats t = t.stats
 
@@ -200,17 +203,32 @@ let get_by_name t name =
   |> Option.map Version.Map.bindings
   |> Option.map (List.map (fun (version, info) -> { name; version; info }))
 
-type version_with_publication_date = {
+type version_status = Avoided | Deprecated
+
+type version_summary = {
   version : Version.t;
-  publication : float;
+  opam_repository_date : float;
+  statuses : version_status list;
 }
+
+let version_statuses info =
+  let status flag value statuses =
+    if has_flag flag info then value :: statuses else statuses
+  in
+  []
+  |> status OpamTypes.Pkgflag_Deprecated Deprecated
+  |> status OpamTypes.Pkgflag_AvoidVersion Avoided
 
 let get_versions t name =
   t.packages |> Name.Map.find_opt name
   |> Option.map (fun p ->
          p |> Version.Map.bindings
          |> List.map (fun (version, info) ->
-                { version; publication = info.Info.publication }))
+                {
+                  version;
+                  opam_repository_date = info.Info.publication;
+                  statuses = version_statuses info;
+                }))
   |> Option.value ~default:[]
   |> List.sort (fun v1 v2 -> Version.compare v2.version v1.version)
 

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -179,12 +179,15 @@ val stats : state -> Statistics.t option
 val get_by_name : state -> Name.t -> t list option
 (** Get the list of packages with the given name. *)
 
-type version_with_publication_date = {
+type version_status = Avoided | Deprecated
+
+type version_summary = {
   version : Version.t;
-  publication : float;
+  opam_repository_date : float;
+  statuses : version_status list;
 }
 
-val get_versions : state -> Name.t -> version_with_publication_date list
+val get_versions : state -> Name.t -> version_summary list
 (** Get the list of versions for a package name, newest coming first. *)
 
 val get_latest : state -> Name.t -> t option

--- a/src/ocamlorg_package/test/dune
+++ b/src/ocamlorg_package/test/dune
@@ -1,3 +1,3 @@
 (tests
- (names package_info_test)
- (libraries alcotest ocamlorg_package))
+ (names package_info_test package_versions_test)
+ (libraries alcotest ocamlorg_package opam-format))

--- a/src/ocamlorg_package/test/package_versions_test.ml
+++ b/src/ocamlorg_package/test/package_versions_test.ml
@@ -1,0 +1,153 @@
+module Package = Ocamlorg_package
+
+let info ?(publication = 0.) ?(flags = []) () =
+  {
+    Package.Info.synopsis = "";
+    description = "";
+    authors = [];
+    maintainers = [];
+    license = "";
+    homepage = [];
+    tags = [];
+    dependencies = [];
+    rev_deps = [];
+    depopts = [];
+    conflicts = [];
+    url = None;
+    publication;
+    flags;
+  }
+
+let package ?publication ?flags name version =
+  Package.create
+    ~name:(Package.Name.of_string name)
+    ~version:(Package.Version.of_string version)
+    (info ?publication ?flags ())
+
+let latest_version state name =
+  Package.get_latest state (Package.Name.of_string name)
+  |> Option.map Package.version
+  |> Option.map Package.Version.to_string
+
+let check_latest expected state name =
+  Alcotest.(check (option string))
+    ("latest version of " ^ name)
+    (Some expected)
+    (latest_version state name)
+
+let avoid_version = OpamTypes.Pkgflag_AvoidVersion
+let deprecated = OpamTypes.Pkgflag_Deprecated
+
+let test_avoided_version_is_not_latest () =
+  let state =
+    Package.mockup_state
+      [
+        package "example" "1.0.0";
+        package ~flags:[ avoid_version ] "example" "2.0.0";
+      ]
+  in
+  check_latest "1.0.0" state "example"
+
+let test_deprecated_version_is_not_latest () =
+  let state =
+    Package.mockup_state
+      [
+        package "example" "1.0.0";
+        package ~flags:[ deprecated ] "example" "2.0.0";
+      ]
+  in
+  check_latest "1.0.0" state "example"
+
+let test_all_discouraged_versions_fall_back_to_highest () =
+  let state =
+    Package.mockup_state
+      [
+        package ~flags:[ avoid_version ] "example" "1.0.0";
+        package ~flags:[ deprecated ] "example" "2.0.0";
+      ]
+  in
+  check_latest "2.0.0" state "example"
+
+let test_all_latest_matches_get_latest () =
+  let state =
+    Package.mockup_state
+      [
+        package "alpha" "1.0.0";
+        package ~flags:[ avoid_version ] "alpha" "2.0.0";
+        package ~flags:[ deprecated ] "beta" "1.0.0";
+        package ~flags:[ deprecated ] "beta" "2.0.0";
+      ]
+  in
+  let all_latest = Package.all_latest state in
+  Alcotest.(check int) "one version per package" 2 (List.length all_latest);
+  List.iter
+    (fun latest ->
+      let name = Package.name latest |> Package.Name.to_string in
+      Alcotest.(check (option string))
+        ("all_latest agrees for " ^ name)
+        (latest_version state name)
+        (Some (Package.version latest |> Package.Version.to_string)))
+    all_latest
+
+let string_of_status = function
+  | Package.Avoided -> "avoided"
+  | Package.Deprecated -> "deprecated"
+
+let test_version_summaries_include_statuses_and_dates () =
+  let state =
+    Package.mockup_state
+      [
+        package ~publication:1. "example" "1.0.0";
+        package ~publication:2. ~flags:[ avoid_version ] "example" "2.0.0";
+        package ~publication:3.
+          ~flags:[ avoid_version; deprecated ]
+          "example" "3.0.0";
+      ]
+  in
+  match Package.get_versions state (Package.Name.of_string "example") with
+  | [ both; avoided; preferred ] ->
+      Alcotest.(check (list string))
+        "versions remain in descending order"
+        [ "3.0.0"; "2.0.0"; "1.0.0" ]
+        (List.map
+           (fun (summary : Package.version_summary) ->
+             Package.Version.to_string summary.version)
+           [ both; avoided; preferred ]);
+      Alcotest.(check (list string))
+        "both statuses are exposed"
+        [ "avoided"; "deprecated" ]
+        (List.map string_of_status both.statuses);
+      Alcotest.(check (list string))
+        "avoid-version is exposed" [ "avoided" ]
+        (List.map string_of_status avoided.statuses);
+      Alcotest.(check (list string))
+        "preferred version has no discouraged status" []
+        (List.map string_of_status preferred.statuses);
+      Alcotest.(check (float 0.))
+        "repository date is preserved" 3. both.opam_repository_date
+  | versions ->
+      Alcotest.failf "expected three version summaries, got %d"
+        (List.length versions)
+
+let test_case name fn = Alcotest.test_case name `Quick fn
+
+let () =
+  Alcotest.run "package versions"
+    [
+      ( "latest selection",
+        [
+          test_case "avoid-version is skipped"
+            test_avoided_version_is_not_latest;
+          test_case "deprecated is skipped"
+            test_deprecated_version_is_not_latest;
+          test_case "all discouraged versions use the highest fallback"
+            test_all_discouraged_versions_fall_back_to_highest;
+          test_case "all_latest uses the same selection"
+            test_all_latest_matches_get_latest;
+        ] );
+      ( "version summaries",
+        [
+          test_case "statuses and repository dates are exposed"
+            test_version_summaries_include_statuses_and_dates;
+        ] );
+    ]

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -890,7 +890,7 @@ module Package_helper = struct
         authors = List.map owner info.authors;
         maintainers = List.map owner info.maintainers;
         license = info.license;
-        publication = info.publication;
+        opam_repository_date = info.publication;
         homepages = info.Ocamlorg_package.Info.homepage;
         source =
           Option.map
@@ -904,11 +904,20 @@ module Package_helper = struct
   (** Query all the versions of a package. *)
   let versions state name =
     Ocamlorg_package.get_versions state name
-    |> List.map (fun (v : Ocamlorg_package.version_with_publication_date) ->
+    |> List.map (fun (v : Ocamlorg_package.version_summary) ->
+           let statuses =
+             List.map
+               (function
+                 | Ocamlorg_package.Avoided -> Ocamlorg_frontend.Package.Avoided
+                 | Ocamlorg_package.Deprecated ->
+                     Ocamlorg_frontend.Package.Deprecated)
+               v.statuses
+           in
            Ocamlorg_frontend.Package.
              {
                version = Ocamlorg_package.Version.to_string v.version;
-               publication = v.publication;
+               opam_repository_date = v.opam_repository_date;
+               statuses;
              })
 
   let search_index_digest ~kind state name =


### PR DESCRIPTION
## Context

The [forum report](https://discuss.ocaml.org/t/https-ocaml-org-p-ocaml-latest-versions-seems-to-have-wrong-misleading-release-dates) describes how `/p/ocaml/latest/versions` could be read as presenting release dates and recommending every listed version.

The dates actually record when package definitions were added to opam-repository. In addition, versions marked `avoid-version` or `deprecated` are not normally selected by opam. Presenting these as release dates in a list headed “Recommended opam package versions” was potentially misleading for people, search crawlers and LLMs.

## Changes

- Select `latest` from versions that are neither avoided nor deprecated, with a deterministic fallback when every version is discouraged.
- Use the same latest-version selection for individual package look-ups and the package index.
- Replace the recommendation-style heading with a neutral package versions heading.
- Group versions into “Latest version”, “Previous versions” and “Versions not normally selected by opam”.
- Add visible `Latest`, `Previous`, `Avoided by opam`, `Deprecated by opam` and `Selected` labels.
- Rename date labels to “Added to opam-repository” and expose UTC ISO dates through `time[datetime]`.
- Improve the table semantics, keyboard focus, accessible names and mobile horizontal scrolling.
- Add package-layer tests for avoided and deprecated latest-version selection, fallback behaviour and status propagation.

Avoided and deprecated versions remain visible so that direct links and historical information continue to work.

## Screenshots

### The `latest` URL

<img width="2672" height="1465" alt="スクリーンショット 2026-07-13 19 11 31" src="https://github.com/user-attachments/assets/61400963-0b58-4489-b1aa-85f82727ed4b" />

### An explicitly selected older version

<img width="2672" height="1465" alt="スクリーンショット 2026-07-13 19 11 41" src="https://github.com/user-attachments/assets/4ff2676d-543f-465d-877c-e0e7281713d4" />

### Versions not normally selected by opam

<img width="2672" height="1465" alt="スクリーンショット 2026-07-13 19 11 53" src="https://github.com/user-attachments/assets/272dbe62-4e5b-45b9-bcd4-d3e4f627b257" />

## Validation

- Front-end template compilation and formatting checks
- Package version selection tests: 5 passed
- Tailwind CSS generation
- `git diff --check`
