### PR TITLE
docs: note Git LFS workaround for pushing to contributor forks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,10 @@ Package docs under `/p/<package>/<version>/doc/` are served from an external doc
 
 ## Pushing to contributor forks
 
-When pushing fixes to cross-repository PRs (contributor forks), Git LFS lock
-verification fails over SSH because we lack HTTPS credentials for the fork.
+When pushing fixes to a contributor's fork you don't own, git-lfs lock
+verification fails: pushing over SSH, git-lfs calls the fork's LFS locks API,
+but you have no lock authorization on a repo you don't own, so it returns 403
+and aborts the push. This is not a gap in your account's rights — you are not
+meant to hold lock rights on a third party's fork.
 
-Workaround: `GIT_LFS_SKIP_PUSH=1 git push <remote> HEAD:<branch>`
+Bypass the lock check: `GIT_LFS_SKIP_PUSH=1 git push <remote> HEAD:<branch>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,10 @@ The rest are automation: **scrape.yml** and **scrape_platform_releases.yml** run
 ### Package Documentation
 
 Package docs under `/p/<package>/<version>/doc/` are served from an external documentation server (`https://sage.ci.dev/current/`) built by [ocaml-docs-ci](https://github.com/ocurrent/ocaml-docs-ci). Configurable via `OCAMLORG_DOC_URL`.
+
+## Pushing to contributor forks
+
+When pushing fixes to cross-repository PRs (contributor forks), Git LFS lock
+verification fails over SSH because we lack HTTPS credentials for the fork.
+
+Workaround: `GIT_LFS_SKIP_PUSH=1 git push <remote> HEAD:<branch>`


### PR DESCRIPTION
Adds a short CLAUDE.md section documenting a recurring gotcha: when pushing fixes to cross-repository PRs (contributor forks), Git LFS lock verification fails over SSH because we lack HTTPS credentials for the fork.

The workaround is to skip LFS lock checking on push:

```
GIT_LFS_SKIP_PUSH=1 git push <remote> HEAD:<branch>
```

Documentation-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)