### PR TITLE
Replace String.lowercase_ascii with Uucp.Case.Fold for i18n-aware comparison

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -65,6 +65,7 @@
    (and
     :with-test
     (>= 1.10.0)))
+  uucp
   ; tools/data-packer
   ppx_deriving_yaml
   ppx_import

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -43,6 +43,7 @@ depends: [
   "ounit"
   "alcotest" {with-test}
   "mdx" {with-test & >= "1.10.0"}
+  "uucp"
   "ppx_deriving_yaml"
   "ppx_import"
   "ppx_stable"

--- a/src/global/dune
+++ b/src/global/dune
@@ -1,3 +1,4 @@
 (library
  (name ocamlorg)
- (public_name ocamlorg.global))
+ (public_name ocamlorg.global)
+ (libraries uucp))

--- a/src/global/import.ml
+++ b/src/global/import.ml
@@ -11,8 +11,24 @@ module String = struct
       false
     with Exit -> true
 
+  let case_fold s =
+    let buf = Buffer.create (length s * 2) in
+    let rec loop i max =
+      if i > max then Buffer.contents buf
+      else
+        let dec = get_utf_8_uchar s i in
+        let u = Uchar.utf_decode_uchar dec in
+        (match Uucp.Case.Fold.fold u with
+        | `Self -> Buffer.add_utf_8_uchar buf u
+        | `Uchars us -> List.iter (Buffer.add_utf_8_uchar buf) us);
+        loop (i + Uchar.utf_decode_length dec) max
+    in
+    loop 0 (length s - 1)
+
+  let caseless_equal a b = case_fold a = case_fold b
+
   let is_sub_ignore_case pattern text =
-    contains_s (lowercase_ascii text) (lowercase_ascii pattern)
+    contains_s (case_fold text) (case_fold pattern)
 
   (* ripped off stringext, itself ripping it off from one of dbuenzli's libs *)
   let cut s ~on =

--- a/src/ocamlorg_data/data.ml
+++ b/src/ocamlorg_data/data.ml
@@ -224,7 +224,7 @@ module Opam_user = struct
     { name; email; github_username; avatar }
 
   let find_by_name s =
-    let pattern = String.lowercase_ascii s in
+    let pattern = Ocamlorg.Import.String.case_fold s in
     let contains s1 s2 =
       try
         let len = String.length s2 in
@@ -236,7 +236,7 @@ module Opam_user = struct
     in
     all
     |> List.find_opt (fun { name; _ } ->
-           contains pattern (String.lowercase_ascii name))
+           contains pattern (Ocamlorg.Import.String.case_fold name))
 end
 
 module Outreachy = struct

--- a/src/ocamlorg_package/lib/import.ml
+++ b/src/ocamlorg_package/lib/import.ml
@@ -10,6 +10,9 @@ module String = struct
       done;
       false
     with Exit -> true
+
+  let case_fold = Ocamlorg.Import.String.case_fold
+  let caseless_equal = Ocamlorg.Import.String.caseless_equal
 end
 
 module List = struct

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -311,7 +311,7 @@ end = struct
     Re.compile atom
 
   let to_request str =
-    let str = String.lowercase_ascii str in
+    let str = String.case_fold str in
     let to_constraint = function
       | [ _; s ] -> Any s
       | [ _; "tag:"; s ] -> Tag s
@@ -329,7 +329,7 @@ end = struct
         |> to_constraint)
       g
 
-  let match_ f s pattern = f (String.lowercase_ascii @@ s) pattern
+  let match_ f s pattern = f (String.case_fold @@ s) pattern
 
   let match_tag ?(f = String.contains_s) pattern package =
     List.exists (fun tag -> match_ f tag pattern) package.info.tags

--- a/src/ocamlorg_web/lib/handler.ml
+++ b/src/ocamlorg_web/lib/handler.ml
@@ -434,8 +434,8 @@ let academic_institutions req =
   let resource_type = Dream.query req "resource_type" in
   let search_user pattern t =
     let open Data.Academic_institution in
-    let pattern = String.lowercase_ascii pattern in
-    let name_is_s { name; _ } = String.lowercase_ascii name = pattern in
+    let pattern = String.case_fold pattern in
+    let name_is_s { name; _ } = String.case_fold name = pattern in
     let name_contains_s { name; _ } = String.is_sub_ignore_case pattern name in
     let score user =
       if name_is_s user then -1

--- a/tool/data-packer/lib/import.ml
+++ b/tool/data-packer/lib/import.ml
@@ -14,7 +14,9 @@ module String = struct
     with Exit -> true
 
   let is_sub_ignore_case pattern text =
-    contains_s (lowercase_ascii text) (lowercase_ascii pattern)
+    contains_s
+      (Ocamlorg.Import.String.case_fold text)
+      (Ocamlorg.Import.String.case_fold pattern)
 
   (* ripped off stringext, itself ripping it off from one of dbuenzli's libs *)
   let cut s ~on =

--- a/tool/data-scrape/lib/platform_release_scraper.ml
+++ b/tool/data-scrape/lib/platform_release_scraper.ml
@@ -172,7 +172,7 @@ let group_releases_by_project all =
     SMap.empty all
 
 let is_prerelease github_tag =
-  let tag = String.lowercase_ascii github_tag in
+  let tag = Ocamlorg.Import.String.case_fold github_tag in
   let has pattern =
     try
       let _ = Str.search_forward (Str.regexp pattern) tag 0 in
@@ -182,13 +182,13 @@ let is_prerelease github_tag =
   has "alpha" || has "beta" || has "rc[0-9]" || has "preview"
 
 let tag_matches_ignore_patterns ignore_patterns github_tag =
-  let tag = String.lowercase_ascii github_tag in
+  let tag = Ocamlorg.Import.String.case_fold github_tag in
   List.exists
     (fun pattern ->
       try
         let _ =
           Str.search_forward
-            (Str.regexp_string (String.lowercase_ascii pattern))
+            (Str.regexp_string (Ocamlorg.Import.String.case_fold pattern))
             tag 0
         in
         true


### PR DESCRIPTION
## Summary

- Replace `String.lowercase_ascii` with Unicode case folding (`Uucp.Case.Fold`) for case-insensitive string comparison
- Define `case_fold` once in `src/global/import.ml`, reuse everywhere via `Ocamlorg.Import.String.case_fold`
- Update `is_sub_ignore_case` to use `case_fold` instead of `lowercase_ascii`
- Swap 7 call sites: academic institution search, package search, opam user search, platform release tag matching
- Leave 3 ASCII-only sites unchanged (env var parsing, slugify, cookbook example)

This fixes case-insensitive matching for non-ASCII text (e.g. searching `école` now matches `ÉCOLE`, which `String.lowercase_ascii` could not handle since it only lowercases A-Z).

`uucp` was already a transitive dependency — this makes it a direct dependency of `ocamlorg.global`.

## Checklist

* [x] Formatted code with `make fmt`
* [x] Resolves #2444

#### Test plan
- [x] `make build` passes
- [x] `make test` passes (21 tests, all OK)
- [x] Verified `case_fold "école" = case_fold "ÉCOLE"` (was false with `lowercase_ascii`, now true)