### PR TITLE
planet: disable dead lthms feed (soap.coffee)

### DIFF
--- a/data/planet-sources.yml
+++ b/data/planet-sources.yml
@@ -232,9 +232,12 @@
   name: Dmitrii Kovanikov
   url: https://chshersh.com/atom.xml
   publish_all: false
+# Feed is dead (soap.coffee no longer resolves, see #3753); disabled so it is
+# no longer scraped, but the already-archived posts are kept.
 - id: lthms
   name: "Thomas Letan’s Blog"
   url: https://soap.coffee/~lthms/tags/ocaml.xml
+  disabled: true
 - id: debajyatidey
   name: Debajyati's Blog
   url: https://debajyatidey.hashnode.dev/rss.xml


### PR DESCRIPTION
## What

Disable the `lthms` feed (Thomas Letan's Blog) in `data/planet-sources.yml`.

## Why

The feed's domain `soap.coffee` no longer resolves — it has no DNS record — and the daily OCaml Planet scrape has failed for it every day since ~Aug 30 with:

```
Downloading https://soap.coffee/~lthms/tags/ocaml.xml ... Failed:
TLS to non-TCP currently unsupported: host=soap.coffee endp=(Unknown "name resolution failed")
failed to scrape lthms: Failure("TLS to non-TCP currently unsupported: ...")
```

This is the same dead-feed class as `dinosaure`/`blog.osau.re`, disabled in #3760, and is tracked in #3753.

## Approach

Following the `dinosaure`/`ocaml-book`/`emilpriver` convention, the feed is **disabled** (`disabled: true`) rather than removed, so the 21 already-archived posts under `data/planet/lthms/` keep rendering — they resolve via the source entry, so removing it would fail the data-packer build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)