### PR TITLE
scrape: raise planet feed timeout, add User-Agent and retry

### DIFF
--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -43,6 +43,7 @@ depends: [
   "ounit"
   "alcotest" {with-test}
   "mdx" {with-test & >= "1.10.0"}
+  "uucp"
   "ppx_deriving_yaml"
   "ppx_import"
   "ppx_stable"
@@ -76,4 +77,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   [ "hilite.0.6.0" "git+https://github.com/patricoferris/hilite#f5368558f765ff6c884fda68acf4d4e9256970b4" ]
+  # Temporary pin for PR tarides/river#16 (expose ?timeout/?user_agent).
+  # Replace with a version constraint once river >= 0.5 is released to opam.
+  [ "river.0.4" "git+https://github.com/tarides/river#c5e889d30e4ef9bcca0d6ad64fe2ab05005023be" ]
 ]

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -77,7 +77,13 @@ build: [
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   [ "hilite.0.6.0" "git+https://github.com/patricoferris/hilite#f5368558f765ff6c884fda68acf4d4e9256970b4" ]
-  # Temporary pin for PR tarides/river#16 (expose ?timeout/?user_agent).
-  # Replace with a version constraint once river >= 0.5 is released to opam.
-  [ "river.0.4" "git+https://github.com/tarides/river#c5e889d30e4ef9bcca0d6ad64fe2ab05005023be" ]
+  # river's ?timeout/?user_agent API (tarides/river#16, ships in 0.5) is
+  # delivered via this git pin. A plain "river" {>= "0.5"} constraint would NOT
+  # work: ocaml.org builds against a frozen opam-repository snapshot (pinned in
+  # Makefile, Dockerfile and the CI workflows), so a newly published river 0.5
+  # is unreachable there. opam honours pin-depends regardless of that snapshot,
+  # which is why this git pin is the delivery mechanism, not a stopgap. Drop it
+  # only when the opam-repository pin is bumped to a commit that includes
+  # river >= 0.5, adding "river" {>= "0.5"} at that point.
+  [ "river.0.5" "git+https://github.com/tarides/river#28281fefebb0633bdaf326c3733dd00b3e153133" ]
 ]

--- a/tool/data-scrape/lib/blog_scraper.ml
+++ b/tool/data-scrape/lib/blog_scraper.ml
@@ -5,6 +5,18 @@ open Data_packer.Import
 (* external RSS feeds that we aggregate - they will all be scraped by the
    scrape.yml workflow *)
 
+(* Connection timeout (seconds) for feed and post fetches. River's built-in
+   default is 3s, which is too aggressive for many feeds and causes spurious
+   scrape failures. *)
+let timeout = 30.
+
+(* Some feed hosts reject requests with an empty/default User-Agent. *)
+let user_agent = "ocaml.org planet aggregator (+https://ocaml.org)"
+
+(* Number of times to attempt a feed fetch before giving up on the source, to
+   absorb transient network/DNS/5xx failures. *)
+let max_attempts = 3
+
 module Source = struct
   type t = {
     id : string;
@@ -93,8 +105,8 @@ let scrape_post ~source (post : River.post) : Scrape_report.entry option =
                || is_sub_ignore_case "caml" title)
         then (
           let url = String.trim (Uri.to_string url) in
-          let preview_image = River.seo_image post in
-          let description = River.meta_description post in
+          let preview_image = River.seo_image ~timeout ~user_agent post in
+          let description = River.meta_description ~timeout ~user_agent post in
           let author = River.author post in
           let metadata : Post.metadata =
             {
@@ -120,9 +132,22 @@ let scrape_post ~source (post : River.post) : Scrape_report.entry option =
           None))
   else None
 
