### PR TITLE
package: bound doc-backend fetches and prefer status.json search-index digest (#3765)

### DIFF
--- a/src/ocamlorg_package/lib/config.ml
+++ b/src/ocamlorg_package/lib/config.ml
@@ -14,6 +14,13 @@ let documentation_status_url =
 let package_caches_ttl =
   env_with_default "OCAMLORG_PACKAGE_CACHES_TTL" "3600" |> float_of_string
 
+(* Upper bound on the size (in bytes) of a single response fetched from the
+   documentation backend. Prevents a pathologically large artifact (e.g. a
+   multi-hundred-MB odoc search index) from being buffered into memory and
+   OOM-killing the server. See ocaml/ocaml.org#3765. Default: 50 MB. *)
+let max_doc_fetch_bytes =
+  env_with_default "OCAMLORG_MAX_DOC_FETCH_BYTES" "52428800" |> int_of_string
+
 let default_cache_dir =
   match Sys.os_type with
   | "Unix" -> Fpath.(v (Sys.getenv "HOME") / ".cache" / "ocamlorg")

--- a/src/ocamlorg_package/lib/config.mli
+++ b/src/ocamlorg_package/lib/config.mli
@@ -4,5 +4,11 @@ val opam_polling : int
 val documentation_url : string
 val documentation_status_url : string
 val package_caches_ttl : float
+
+val max_doc_fetch_bytes : int
+(** Upper bound (bytes) on a single response fetched from the documentation
+    backend, to avoid buffering a pathologically large artifact into memory.
+    Overridable via [OCAMLORG_MAX_DOC_FETCH_BYTES]. *)
+
 val opam_repository_path : Fpath.t
 val package_state_path : Fpath.t

--- a/src/ocamlorg_package/lib/documentation.ml
+++ b/src/ocamlorg_package/lib/documentation.ml
@@ -8,8 +8,16 @@ module Status = struct
     failed : bool;
     files : string list;
     redirections : redirection list;
+    search_index_digest : string option; [@default None]
+        (* Optional: digest of the odoc search index (doc/index.js), computed by
+           ocaml-docs-ci / voodoo. When present, ocaml.org uses it directly
+           instead of downloading the whole index to hash it. See
+           ocaml/ocaml.org#3765 and ocurrent/ocaml-docs-ci#193. *)
   }
-  [@@deriving yojson]
+  [@@deriving yojson { strict = false }]
+  (* [strict = false]: tolerate unknown fields so the docs backend can extend
+     status.json (e.g. adding [search_index_digest]) without breaking parsing on
+     older/newer deployments. *)
 
   let has_file (v : t) (options : string list) : string option =
     let children = v.files in
@@ -113,13 +121,52 @@ let http_get url =
       let* response, body =
         Cohttp_lwt_unix.Client.get ~headers (Uri.of_string url)
       in
+      let max_bytes = Config.max_doc_fetch_bytes in
+      (* Reject an over-large response rather than buffering it whole. We do not
+         drain the body on rejection: draining would still transfer every byte;
+         dropping it lets the connection be torn down so we stop pulling the
+         payload. See ocaml/ocaml.org#3765. *)
+      let too_large n =
+        Logs.warn (fun m ->
+            m "Response too large (%d bytes > %d limit) for %s" n max_bytes url);
+        Lwt.return
+          (Error
+             (`Msg
+               (Printf.sprintf "response too large (> %d bytes) for %s"
+                  max_bytes url)))
+      in
       match Cohttp.Code.(code_of_status response.status |> is_success) with
-      | true ->
-          let+ body = Cohttp_lwt.Body.to_string body in
-          Ok body
       | false ->
           let+ () = Cohttp_lwt.Body.drain_body body in
-          Error (`Msg ("Failed to fetch " ^ url)))
+          Error (`Msg ("Failed to fetch " ^ url))
+      | true -> (
+          match
+            Cohttp.Header.get response.headers "content-length"
+            |> Fun.flip Option.bind int_of_string_opt
+          with
+          | Some n when n > max_bytes -> too_large n
+          | _ ->
+              (* No trustworthy Content-Length: stream and enforce the cap as we
+                 read, so a chunked or mislabelled response can't blow up
+                 memory. *)
+              let buf = Buffer.create 65536 in
+              let exception Too_large in
+              Lwt.catch
+                (fun () ->
+                  let* () =
+                    Cohttp_lwt.Body.to_stream body
+                    |> Lwt_stream.iter_s (fun chunk ->
+                           if
+                             Buffer.length buf + String.length chunk > max_bytes
+                           then raise Too_large
+                           else (
+                             Buffer.add_string buf chunk;
+                             Lwt.return_unit))
+                  in
+                  Lwt.return (Ok (Buffer.contents buf)))
+                (function
+                  | Too_large -> too_large (Buffer.length buf)
+                  | e -> Lwt.reraise e)))
     (function
       | e ->
           Logs.err (fun m -> m "%s" (Printexc.to_string e));
@@ -241,7 +288,9 @@ end = struct
   let add name version kind sidebar =
     let name = Name.to_string name in
     let version = Version.to_string version in
-    Hashtbl.add cache (name, version, kind) sidebar
+    (* [replace], not [add]: concurrent misses for the same key would otherwise
+       accumulate duplicate entries in this never-expiring cache. *)
+    Hashtbl.replace cache (name, version, kind) sidebar
 
   let get name version kind =
     let name = Name.to_string name in
@@ -364,37 +413,6 @@ type doc_cache = {
 let doc_cache_empty =
   { doc_status_cache = Name.Map.empty; search_index_cache = Name.Map.empty }
 
-(* TODO: should be computed by ocaml-docs-ci / voodoo and be part of
-   status.json *)
-let search_index_digest ~kind state t : string option Lwt.t =
-  let open Lwt.Syntax in
-  let get_and_cache () =
-    let+ content = search_index ~kind t in
-    let digest =
-      match content with Some s -> Some (s |> Digest.string) | _ -> None
-    in
-    let entry = { hash_digest = digest; time = Unix.gettimeofday () } in
-    state.search_index_cache <-
-      Name.Map.update t.name
-        (Version.Map.add t.version entry)
-        (Version.Map.singleton t.version entry)
-        state.search_index_cache;
-    digest
-  in
-
-  let has_cache_expired time =
-    Unix.gettimeofday () -. time > Config.package_caches_ttl
-  in
-
-  match
-    Name.Map.find_opt t.name state.search_index_cache
-    |> Option.map (Version.Map.find_opt t.version)
-    |> Option.value ~default:None
-  with
-  | None -> get_and_cache ()
-  | Some { time; _ } when has_cache_expired time -> get_and_cache ()
-  | Some { hash_digest; _ } -> Lwt.return hash_digest
-
 let status ~kind state (t : Package.t) : Status.t option Lwt.t =
   let open Lwt.Syntax in
   let package_url =
@@ -438,3 +456,45 @@ let status ~kind state (t : Package.t) : Status.t option Lwt.t =
   | None -> get_and_cache ()
   | Some { time; _ } when has_cache_expired time -> get_and_cache ()
   | Some { documentation_status; _ } -> Lwt.return documentation_status
+
+let search_index_digest ~kind state t : string option Lwt.t =
+  let open Lwt.Syntax in
+  (* Downloads the whole search index just to hash it. Only reached when the
+     backend does not publish the digest in status.json; see the status-first
+     branch below, ocaml/ocaml.org#3765 and ocurrent/ocaml-docs-ci#193. *)
+  let get_and_cache () =
+    let+ content = search_index ~kind t in
+    let digest =
+      match content with Some s -> Some (s |> Digest.string) | _ -> None
+    in
+    let entry = { hash_digest = digest; time = Unix.gettimeofday () } in
+    state.search_index_cache <-
+      Name.Map.update t.name
+        (Version.Map.add t.version entry)
+        (Version.Map.singleton t.version entry)
+        state.search_index_cache;
+    digest
+  in
+
+  let has_cache_expired time =
+    Unix.gettimeofday () -. time > Config.package_caches_ttl
+  in
+
+  let from_index_download () =
+    match
+      Name.Map.find_opt t.name state.search_index_cache
+      |> Option.map (Version.Map.find_opt t.version)
+      |> Option.value ~default:None
+    with
+    | None -> get_and_cache ()
+    | Some { time; _ } when has_cache_expired time -> get_and_cache ()
+    | Some { hash_digest; _ } -> Lwt.return hash_digest
+  in
+
+  (* Prefer the digest published in status.json: it avoids downloading the
+     (potentially huge) search index. Fall back to downloading and hashing only
+     when the backend doesn't provide it. *)
+  let* status = status ~kind state t in
+  match Option.bind status (fun s -> s.Status.search_index_digest) with
+  | Some _ as digest -> Lwt.return digest
+  | None -> from_index_download ()

--- a/src/ocamlorg_package/test/documentation_status_test.ml
+++ b/src/ocamlorg_package/test/documentation_status_test.ml
@@ -1,0 +1,57 @@
+module Status = Ocamlorg_package.Documentation.Status
+
+(* status.json as currently emitted by the docs backend: no search_index_digest
+   field. Parsing must succeed and default the field to None. *)
+let without_digest =
+  {|{
+    "name": "foo",
+    "version": "1.0.0",
+    "failed": false,
+    "files": ["index.html"],
+    "redirections": []
+  }|}
+
+(* Forward-compatible: once ocaml-docs-ci/voodoo publishes the digest
+   (ocurrent/ocaml-docs-ci#193), it must be picked up. *)
+let with_digest =
+  {|{
+    "name": "foo",
+    "version": "1.0.0",
+    "failed": false,
+    "files": ["index.html"],
+    "redirections": [],
+    "search_index_digest": "deadbeef"
+  }|}
+
+(* Unknown extra fields must be ignored, not rejected. *)
+let with_extra_field =
+  {|{
+    "name": "foo",
+    "version": "1.0.0",
+    "failed": false,
+    "files": ["index.html"],
+    "redirections": [],
+    "some_future_field": 42
+  }|}
+
+let parse s = Yojson.Safe.from_string s |> Status.of_yojson |> Result.get_ok
+let test_case n = Alcotest.test_case n `Quick
+
+let () =
+  Alcotest.run "documentation_status"
+    [
+      ( "status.json parsing",
+        [
+          test_case "missing digest defaults to None" (fun () ->
+              let t = parse without_digest in
+              Alcotest.(check (option string))
+                "no digest" None t.Status.search_index_digest);
+          test_case "digest is read when present" (fun () ->
+              let t = parse with_digest in
+              Alcotest.(check (option string))
+                "digest present" (Some "deadbeef") t.Status.search_index_digest);
+          test_case "unknown fields are ignored" (fun () ->
+              let t = parse with_extra_field in
+              Alcotest.(check string) "name still parsed" "foo" t.Status.name);
+        ] );
+    ]

--- a/src/ocamlorg_package/test/dune
+++ b/src/ocamlorg_package/test/dune
@@ -1,3 +1,3 @@
 (tests
- (names package_info_test package_versions_test)
- (libraries alcotest ocamlorg_package opam-format))
+ (names package_info_test package_versions_test documentation_status_test)
+ (libraries alcotest ocamlorg_package opam-format yojson))


### PR DESCRIPTION
## What & why

Fixes #3765. Documentation-page renders call `search_index_digest`, which
downloaded a package's **entire** odoc search index (`doc/index.js`) into memory
just to MD5 it for a cache-busting script URL. When the `awso` package published
a **371 MB** `index.js`, crawler traffic caused overlapping 60 s+ downloads that
each held their own copy; the server heap grew to 10–12 GB and was repeatedly
OOM-killed, surfacing as site-wide Varnish `503 Backend fetch failed`.

Root-cause write-up: ocaml/infrastructure#192.

## Changes (all in `src/ocamlorg_package/lib/`)

1. **Size ceiling on `http_get`.** Responses larger than
   `OCAMLORG_MAX_DOC_FETCH_BYTES` (default **50 MB**) are rejected: a
   `Content-Length` over the cap is refused without downloading the body, and
   responses without a trustworthy `Content-Length` are streamed and aborted
   once the cap is exceeded. All five call sites already handle `Error`/`None`
   gracefully — for an oversized package the search box is simply absent and the
   page otherwise renders normally.

2. **Prefer the digest from `status.json`.** `search_index_digest` now uses a
   digest published in `status.json` when present, and only falls back to
   downloading-and-hashing the index otherwise. `Status.t` gains an optional
   `search_index_digest` field and is now parsed with `{ strict = false }` so the
   docs backend can extend `status.json` without breaking parsing on
   older/newer deployments. This half is a **no-op until the producer side ships
   the field** (tracked in ocurrent/ocaml-docs-ci#193) — but combined with 1 it
   removes the OOM vector regardless.

3. **`Sidebar_cache` uses `Hashtbl.replace`** instead of `add`, so concurrent
   misses can't accumulate duplicate entries in this never-expiring cache.

## Tests

Adds `documentation_status_test.ml`: `status.json` parses with the digest
missing (→ `None`), present (→ `Some`), and with unknown extra fields (ignored).
`dune build @runtest` is green.

## Notes for reviewers

- The interim mitigation (blocking `/p/awso/*` at Varnish) is already in place;
  this PR is the durable app-side fix.
- `{ strict = false }` is deliberate: `ppx_deriving_yojson` rejects unknown
  fields by default, so without it a future `status.json` carrying the new digest
  field would fail to parse on replicas not yet running this code.

Refs: ocaml/infrastructure#192, ocurrent/ocaml-docs-ci#193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
