### PR TITLE
planet: add gilwath feed (OCaml-filtered), disable dead dinosaure feed

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -212,10 +212,13 @@
 - id: robur.coop
   name: Robur Cooperative
   url: https://blog.robur.coop/feed.xml
+# Feed is dead (blog.osau.re no longer resolves, see #3753); disabled so it is
+# no longer scraped, but the already-archived posts are kept.
 - id: dinosaure
   name: Romain Calascibetta
   url: https://blog.osau.re/feed.xml
   publish_all: false
+  disabled: true
 # Feed is dead (see #3753); disabled so it is no longer scraped, but the
 # already-archived posts are kept.
 - id: emilpriver
@@ -289,3 +292,8 @@
 - id: samoht
   name: Thomas Gazagnaire
   url: https://gazagnaire.org/feed.xml
+# Mixed OCaml/Scala blog; publish_all: false keeps only the caml-related posts.
+- id: gilwath
+  name: Benjamin Thuillier
+  url: https://gilwath.com/atom.xml
+  publish_all: false


### PR DESCRIPTION
## Add: gilwath (Benjamin Thuillier)

Adds [gilwath.com](https://gilwath.com) to the OCaml Planet.

- Atom feed `https://gilwath.com/atom.xml` — verified it parses cleanly with Syndic (7 entries).
- It's a **mixed OCaml/Scala** blog, so `publish_all: false`. The scraper's caml filter (title/content contains "caml") keeps the OCaml posts — *Discovering OCaml as a Scala Developer* parts 1–3 and *Building a CV page with YOCaml* — and drops the pure-Scala ones (*Typesafe API in Scala with Tapir* 1–2, *Automatic Typeclass Derivation in Scala 3*).

## Disable: dinosaure (blog.osau.re)

The domain no longer resolves and the daily scrape fails on it (tracked in #3753). Disabled rather than removed, matching the ocaml-book/emilpriver convention:

- The 23 already-archived posts under `data/planet/dinosaure/` carry no `source:` frontmatter and resolve their source via the `planet-sources.yml` entry. Removing the entry would fail the data-packer build (`No source found for: planet/dinosaure/…`), so `disabled: true` keeps them rendering while stopping the scrape.

Verified locally: `dune build src/ocamlorg_data/` packs the data blob successfully, so all archived posts (including dinosaure's) still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)