### PR TITLE
planet: opt-in feed repair, enable it for the MirageOS feed (#3753)

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -127,9 +127,13 @@
   name: Mike McClurg
   url: https://mcclurmc.wordpress.com/feed/
   publish_all: false
+# repair: the feed is valid Atom but embeds unclosed HTML void elements
+# (<img>) in its type="xhtml" content, which strict XML parsing rejects.
+# river's ~repair self-closes them before parsing. See tarides/river#17, #3753.
 - id: mirage
   name: MirageOS
   url: https://mirage.io/feed.xml
+  repair: true
 - id: ocaml-book
   name: OCaml Book
   url: http://ocaml-book.com/blog?format=rss

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -77,13 +77,15 @@ build: [
 dev-repo: "git+https://github.com/ocaml/ocaml.org.git"
 pin-depends: [
   [ "hilite.0.6.0" "git+https://github.com/patricoferris/hilite#f5368558f765ff6c884fda68acf4d4e9256970b4" ]
-  # river's ?timeout/?user_agent API (tarides/river#16, ships in 0.5) is
-  # delivered via this git pin. A plain "river" {>= "0.5"} constraint would NOT
-  # work: ocaml.org builds against a frozen opam-repository snapshot (pinned in
-  # Makefile, Dockerfile and the CI workflows), so a newly published river 0.5
-  # is unreachable there. opam honours pin-depends regardless of that snapshot,
-  # which is why this git pin is the delivery mechanism, not a stopgap. Drop it
-  # only when the opam-repository pin is bumped to a commit that includes
-  # river >= 0.5, adding "river" {>= "0.5"} at that point.
-  [ "river.0.5" "git+https://github.com/tarides/river#28281fefebb0633bdaf326c3733dd00b3e153133" ]
+  # river's ?timeout/?user_agent (tarides/river#16) and ?repair
+  # (tarides/river#17) APIs are delivered via this git pin. A plain
+  # "river" {>= "0.5"} constraint would NOT work: ocaml.org builds against a
+  # frozen opam-repository snapshot (pinned in Makefile, Dockerfile and the CI
+  # workflows), so a newly published river is unreachable there. opam honours
+  # pin-depends regardless of that snapshot, which is why this git pin is the
+  # delivery mechanism, not a stopgap. The pin is a fork branch = river 0.5
+  # (timeout) plus ~repair, pending tarides/river#17; repoint it to
+  # tarides/river once that merges, and drop it once the opam-repository pin is
+  # bumped to a commit that includes ~repair, adding "river" {>= ...} then.
+  [ "river.0.5" "git+https://github.com/cuihtlauac/river#8159e71e9a4847882a9da9b61c05b23ac065a0d2" ]
 ]

--- a/tool/data-packer/lib/blog_parser.ml
+++ b/tool/data-packer/lib/blog_parser.ml
@@ -12,6 +12,7 @@ module Source = struct
     url : string;
     publish_all : bool option;
     disabled : bool option;
+    repair : bool option; (* scrape-only; ignored when building site data *)
   }
   [@@deriving of_yaml]
 
@@ -27,7 +28,7 @@ module Source = struct
       in
       Ok
         (sources
-        |> List.map (fun { id; name; url; publish_all; disabled } ->
+        |> List.map (fun { id; name; url; publish_all; disabled; repair = _ } ->
                {
                  Data_intf.Blog.id;
                  name;

--- a/tool/data-scrape/lib/blog_scraper.ml
+++ b/tool/data-scrape/lib/blog_scraper.ml
@@ -24,12 +24,17 @@ module Source = struct
     url : string;
     publish_all : bool option;
     disabled : bool option;
+    repair : bool option;
   }
   [@@deriving yaml]
 
   type sources = t list [@@deriving yaml]
 
-  let all () : Data_intf.Blog.source list =
+  (* A site [Blog.source] together with scrape-only options that are not part of
+     the published data model. *)
+  type resolved = { source : Data_intf.Blog.source; repair : bool }
+
+  let all () : resolved list =
     let file = "planet-sources.yml" in
     let result =
       let ( let* ) = Result.bind in
@@ -39,14 +44,18 @@ module Source = struct
       in
       Ok
         (sources
-        |> List.map (fun { id; name; url; publish_all; disabled } ->
+        |> List.map (fun { id; name; url; publish_all; disabled; repair } ->
                {
-                 Data_intf.Blog.id;
-                 name;
-                 url;
-                 description = "";
-                 publish_all = Option.value ~default:true publish_all;
-                 disabled = Option.value ~default:false disabled;
+                 source =
+                   {
+                     Data_intf.Blog.id;
+                     name;
+                     url;
+                     description = "";
+                     publish_all = Option.value ~default:true publish_all;
+                     disabled = Option.value ~default:false disabled;
+                   };
+                 repair = Option.value ~default:false repair;
                }))
     in
     result
@@ -135,19 +144,23 @@ let scrape_post ~source (post : River.post) : Scrape_report.entry option =
 (* Fetch a feed, retrying with exponential backoff on failure. The final attempt
    lets the exception propagate to [scrape_source]'s handler, which records the
    source as an error for this run. *)
-let rec fetch_with_retry ?(attempt = 1) (source : Data_intf.Blog.source) =
-  try River.fetch ~timeout ~user_agent { name = source.name; url = source.url }
+let rec fetch_with_retry ?(attempt = 1) ~repair (source : Data_intf.Blog.source)
+    =
+  try
+    River.fetch ~timeout ~user_agent ~repair
+      { name = source.name; url = source.url }
   with e when attempt < max_attempts ->
     let delay = 2. ** float_of_int attempt in
     print_endline
       (Printf.sprintf "retry %d/%d for %s in %.0fs: %s" attempt
          (max_attempts - 1) source.id delay (Printexc.to_string e));
     Unix.sleepf delay;
-    fetch_with_retry ~attempt:(attempt + 1) source
+    fetch_with_retry ~attempt:(attempt + 1) ~repair source
 
-let scrape_source (source : Data_intf.Blog.source) : Scrape_report.entry list =
+let scrape_source ({ source; repair } : Source.resolved) :
+    Scrape_report.entry list =
   try
-    [ fetch_with_retry source ]
+    [ fetch_with_retry ~repair source ]
     |> River.posts
     |> List.filter_map (scrape_post ~source)
   with e ->
@@ -157,5 +170,5 @@ let scrape_source (source : Data_intf.Blog.source) : Scrape_report.entry list =
 
 let scrape () : Scrape_report.entry list =
   Source.all ()
-  |> List.filter (fun ({ disabled; _ } : Data_intf.Blog.source) -> not disabled)
+  |> List.filter (fun ({ source; _ } : Source.resolved) -> not source.disabled)
   |> List.concat_map scrape_source


### PR DESCRIPTION
Part of #3753. Depends on **tarides/river#17**.

## Problem

`https://mirage.io/feed.xml` is valid Atom, but its `type="xhtml"` content embeds HTML **void elements** that aren't self-closed (`<img ...>`). Strict XML parsing (xmlm → Syndic) rejects the *whole* feed, so the planet scraper fails it with `Failure "Neither Atom nor RSS2 feed"` and MirageOS posts never appear. hannesm confirmed on #3753 that the feed is otherwise fine.

## Approach — opt-in, per feed

river now has an opt-in `~repair` flag (tarides/river#17) that, **only when a feed fails to parse as-is**, retries after self-closing HTML void elements. Well-formed feeds are never touched.

This PR wires that through the scraper as a **per-source** option, so repair is applied only to feeds we've verified are recoverable this way — not globally:

- `data/planet-sources.yml`: new `repair:` key, set `repair: true` on `mirage`.
- `blog_scraper.ml`: parse the key and pass `~repair` to `River.fetch`. Because repair is purely a scrape-time concern, it's deliberately kept **out** of the published `Data_intf.Blog.source` data model (which would ripple into the bin-packed `data.ml`); it's carried in a local `resolved` record instead.
- `blog_parser.ml`: accept and ignore the new key so the site build still reads the file.
- `ocamlorg.opam.template`: pin river to the branch with `~repair` until tarides/river#17 is released.

## Verification

- river branch built + unit-tested (unclosed / redundantly-closed / self-closed `<img>` shapes; well-formed feed left untouched).
- Proven on the **real** mirage.io feed: strict parse fails; with repair, 78 entries parse.
- `dune build tool/data-scrape/bin/scrape.exe` and `dune build tool/data-packer` both green with the pinned river.

## Relationship to #3755

#3755 removes the two genuinely dead feeds (`ocaml-book`, `emilpriver`) and adds a "wait for upstream" note on `mirage`. This PR **supersedes that note** by actually fixing `mirage`. If #3755 merges first, I'll resolve the trivial overlap on the mirage entry.

## Follow-up

Once tarides/river#17 is released to opam-repository, drop the `river` pin-depends.