### PR TITLE
planet: disable dead ocaml-book and emilpriver feeds (#3753)

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -135,6 +135,12 @@
 - id: mirage
   name: MirageOS
   url: https://mirage.io/feed.xml
+# Feed is dead (see #3753); disabled so it is no longer scraped, but the
+# already-archived posts are kept.
+- id: ocaml-book
+  name: OCaml Book
+  url: http://ocaml-book.com/blog?format=rss
+  disabled: true
 - id: ocamllabs
   name: OCaml Labs compiler hacking
   url: http://ocamllabs.io/compiler-hacking/rss.xml
@@ -210,6 +216,12 @@
   name: Romain Calascibetta
   url: https://blog.osau.re/feed.xml
   publish_all: false
+# Feed is dead (see #3753); disabled so it is no longer scraped, but the
+# already-archived posts are kept.
+- id: emilpriver
+  name: Emil Privér
+  url: https://priver.dev/tags/ocaml/index.xml
+  disabled: true
 - id: melange
   name: Melange Blog
   url: https://melange.re/blog/feed.rss

--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -127,12 +127,14 @@
   name: Mike McClurg
   url: https://mcclurmc.wordpress.com/feed/
   publish_all: false
+# Feed is valid Atom, but mirage.io emits HTML (not XHTML) inside it, so
+# the <img> tags are not self-closed and syndic rejects the whole feed as
+# malformed XML ("Neither Atom nor RSS2 feed"). Not a cmarkit bug: the
+# mirage.io site generator should render with cmarkit's xhtml_renderer,
+# which self-closes void elements. See dbuenzli/cmarkit#32 and #3753.
 - id: mirage
   name: MirageOS
   url: https://mirage.io/feed.xml
-- id: ocaml-book
-  name: OCaml Book
-  url: http://ocaml-book.com/blog?format=rss
 - id: ocamllabs
   name: OCaml Labs compiler hacking
   url: http://ocamllabs.io/compiler-hacking/rss.xml
@@ -208,9 +210,6 @@
   name: Romain Calascibetta
   url: https://blog.osau.re/feed.xml
   publish_all: false
-- id: emilpriver
-  name: Emil Privér
-  url: https://priver.dev/tags/ocaml/index.xml
 - id: melange
   name: Melange Blog
   url: https://melange.re/blog/feed.rss


### PR DESCRIPTION
Closes part of #3753.

## What

Two planet sources whose blogs the authors confirmed are gone (in #3753):

- **`ocaml-book`** (John Whitington): *"Mine is gone. The link to it can be deleted."*
- **`emilpriver`** (Emil Privér): *"same!"*

Both are marked **`disabled: true`** in `data/planet-sources.yml` rather than removed. The scraper skips disabled sources (`blog_scraper.ml`), so they stop failing every nightly scrape, while the already-archived posts stay in the repo and remain published on the site/feed. Removing the source entries outright would orphan those posts and break `gen_feed` (`No source found for: planet/emilpriver/...`), since the packer looks each post's source up by its directory name.

For **`mirage`** I did **not** disable the source — hannesm confirmed the feed is valid Atom. The `Failure("Neither Atom nor RSS2 feed")` comes from the feed embedding non-XHTML HTML (unclosed `<img>`), which makes syndic reject it as malformed XML. Per dbuenzli/cmarkit#32 this is **not a cmarkit bug** (and therefore **not fixable by an opam-repo pin bump**): the mirage.io site generator should render with cmarkit's `xhtml_renderer`, which self-closes void elements. I added a comment on the entry pointing at cmarkit#32 and this issue, and left it enabled pending the upstream fix.

## Notes

- Archived posts are intentionally kept: `data/planet/emilpriver/` (9) and `data/planet/ocaml-book/` (6). This PR only stops future scraping. Say the word if those should be purged instead.
- Still open in #3753: `dinosaure` (blog.osau.re — DNS fails) and `patricoferris` — no reply from the authors yet, left untouched.