### PR TITLE
Fix typo in 0it_03_list.md

### DIFF
--- a/data/tutorials/language/0it_03_lists.md
+++ b/data/tutorials/language/0it_03_lists.md
@@ -262,7 +262,7 @@ true, the second those for which it is false.
 Note that the documentation for
 [`filter`](/manual/api/List.html#VALfilter)  and
 [`partition`](/manual/api/List.html#VALpartition) tells us that the
-order of the input is preserved in the output. Where this is not stated it the
+order of the input is preserved in the output. Where this is not stated in the
 documentation, it cannot be assumed.
 
 ### Association Lists


### PR DESCRIPTION
Tiny mistake, changed it to in