### PR TITLE
Format doc_status_url comment (ocamlformat)

### DIFF
--- a/src/ocamlorg_package/lib/documentation.ml
+++ b/src/ocamlorg_package/lib/documentation.ml
@@ -257,9 +257,9 @@ let generic_url base ~kind name version =
 let package_url ~kind name version =
   generic_url Config.documentation_url ~kind name version
 
-(* Build status is tracked per package version, not per universe (universes
-   only disambiguate cross-reference link targets), so the status URL always
-   uses the [`Package] form even when reached from a universe doc page. *)
+(* Build status is tracked per package version, not per universe (universes only
+   disambiguate cross-reference link targets), so the status URL always uses the
+   [`Package] form even when reached from a universe doc page. *)
 let doc_status_url name version =
   generic_url Config.documentation_status_url ~kind:`Package name version
 


### PR DESCRIPTION
Follow-up to #3716. The explanatory comment added on `doc_status_url` was not run through ocamlformat before that PR merged, which turned the `Format code` CI step red on `main` (build and tests passed; formatting only).

This reflows the comment with the pinned ocamlformat 0.26.2. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)