+(* Fetch a feed, retrying with exponential backoff on failure. The final attempt
+   lets the exception propagate to [scrape_source]'s handler, which records the
+   source as an error for this run. *)
+let rec fetch_with_retry ?(attempt = 1) (source : Data_intf.Blog.source) =
+  try River.fetch ~timeout ~user_agent { name = source.name; url = source.url }
+  with e when attempt < max_attempts ->
+    let delay = 2. ** float_of_int attempt in
+    print_endline
+      (Printf.sprintf "retry %d/%d for %s in %.0fs: %s" attempt
+         (max_attempts - 1) source.id delay (Printexc.to_string e));
+    Unix.sleepf delay;
+    fetch_with_retry ~attempt:(attempt + 1) source
+
 let scrape_source (source : Data_intf.Blog.source) : Scrape_report.entry list =
   try
-    [ River.fetch { name = source.name; url = source.url } ]
+    [ fetch_with_retry source ]
     |> River.posts
     |> List.filter_map (scrape_post ~source)
   with e ->

--- a/tool/data-scrape/lib/dune
+++ b/tool/data-scrape/lib/dune
@@ -18,6 +18,7 @@
   ; XML for youtube scraper
   xmlm
   ; Common utilities
+  unix
   uri
   yaml
   str


### PR DESCRIPTION
## Problem

OCaml Planet scraping intermittently drops feeds because river's HTTP client
has a hardcoded 3s timeout and sends no descriptive User-Agent. Slow-but-alive
feeds get cut off, and transient network/DNS/5xx blips kill a source for the
whole run (the scraper catches the exception and records the source as an
error).

## Change

`tool/data-scrape/lib/blog_scraper.ml`:

- Pass an explicit **30s `?timeout`** and a descriptive **`?user_agent`**
  (`ocaml.org planet aggregator (+https://ocaml.org)`) to
  `River.fetch` / `River.seo_image` / `River.meta_description`. These optional
  parameters were added upstream in tarides/river#16.
- Wrap the feed fetch in **`fetch_with_retry`** — 3 attempts with exponential
  backoff (2s, 4s) — so a transient failure no longer drops the source; the
  final attempt still falls through to the existing per-source error handler.
- `tool/data-scrape/lib/dune`: add `unix` (for `Unix.sleepf`).

`ocamlorg.opam`: a **`pin-depends`** on tarides/river master (which carries #16
plus the 0.5 release prep).

### Why a git pin and not a version constraint

ocaml.org builds against a **frozen opam-repository snapshot** (pinned to
`584630e7` in `Makefile`, `Dockerfile`, and the CI workflows including
`release-scrapers.yml`). A `"river" {>= "0.5"}` constraint would be unsolvable
there even after river 0.5 is published upstream, because that snapshot doesn't
contain it. `opam` honours `pin-depends` regardless of the snapshot, and
`release-scrapers.yml` runs `opam install --deps-only .`, so the git pin is the
mechanism that actually delivers the fix to the production scraper. The pin can
be dropped (and replaced by a version constraint) only once the
opam-repository pin is bumped to a commit that includes river 0.5 — see the
inline comment in `ocamlorg.opam`.

## Validation

**Upstream (river#16):** merged, and verified with a self-contained
backward-compatibility harness (in-process HTTP server, no network) — unchanged
call sites still compile, the 3s default is preserved, `?timeout` controls the
bound both ways, and `?user_agent` is sent verbatim.

**This change (live A/B over 74 active sources):**

| | errors |
|---|---|
| before (3s, no retry/UA) | 6 |
| after (30s + retry + UA) | 5 |

The one timeout-class failure (`psellos`, `Http.Timeout` at 3s — responds in
<30s) recovered. The 5 residual errors are orthogonal and un-fixable by a
timeout change: 3 malformed/non-feed sources, 1 DNS-dead host, 1 hard 404 —
tracked separately in #3753. Timeouts are stochastic, so this run is a floor on
the benefit; the retry additionally absorbs transient failures that didn't
happen to occur in this window. Cost: the run takes longer (~100s vs ~27s)
because dead feeds now wait out the 30s×retries instead of bailing at 3s —
acceptable for the nightly scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)